### PR TITLE
chore(theme): remove legacy light theme alias

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -147,7 +147,7 @@ const headerIcons = {
 };
 
 const THEME_OPTIONS: Array<{
-  key: Exclude<Theme, 'light'>;
+  key: Theme;
   labelKey: string;
   icon: ReactNode;
 }> = [

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -10,7 +10,6 @@ import { STORAGE_KEY_THEME } from '@/utils/constants';
 
 type ResolvedTheme = 'light' | 'dark';
 type AppliedTheme = ResolvedTheme | 'white';
-type SelectableTheme = Exclude<Theme, 'light'>;
 
 interface ThemeState {
   theme: Theme;
@@ -35,19 +34,18 @@ const normalizeResolvedTheme = (theme: AppliedTheme): ResolvedTheme => {
   return theme === 'dark' ? 'dark' : 'light';
 };
 
-const normalizeTheme = (theme: Theme): SelectableTheme => {
-  return theme === 'light' ? 'white' : theme;
+const isTheme = (theme: unknown): theme is Theme => {
+  return theme === 'auto' || theme === 'white' || theme === 'dark';
 };
 
 const resolveTheme = (theme: Theme): AppliedTheme => {
-  const normalizedTheme = normalizeTheme(theme);
-  if (normalizedTheme === 'auto') {
+  if (theme === 'auto') {
     return resolveAutoTheme();
   }
-  if (normalizedTheme === 'white') {
+  if (theme === 'white') {
     return 'white';
   }
-  return normalizedTheme;
+  return theme;
 };
 
 const applyTheme = (resolved: AppliedTheme) => {
@@ -71,19 +69,18 @@ export const useThemeStore = create<ThemeState>()(
       resolvedTheme: 'light',
 
       setTheme: (theme) => {
-        const normalizedTheme = normalizeTheme(theme);
-        const resolved = resolveTheme(normalizedTheme);
+        const resolved = resolveTheme(theme);
         applyTheme(resolved);
         set({
-          theme: normalizedTheme,
+          theme,
           resolvedTheme: normalizeResolvedTheme(resolved),
         });
       },
 
       cycleTheme: () => {
         const { theme, setTheme } = get();
-        const order: SelectableTheme[] = ['auto', 'white', 'dark'];
-        const currentIndex = order.indexOf(normalizeTheme(theme));
+        const order: Theme[] = ['auto', 'white', 'dark'];
+        const currentIndex = order.indexOf(theme);
         const nextTheme = order[(currentIndex + 1) % order.length];
         setTheme(nextTheme);
       },
@@ -92,7 +89,7 @@ export const useThemeStore = create<ThemeState>()(
         const { theme, setTheme } = get();
 
         // 应用已保存的主题
-        setTheme(theme);
+        setTheme(isTheme(theme) ? theme : 'auto');
 
         // 监听系统主题变化（仅在 auto 模式下生效）
         if (!window.matchMedia) {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,7 +2,7 @@
  * 通用类型定义
  */
 
-export type Theme = 'light' | 'white' | 'dark' | 'auto';
+export type Theme = 'white' | 'dark' | 'auto';
 
 export type Language = 'zh-CN' | 'zh-TW' | 'en' | 'ru';
 


### PR DESCRIPTION
## Summary
Remove the legacy `light` theme alias now that the parchment theme has been removed.

## Changes
- Remove `light` from the public `Theme` union.
- Drop the `light -> white` normalization path from the theme store.
- Use the final `Theme` type directly for toolbar theme options.
- Fall back invalid persisted theme values to `auto`.

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `git diff --check`