### PR TITLE
fix: keep notifications below the header

### DIFF
--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -247,12 +247,12 @@ textarea {
 
 .notification-container {
   position: fixed;
-  top: $spacing-lg;
+  top: calc(var(--header-height, 50px) + 12px);
   right: $spacing-lg;
   display: flex;
   flex-direction: column;
   gap: $spacing-sm;
-  z-index: $z-notification;
+  z-index: 10050;
   max-width: 360px;
 }
 


### PR DESCRIPTION
## Summary
Fix notification toasts being covered by the top toolbar.

## Cause
The notification container was positioned from the top of the viewport without accounting for the fixed header.

## Solution
Offset notifications by the configured header height and raise their stacking order above the toolbar.

## Testing
- Not run; CSS-only layout fix.