### PR TITLE
refactor(ui): normalize compact button density

### DIFF
--- a/src/components/config/ApiKeysCardEditor.tsx
+++ b/src/components/config/ApiKeysCardEditor.tsx
@@ -561,7 +561,7 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
                 <div className="item-actions">
                   <Button
                     variant="secondary"
-                    size="sm"
+                    size="xs"
                     onClick={() => openAliasModal(renderApiKeyIds[index] ?? '')}
                     disabled={disabled || aliasesLoading || !aliasesAvailable}
                   >
@@ -569,7 +569,7 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
                   </Button>
                   <Button
                     variant="secondary"
-                    size="sm"
+                    size="xs"
                     onClick={() => handleCopy(key)}
                     disabled={disabled}
                   >
@@ -577,7 +577,7 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
                   </Button>
                   <Button
                     variant="secondary"
-                    size="sm"
+                    size="xs"
                     onClick={() => openEditModal(renderApiKeyIds[index] ?? '')}
                     disabled={disabled}
                   >
@@ -585,7 +585,7 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
                   </Button>
                   <Button
                     variant="danger"
-                    size="sm"
+                    size="xs"
                     onClick={() => handleDelete(renderApiKeyIds[index] ?? '')}
                     disabled={disabled}
                   >

--- a/src/components/config/VisualConfigEditorBlocks.tsx
+++ b/src/components/config/VisualConfigEditorBlocks.tsx
@@ -211,13 +211,13 @@ const StringListEditor = memo(function StringListEditor({
             onChange={(nextValue) => updateItem(index, nextValue)}
             disabled={disabled}
           />
-          <Button variant="ghost" size="sm" onClick={() => removeItem(index)} disabled={disabled}>
+          <Button variant="ghost" size="xs" onClick={() => removeItem(index)} disabled={disabled}>
             {t('config_management.visual.common.delete')}
           </Button>
         </div>
       ))}
       <div className={styles.actionRow}>
-        <Button variant="secondary" size="sm" onClick={addItem} disabled={disabled}>
+        <Button variant="secondary" size="xs" onClick={addItem} disabled={disabled}>
           {t('config_management.visual.common.add')}
         </Button>
       </div>
@@ -260,13 +260,13 @@ const PayloadHeadersEditor = memo(function PayloadHeadersEditor({
             onChange={(nextValue) => updateHeader(index, { value: nextValue })}
             disabled={disabled}
           />
-          <Button variant="ghost" size="sm" onClick={() => removeHeader(index)} disabled={disabled}>
+          <Button variant="ghost" size="xs" onClick={() => removeHeader(index)} disabled={disabled}>
             {t('config_management.visual.common.delete')}
           </Button>
         </div>
       ))}
       <div className={styles.actionRow}>
-        <Button variant="secondary" size="sm" onClick={addHeader} disabled={disabled}>
+        <Button variant="secondary" size="xs" onClick={addHeader} disabled={disabled}>
           {t('config_management.visual.payload_rules.add_header')}
         </Button>
       </div>
@@ -405,7 +405,7 @@ const PayloadConditionsEditor = memo(function PayloadConditionsEditor({
               {renderValueEditor(condition, index)}
               <Button
                 variant="ghost"
-                size="sm"
+                size="xs"
                 className={styles.payloadRowActionButton}
                 onClick={() => removeCondition(index)}
                 disabled={disabled}
@@ -420,7 +420,7 @@ const PayloadConditionsEditor = memo(function PayloadConditionsEditor({
         );
       })}
       <div className={styles.actionRow}>
-        <Button variant="secondary" size="sm" onClick={addCondition} disabled={disabled}>
+        <Button variant="secondary" size="xs" onClick={addCondition} disabled={disabled}>
           {t('config_management.visual.payload_rules.add_condition')}
         </Button>
       </div>
@@ -649,7 +649,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
             </div>
             <Button
               variant="ghost"
-              size="sm"
+              size="xs"
               onClick={() => removeRule(ruleIndex)}
               disabled={disabled}
             >
@@ -726,7 +726,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
                     )}
                     <Button
                       variant="ghost"
-                      size="sm"
+                      size="xs"
                       className={styles.payloadRowActionButton}
                       onClick={() => toggleModelAdvanced(model)}
                       disabled={disabled}
@@ -737,7 +737,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
                     </Button>
                     <Button
                       variant="ghost"
-                      size="sm"
+                      size="xs"
                       className={styles.payloadRowActionButton}
                       onClick={() => removeModel(ruleIndex, modelIndex)}
                       disabled={disabled}
@@ -829,7 +829,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
             <div className={styles.actionRow}>
               <Button
                 variant="secondary"
-                size="sm"
+                size="xs"
                 onClick={() => addModel(ruleIndex)}
                 disabled={disabled}
               >
@@ -879,7 +879,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
                     {renderParamValueEditor(ruleIndex, paramIndex, param)}
                     <Button
                       variant="ghost"
-                      size="sm"
+                      size="xs"
                       className={styles.payloadRowActionButton}
                       onClick={() => removeParam(ruleIndex, paramIndex)}
                       disabled={disabled}
@@ -896,7 +896,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
             <div className={styles.actionRow}>
               <Button
                 variant="secondary"
-                size="sm"
+                size="xs"
                 onClick={() => addParam(ruleIndex)}
                 disabled={disabled}
               >
@@ -914,7 +914,7 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
       )}
 
       <div className={styles.actionRow}>
-        <Button variant="secondary" size="sm" onClick={addRule} disabled={disabled}>
+        <Button variant="secondary" size="xs" onClick={addRule} disabled={disabled}>
           {t('config_management.visual.payload_rules.add_rule')}
         </Button>
       </div>
@@ -973,7 +973,7 @@ export const PayloadFilterRulesEditor = memo(function PayloadFilterRulesEditor({
             </div>
             <Button
               variant="ghost"
-              size="sm"
+              size="xs"
               onClick={() => removeRule(ruleIndex)}
               disabled={disabled}
             >
@@ -1007,7 +1007,7 @@ export const PayloadFilterRulesEditor = memo(function PayloadFilterRulesEditor({
                 />
                 <Button
                   variant="ghost"
-                  size="sm"
+                  size="xs"
                   className={styles.payloadRowActionButton}
                   onClick={() => removeModel(ruleIndex, modelIndex)}
                   disabled={disabled}
@@ -1019,7 +1019,7 @@ export const PayloadFilterRulesEditor = memo(function PayloadFilterRulesEditor({
             <div className={styles.actionRow}>
               <Button
                 variant="secondary"
-                size="sm"
+                size="xs"
                 onClick={() => addModel(ruleIndex)}
                 disabled={disabled}
               >
@@ -1050,7 +1050,7 @@ export const PayloadFilterRulesEditor = memo(function PayloadFilterRulesEditor({
       )}
 
       <div className={styles.actionRow}>
-        <Button variant="secondary" size="sm" onClick={addRule} disabled={disabled}>
+        <Button variant="secondary" size="xs" onClick={addRule} disabled={disabled}>
           {t('config_management.visual.payload_rules.add_rule')}
         </Button>
       </div>

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -64,7 +64,7 @@ export function ProviderList<T>({
             <div className={actionsClassName ?? 'item-actions'}>
               <Button
                 variant="secondary"
-                size="sm"
+                size="xs"
                 onClick={() => onEdit(item, index)}
                 disabled={actionsDisabled}
               >
@@ -72,7 +72,7 @@ export function ProviderList<T>({
               </Button>
               <Button
                 variant="danger"
-                size="sm"
+                size="xs"
                 onClick={() => onDelete(item, index)}
                 disabled={actionsDisabled}
               >

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,12 +1,13 @@
 import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 
 type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
-type ButtonSize = 'md' | 'sm';
+type ButtonSize = 'md' | 'sm' | 'xs';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   fullWidth?: boolean;
+  iconOnly?: boolean;
   loading?: boolean;
 }
 
@@ -15,6 +16,7 @@ export function Button({
   variant = 'primary',
   size = 'md',
   fullWidth = false,
+  iconOnly = false,
   loading = false,
   className = '',
   disabled,
@@ -24,7 +26,8 @@ export function Button({
   const classes = [
     'btn',
     `btn-${variant}`,
-    size === 'sm' ? 'btn-sm' : '',
+    size !== 'md' ? `btn-${size}` : '',
+    iconOnly ? 'btn-icon-only' : '',
     fullWidth ? 'btn-full' : '',
     className
   ]

--- a/src/components/ui/HeaderInputList.tsx
+++ b/src/components/ui/HeaderInputList.tsx
@@ -62,7 +62,8 @@ export function HeaderInputList({
             />
             <Button
               variant="ghost"
-              size="sm"
+              size="xs"
+              iconOnly
               onClick={() => removeEntry(index)}
               disabled={disabled || currentEntries.length <= 1}
               title={removeButtonTitle}
@@ -73,7 +74,7 @@ export function HeaderInputList({
           </div>
         </Fragment>
       ))}
-      <Button variant="secondary" size="sm" onClick={addEntry} disabled={disabled} className="align-start">
+      <Button variant="secondary" size="xs" onClick={addEntry} disabled={disabled} className="align-start">
         {addLabel}
       </Button>
     </div>

--- a/src/components/ui/ModelInputList.tsx
+++ b/src/components/ui/ModelInputList.tsx
@@ -81,7 +81,8 @@ export function ModelInputList({
             />
             <Button
               variant="ghost"
-              size="sm"
+              size="xs"
+              iconOnly
               onClick={() => removeEntry(index)}
               disabled={disabled || currentEntries.length <= 1}
               className={removeButtonClassName}
@@ -94,7 +95,7 @@ export function ModelInputList({
         </Fragment>
       ))}
       {!hideAddButton && addLabel && (
-        <Button variant="secondary" size="sm" onClick={addEntry} disabled={disabled} className="align-start">
+        <Button variant="secondary" size="xs" onClick={addEntry} disabled={disabled} className="align-start">
           {addLabel}
         </Button>
       )}

--- a/src/features/aiProviders/AiProvidersOpenAIEditPage.tsx
+++ b/src/features/aiProviders/AiProvidersOpenAIEditPage.tsx
@@ -469,7 +469,7 @@ export function AiProvidersOpenAIEditPage() {
                 <div className={styles.keyTableColAction}>
                   <Button
                     variant="secondary"
-                    size="sm"
+                    size="xs"
                     onClick={() => void testSingleKey(index)}
                     disabled={saving || disableControls || isTestingKeys || !canTestKey}
                     loading={keyStatus === 'loading'}
@@ -478,7 +478,7 @@ export function AiProvidersOpenAIEditPage() {
                   </Button>
                   <Button
                     variant="ghost"
-                    size="sm"
+                    size="xs"
                     onClick={() => removeEntry(index)}
                     disabled={saving || disableControls || isTestingKeys || list.length <= 1}
                   >

--- a/src/features/aiProviders/AiProvidersPage.module.scss
+++ b/src/features/aiProviders/AiProvidersPage.module.scss
@@ -106,7 +106,7 @@ $openai-toolbar-control-height: 36px;
     height: $openai-toolbar-control-height;
     padding: 0 12px;
     border-color: var(--border-subtle);
-    border-radius: 6px;
+    border-radius: 12px;
     background: var(--surface-subtle);
     box-shadow: none;
     font-size: 13px;
@@ -120,7 +120,7 @@ $openai-toolbar-control-height: 36px;
   height: $openai-toolbar-control-height;
   padding: 0 10px;
   border-color: var(--border-subtle);
-  border-radius: 6px;
+  border-radius: 12px;
   background: var(--surface-subtle);
   color: var(--text-primary);
   gap: 6px;
@@ -194,7 +194,7 @@ $openai-toolbar-control-height: 36px;
   width: 164px;
   height: $openai-toolbar-control-height;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
+  border-radius: 12px;
   background: var(--surface-subtle);
   overflow: hidden;
   transition:
@@ -359,6 +359,7 @@ $openai-toolbar-control-height: 36px;
 .openaiAddButton:global(.btn.btn-primary) {
   height: $openai-toolbar-control-height;
   padding: 0 12px;
+  border-radius: 12px;
 }
 
 .modelDropdownItems {
@@ -417,7 +418,7 @@ $openai-toolbar-control-height: 36px;
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: 12px;
   font-size: 13px;
   font-weight: 600;
   line-height: 1.1;

--- a/src/features/authFiles/AuthFilesPage.module.scss
+++ b/src/features/authFiles/AuthFilesPage.module.scss
@@ -12,7 +12,7 @@
 
 .headerActions {
   display: flex;
-  gap: $spacing-sm;
+  gap: 6px;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
@@ -21,6 +21,12 @@
 
   :global(.btn) {
     min-width: 0;
+  }
+
+  :global(.btn.btn-sm) {
+    min-height: 34px;
+    padding: 0 10px;
+    border-radius: 12px;
   }
 
   @include mobile {
@@ -55,16 +61,16 @@
 .filterSection {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
-  margin-bottom: $spacing-lg;
+  gap: 12px;
+  margin-bottom: $spacing-md;
 }
 
 .filterPanel {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 14px;
-  border-radius: 12px;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 14px;
   border: 1px solid var(--glass-border);
   background: var(--glass-bg);
   box-shadow: none;
@@ -77,11 +83,11 @@
 
 .filterPanelHeader {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: $spacing-md;
+  gap: 12px;
   min-width: 0;
-  padding-bottom: 12px;
+  padding-bottom: 10px;
   border-bottom: 1px solid color-mix(in srgb, var(--border-color) 56%, transparent);
 
   @include mobile {
@@ -127,7 +133,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
 
   @include mobile {
@@ -140,10 +146,11 @@
 .filterTag {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 12px 7px 8px;
-  border-radius: 10px;
-  font-size: 13px;
+  gap: 6px;
+  min-height: 34px;
+  padding: 5px 10px 5px 7px;
+  border-radius: 12px;
+  font-size: 12px;
   font-weight: 600;
   line-height: 1.2;
   border: 1px solid var(--border-secondary);
@@ -178,13 +185,13 @@
 .filterTagLabel {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   min-width: 0;
 }
 
 .filterTagIconWrap {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -217,9 +224,9 @@
 .filterTagCount {
   display: inline-grid;
   place-items: center;
-  min-width: 20px;
-  height: 20px;
-  padding: 0 6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
   border-radius: 6px;
   background: color-mix(in srgb, var(--filter-color) 12%, transparent);
   color: var(--text-tertiary);
@@ -242,8 +249,8 @@
 
 .filterControls {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(96px, 132px) minmax(160px, 220px);
-  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) minmax(88px, 120px) minmax(150px, 200px);
+  gap: 8px;
   align-items: flex-end;
   min-width: 0;
 
@@ -253,7 +260,11 @@
   }
 
   :global(.input) {
-    height: 40px;
+    height: 36px;
+    min-height: 36px;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-radius: 12px;
     box-sizing: border-box;
   }
 
@@ -269,7 +280,7 @@
 .filterItem {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
 
   label {
@@ -287,7 +298,7 @@
   grid-column: 1 / -1;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  column-gap: 12px;
+  column-gap: 8px;
   min-width: 0;
 
   label {
@@ -304,8 +315,8 @@
 .filterToggleGroup {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 8px;
-  min-height: 40px;
+  gap: 6px;
+  min-height: 36px;
   width: fit-content;
   max-width: 100%;
 
@@ -320,9 +331,9 @@
   display: flex;
   align-items: center;
   min-width: 0;
-  min-height: 40px;
-  padding: 0 10px;
-  border-radius: 8px;
+  min-height: 36px;
+  padding: 0 8px;
+  border-radius: 12px;
   border: none;
   background: transparent;
 
@@ -343,7 +354,7 @@
 .filterToggle {
   display: flex;
   align-items: center;
-  min-height: 40px;
+  min-height: 36px;
   padding-inline: 2px;
 }
 
@@ -359,14 +370,14 @@
 
 .pageSizeSelect {
   width: 100%;
-  padding: 8px 12px;
+  padding: 0 10px;
   border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
-  border-radius: 8px;
+  border-radius: 12px;
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   cursor: text;
-  height: 40px;
+  height: 36px;
   box-sizing: border-box;
 
   &:focus {
@@ -836,14 +847,14 @@
   .cardUtilityActions {
     gap: 2px;
     padding: 2px;
-    border-radius: 6px;
+    border-radius: 8px;
   }
 
   .iconButton:global(.btn.btn-sm) {
     width: 28px;
     height: 28px;
     min-width: 28px;
-    border-radius: 6px;
+    border-radius: 8px;
   }
 
   .statusToggle {
@@ -1042,6 +1053,12 @@
 .sortSelect {
   width: 100%;
   min-width: 0;
+
+  :global(button) {
+    height: 36px;
+    border-radius: 12px;
+    font-size: 13px;
+  }
 }
 
 .healthStatusMessage {
@@ -1052,7 +1069,7 @@
   color: var(--warning-text);
   background-color: color-mix(in srgb, var(--warning-bg) 60%, transparent);
   border: 1px solid color-mix(in srgb, var(--warning-border) 60%, transparent);
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 8px 10px;
   word-break: break-word;
 }
@@ -1471,7 +1488,7 @@
   min-width: 32px;
   padding: 0;
   box-sizing: border-box;
-  border-radius: 8px;
+  border-radius: 10px;
   gap: 0;
 }
 
@@ -1494,7 +1511,7 @@
   align-items: center;
   gap: 3px;
   padding: 2px;
-  border-radius: 8px;
+  border-radius: 10px;
   background: transparent;
 }
 
@@ -1518,7 +1535,7 @@
   min-width: 32px;
   padding: 0;
   box-sizing: border-box;
-  border-radius: 8px;
+  border-radius: 10px;
   gap: 0;
 }
 

--- a/src/features/authFiles/components/OAuthExcludedCard.tsx
+++ b/src/features/authFiles/components/OAuthExcludedCard.tsx
@@ -48,10 +48,10 @@ export function OAuthExcludedCard(props: OAuthExcludedCardProps) {
                 </div>
               </div>
               <div className={styles.excludedActions}>
-                <Button variant="secondary" size="sm" onClick={() => onEdit(provider)}>
+                <Button variant="secondary" size="xs" onClick={() => onEdit(provider)}>
                   {t('common.edit')}
                 </Button>
-                <Button variant="danger" size="sm" onClick={() => onDelete(provider)}>
+                <Button variant="danger" size="xs" onClick={() => onDelete(provider)}>
                   {t('oauth_excluded.delete')}
                 </Button>
               </div>

--- a/src/features/authFiles/components/OAuthModelAliasCard.tsx
+++ b/src/features/authFiles/components/OAuthModelAliasCard.tsx
@@ -96,7 +96,8 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
               <h4 className={styles.aliasChartTitle}>{t('oauth_model_alias.chart_title')}</h4>
               <Button
                 variant="ghost"
-                size="sm"
+                size="xs"
+                iconOnly
                 onClick={() => diagramRef.current?.collapseAll()}
                 disabled={disableControls || modelAliasError === 'unsupported'}
                 title={t('oauth_model_alias.diagram_collapse')}
@@ -135,10 +136,10 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
                 </div>
               </div>
               <div className={styles.excludedActions}>
-                <Button variant="secondary" size="sm" onClick={() => onEditProvider(provider)}>
+                <Button variant="secondary" size="xs" onClick={() => onEditProvider(provider)}>
                   {t('common.edit')}
                 </Button>
-                <Button variant="danger" size="sm" onClick={() => onDeleteProvider(provider)}>
+                <Button variant="danger" size="xs" onClick={() => onDeleteProvider(provider)}>
                   {t('oauth_model_alias.delete')}
                 </Button>
               </div>

--- a/src/features/config/ConfigPage.module.scss
+++ b/src/features/config/ConfigPage.module.scss
@@ -8,7 +8,7 @@
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: $spacing-md;
   box-sizing: border-box;
   overflow-y: auto;
   padding-bottom: calc(
@@ -21,9 +21,9 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 10px;
   min-width: 0;
-  padding-bottom: 16px;
+  padding-bottom: 12px;
   border-bottom: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
 
   @include mobile {
@@ -35,9 +35,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 38px;
-  padding: 0 14px;
-  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 12px;
   border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
   background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
   color: var(--text-primary);
@@ -54,8 +54,8 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 4px;
-  border-radius: 999px;
+  padding: 3px;
+  border-radius: 14px;
   background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
   width: fit-content;
@@ -74,11 +74,12 @@
 
 .tabItem {
   @include button-reset;
-  padding: 10px 16px;
-  border-radius: 999px;
+  min-height: 32px;
+  padding: 0 14px;
+  border-radius: 12px;
   border: 1px solid transparent;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
   white-space: nowrap;
   transition:
@@ -179,9 +180,9 @@
 .managerSection {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: 12px;
   min-width: 0;
-  padding: $spacing-md;
+  padding: 12px;
   border: 1px solid color-mix(in srgb, var(--border-subtle) 84%, transparent);
   border-radius: 8px;
 
@@ -194,7 +195,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: $spacing-md;
+  gap: 12px;
   min-width: 0;
 
   > div {
@@ -226,11 +227,11 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  min-height: 30px;
+  min-height: 28px;
   max-width: 100%;
   padding: 0 10px;
   border: 1px solid color-mix(in srgb, var(--primary-color) 26%, var(--border-color));
-  border-radius: 999px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--primary-color) 9%, var(--bg-primary));
   color: var(--text-primary);
   font-size: 12px;
@@ -295,7 +296,7 @@
 .managerConfigGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: $spacing-md;
+  gap: 12px;
 
   :global(.form-group) {
     margin-bottom: 0;
@@ -309,7 +310,7 @@
 .managerField {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
 }
 
@@ -320,11 +321,12 @@
 }
 
 .managerSelectTrigger {
-  height: 46px !important;
-  padding: 10px 12px !important;
+  height: 40px !important;
+  padding: 0 12px !important;
   background-color: var(--bg-primary) !important;
+  border-radius: 12px !important;
   box-shadow: none !important;
-  font-size: inherit !important;
+  font-size: 14px !important;
   font-weight: 400 !important;
 }
 
@@ -401,7 +403,11 @@
 
 .searchInput {
   flex: 1;
-  border-radius: 16px !important;
+  height: 38px;
+  min-height: 38px;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  border-radius: 12px !important;
   padding-right: 132px !important;
 }
 
@@ -416,7 +422,7 @@
   align-items: center;
   min-height: 28px;
   padding: 0 10px;
-  border-radius: 999px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-color) 84%, transparent);
   color: var(--text-secondary);
@@ -431,9 +437,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
   background: var(--primary-color);
   border: 1px solid var(--primary-color);
   color: #fff;
@@ -459,11 +465,11 @@
   flex-shrink: 0;
 
   button {
-    min-width: 36px;
-    width: 36px;
-    height: 36px;
+    min-width: 34px;
+    width: 34px;
+    height: 34px;
     padding: 0 !important;
-    border-radius: 999px;
+    border-radius: 12px;
   }
 
   @include mobile {

--- a/src/features/dashboard/components/VersionCard.tsx
+++ b/src/features/dashboard/components/VersionCard.tsx
@@ -418,7 +418,8 @@ export function VersionCard({
                 <Button
                   type="button"
                   variant="ghost"
-                  size="sm"
+                  size="xs"
+                  iconOnly
                   className={styles.versionAction}
                   onClick={(event) => {
                     event.stopPropagation();
@@ -447,7 +448,8 @@ export function VersionCard({
                 <Button
                   type="button"
                   variant="ghost"
-                  size="sm"
+                  size="xs"
+                  iconOnly
                   className={styles.versionAction}
                   onClick={() => void handleApiVersionCheck()}
                   loading={checkingApiVersion}

--- a/src/features/login/LoginPage.module.scss
+++ b/src/features/login/LoginPage.module.scss
@@ -170,6 +170,12 @@
   }
 }
 
+.setupCard :global(.btn:not(.btn-sm):not(.btn-xs)) {
+  height: 48px;
+  min-height: 48px;
+  font-size: 16px;
+}
+
 .setupHeader {
   position: relative;
   display: flex;

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -693,7 +693,7 @@ export function LoginPage() {
                     rightElement={
                       <button
                         type="button"
-                        className="btn btn-ghost btn-sm"
+                        className="btn btn-ghost btn-xs btn-icon-only"
                         onClick={() => setShowKey((prev) => !prev)}
                         aria-label={showKey ? t('login.hide_key') : t('login.show_key')}
                         title={showKey ? t('login.hide_key') : t('login.show_key')}

--- a/src/features/logs/LogsPage.module.scss
+++ b/src/features/logs/LogsPage.module.scss
@@ -16,13 +16,13 @@
 .tabBar {
   display: flex;
   gap: $spacing-xs;
-  margin-bottom: $spacing-lg;
+  margin-bottom: $spacing-md;
   border-bottom: 1px solid var(--border-color);
 }
 
 .tabItem {
   @include button-reset;
-  padding: 12px 20px;
+  padding: 10px 16px;
   font-size: 14px;
   font-weight: 500;
   color: var(--text-secondary);
@@ -53,7 +53,7 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: $spacing-md;
   flex: 1;
   min-height: 0;
 
@@ -80,7 +80,7 @@
 .toolbar {
   display: flex;
   align-items: center;
-  gap: $spacing-sm;
+  gap: 6px;
   flex-wrap: wrap;
   margin-left: auto;
 
@@ -94,9 +94,9 @@
 .filters {
   display: flex;
   align-items: center;
-  gap: $spacing-md;
+  gap: 8px;
   flex-wrap: wrap;
-  margin-bottom: $spacing-md;
+  margin-bottom: 10px;
 
   :global(.form-group) {
     margin: 0;
@@ -111,17 +111,25 @@
 .searchWrapper {
   flex: 1;
   min-width: 220px;
-  max-width: 420px;
+  max-width: 380px;
 }
 
 .filterPanelHeader {
   display: flex;
   align-items: center;
-  flex: 1 1 100%;
+  flex: 0 0 auto;
 }
 
 .filterPanelToggle {
   white-space: nowrap;
+}
+
+.filterPanelToggle:global(.btn.btn-sm),
+.actionButton:global(.btn.btn-sm) {
+  height: 34px;
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 12px;
 }
 
 .filterPanelButtonContent {
@@ -134,7 +142,7 @@
   display: inline-flex;
   align-items: center;
   padding: 2px 8px;
-  border-radius: $radius-full;
+  border-radius: 11px;
   background: rgba($primary-color, 0.12);
   color: var(--primary-color);
   font-size: 12px;
@@ -144,9 +152,9 @@
 .structuredFilters {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   flex: 1 1 100%;
-  padding: 8px 10px;
+  padding: 6px 8px;
   background: var(--surface-subtle);
   border: 1px solid var(--border-subtle);
   border-radius: $radius-md;
@@ -155,7 +163,7 @@
 .filterChipGroup {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
@@ -163,14 +171,14 @@
   font-size: 12px;
   color: var(--text-secondary);
   font-weight: 700;
-  line-height: 28px;
+  line-height: 26px;
   min-width: 68px;
 }
 
 .filterChipList {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px;
   flex-wrap: wrap;
   flex: 1;
 }
@@ -180,15 +188,15 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 10px;
-  border-radius: $radius-full;
+  padding: 3px 8px;
+  border-radius: 12px;
   border: 1px solid var(--border-color);
   background: var(--bg-primary);
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.3;
   cursor: pointer;
-  max-width: 280px;
+  max-width: 240px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -246,7 +254,12 @@
 }
 
 .searchInput {
+  height: 36px;
+  min-height: 36px;
+  padding-top: 0 !important;
   padding-right: 44px !important;
+  padding-bottom: 0 !important;
+  border-radius: 12px !important;
 }
 
 .searchIcon {
@@ -261,7 +274,7 @@
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: $radius-full;
+  border-radius: 12px;
   color: var(--text-secondary);
 
   &:hover {
@@ -630,7 +643,7 @@
       flex: 0 0 auto;
       gap: $spacing-sm;
       margin-bottom: $spacing-sm;
-      max-height: 260px;
+      max-height: 220px;
       overflow: auto;
       padding-right: 4px;
       overscroll-behavior: contain;
@@ -677,7 +690,7 @@
 
   @media (min-width: 769px) {
     .filters {
-      max-height: 180px;
+      max-height: 160px;
     }
 
     .logPanel {

--- a/src/features/monitoring/CodexInspectionPage.module.scss
+++ b/src/features/monitoring/CodexInspectionPage.module.scss
@@ -21,7 +21,7 @@
 .page {
   container: codex-inspection-page / inline-size;
   display: grid;
-  gap: 20px;
+  gap: 16px;
   min-width: 0;
 }
 
@@ -35,9 +35,9 @@
 }
 
 .panel {
-  padding: 22px;
+  padding: 18px;
   display: grid;
-  gap: 16px;
+  gap: 12px;
   min-width: 0;
 }
 
@@ -45,7 +45,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 14px;
+  gap: 12px;
 }
 
 .panelHeading {
@@ -75,15 +75,15 @@
 
 .statusPanel {
   display: grid;
-  gap: 16px;
-  padding: 22px;
+  gap: 12px;
+  padding: 18px;
 }
 
 .statusBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
@@ -91,14 +91,14 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 14px;
+  gap: 10px;
   min-width: 0;
 }
 
 .statusActions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
   justify-content: flex-end;
 }
@@ -107,9 +107,9 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  min-height: 36px;
-  padding: 0 14px;
-  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 12px;
   border: 1px solid var(--inspect-line);
   background: var(--inspect-surface-elevated);
   color: var(--inspect-ink);
@@ -168,9 +168,9 @@
 .statusMeta span {
   display: inline-flex;
   align-items: center;
-  min-height: 30px;
-  padding: 0 12px;
-  border-radius: 999px;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 12px;
   background: var(--inspect-surface-muted);
   white-space: nowrap;
 }
@@ -203,22 +203,22 @@
 }
 
 .iconButton {
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   padding: 0;
-  border-radius: 999px;
+  border-radius: 12px;
 }
 
 .foldButton {
   min-height: 32px;
-  padding: 0 12px;
-  border-radius: 999px;
+  padding: 0 10px;
+  border-radius: 12px;
 }
 
 .quickLink {
-  min-height: 36px;
-  padding: 0 12px;
-  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 12px;
   color: var(--inspect-muted);
 }
 
@@ -240,9 +240,9 @@
 
 .progressSection {
   display: grid;
-  gap: 10px;
-  padding: 14px 16px;
-  border-radius: 18px;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 14px;
   border: 1px solid color-mix(in srgb, var(--inspect-accent) 22%, var(--inspect-line));
   background: color-mix(in srgb, var(--inspect-accent) 6%, var(--inspect-surface));
 }
@@ -252,7 +252,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
 }
 
 .progressHeader strong {
@@ -294,15 +294,15 @@
 .summaryGrid {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 14px;
+  gap: 10px;
 }
 
 .summaryCard {
   display: grid;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
-  min-height: 138px;
-  padding: 18px;
+  min-height: 112px;
+  padding: 14px;
   background: var(--inspect-surface-elevated);
   transition:
     transform 0.18s ease,
@@ -343,7 +343,7 @@
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
-  font-size: clamp(24px, 2vw, 32px);
+  font-size: clamp(22px, 1.8vw, 30px);
   line-height: 1;
   letter-spacing: 0;
   text-overflow: ellipsis;
@@ -380,7 +380,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 12px;
+  gap: 8px;
   margin-top: -2px;
   flex-wrap: wrap;
 }
@@ -388,9 +388,9 @@
 .segmentedControl {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 6px;
-  padding: 6px;
-  border-radius: 999px;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 14px;
   border: 1px solid var(--inspect-line);
   background: var(--inspect-surface-elevated);
 }
@@ -398,11 +398,11 @@
 .segmentButton {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  min-height: 32px;
-  padding: 0 14px;
+  gap: 6px;
+  min-height: 28px;
+  padding: 0 10px;
   border: 0;
-  border-radius: 999px;
+  border-radius: 12px;
   background: transparent;
   color: var(--inspect-muted);
   font-size: 13px;
@@ -432,10 +432,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 22px;
+  min-width: 20px;
   height: 18px;
   padding: 0 6px;
-  border-radius: 999px;
+  border-radius: 8px;
   background: color-mix(in srgb, var(--inspect-line) 86%, transparent);
   color: inherit;
   font-size: 11px;
@@ -457,7 +457,7 @@
   width: 100%;
   min-width: 920px;
   border-collapse: separate;
-  border-spacing: 0 10px;
+  border-spacing: 0 8px;
   table-layout: fixed;
 }
 
@@ -501,7 +501,7 @@
 }
 
 .table tbody td {
-  padding: 14px 14px;
+  padding: 10px 12px;
   vertical-align: middle;
   border-top: 1px solid var(--inspect-line);
   border-bottom: 1px solid var(--inspect-line);
@@ -510,12 +510,12 @@
 
 .table tbody td:first-child {
   border-left: 1px solid var(--inspect-line);
-  border-radius: 18px 0 0 18px;
+  border-radius: 16px 0 0 16px;
 }
 
 .table tbody td:last-child {
   border-right: 1px solid var(--inspect-line);
-  border-radius: 0 18px 18px 0;
+  border-radius: 0 16px 16px 0;
 }
 
 .primaryCell {
@@ -569,7 +569,7 @@
   align-items: center;
   min-height: 26px;
   padding: 0 10px;
-  border-radius: 999px;
+  border-radius: 12px;
   border: 1px solid var(--inspect-line);
   background: var(--inspect-surface);
   color: var(--inspect-muted);
@@ -597,7 +597,7 @@
   align-items: center;
   min-height: 26px;
   padding: 0 10px;
-  border-radius: 999px;
+  border-radius: 12px;
   font-size: 12px;
   font-weight: 700;
 }
@@ -644,7 +644,7 @@
   gap: 12px;
   align-items: start;
   padding: 8px 12px 8px 16px;
-  border-radius: 10px;
+  border-radius: 12px;
   border: 0;
   background: transparent;
   transition: background-color 0.18s ease;
@@ -692,8 +692,8 @@
 }
 
 .logCollapsedBar {
-  padding: 14px 16px;
-  border-radius: 14px;
+  padding: 10px 12px;
+  border-radius: 12px;
   background: var(--inspect-surface-muted);
   color: var(--inspect-muted);
   font-size: 13px;
@@ -701,18 +701,18 @@
 
 .settingsModal :global(.modal-body) {
   display: grid;
-  gap: 20px;
+  gap: 14px;
 }
 
 .settingsBody {
   display: grid;
-  gap: 16px;
+  gap: 12px;
 }
 
 .settingsSectionCard {
   display: grid;
-  gap: 16px;
-  padding: 18px 20px 20px;
+  gap: 12px;
+  padding: 14px 16px 16px;
   border: 1px solid var(--inspect-line);
   border-radius: 8px;
   background: var(--inspect-surface);
@@ -747,7 +747,7 @@
 .settingsGrid {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 14px;
+  gap: 10px;
 }
 
 .settingsGridStrategy .settingsField {
@@ -772,11 +772,11 @@
 }
 
 .settingsField :global(.input) {
-  min-height: 44px;
+  min-height: 40px;
 }
 
 .settingsField input {
-  min-height: 44px;
+  min-height: 40px;
 }
 
 .settingsAutoContent {
@@ -793,7 +793,7 @@
 .settingsAutoCards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 
 .settingsAutoOption {
@@ -804,10 +804,10 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: start;
-  gap: 12px;
+  gap: 10px;
   min-width: 0;
-  min-height: 132px;
-  padding: 16px;
+  min-height: 110px;
+  padding: 12px;
   border: 1px solid color-mix(in srgb, var(--auto-color) 24%, var(--inspect-line));
   border-radius: 8px;
   background: color-mix(in srgb, var(--auto-color) 5%, var(--inspect-surface));
@@ -851,8 +851,8 @@
 .settingsAutoOptionIcon {
   display: inline-grid;
   place-items: center;
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   border-radius: 8px;
   background: color-mix(in srgb, var(--auto-color) 12%, var(--inspect-surface));
   color: var(--auto-color-strong);
@@ -884,7 +884,7 @@
   width: 22px;
   height: 22px;
   border: 1px solid color-mix(in srgb, var(--auto-color) 42%, var(--inspect-line));
-  border-radius: 999px;
+  border-radius: 8px;
   color: var(--inspect-surface);
 }
 

--- a/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -34,9 +34,9 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 10px;
-  flex-wrap: wrap;
-  min-width: min(100%, 520px);
+  gap: 8px;
+  flex-wrap: nowrap;
+  min-width: 0;
 }
 
 .statusDot {
@@ -51,17 +51,17 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: 8px;
+  flex-wrap: nowrap;
+  gap: 6px;
   min-width: 0;
 }
 
 .statusMeta span {
   display: inline-flex;
   align-items: center;
-  min-height: 34px;
-  padding: 0 12px;
-  border-radius: 999px;
+  min-height: 32px;
+  padding: 0 10px;
+  border-radius: 12px;
   background: var(--monitor-surface-muted);
   color: var(--monitor-muted);
   font-size: 12px;
@@ -162,13 +162,16 @@
 
 .segmentedControl {
   display: inline-flex;
+  align-items: center;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
-  padding: 6px;
-  border-radius: 999px;
+  gap: 4px;
+  height: 36px;
+  padding: 3px;
+  border-radius: 14px;
   border: 1px solid var(--monitor-line);
   background: var(--monitor-surface-elevated);
+  box-sizing: border-box;
 }
 
 .segmentButton,
@@ -190,14 +193,14 @@
 }
 
 .actionBar {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  gap: 10px;
   min-width: 0;
-  padding: 12px;
+  padding: 8px 10px;
   border: 1px solid var(--monitor-line);
-  border-radius: 20px;
+  border-radius: 16px;
   background: var(--monitor-surface);
   box-shadow: var(--shadow);
 }
@@ -214,8 +217,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  flex: 1 1 auto;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
   min-width: 0;
 
@@ -230,10 +232,11 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-height: 38px;
-  padding: 0 13px;
+  height: 34px;
+  min-height: 34px;
+  padding: 0 10px;
   border: 1px solid var(--monitor-line);
-  border-radius: 999px;
+  border-radius: 12px;
   background: var(--monitor-surface-elevated);
   color: var(--monitor-ink);
   font: inherit;
@@ -271,10 +274,11 @@
 }
 
 .segmentButton {
-  min-height: 38px;
-  padding: 0 16px;
+  height: 28px;
+  min-height: 28px;
+  padding: 0 10px;
   border: 0;
-  border-radius: 999px;
+  border-radius: 12px;
   background: transparent;
   color: var(--monitor-muted);
   font-size: 13px;
@@ -342,6 +346,7 @@
   align-items: center;
   gap: 8px;
   flex-wrap: nowrap;
+  min-width: 0;
 }
 
 .syncPill,
@@ -354,9 +359,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 36px;
-  padding: 0 12px;
-  border-radius: 999px;
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 12px;
   border: 1px solid var(--monitor-line);
   background: var(--monitor-surface-elevated);
 }
@@ -371,8 +376,8 @@
 }
 
 .syncPill {
-  min-height: 44px;
-  padding: 0 14px;
+  min-height: 38px;
+  padding: 0 12px;
 }
 
 .metaPill,
@@ -419,10 +424,11 @@
 .autoRefreshField {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  min-height: 44px;
-  padding: 0 10px 0 14px;
-  border-radius: 16px;
+  gap: 6px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 7px 0 9px;
+  border-radius: 12px;
   border: 1px solid var(--monitor-line);
   background: var(--monitor-surface);
 }
@@ -430,7 +436,7 @@
 .autoRefreshLabel {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   color: var(--monitor-muted);
   font-size: 12px;
   font-weight: 600;
@@ -438,20 +444,20 @@
 }
 
 .autoRefreshSelect {
-  width: 116px;
+  width: 108px;
   flex: 0 0 auto;
 }
 
 .autoRefreshSelectTrigger {
-  min-width: 92px;
-  height: 36px !important;
+  min-width: 84px;
+  height: 32px !important;
   padding: 0 2px 0 8px !important;
   border: 0 !important;
-  border-radius: 12px !important;
+  border-radius: 10px !important;
   background: transparent !important;
   box-shadow: none !important;
   color: var(--monitor-ink);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   line-height: 1;
 }
@@ -469,17 +475,25 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-width: 112px;
-  min-height: 44px;
-  padding: 0 16px;
+  min-width: 96px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 12px;
   border: 1px solid var(--monitor-line);
-  border-radius: 16px;
+  border-radius: 12px;
   background: var(--monitor-surface);
   color: var(--monitor-ink);
   font: inherit;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 700;
   cursor: pointer;
+  white-space: nowrap;
+}
+
+.refreshControls .clearButton {
+  height: 36px;
+  min-height: 36px;
+  border-radius: 12px;
   white-space: nowrap;
 }
 
@@ -508,7 +522,7 @@
 
 .panel {
   min-width: 0;
-  padding: 22px;
+  padding: 18px;
 }
 
 .panelHeader {
@@ -700,39 +714,42 @@
 
 .controlBar,
 .toolbarControls {
-  display: flex;
   align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--monitor-line) 82%, transparent);
+}
+
+.controlBar {
+  display: grid;
+  grid-template-columns: auto minmax(160px, 1fr) auto;
+}
+
+.toolbarControls {
+  display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 14px;
-  padding-bottom: 14px;
-  border-bottom: 1px solid color-mix(in srgb, var(--monitor-line) 82%, transparent);
 }
 
 .filterBar {
   display: grid;
-  gap: 12px;
+  gap: 8px;
   min-width: 0;
-}
-
-.filterBarCollapsed {
-  display: none;
 }
 
 .filterGrid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   align-items: start;
-  gap: 12px;
+  gap: 8px;
+}
 
-  @include narrow-laptop {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  @include compact-desktop {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.filterSelectTrigger {
+  height: 36px !important;
+  border-radius: 12px !important;
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .filterAccountStack {
@@ -745,27 +762,14 @@
   margin-bottom: 0;
 }
 
-.filterSearchRow {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 10px;
-}
-
-.filterSearchInputWrap,
-.filterSearchAction {
+.filterSearchInputWrap {
   min-width: 0;
 }
 
 .filterSearchInputWrap :global(.form-group) {
-  min-width: min(100%, 360px);
+  width: 100%;
+  min-width: 0;
   margin-bottom: 0;
-}
-
-.filterSearchAction {
-  display: flex;
-  align-items: stretch;
-  justify-content: flex-end;
 }
 
 .filterChip {
@@ -774,7 +778,7 @@
   min-height: 34px;
   max-width: 100%;
   padding: 0 12px;
-  border-radius: 999px;
+  border-radius: 12px;
   border: 1px solid var(--monitor-line);
   background: var(--monitor-surface);
   color: var(--monitor-muted);
@@ -794,9 +798,13 @@
 .searchInput,
 .filterSearchInput {
   width: 100%;
-  min-height: 46px;
+  height: 36px;
+  min-height: 36px;
+  padding-top: 0;
   padding-right: 40px;
-  border-radius: 16px;
+  padding-bottom: 0;
+  border-radius: 12px;
+  font-size: 13px;
 }
 
 .toolbarMeta,
@@ -831,7 +839,7 @@
   align-items: center;
   min-height: 30px;
   padding: 0 10px;
-  border-radius: 999px;
+  border-radius: 12px;
   border: 1px solid var(--monitor-line);
   background: var(--monitor-surface-elevated);
   color: var(--monitor-muted);
@@ -839,6 +847,7 @@
 }
 
 .filterToggleChip {
+  height: 30px;
   min-height: 30px;
   padding: 0 10px;
   color: var(--monitor-muted);
@@ -852,22 +861,38 @@
 
 .errorBox,
 .callout {
-  display: grid;
-  gap: 6px;
-  padding: 14px 16px;
-  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
   border: 1px solid var(--monitor-line);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.errorBox strong,
+.callout strong {
+  flex: 0 0 auto;
+  font-size: 12px;
+}
+
+.errorBox span,
+.callout span {
+  flex: 1 1 320px;
+  min-width: 0;
 }
 
 .errorBox {
-  margin-top: 14px;
+  margin-top: 8px;
   border-color: color-mix(in srgb, var(--monitor-red) 28%, var(--monitor-line));
   background: color-mix(in srgb, var(--monitor-red) 10%, var(--monitor-surface));
   color: var(--monitor-red);
 }
 
 .callout {
-  margin-top: 14px;
+  margin-top: 8px;
   border-color: color-mix(in srgb, var(--monitor-accent) 24%, var(--monitor-line));
   background: color-mix(in srgb, var(--monitor-accent) 8%, var(--monitor-surface));
 }
@@ -991,17 +1016,11 @@
 @container monitoring-page (max-width: 1240px) {
   .statusBar,
   .statusMeta {
-    justify-content: flex-start;
-  }
-
-  .actionBar {
-    align-items: flex-start;
-    flex-direction: column;
+    justify-content: flex-end;
   }
 
   .actionBarMeta {
-    justify-content: flex-start;
-    width: 100%;
+    justify-content: flex-end;
   }
 
   .masthead {
@@ -1022,14 +1041,6 @@
     justify-content: flex-start;
   }
 
-  .refreshControls {
-    flex-wrap: wrap;
-  }
-
-  .filterGrid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
   .summaryHero,
   .summarySub,
   .summaryGrid {
@@ -1038,6 +1049,53 @@
 
   .accountOverviewCardGrid {
     grid-template-columns: repeat(2, minmax(360px, 1fr));
+  }
+}
+
+@container monitoring-page (max-width: 960px) {
+  .actionBar {
+    grid-template-columns: 1fr;
+  }
+
+  .actionBarMeta,
+  .statusBar,
+  .statusMeta {
+    justify-content: flex-start;
+  }
+
+  .actionBarMeta {
+    width: 100%;
+  }
+
+  .statusBar,
+  .statusMeta,
+  .actionBarMeta {
+    flex-wrap: wrap;
+  }
+
+  .controlBar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+  }
+
+  .controlBar .segmentedControl {
+    order: 1;
+    justify-content: flex-start;
+  }
+
+  .controlBar .refreshControls {
+    order: 2;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .controlBar .filterSearchInputWrap {
+    order: 3;
+    grid-column: 1 / -1;
+  }
+
+  .filterGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -1097,18 +1155,6 @@
   .accountOverviewSortBar,
   .realtimeHeaderActions {
     justify-content: flex-start;
-  }
-
-  .filterSearchRow :global(.form-group) {
-    min-width: 0;
-  }
-
-  .filterSearchRow {
-    grid-template-columns: 1fr;
-  }
-
-  .filterSearchAction {
-    justify-content: stretch;
   }
 }
 
@@ -1172,9 +1218,27 @@
   .actionGroup,
   .actionBarMeta,
   .refreshControls,
-  .filterSearchRow,
+  .filterSearchInputWrap,
   .realtimeHeaderActions {
     width: 100%;
+  }
+
+  .controlBar {
+    grid-template-columns: 1fr;
+  }
+
+  .controlBar .segmentedControl,
+  .controlBar .refreshControls,
+  .controlBar .filterSearchInputWrap {
+    grid-column: 1;
+  }
+
+  .controlBar .filterSearchInputWrap {
+    order: 2;
+  }
+
+  .controlBar .refreshControls {
+    order: 3;
   }
 
   .controlBar,
@@ -1189,6 +1253,11 @@
   .segmentedControl,
   .realtimeHeaderActions {
     justify-content: flex-start;
+  }
+
+  .segmentedControl {
+    height: auto;
+    min-height: 38px;
   }
 
   .actionButton {
@@ -1278,10 +1347,6 @@
 
   .accountOverviewSortLabel {
     white-space: normal;
-  }
-
-  .filterSearchRow :global(.form-group) {
-    min-width: 0;
   }
 
   .refreshButton,
@@ -1406,6 +1471,7 @@
 
   .segmentButton {
     flex: 1 1 calc(50% - 6px);
+    height: 36px;
     min-height: 36px;
     padding: 0 12px;
   }

--- a/src/features/monitoring/components/MonitoringFiltersPanel.tsx
+++ b/src/features/monitoring/components/MonitoringFiltersPanel.tsx
@@ -1,12 +1,7 @@
 import type { TFunction } from 'i18next';
 import { Input } from '@/components/ui/Input';
 import { Select, type SelectOption } from '@/components/ui/Select';
-import {
-  IconRefreshCw,
-  IconSearch,
-  IconSlidersHorizontal,
-  IconTimer,
-} from '@/components/ui/icons';
+import { IconRefreshCw, IconSearch, IconSlidersHorizontal, IconTimer } from '@/components/ui/icons';
 import { MonitoringPanel } from '@/features/monitoring/components/MonitoringPanel';
 import type { MonitoringTimeRange } from '@/features/monitoring/hooks/useMonitoringData';
 import styles from '../MonitoringCenterPage.module.scss';
@@ -110,6 +105,17 @@ export function MonitoringFiltersPanel({
           ))}
         </div>
 
+        <div className={styles.filterSearchInputWrap}>
+          <Input
+            value={searchInput}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder={t('monitoring.search_placeholder')}
+            className={styles.filterSearchInput}
+            rightElement={<IconSearch size={16} />}
+            aria-label={t('monitoring.search_placeholder')}
+          />
+        </div>
+
         <div className={styles.refreshControls}>
           <div className={styles.autoRefreshField}>
             <span className={styles.autoRefreshLabel}>
@@ -142,6 +148,11 @@ export function MonitoringFiltersPanel({
             />
             <span className={styles.refreshButtonLabel}>{t('usage_stats.refresh')}</span>
           </button>
+
+          <button type="button" className={styles.clearButton} onClick={onClearFilters}>
+            <IconSlidersHorizontal size={16} />
+            <span>{t('monitoring.clear_filters')}</span>
+          </button>
         </div>
       </div>
 
@@ -153,6 +164,7 @@ export function MonitoringFiltersPanel({
               options={accountOptions}
               onChange={onAccountFilterChange}
               ariaLabel={t('monitoring.filter_account')}
+              triggerClassName={styles.filterSelectTrigger}
             />
           </div>
           <Select
@@ -160,50 +172,36 @@ export function MonitoringFiltersPanel({
             options={providerOptions}
             onChange={onProviderChange}
             ariaLabel={t('monitoring.filter_provider')}
+            triggerClassName={styles.filterSelectTrigger}
           />
           <Select
             value={selectedModel}
             options={modelOptions}
             onChange={onModelChange}
             ariaLabel={t('monitoring.filter_model')}
+            triggerClassName={styles.filterSelectTrigger}
           />
           <Select
             value={selectedChannel}
             options={channelOptions}
             onChange={onChannelChange}
             ariaLabel={t('monitoring.filter_channel')}
+            triggerClassName={styles.filterSelectTrigger}
           />
           <Select
             value={selectedApiKeyHash}
             options={apiKeyOptions}
             onChange={onApiKeyChange}
             ariaLabel={t('monitoring.filter_api_key')}
+            triggerClassName={styles.filterSelectTrigger}
           />
           <Select
             value={selectedStatus}
             options={statusOptions}
             onChange={onStatusChange}
             ariaLabel={t('monitoring.filter_status')}
+            triggerClassName={styles.filterSelectTrigger}
           />
-        </div>
-
-        <div className={styles.filterSearchRow}>
-          <div className={styles.filterSearchInputWrap}>
-            <Input
-              value={searchInput}
-              onChange={(event) => onSearchChange(event.target.value)}
-              placeholder={t('monitoring.search_placeholder')}
-              className={styles.filterSearchInput}
-              rightElement={<IconSearch size={16} />}
-              aria-label={t('monitoring.search_placeholder')}
-            />
-          </div>
-          <div className={styles.filterSearchAction}>
-            <button type="button" className={styles.clearButton} onClick={onClearFilters}>
-              <IconSlidersHorizontal size={16} />
-              <span>{t('monitoring.clear_filters')}</span>
-            </button>
-          </div>
         </div>
       </div>
 

--- a/src/features/quota/QuotaPage.module.scss
+++ b/src/features/quota/QuotaPage.module.scss
@@ -4,12 +4,12 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: $spacing-md;
 }
 
 .headerActions {
   display: flex;
-  gap: $spacing-sm;
+  gap: 6px;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
@@ -64,9 +64,9 @@
 .toolbar {
   display: grid;
   grid-template-columns: minmax(260px, 1fr) minmax(190px, 260px);
-  gap: $spacing-md;
+  gap: 10px;
   align-items: end;
-  padding: $spacing-md;
+  padding: 12px;
   border: 1px solid var(--glass-border);
   border-radius: $radius-lg;
   background: var(--glass-bg);
@@ -82,15 +82,31 @@
   :global(.form-group) {
     margin-bottom: 0;
   }
+
+  :global(.input) {
+    height: 36px;
+    min-height: 36px;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-radius: 12px;
+    font-size: 13px;
+  }
 }
 
 .sortField {
   display: flex;
   flex-direction: column;
-  gap: $spacing-xs;
+  gap: 4px;
+
+  :global(button) {
+    height: 36px;
+    border-radius: 12px;
+    font-size: 13px;
+  }
 }
 
 .toolbarLabel {
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -173,7 +189,7 @@
   gap: $spacing-xs;
   align-items: center;
   padding: 3px;
-  border-radius: 999px;
+  border-radius: 14px;
   background: color-mix(in srgb, var(--surface-subtle) 92%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-subtle) 88%, transparent);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
@@ -185,8 +201,10 @@
 }
 
 .viewModeButton:global(.btn.btn-sm) {
-  padding: 8px 14px;
-  border-radius: 999px;
+  height: 30px;
+  min-height: 30px;
+  padding: 0 12px;
+  border-radius: 12px;
   border-color: transparent;
   background: transparent;
   color: var(--text-secondary);
@@ -221,8 +239,10 @@
 }
 
 .refreshAllButton:global(.btn.btn-sm) {
+  height: 34px;
+  min-height: 34px;
   padding-inline: 14px;
-  border-radius: 999px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--primary-color) 12%, var(--surface-subtle));
   border-color: color-mix(in srgb, var(--primary-color) 22%, var(--border-color));
   color: var(--text-primary);

--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -14,9 +14,13 @@ button:disabled {
   justify-content: center;
   gap: $spacing-sm;
   border: 1px solid transparent;
-  border-radius: var(--app-radius-sm);
-  padding: 10px 14px;
+  border-radius: var(--app-radius-md);
+  height: 40px;
+  padding: 0 14px;
+  font-size: 14px;
   font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
   cursor: pointer;
   transition: all $transition-fast;
   background-color: var(--app-surface-muted);
@@ -112,15 +116,56 @@ button:disabled {
     width: 100%;
   }
 
-  &.btn-sm {
-    padding: 8px 10px;
-    font-size: 14px;
+  &:where(.btn-sm) {
+    height: 34px;
+    padding: 0 12px;
+    border-radius: var(--app-radius-md);
+    font-size: 13px;
+    gap: 6px;
+  }
+
+  &:where(.btn-xs) {
+    height: 30px;
+    padding: 0 10px;
+    border-radius: 10px;
+    font-size: 12px;
+    gap: 6px;
+  }
+
+  &:where(.btn-icon-only) {
+    width: 40px;
+    min-width: 40px;
+    padding: 0;
+    gap: 0;
+  }
+
+  &:where(.btn-sm):where(.btn-icon-only) {
+    width: 34px;
+    min-width: 34px;
+  }
+
+  &:where(.btn-xs):where(.btn-icon-only) {
+    width: 30px;
+    min-width: 30px;
   }
 
   &:disabled {
     opacity: 0.6;
     cursor: not-allowed;
     box-shadow: none;
+  }
+
+  > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: inherit;
+    min-width: 0;
+    line-height: inherit;
+  }
+
+  svg {
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
Normalize global and page-level button density across the frontend UI.

## Changes
- Add explicit compact button sizes and icon-only button support
- Compact shared list, row, toolbar, and filter action buttons
- Align monitoring, auth files, providers, config, logs, and quota controls
- Preserve larger primary flow actions where they are appropriate

## Testing
- npm run type-check
- npm test
- npm run build
- npm run lint
- git diff --check
- Browser-verified compact button heights on affected pages