### PR TITLE
fix(pricing): avoid double billing cached input tokens

### DIFF
--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -80,14 +80,14 @@ func TestSummaryAggregatesCostsAndWindows(t *testing.T) {
 	if resp.Today.AverageLatencyMS == nil || *resp.Today.AverageLatencyMS != 150 {
 		t.Fatalf("average latency = %#v", resp.Today.AverageLatencyMS)
 	}
-	if math.Abs(resp.Today.TotalCost-4.25) > 0.000001 {
+	if math.Abs(resp.Today.TotalCost-3.75) > 0.000001 {
 		t.Fatalf("total cost = %v", resp.Today.TotalCost)
 	}
 	if resp.Rolling30M.TotalCalls != 2 || resp.Rolling30M.TotalTokens != 100 {
 		t.Fatalf("rolling = %#v", resp.Rolling30M)
 	}
 	if len(resp.TopModelsToday) != 1 || resp.TopModelsToday[0].Model != "gpt-a" ||
-		resp.TopModelsToday[0].Calls != 2 || math.Abs(resp.TopModelsToday[0].Cost-4.25) > 0.000001 {
+		resp.TopModelsToday[0].Calls != 2 || math.Abs(resp.TopModelsToday[0].Cost-3.75) > 0.000001 {
 		t.Fatalf("top models = %#v", resp.TopModelsToday)
 	}
 	if len(resp.RecentFailures) != 1 || resp.RecentFailures[0].Model != "gpt-b" ||

--- a/apps/manager-server/internal/service/pricing/cost.go
+++ b/apps/manager-server/internal/service/pricing/cost.go
@@ -14,16 +14,21 @@ type ModelTokens struct {
 }
 
 // CostForModel computes the dollar cost for a single (model, tokens) pair.
-// Cached tokens use the cache price (often discounted); when a model has no
-// entry in the price book the cost is reported as zero.
+// Cached tokens are included in input tokens by upstream usage payloads, so
+// only non-cached input tokens use the prompt price.
 func CostForModel(modelName string, tokens ModelTokens, prices map[string]model.ModelPrice) float64 {
 	price, ok := prices[modelName]
 	if !ok {
 		return 0
 	}
-	return float64(tokens.InputTokens)*price.Prompt/PerMillion +
-		float64(tokens.OutputTokens)*price.Completion/PerMillion +
-		float64(tokens.CachedTokens)*price.Cache/PerMillion
+	inputTokens := maxInt64(tokens.InputTokens, 0)
+	outputTokens := maxInt64(tokens.OutputTokens, 0)
+	cachedTokens := maxInt64(tokens.CachedTokens, 0)
+	promptTokens := maxInt64(inputTokens-cachedTokens, 0)
+
+	return float64(promptTokens)*price.Prompt/PerMillion +
+		float64(outputTokens)*price.Completion/PerMillion +
+		float64(cachedTokens)*price.Cache/PerMillion
 }
 
 // SumCost folds CostForModel over a slice of (model, tokens) tuples.
@@ -39,4 +44,11 @@ func SumCost(items []Item, prices map[string]model.ModelPrice) float64 {
 		total += CostForModel(item.Model, item.Tokens, prices)
 	}
 	return total
+}
+
+func maxInt64(left, right int64) int64 {
+	if left > right {
+		return left
+	}
+	return right
 }

--- a/apps/manager-server/internal/service/pricing/cost_test.go
+++ b/apps/manager-server/internal/service/pricing/cost_test.go
@@ -1,0 +1,39 @@
+package pricing
+
+import (
+	"math"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+)
+
+func TestCostForModelSeparatesCachedInputTokens(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-cached": {Prompt: 2, Completion: 4, Cache: 1},
+	}
+
+	cost := CostForModel("gpt-cached", ModelTokens{
+		InputTokens:  1_000_000,
+		OutputTokens: 500_000,
+		CachedTokens: 250_000,
+	}, prices)
+
+	if math.Abs(cost-3.75) > 0.000001 {
+		t.Fatalf("cost = %v, want 3.75", cost)
+	}
+}
+
+func TestCostForModelDoesNotCreateNegativePromptCost(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-cached": {Prompt: 10, Cache: 1},
+	}
+
+	cost := CostForModel("gpt-cached", ModelTokens{
+		InputTokens:  100_000,
+		CachedTokens: 250_000,
+	}, prices)
+
+	if math.Abs(cost-0.25) > 0.000001 {
+		t.Fatalf("cost = %v, want 0.25", cost)
+	}
+}

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -133,4 +133,21 @@ describe('calculateCost model price preference', () => {
     );
     expect(cost).toBeCloseTo(50);
   });
+
+  it('charges cached input tokens only at the cache price', () => {
+    const cost = calculateCost(
+      {
+        tokens: {
+          input_tokens: 1_000_000,
+          output_tokens: 500_000,
+          cached_tokens: 250_000,
+        },
+        __modelName: 'gpt-5.5',
+      },
+      {
+        'gpt-5.5': { prompt: 2, completion: 4, cache: 1 },
+      }
+    );
+    expect(cost).toBeCloseTo(3.75);
+  });
 });


### PR DESCRIPTION
## Summary
Fix cached input token cost estimates so cached tokens are not charged at both prompt and cache rates.

## Cause
Upstream input token totals include cached tokens, but the backend aggregate calculator charged full input tokens at prompt price and cached tokens again at cache price.

## Solution
- Subtract cached tokens from billable prompt tokens in shared manager-server pricing.
- Clamp prompt tokens to avoid negative cost when cached tokens exceed input totals.
- Add backend and frontend regression tests for cached token pricing.

## Testing
- [x] `go test ./...`
- [x] `npm --workspace apps/web run test -- src/utils/usage.test.ts`