### PR TITLE
feat(codex-inspection): validate schedule time zone with tzdata

### DIFF
--- a/Dockerfile.manager-server
+++ b/Dockerfile.manager-server
@@ -19,7 +19,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/cpa-manager-plus ./cmd/cpa-manager-plus
 
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates wget
+RUN apk add --no-cache ca-certificates wget tzdata
 WORKDIR /app
 COPY --from=service-build /out/cpa-manager-plus /usr/local/bin/cpa-manager-plus
 ENV HTTP_ADDR=0.0.0.0:18317

--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"

--- a/apps/manager-server/internal/http/response/error.go
+++ b/apps/manager-server/internal/http/response/error.go
@@ -23,7 +23,8 @@ func SetupErrorStatus(err error) int {
 		return http.StatusUnauthorized
 	case strings.Contains(message, "cpaBaseUrl and managementKey are required"),
 		strings.Contains(message, "CPA redis-usage-queue-retention-seconds"),
-		strings.Contains(message, "pollIntervalMs must be less than or equal"):
+		strings.Contains(message, "pollIntervalMs must be less than or equal"),
+		strings.Contains(message, "invalid time zone"):
 		return http.StatusBadRequest
 	case strings.Contains(message, "management API validation failed"),
 		strings.Contains(message, "enable CPA usage statistics failed"):
@@ -40,7 +41,8 @@ func ManagerConfigErrorStatus(err error) int {
 		return http.StatusConflict
 	case strings.Contains(message, "cpaBaseUrl and managementKey are required"),
 		strings.Contains(message, "CPA redis-usage-queue-retention-seconds"),
-		strings.Contains(message, "pollIntervalMs must be less than or equal"):
+		strings.Contains(message, "pollIntervalMs must be less than or equal"),
+		strings.Contains(message, "invalid time zone"):
 		return http.StatusBadRequest
 	case strings.Contains(message, "management API validation failed"),
 		strings.Contains(message, "management API config request failed"),
@@ -81,6 +83,8 @@ func UsageServiceErrorCode(err error) string {
 		return "cpa_usage_retention_invalid"
 	case strings.Contains(message, "pollIntervalMs must be less than or equal"):
 		return "poll_interval_exceeds_retention"
+	case strings.Contains(message, "invalid time zone"):
+		return "invalid_time_zone"
 	case strings.Contains(message, "management API validation failed"):
 		return "management_api_validation_failed"
 	case strings.Contains(message, "management API config request failed"):

--- a/apps/manager-server/internal/httpapi/server_test.go
+++ b/apps/manager-server/internal/httpapi/server_test.go
@@ -426,6 +426,26 @@ func TestManagerConfigRejectsPollIntervalAboveRetention(t *testing.T) {
 	}
 }
 
+func TestManagerConfigRejectsInvalidCodexInspectionTimeZone(t *testing.T) {
+	handler := newTestHandler(t, "http://example.test", false)
+	body := bytes.NewBufferString(`{"config":{"collector":{"enabled":false},"codexInspection":{"schedule":{"mode":"time_points","timePoints":["09:00"],"timeZone":"Mars/Olympus"}},"externalUsageService":{"enabled":false}}}`)
+	req := httptest.NewRequest(http.MethodPut, "/usage-service/config", body)
+	req.Header.Set("Authorization", "Bearer "+testutil.AdminKey)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("save status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "invalid time zone") {
+		t.Fatalf("response body = %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"code":"invalid_time_zone"`) {
+		t.Fatalf("response body = %s", rr.Body.String())
+	}
+}
+
 func TestManagerConfigReadsLegacySetup(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v0/management/config" && r.Header.Get("Authorization") == "Bearer management-key" {

--- a/apps/manager-server/internal/model/codex_inspection.go
+++ b/apps/manager-server/internal/model/codex_inspection.go
@@ -199,6 +199,25 @@ func NormalizeCodexInspectionTimeZone(value string, fallback string) string {
 	return trimmed
 }
 
+func ValidateCodexInspectionConfig(input ManagerCodexInspectionConfig) error {
+	return ValidateCodexInspectionSchedule(input.Schedule)
+}
+
+func ValidateCodexInspectionSchedule(input ManagerCodexInspectionScheduleConfig) error {
+	return ValidateCodexInspectionTimeZone(input.TimeZone)
+}
+
+func ValidateCodexInspectionTimeZone(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if _, err := time.LoadLocation(trimmed); err != nil {
+		return fmt.Errorf("invalid time zone %q: %w", trimmed, err)
+	}
+	return nil
+}
+
 // ResolveCodexInspectionLocation returns the time.Location for the schedule.
 // An empty or invalid time zone resolves to time.Local so existing deployments
 // keep using the server's local time.

--- a/apps/manager-server/internal/model/codex_inspection_test.go
+++ b/apps/manager-server/internal/model/codex_inspection_test.go
@@ -28,6 +28,30 @@ func TestNormalizeCodexInspectionTimeZone(t *testing.T) {
 	}
 }
 
+func TestValidateCodexInspectionTimeZone(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"empty uses server default", "", false},
+		{"valid IANA", "Asia/Shanghai", false},
+		{"whitespace is trimmed", "  Europe/Berlin  ", false},
+		{"invalid is rejected", "Mars/Olympus", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateCodexInspectionTimeZone(c.value)
+			if c.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestResolveCodexInspectionLocation(t *testing.T) {
 	if loc := ResolveCodexInspectionLocation(""); loc != time.Local {
 		t.Fatalf("empty timezone should resolve to time.Local, got %v", loc)

--- a/apps/manager-server/internal/service/managerconfig/service.go
+++ b/apps/manager-server/internal/service/managerconfig/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	collectorservice "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
@@ -65,6 +66,9 @@ func (s *Service) Get(ctx context.Context) (Response, error) {
 func (s *Service) Update(ctx context.Context, submitted store.ManagerConfig) (Response, error) {
 	current, source, _, err := s.ResolveManagerConfigWithSource(ctx)
 	if err != nil {
+		return Response{}, err
+	}
+	if err := model.ValidateCodexInspectionConfig(submitted.CodexInspection); err != nil {
 		return Response{}, err
 	}
 	next := s.MergeSubmittedManagerConfig(current, submitted)

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2155,6 +2155,7 @@
     "management_api_config_failed": "Failed to read CPA configuration from the Management API.",
     "cpa_usage_retention_invalid": "CPA usage queue retention must be greater than 0.",
     "poll_interval_exceeds_retention": "The collection polling interval must be less than or equal to the CPA usage queue retention window.",
+    "invalid_time_zone": "Failed to save the time zone. Check the time zone name or make sure tzdata is installed in the runtime environment.",
     "enable_cpa_usage_statistics_failed": "Failed to enable CPA usage statistics.",
     "setup_env_managed": "Setup is managed by environment variables.",
     "invalid_existing_management_key": "The existing setup rejected this Management Key.",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -2151,6 +2151,7 @@
     "management_api_config_failed": "Не удалось прочитать конфигурацию CPA через Management API.",
     "cpa_usage_retention_invalid": "Время хранения очереди CPA usage должно быть больше 0.",
     "poll_interval_exceeds_retention": "Интервал опроса сборщика должен быть не больше окна хранения очереди CPA usage.",
+    "invalid_time_zone": "Не удалось сохранить часовой пояс. Проверьте название часового пояса или убедитесь, что tzdata установлен в среде выполнения.",
     "enable_cpa_usage_statistics_failed": "Не удалось включить CPA usage statistics.",
     "setup_env_managed": "Настройка управляется переменными окружения.",
     "invalid_existing_management_key": "Существующая настройка отклонила этот ключ управления.",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -2155,6 +2155,7 @@
     "management_api_config_failed": "读取 CPA 配置失败，请检查 Management API。",
     "cpa_usage_retention_invalid": "CPA 用量队列保留时间必须大于 0。",
     "poll_interval_exceeds_retention": "采集轮询间隔必须小于等于 CPA 用量队列保留时间。",
+    "invalid_time_zone": "时区保存失败，请检查时区名称或确认运行环境已安装 tzdata。",
     "enable_cpa_usage_statistics_failed": "启用 CPA 用量统计失败。",
     "setup_env_managed": "初始化配置由环境变量管理。",
     "invalid_existing_management_key": "现有配置拒绝了该管理密钥。",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -2180,6 +2180,7 @@
     "management_api_config_failed": "讀取 CPA 設定失敗，請檢查 Management API。",
     "cpa_usage_retention_invalid": "CPA 用量佇列保留時間必須大於 0。",
     "poll_interval_exceeds_retention": "採集輪詢間隔必須小於等於 CPA 用量佇列保留時間。",
+    "invalid_time_zone": "時區儲存失敗，請檢查時區名稱或確認執行環境已安裝 tzdata。",
     "enable_cpa_usage_statistics_failed": "啟用 CPA 用量統計失敗。",
     "setup_env_managed": "初始化設定由環境變數管理。",
     "invalid_existing_management_key": "現有設定拒絕了該管理金鑰。",

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -12,6 +12,7 @@ const USAGE_SERVICE_ERROR_CODES = new Set([
   'management_api_config_failed',
   'cpa_usage_retention_invalid',
   'poll_interval_exceeds_retention',
+  'invalid_time_zone',
   'enable_cpa_usage_statistics_failed',
   'setup_env_managed',
   'invalid_existing_management_key',


### PR DESCRIPTION
## Summary
- Validate the codex inspection schedule's `timeZone` on save, returning HTTP 400 with structured code `invalid_time_zone` instead of letting the scheduler fail later when it tries to load the zone.
- Bundle `tzdata` into the Manager Server runtime (Alpine package + Go `time/tzdata` blank import) so valid IANA zones like `Asia/Shanghai` resolve consistently regardless of the host image.
- Surface the new error in the web UI via the usage-service error code set and add localized copy for en, zh-CN, zh-TW, and ru.

## Test plan
- [x] `go test ./apps/manager-server/internal/model/...` — covers `TestValidateCodexInspectionTimeZone`
- [x] `go test ./apps/manager-server/internal/httpapi/...` — covers `TestManagerConfigRejectsInvalidCodexInspectionTimeZone`
- [x] Build the Manager Server Docker image and confirm `/usr/share/zoneinfo` is present and a valid zone (e.g. `Europe/Berlin`) can be saved end-to-end
- [x] In the web UI, submit an invalid time zone (e.g. `Mars/Olympus`) and verify the localized error message is shown for each supported locale