### PR TITLE
fix: gate panel features by runtime mode

### DIFF
--- a/apps/manager-server/internal/http/controller/proxy/handler.go
+++ b/apps/manager-server/internal/http/controller/proxy/handler.go
@@ -13,14 +13,14 @@ type Handler struct {
 }
 
 func (h *Handler) Management(w http.ResponseWriter, r *http.Request) {
-	if !middleware.AuthorizePanel(w, r, h.App.AdminAuthService) {
+	if !middleware.AuthorizeAdmin(w, r, h.App.AdminAuthService) {
 		return
 	}
 	h.App.ProxyService.ProxyManagement(w, r, response.Error)
 }
 
 func (h *Handler) CPA(w http.ResponseWriter, r *http.Request) {
-	if !middleware.AuthorizePanel(w, r, h.App.AdminAuthService) {
+	if !middleware.AuthorizeAdmin(w, r, h.App.AdminAuthService) {
 		return
 	}
 	h.App.ProxyService.ProxyCPA(w, r, response.Error)

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -199,6 +199,12 @@ func TestServerCompatExternalPanelModeUsesCPAManagementKey(t *testing.T) {
 	if !strings.Contains(usageRR.Body.String(), `"total_requests":1`) {
 		t.Fatalf("usage body = %s", usageRR.Body.String())
 	}
+
+	proxyRR := testutil.Request(t, handler, http.MethodGet, "/v0/management/config", "", "management-key")
+	testutil.RequireStatus(t, proxyRR, http.StatusUnauthorized)
+	if !strings.Contains(proxyRR.Body.String(), `"code":"invalid_admin_key"`) {
+		t.Fatalf("proxy body = %s", proxyRR.Body.String())
+	}
 }
 
 func TestServerCompatStatusAuthAndCounts(t *testing.T) {

--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -33,7 +33,8 @@ import {
   useThemeStore,
 } from '@/stores';
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
-import { useRequestMonitoringAvailability } from '@/hooks/useRequestMonitoringAvailability';
+import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
+import { isFileLogsAvailable } from '@/features/logs/logFeatureAvailability';
 import { LANGUAGE_LABEL_KEYS, LANGUAGE_ORDER } from '@/utils/constants';
 import { isSupportedLanguage } from '@/utils/language';
 import type { Theme } from '@/types';
@@ -173,7 +174,7 @@ export function MainLayout() {
   const config = useConfigStore((state) => state.config);
   const fetchConfig = useConfigStore((state) => state.fetchConfig);
   const clearCache = useConfigStore((state) => state.clearCache);
-  const requestMonitoringAvailability = useRequestMonitoringAvailability();
+  const featureAvailability = usePanelFeatureAvailability();
 
   const theme = useThemeStore((state) => state.theme);
   const setTheme = useThemeStore((state) => state.setTheme);
@@ -342,8 +343,9 @@ export function MainLayout() {
     });
   }, [fetchConfig]);
 
+  const fileLogsAvailable = isFileLogsAvailable(config);
   const operationNavItems: NavItem[] = [
-    ...(requestMonitoringAvailability.available
+    ...(featureAvailability.requestMonitoringAvailable
       ? [
           {
             path: '/monitoring',
@@ -352,7 +354,7 @@ export function MainLayout() {
           },
         ]
       : []),
-    ...(config?.loggingToFile
+    ...(fileLogsAvailable
       ? [{ path: '/logs', label: t('nav.logs'), icon: sidebarIcons.logs }]
       : []),
   ];

--- a/apps/web/src/features/config/ConfigPage.tsx
+++ b/apps/web/src/features/config/ConfigPage.tsx
@@ -259,12 +259,24 @@ export function ConfigPage() {
         usageServiceBase,
       });
       if (!normalized) return;
-      setUsageServiceConfig({
-        enabled: true,
-        serviceBase: normalized,
-      });
+      setUsageServiceConfig(
+        {
+          enabled: true,
+          serviceBase: normalized,
+        },
+        {
+          panelBase: detectedPanelBase,
+          panelHostMode: panelHostedByUsageService === true ? 'manager_embedded' : 'external_panel',
+        }
+      );
     },
-    [setUsageServiceConfig, usageServiceBase, usageServiceEnabled]
+    [
+      detectedPanelBase,
+      panelHostedByUsageService,
+      setUsageServiceConfig,
+      usageServiceBase,
+      usageServiceEnabled,
+    ]
   );
 
   const applyManagerConfigResponse = useCallback(
@@ -463,10 +475,16 @@ export function ConfigPage() {
       };
       const response = await usageServiceApi.saveManagerConfig(serviceBase, nextConfig, managementKey);
       applyManagerConfigResponse(response, serviceBase);
-      setUsageServiceConfig({
-        enabled: true,
-        serviceBase,
-      });
+      setUsageServiceConfig(
+        {
+          enabled: true,
+          serviceBase,
+        },
+        {
+          panelBase: detectedPanelBase,
+          panelHostMode: panelHostedByUsageService === true ? 'manager_embedded' : 'external_panel',
+        }
+      );
       showNotification(t('config_management.manager.save_success'), 'success');
     } catch (error: unknown) {
       const message = getUsageServiceDisplayError(error, 'usage_service_errors.request_failed');

--- a/apps/web/src/features/login/LoginPage.tsx
+++ b/apps/web/src/features/login/LoginPage.tsx
@@ -203,9 +203,19 @@ export function LoginPage() {
           setMigrationStatus('');
         }
 
-        const autoLoggedIn = await restoreSession();
+        const hostedManagementPage =
+          typeof window !== 'undefined' && /\/management\.html$/i.test(window.location.pathname);
+        const autoLoginExpectedPanelBase =
+          detectedUsageService || hostedManagementPage ? detectedBase : undefined;
+        const autoLoggedIn = await restoreSession({
+          expectedMode: detectedUsageService ? 'manager_embedded' : 'external_panel',
+          expectedPanelBase: autoLoginExpectedPanelBase,
+        });
         if (detectedUsageService) {
-          setUsageServiceConfig({ enabled: true, serviceBase: detectedBase });
+          setUsageServiceConfig(
+            { enabled: true, serviceBase: detectedBase },
+            { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
+          );
         }
         if (autoLoggedIn) {
           setAutoLoginSuccess(true);
@@ -362,16 +372,24 @@ export function LoginPage() {
           },
           trimmedAdminKey
         );
-        setUsageServiceConfig({ enabled: true, serviceBase: detectedBase });
+        setUsageServiceConfig(
+          { enabled: true, serviceBase: detectedBase },
+          { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
+        );
         localStorage.setItem(USAGE_SERVICE_LAST_CPA_BASE_KEY, baseToUse);
       } else if (isManagerServerMode) {
-        setUsageServiceConfig({ enabled: true, serviceBase: detectedBase });
+        setUsageServiceConfig(
+          { enabled: true, serviceBase: detectedBase },
+          { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
+        );
       }
 
       await login({
         apiBase: isManagerServerMode ? detectedBase : baseToUse,
         managementKey: isManagerServerMode ? trimmedAdminKey : trimmedCPAKey,
         rememberPassword: rememberCredential,
+        sessionMode: isManagerServerMode ? 'manager_embedded' : 'external_panel',
+        sessionPanelBase: detectedBase,
       });
       showNotification(t('common.connected_status'), 'success');
       navigate('/', { replace: true });

--- a/apps/web/src/features/logs/logFeatureAvailability.test.ts
+++ b/apps/web/src/features/logs/logFeatureAvailability.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { isFileLogsAvailable } from './logFeatureAvailability';
+
+describe('isFileLogsAvailable', () => {
+  it('only enables log viewer when file logging is explicitly true', () => {
+    expect(isFileLogsAvailable({ loggingToFile: true })).toBe(true);
+    expect(isFileLogsAvailable({ loggingToFile: false })).toBe(false);
+    expect(isFileLogsAvailable({})).toBe(false);
+    expect(isFileLogsAvailable(null)).toBe(false);
+  });
+});

--- a/apps/web/src/features/logs/logFeatureAvailability.ts
+++ b/apps/web/src/features/logs/logFeatureAvailability.ts
@@ -1,0 +1,5 @@
+import type { Config } from '@/types';
+
+export function isFileLogsAvailable(config?: Pick<Config, 'loggingToFile'> | null): boolean {
+  return config?.loggingToFile === true;
+}

--- a/apps/web/src/features/monitoring/ModelPricesPage.tsx
+++ b/apps/web/src/features/monitoring/ModelPricesPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { IconPencil, IconSearch, IconTrash2, IconX } from '@/components/ui/icons';
+import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 import type { ModelPriceSyncCandidate, ModelPriceSyncResponse } from '@/services/api/usageService';
 import { useNotificationStore } from '@/stores';
 import { useUsageData } from '@/features/monitoring/hooks/useUsageData';
@@ -34,6 +35,7 @@ const resolveErrorMessage = (error: unknown, fallback: string) => {
 export function ModelPricesPage() {
   const { t } = useTranslation();
   const { showNotification } = useNotificationStore();
+  const featureAvailability = usePanelFeatureAvailability();
   const { usage, loading, modelPrices, setModelPrices, syncModelPrices, usageServiceAvailable } =
     useUsageData();
   const [search, setSearch] = useState('');
@@ -49,7 +51,7 @@ export function ModelPricesPage() {
     [modelPrices, usage]
   );
 
-  const candidateSets = syncResult?.candidates ?? [];
+  const candidateSets = useMemo(() => syncResult?.candidates ?? [], [syncResult?.candidates]);
   const rows = useMemo(
     () => buildModelPriceRows(usage, modelPrices, candidateSets),
     [candidateSets, modelPrices, usage]
@@ -162,9 +164,11 @@ export function ModelPricesPage() {
     <div className={styles.page}>
       <section className={styles.actionBar} aria-label={t('common.action')}>
         <div className={styles.titleGroup}>
-          <Link to="/monitoring" className={styles.backLink}>
-            {t('model_prices.back_to_monitoring')}
-          </Link>
+          {featureAvailability.requestMonitoringAvailable ? (
+            <Link to="/monitoring" className={styles.backLink}>
+              {t('model_prices.back_to_monitoring')}
+            </Link>
+          ) : null}
         </div>
         <div className={styles.actionGroup}>
           <span className={styles.metaPill}>

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -100,6 +100,7 @@ import {
 import { useHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { useInterval } from '@/hooks/useInterval';
 import { useRequestMonitoringAvailability } from '@/hooks/useRequestMonitoringAvailability';
+import { isFileLogsAvailable } from '@/features/logs/logFeatureAvailability';
 import { authFilesApi } from '@/services/api';
 import { useAuthStore, useConfigStore, useNotificationStore } from '@/stores';
 import { formatFileSize } from '@/utils/format';
@@ -1071,6 +1072,20 @@ export function MonitoringCenterPage() {
     [importUsageFile, showConfirmation, showNotification, t]
   );
 
+  if (monitoringUnavailable) {
+    return (
+      <div className={styles.page}>
+        <MonitoringStatusHeader
+          showLoadingOverlay={false}
+          monitoringUnavailable={monitoringUnavailable}
+          monitoringUnavailableTitle={monitoringUnavailableTitle}
+          monitoringUnavailableBody={monitoringUnavailableBody}
+          t={t}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.page}>
       <MonitoringStatusHeader
@@ -1085,7 +1100,8 @@ export function MonitoringCenterPage() {
         usageTransferAvailable={usageTransferAvailable}
         usageExporting={usageExporting}
         usageImporting={usageImporting}
-        loggingToFile={Boolean(config?.loggingToFile)}
+        loggingToFile={isFileLogsAvailable(config)}
+        modelPricesAvailable={requestMonitoringAvailability.modelPricesAvailable}
         usageImportInputRef={usageImportInputRef}
         t={t}
         onUsageExport={handleUsageExport}

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
@@ -13,10 +13,9 @@ import {
   formatTimestamp,
   type StatusTone,
 } from '@/features/monitoring/model/codexInspectionPresentation';
-import { buildUsageServiceBaseCandidates } from '@/entities/usageService/baseResolver';
+import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 import {
   getUsageServiceErrorCode,
-  isUsageServiceId,
   usageServiceApi,
   type CodexInspectionLog,
   type CodexInspectionResult,
@@ -26,7 +25,7 @@ import {
   type ManagerCodexInspectionScheduleMode,
   type ManagerConfig,
 } from '@/services/api/usageService';
-import { useAuthStore, useNotificationStore, useUsageServiceStore } from '@/stores';
+import { useAuthStore, useNotificationStore } from '@/stores';
 import styles from './CodexInspectionPage.module.scss';
 
 type ServerCodexInspectionDraft = {
@@ -415,11 +414,8 @@ function formatServiceHost(base: string): string {
 
 export function ServerCodexInspectionPage() {
   const { t, i18n } = useTranslation();
-  const apiBase = useAuthStore((state) => state.apiBase);
   const managementKey = useAuthStore((state) => state.managementKey);
-  const usageServiceEnabled = useUsageServiceStore((state) => state.enabled);
-  const usageServiceBase = useUsageServiceStore((state) => state.serviceBase);
-  const usageServiceRevision = useUsageServiceStore((state) => state.revision);
+  const featureAvailability = usePanelFeatureAvailability();
   const showNotification = useNotificationStore((state) => state.showNotification);
   const showConfirmation = useNotificationStore((state) => state.showConfirmation);
 
@@ -438,16 +434,6 @@ export function ServerCodexInspectionPage() {
   const [logLevelFilter, setLogLevelFilter] = useState<'all' | 'info' | 'success' | 'warning' | 'error'>('all');
   const refreshInFlightRef = useRef(false);
 
-  const candidates = useMemo(
-    () =>
-      buildUsageServiceBaseCandidates({
-        apiBase,
-        usageServiceEnabled,
-        usageServiceBase,
-      }),
-    [apiBase, usageServiceBase, usageServiceEnabled]
-  );
-
   const loadRunDetail = useCallback(
     async (base: string, id: number) => {
       const nextDetail = await usageServiceApi.getCodexInspectionRun(base, managementKey, id);
@@ -462,24 +448,12 @@ export function ServerCodexInspectionPage() {
     setLoading(true);
     setError('');
     try {
-      let resolvedBase = '';
-      let responseConfig: ManagerConfig | null = null;
-      for (const candidate of candidates) {
-        try {
-          const info = await usageServiceApi.getInfo(candidate);
-          if (!isUsageServiceId(info.service)) continue;
-          const response = await usageServiceApi.getManagerConfig(candidate, managementKey);
-          resolvedBase = candidate;
-          responseConfig = response.config;
-          break;
-        } catch {
-          // Continue probing candidates; a regular CPA panel is expected to fail here.
-        }
-      }
-
-      if (!resolvedBase || !responseConfig) {
+      const resolvedBase = featureAvailability.managerServiceBase;
+      if (!resolvedBase || !featureAvailability.serverCodexInspectionAvailable) {
         throw new Error(t('monitoring.server_codex_inspection_service_unavailable'));
       }
+      const response = await usageServiceApi.getManagerConfig(resolvedBase, managementKey);
+      const responseConfig = response.config;
 
       setServiceBase(resolvedBase);
       setManagerConfig(responseConfig);
@@ -510,16 +484,31 @@ export function ServerCodexInspectionPage() {
     } finally {
       setLoading(false);
     }
-  }, [candidates, loadRunDetail, managementKey, t]);
+  }, [
+    featureAvailability.managerServiceBase,
+    featureAvailability.serverCodexInspectionAvailable,
+    loadRunDetail,
+    managementKey,
+    t,
+  ]);
 
   useEffect(() => {
-    if (!managementKey || candidates.length === 0) {
+    if (featureAvailability.checking) {
+      return;
+    }
+    if (!managementKey || !featureAvailability.serverCodexInspectionAvailable) {
       setLoading(false);
       setError(t('monitoring.server_codex_inspection_connection_required'));
       return;
     }
     void loadPageData();
-  }, [candidates, loadPageData, managementKey, t, usageServiceRevision]);
+  }, [
+    featureAvailability.checking,
+    featureAvailability.serverCodexInspectionAvailable,
+    loadPageData,
+    managementKey,
+    t,
+  ]);
 
   const selectedConfig = useMemo(
     () => resolveServerCodexConfig(managerConfig?.codexInspection),

--- a/apps/web/src/features/monitoring/components/CodexInspectionModeTabs.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionModeTabs.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 import styles from '../CodexInspectionPage.module.scss';
 
 export type CodexInspectionMode = 'local' | 'server';
@@ -27,10 +28,17 @@ const MODES: ReadonlyArray<{
 
 export function CodexInspectionModeTabs({ activeMode }: CodexInspectionModeTabsProps) {
   const { t } = useTranslation();
+  const availability = usePanelFeatureAvailability();
   const activeLabel = t(
     activeMode === 'local'
       ? 'monitoring.codex_inspection_mode_local'
       : 'monitoring.codex_inspection_mode_server'
+  );
+  const visibleModes = MODES.filter(
+    (item) =>
+      item.mode === 'local' ||
+      item.mode === activeMode ||
+      availability.serverCodexInspectionAvailable
   );
 
   return (
@@ -44,7 +52,7 @@ export function CodexInspectionModeTabs({ activeMode }: CodexInspectionModeTabsP
           role="tablist"
           aria-label={t('monitoring.codex_inspection_mode_label')}
         >
-          {MODES.map((item) => {
+          {visibleModes.map((item) => {
             const active = activeMode === item.mode;
             return (
               <Link

--- a/apps/web/src/features/monitoring/components/MonitoringActionBar.tsx
+++ b/apps/web/src/features/monitoring/components/MonitoringActionBar.tsx
@@ -9,6 +9,7 @@ type MonitoringActionBarProps = {
   usageExporting: boolean;
   usageImporting: boolean;
   loggingToFile: boolean;
+  modelPricesAvailable: boolean;
   usageImportInputRef: RefObject<HTMLInputElement | null>;
   t: TFunction;
   onUsageExport: () => void | Promise<void>;
@@ -22,6 +23,7 @@ export function MonitoringActionBar({
   usageExporting,
   usageImporting,
   loggingToFile,
+  modelPricesAvailable,
   usageImportInputRef,
   t,
   onUsageExport,
@@ -60,10 +62,12 @@ export function MonitoringActionBar({
           <IconFileText size={16} />
           <span>{usageImporting ? t('common.loading') : t('usage_stats.import')}</span>
         </button>
-        <Link to="/model-prices" className={styles.actionButton}>
-          <IconSettings size={16} />
-          <span>{t('usage_stats.model_price_settings')}</span>
-        </Link>
+        {modelPricesAvailable ? (
+          <Link to="/model-prices" className={styles.actionButton}>
+            <IconSettings size={16} />
+            <span>{t('usage_stats.model_price_settings')}</span>
+          </Link>
+        ) : null}
         <input
           ref={usageImportInputRef}
           type="file"

--- a/apps/web/src/hooks/usePanelFeatureAvailability.test.ts
+++ b/apps/web/src/hooks/usePanelFeatureAvailability.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { ManagerConfig } from '@/services/api/usageService';
+import {
+  buildPanelManagerServiceCandidates,
+  managerConfigMatchesPanel,
+  resolvePanelFeatureAvailability,
+} from './usePanelFeatureAvailability';
+
+const buildManagerConfig = (overrides: Partial<ManagerConfig> = {}): ManagerConfig => ({
+  cpaConnection: {
+    cpaBaseUrl: 'http://cpa.local:8317',
+    managementKey: 'management-key',
+  },
+  collector: {
+    enabled: true,
+    collectorMode: 'auto',
+    queue: 'usage',
+    popSide: 'right',
+    batchSize: 100,
+    pollIntervalMs: 500,
+    queryLimit: 50000,
+  },
+  externalUsageService: {
+    enabled: true,
+    serviceBase: 'http://manager.local:18317',
+  },
+  ...overrides,
+});
+
+describe('panel feature availability', () => {
+  it('uses the current embedded Manager Server as the only Docker-mode candidate', () => {
+    expect(
+      buildPanelManagerServiceCandidates({
+        panelHostedByUsageService: true,
+        panelBase: 'http://manager.local:18317',
+        apiBase: 'http://cpa.local:8317',
+        usageServiceEnabled: true,
+        usageServiceBase: 'http://old-manager.local:18317',
+      })
+    ).toEqual(['http://manager.local:18317']);
+  });
+
+  it('requires external Manager Server config to match the current CPA panel', () => {
+    expect(
+      managerConfigMatchesPanel({
+        panelHostedByUsageService: false,
+        apiBase: 'http://cpa.local:8317',
+        config: buildManagerConfig(),
+      })
+    ).toBe(true);
+
+    expect(
+      managerConfigMatchesPanel({
+        panelHostedByUsageService: false,
+        apiBase: 'http://other-cpa.local:8317',
+        config: buildManagerConfig(),
+      })
+    ).toBe(false);
+
+    expect(
+      managerConfigMatchesPanel({
+        panelHostedByUsageService: false,
+        apiBase: 'http://cpa.local:8317',
+        config: buildManagerConfig({
+          externalUsageService: { enabled: false, serviceBase: '' },
+        }),
+      })
+    ).toBe(false);
+  });
+
+  it('marks Manager-only features available while separately gating request monitoring', () => {
+    const availability = resolvePanelFeatureAvailability({
+      panelHostedByUsageService: false,
+      panelBase: 'http://cpa.local:8317',
+      managerServiceBase: 'http://manager.local:18317',
+      managerConfig: buildManagerConfig({
+        collector: {
+          ...buildManagerConfig().collector,
+          enabled: false,
+        },
+      }),
+      hasManagerCandidate: true,
+      managementKey: 'management-key',
+    });
+
+    expect(availability.managerServiceAvailable).toBe(true);
+    expect(availability.modelPricesAvailable).toBe(true);
+    expect(availability.serverCodexInspectionAvailable).toBe(true);
+    expect(availability.requestMonitoringAvailable).toBe(false);
+    expect(availability.reason).toBe('monitoring_disabled');
+  });
+});

--- a/apps/web/src/hooks/usePanelFeatureAvailability.ts
+++ b/apps/web/src/hooks/usePanelFeatureAvailability.ts
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  isUsageServiceId,
+  normalizeUsageServiceBase,
+  usageServiceApi,
+  type ManagerConfig,
+} from '@/services/api/usageService';
+import { useAuthStore, useUsageServiceStore } from '@/stores';
+import { detectApiBaseFromLocation } from '@/utils/connection';
+
+export type PanelHostMode = 'manager_embedded' | 'external_panel';
+
+export type PanelFeatureUnavailableReason =
+  | 'checking'
+  | 'service_not_configured'
+  | 'service_unavailable'
+  | 'monitoring_disabled';
+
+export interface PanelFeatureAvailability {
+  checking: boolean;
+  panelHostMode: PanelHostMode;
+  panelBase: string;
+  managerServiceBase: string;
+  managerServiceAvailable: boolean;
+  requestMonitoringAvailable: boolean;
+  modelPricesAvailable: boolean;
+  serverCodexInspectionAvailable: boolean;
+  dockerSetupAvailable: boolean;
+  externalManagerConfigAvailable: boolean;
+  reason: PanelFeatureUnavailableReason | '';
+}
+
+export interface ResolvePanelFeatureAvailabilityInput {
+  checking?: boolean;
+  panelHostedByUsageService: boolean;
+  panelBase: string;
+  managerServiceBase: string;
+  managerConfig: ManagerConfig | null;
+  hasManagerCandidate: boolean;
+  managementKey: string;
+}
+
+const normalizeBase = (value?: string) => normalizeUsageServiceBase(value || '');
+
+const buildUnavailableState = (
+  input: ResolvePanelFeatureAvailabilityInput,
+  reason: PanelFeatureUnavailableReason
+): PanelFeatureAvailability => ({
+  checking: input.checking === true,
+  panelHostMode: input.panelHostedByUsageService ? 'manager_embedded' : 'external_panel',
+  panelBase: normalizeBase(input.panelBase),
+  managerServiceBase: '',
+  managerServiceAvailable: false,
+  requestMonitoringAvailable: false,
+  modelPricesAvailable: false,
+  serverCodexInspectionAvailable: false,
+  dockerSetupAvailable: input.panelHostedByUsageService,
+  externalManagerConfigAvailable: !input.panelHostedByUsageService,
+  reason,
+});
+
+export function resolvePanelFeatureAvailability(
+  input: ResolvePanelFeatureAvailabilityInput
+): PanelFeatureAvailability {
+  if (!input.managementKey) {
+    return buildUnavailableState(input, 'service_not_configured');
+  }
+
+  const managerServiceBase = normalizeBase(input.managerServiceBase);
+  if (!managerServiceBase || !input.managerConfig) {
+    return buildUnavailableState(
+      input,
+      input.hasManagerCandidate ? 'service_unavailable' : 'service_not_configured'
+    );
+  }
+
+  const hasCPAConnection = Boolean(
+    input.managerConfig.cpaConnection?.cpaBaseUrl &&
+      input.managerConfig.cpaConnection?.managementKey
+  );
+  const collectorEnabled = input.managerConfig.collector?.enabled !== false;
+  const requestMonitoringAvailable = hasCPAConnection && collectorEnabled;
+
+  return {
+    checking: input.checking === true,
+    panelHostMode: input.panelHostedByUsageService ? 'manager_embedded' : 'external_panel',
+    panelBase: normalizeBase(input.panelBase),
+    managerServiceBase,
+    managerServiceAvailable: true,
+    requestMonitoringAvailable,
+    modelPricesAvailable: true,
+    serverCodexInspectionAvailable: true,
+    dockerSetupAvailable: input.panelHostedByUsageService,
+    externalManagerConfigAvailable: !input.panelHostedByUsageService,
+    reason: requestMonitoringAvailable
+      ? ''
+      : !hasCPAConnection
+        ? 'service_not_configured'
+        : 'monitoring_disabled',
+  };
+}
+
+export interface BuildPanelManagerServiceCandidatesInput {
+  panelHostedByUsageService: boolean;
+  panelBase: string;
+  apiBase: string;
+  usageServiceEnabled: boolean;
+  usageServiceBase: string;
+  storedPanelBase?: string;
+  storedPanelHostMode?: PanelHostMode | '';
+}
+
+export function buildPanelManagerServiceCandidates({
+  panelHostedByUsageService,
+  panelBase,
+  apiBase,
+  usageServiceEnabled,
+  usageServiceBase,
+  storedPanelBase,
+  storedPanelHostMode,
+}: BuildPanelManagerServiceCandidatesInput): string[] {
+  const normalizedPanelBase = normalizeBase(panelBase);
+  if (panelHostedByUsageService) {
+    return normalizedPanelBase ? [normalizedPanelBase] : [];
+  }
+
+  const candidates: string[] = [];
+  const normalizedStoredPanelBase = normalizeBase(storedPanelBase);
+  const storedConfigMatchesPanel =
+    !normalizedStoredPanelBase ||
+    normalizedStoredPanelBase === normalizedPanelBase ||
+    storedPanelHostMode === 'external_panel';
+
+  if (usageServiceEnabled && storedConfigMatchesPanel) {
+    const normalizedUsageServiceBase = normalizeBase(usageServiceBase);
+    if (normalizedUsageServiceBase) {
+      candidates.push(normalizedUsageServiceBase);
+    }
+  }
+
+  const normalizedApiBase = normalizeBase(apiBase);
+  if (normalizedApiBase && normalizedApiBase !== normalizedPanelBase) {
+    candidates.push(normalizedApiBase);
+  }
+
+  return Array.from(new Set(candidates));
+}
+
+export function managerConfigMatchesPanel({
+  panelHostedByUsageService,
+  apiBase,
+  config,
+}: {
+  panelHostedByUsageService: boolean;
+  apiBase: string;
+  config: ManagerConfig;
+}): boolean {
+  if (panelHostedByUsageService) {
+    return true;
+  }
+  if (config.externalUsageService?.enabled !== true) {
+    return false;
+  }
+  const configuredCPA = normalizeBase(config.cpaConnection?.cpaBaseUrl);
+  const currentCPA = normalizeBase(apiBase);
+  return Boolean(configuredCPA && currentCPA && configuredCPA === currentCPA);
+}
+
+const initialAvailability: PanelFeatureAvailability = {
+  checking: true,
+  panelHostMode: 'external_panel',
+  panelBase: '',
+  managerServiceBase: '',
+  managerServiceAvailable: false,
+  requestMonitoringAvailable: false,
+  modelPricesAvailable: false,
+  serverCodexInspectionAvailable: false,
+  dockerSetupAvailable: false,
+  externalManagerConfigAvailable: true,
+  reason: 'checking',
+};
+
+export function usePanelFeatureAvailability(): PanelFeatureAvailability {
+  const apiBase = useAuthStore((state) => state.apiBase);
+  const managementKey = useAuthStore((state) => state.managementKey);
+  const usageServiceEnabled = useUsageServiceStore((state) => state.enabled);
+  const usageServiceBase = useUsageServiceStore((state) => state.serviceBase);
+  const usageServiceRevision = useUsageServiceStore((state) => state.revision);
+  const storedPanelBase = useUsageServiceStore((state) => state.panelBase);
+  const storedPanelHostMode = useUsageServiceStore((state) => state.panelHostMode);
+  const panelBase = useMemo(() => detectApiBaseFromLocation(), []);
+  const [state, setState] = useState<PanelFeatureAvailability>(initialAvailability);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const detect = async () => {
+      const normalizedPanelBase = normalizeBase(panelBase);
+      if (!managementKey) {
+        setState(
+          resolvePanelFeatureAvailability({
+            checking: false,
+            panelHostedByUsageService: false,
+            panelBase: normalizedPanelBase,
+            managerServiceBase: '',
+            managerConfig: null,
+            hasManagerCandidate: false,
+            managementKey,
+          })
+        );
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        checking: true,
+        panelBase: normalizedPanelBase,
+        reason: 'checking',
+      }));
+
+      let panelHostedByUsageService = false;
+      try {
+        const info = await usageServiceApi.getInfo(normalizedPanelBase);
+        panelHostedByUsageService = isUsageServiceId(info.service);
+      } catch {
+        panelHostedByUsageService = false;
+      }
+
+      const candidates = buildPanelManagerServiceCandidates({
+        panelHostedByUsageService,
+        panelBase: normalizedPanelBase,
+        apiBase,
+        usageServiceEnabled,
+        usageServiceBase,
+        storedPanelBase,
+        storedPanelHostMode,
+      });
+
+      for (const candidate of candidates) {
+        try {
+          const info = await usageServiceApi.getInfo(candidate);
+          if (!isUsageServiceId(info.service)) continue;
+          const response = await usageServiceApi.getManagerConfig(candidate, managementKey);
+          if (
+            !managerConfigMatchesPanel({
+              panelHostedByUsageService,
+              apiBase,
+              config: response.config,
+            })
+          ) {
+            continue;
+          }
+          if (cancelled) return;
+          setState(
+            resolvePanelFeatureAvailability({
+              checking: false,
+              panelHostedByUsageService,
+              panelBase: normalizedPanelBase,
+              managerServiceBase: candidate,
+              managerConfig: response.config,
+              hasManagerCandidate: candidates.length > 0,
+              managementKey,
+            })
+          );
+          return;
+        } catch {
+          // Continue probing; a regular CPA endpoint or unreachable Manager Server is expected here.
+        }
+      }
+
+      if (cancelled) return;
+      setState(
+        resolvePanelFeatureAvailability({
+          checking: false,
+          panelHostedByUsageService,
+          panelBase: normalizedPanelBase,
+          managerServiceBase: '',
+          managerConfig: null,
+          hasManagerCandidate: candidates.length > 0,
+          managementKey,
+        })
+      );
+    };
+
+    void detect();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    apiBase,
+    managementKey,
+    panelBase,
+    storedPanelBase,
+    storedPanelHostMode,
+    usageServiceBase,
+    usageServiceEnabled,
+    usageServiceRevision,
+  ]);
+
+  return state;
+}

--- a/apps/web/src/hooks/useRequestMonitoringAvailability.ts
+++ b/apps/web/src/hooks/useRequestMonitoringAvailability.ts
@@ -1,13 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
-import {
-  buildUsageServiceBaseCandidates,
-  hasConfiguredUsageServiceBase,
-} from '@/entities/usageService/baseResolver';
-import {
-  isUsageServiceId,
-  usageServiceApi,
-} from '@/services/api/usageService';
-import { useAuthStore, useUsageServiceStore } from '@/stores';
+import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 
 export type RequestMonitoringUnavailableReason =
   | 'checking'
@@ -18,95 +9,20 @@ export type RequestMonitoringUnavailableReason =
 export interface RequestMonitoringAvailability {
   checking: boolean;
   available: boolean;
+  managerServiceAvailable: boolean;
+  modelPricesAvailable: boolean;
   serviceBase: string;
   reason: RequestMonitoringUnavailableReason | '';
 }
 
 export function useRequestMonitoringAvailability(): RequestMonitoringAvailability {
-  const apiBase = useAuthStore((state) => state.apiBase);
-  const managementKey = useAuthStore((state) => state.managementKey);
-  const usageServiceEnabled = useUsageServiceStore((state) => state.enabled);
-  const usageServiceBase = useUsageServiceStore((state) => state.serviceBase);
-  const usageServiceRevision = useUsageServiceStore((state) => state.revision);
-  const [state, setState] = useState<RequestMonitoringAvailability>({
-    checking: true,
-    available: false,
-    serviceBase: '',
-    reason: 'checking',
-  });
-
-  const candidates = useMemo(() => {
-    return buildUsageServiceBaseCandidates({
-      apiBase,
-      usageServiceEnabled,
-      usageServiceBase,
-    });
-  }, [apiBase, usageServiceBase, usageServiceEnabled]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const detect = async () => {
-      if (!managementKey || candidates.length === 0) {
-        setState({
-          checking: false,
-          available: false,
-          serviceBase: '',
-          reason: 'service_not_configured',
-        });
-        return;
-      }
-
-      setState((current) => ({ ...current, checking: true, reason: 'checking' }));
-      const hasConfiguredUsageService = hasConfiguredUsageServiceBase({
-        usageServiceEnabled,
-        usageServiceBase,
-      });
-
-      for (const candidate of candidates) {
-        try {
-          const info = await usageServiceApi.getInfo(candidate);
-          if (!isUsageServiceId(info.service)) {
-            continue;
-          }
-          const response = await usageServiceApi.getManagerConfig(candidate, managementKey);
-          const collectorEnabled = response.config.collector?.enabled !== false;
-          const hasCPAConnection = Boolean(
-            response.config.cpaConnection?.cpaBaseUrl &&
-              response.config.cpaConnection?.managementKey
-          );
-          if (cancelled) return;
-          setState({
-            checking: false,
-            available: collectorEnabled && hasCPAConnection,
-            serviceBase: candidate,
-            reason: !collectorEnabled
-              ? 'monitoring_disabled'
-              : hasCPAConnection
-                ? ''
-                : 'service_not_configured',
-          });
-          return;
-        } catch {
-          // A regular CPA panel or an unreachable external Usage Service is handled below.
-        }
-      }
-
-      if (cancelled) return;
-      setState({
-        checking: false,
-        available: false,
-        serviceBase: '',
-        reason: hasConfiguredUsageService ? 'service_unavailable' : 'service_not_configured',
-      });
-    };
-
-    void detect();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [candidates, managementKey, usageServiceBase, usageServiceEnabled, usageServiceRevision]);
-
-  return state;
+  const availability = usePanelFeatureAvailability();
+  return {
+    checking: availability.checking,
+    available: availability.requestMonitoringAvailable,
+    managerServiceAvailable: availability.managerServiceAvailable,
+    modelPricesAvailable: availability.modelPricesAvailable,
+    serviceBase: availability.managerServiceBase,
+    reason: availability.reason,
+  };
 }

--- a/apps/web/src/router/MainRoutes.tsx
+++ b/apps/web/src/router/MainRoutes.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import { Navigate, useRoutes, type Location } from 'react-router-dom';
 import { DashboardPage } from '@/pages/DashboardPage';
 import { AiProvidersPage } from '@/pages/AiProvidersPage';
@@ -23,6 +24,55 @@ import { ServerCodexInspectionPage } from '@/pages/ServerCodexInspectionPage';
 import { ConfigPage } from '@/pages/ConfigPage';
 import { LogsPage } from '@/pages/LogsPage';
 import { SystemPage } from '@/pages/SystemPage';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
+import { isFileLogsAvailable } from '@/features/logs/logFeatureAvailability';
+import { useConfigStore } from '@/stores';
+
+type FeatureKey = 'requestMonitoring' | 'modelPrices' | 'serverCodexInspection';
+
+function FeatureGate({ feature, children }: { feature: FeatureKey; children: ReactElement }) {
+  const availability = usePanelFeatureAvailability();
+  const enabled =
+    feature === 'requestMonitoring'
+      ? availability.requestMonitoringAvailable
+      : feature === 'modelPrices'
+        ? availability.modelPricesAvailable
+        : availability.serverCodexInspectionAvailable;
+
+  if (availability.checking) {
+    return <LoadingSpinner />;
+  }
+
+  if (!enabled) {
+    return <Navigate to="/config" replace />;
+  }
+
+  return children;
+}
+
+function LogsGate({ children }: { children: ReactElement }) {
+  const config = useConfigStore((state) => state.config);
+  const fetchConfig = useConfigStore((state) => state.fetchConfig);
+  const requestedRef = useRef(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (config || requestedRef.current) return;
+    requestedRef.current = true;
+    fetchConfig().catch(() => setFailed(true));
+  }, [config, fetchConfig]);
+
+  if (!config && !failed) {
+    return <LoadingSpinner />;
+  }
+
+  if (!isFileLogsAvailable(config)) {
+    return <Navigate to="/config" replace />;
+  }
+
+  return children;
+}
 
 const mainRoutes = [
   { path: '/', element: <DashboardPage /> },
@@ -76,17 +126,56 @@ const mainRoutes = [
   { path: '/oauth', element: <OAuthPage /> },
   { path: '/quota', element: <QuotaPage /> },
   { path: '/codex-inspection', element: <CodexInspectionPage /> },
-  { path: '/codex-inspection/server', element: <ServerCodexInspectionPage /> },
-  { path: '/model-prices', element: <ModelPricesPage /> },
-  { path: '/monitoring', element: <MonitoringCenterPage /> },
-  { path: '/monitoring/model-prices', element: <Navigate to="/model-prices" replace /> },
+  {
+    path: '/codex-inspection/server',
+    element: (
+      <FeatureGate feature="serverCodexInspection">
+        <ServerCodexInspectionPage />
+      </FeatureGate>
+    ),
+  },
+  {
+    path: '/model-prices',
+    element: (
+      <FeatureGate feature="modelPrices">
+        <ModelPricesPage />
+      </FeatureGate>
+    ),
+  },
+  {
+    path: '/monitoring',
+    element: (
+      <FeatureGate feature="requestMonitoring">
+        <MonitoringCenterPage />
+      </FeatureGate>
+    ),
+  },
+  {
+    path: '/monitoring/model-prices',
+    element: (
+      <FeatureGate feature="modelPrices">
+        <Navigate to="/model-prices" replace />
+      </FeatureGate>
+    ),
+  },
   { path: '/monitoring/codex-inspection', element: <Navigate to="/codex-inspection" replace /> },
   {
     path: '/monitoring/codex-inspection/server',
-    element: <Navigate to="/codex-inspection/server" replace />,
+    element: (
+      <FeatureGate feature="serverCodexInspection">
+        <Navigate to="/codex-inspection/server" replace />
+      </FeatureGate>
+    ),
   },
   { path: '/config', element: <ConfigPage /> },
-  { path: '/logs', element: <LogsPage /> },
+  {
+    path: '/logs',
+    element: (
+      <LogsGate>
+        <LogsPage />
+      </LogsGate>
+    ),
+  },
   { path: '/system', element: <SystemPage /> },
   { path: '*', element: <Navigate to="/" replace /> },
 ];

--- a/apps/web/src/router/ProtectedRoute.tsx
+++ b/apps/web/src/router/ProtectedRoute.tsx
@@ -2,13 +2,15 @@ import { useEffect, useState, type ReactElement } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@/stores';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { isUsageServiceId, usageServiceApi } from '@/services/api/usageService';
+import { detectApiBaseFromLocation } from '@/utils/connection';
 
 export function ProtectedRoute({ children }: { children: ReactElement }) {
   const location = useLocation();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const managementKey = useAuthStore((state) => state.managementKey);
   const apiBase = useAuthStore((state) => state.apiBase);
-  const checkAuth = useAuthStore((state) => state.checkAuth);
+  const restoreSession = useAuthStore((state) => state.restoreSession);
   const [checking, setChecking] = useState(false);
 
   useEffect(() => {
@@ -16,14 +18,29 @@ export function ProtectedRoute({ children }: { children: ReactElement }) {
       if (!isAuthenticated && managementKey && apiBase) {
         setChecking(true);
         try {
-          await checkAuth();
+          const detectedBase = detectApiBaseFromLocation();
+          let detectedUsageService = false;
+          try {
+            const info = await usageServiceApi.getInfo(detectedBase);
+            detectedUsageService = isUsageServiceId(info.service);
+          } catch {
+            detectedUsageService = false;
+          }
+          const hostedManagementPage =
+            typeof window !== 'undefined' &&
+            /\/management\.html$/i.test(window.location.pathname);
+          await restoreSession({
+            expectedMode: detectedUsageService ? 'manager_embedded' : 'external_panel',
+            expectedPanelBase:
+              detectedUsageService || hostedManagementPage ? detectedBase : undefined,
+          });
         } finally {
           setChecking(false);
         }
       }
     };
     tryRestore();
-  }, [apiBase, isAuthenticated, managementKey, checkAuth]);
+  }, [apiBase, isAuthenticated, managementKey, restoreSession]);
 
   if (checking) {
     return (

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -5,7 +5,7 @@
 
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import type { AuthState, LoginCredentials, ConnectionStatus } from '@/types';
+import type { AuthSessionMode, AuthState, LoginCredentials, ConnectionStatus } from '@/types';
 import { STORAGE_KEY_AUTH } from '@/utils/constants';
 import { obfuscatedStorage } from '@/services/storage/secureStorage';
 import { apiClient } from '@/services/api/client';
@@ -14,6 +14,8 @@ import { useModelsStore } from './useModelsStore';
 import { detectApiBaseFromLocation, normalizeApiBase } from '@/utils/connection';
 
 interface AuthStoreState extends AuthState {
+  sessionMode: AuthSessionMode | '';
+  sessionPanelBase: string;
   connectionStatus: ConnectionStatus;
   connectionError: string | null;
 
@@ -21,12 +23,40 @@ interface AuthStoreState extends AuthState {
   login: (credentials: LoginCredentials) => Promise<void>;
   logout: () => void;
   checkAuth: () => Promise<boolean>;
-  restoreSession: () => Promise<boolean>;
+  restoreSession: (options?: RestoreSessionOptions) => Promise<boolean>;
   updateServerVersion: (version: string | null, buildDate?: string | null) => void;
   updateConnectionStatus: (status: ConnectionStatus, error?: string | null) => void;
 }
 
+interface RestoreSessionOptions {
+  expectedMode?: AuthSessionMode;
+  expectedPanelBase?: string;
+}
+
 let restoreSessionPromise: Promise<boolean> | null = null;
+
+const sessionMatchesExpectedRuntime = ({
+  expectedMode,
+  expectedPanelBase,
+  resolvedBase,
+  sessionMode,
+}: {
+  expectedMode?: AuthSessionMode;
+  expectedPanelBase?: string;
+  resolvedBase: string;
+  sessionMode: AuthSessionMode | '';
+}) => {
+  const normalizedExpectedPanelBase = normalizeApiBase(expectedPanelBase || '');
+  if (!expectedMode) return true;
+  if (sessionMode && sessionMode !== expectedMode) return false;
+  if (expectedMode === 'manager_embedded' && normalizedExpectedPanelBase) {
+    return resolvedBase === normalizedExpectedPanelBase;
+  }
+  if (expectedMode === 'external_panel' && normalizedExpectedPanelBase) {
+    return resolvedBase === normalizedExpectedPanelBase;
+  }
+  return true;
+};
 
 export const useAuthStore = create<AuthStoreState>()(
   persist(
@@ -38,11 +68,13 @@ export const useAuthStore = create<AuthStoreState>()(
       rememberPassword: false,
       serverVersion: null,
       serverBuildDate: null,
+      sessionMode: '',
+      sessionPanelBase: '',
       connectionStatus: 'disconnected',
       connectionError: null,
 
       // 恢复会话并自动登录
-      restoreSession: () => {
+      restoreSession: (options) => {
         if (restoreSessionPromise) return restoreSessionPromise;
 
         restoreSessionPromise = (async () => {
@@ -54,15 +86,38 @@ export const useAuthStore = create<AuthStoreState>()(
             obfuscatedStorage.getItem<string>('apiUrl', { encrypt: true });
           const legacyKey = obfuscatedStorage.getItem<string>('managementKey');
 
-          const { apiBase, managementKey, rememberPassword } = get();
+          const { apiBase, managementKey, rememberPassword, sessionMode } = get();
           const resolvedBase = normalizeApiBase(apiBase || legacyBase || detectApiBaseFromLocation());
           const resolvedKey = managementKey || legacyKey || '';
           const resolvedRememberPassword = rememberPassword || Boolean(managementKey) || Boolean(legacyKey);
 
+          if (
+            !sessionMatchesExpectedRuntime({
+              expectedMode: options?.expectedMode,
+              expectedPanelBase: options?.expectedPanelBase,
+              resolvedBase,
+              sessionMode,
+            })
+          ) {
+            const fallbackBase = normalizeApiBase(options?.expectedPanelBase || detectApiBaseFromLocation());
+            set({
+              apiBase: fallbackBase,
+              managementKey: '',
+              rememberPassword: false,
+              sessionMode: options?.expectedMode ?? '',
+              sessionPanelBase: normalizeApiBase(options?.expectedPanelBase || ''),
+            });
+            apiClient.setConfig({ apiBase: fallbackBase, managementKey: '' });
+            localStorage.removeItem('isLoggedIn');
+            return false;
+          }
+
           set({
             apiBase: resolvedBase,
             managementKey: resolvedKey,
-            rememberPassword: resolvedRememberPassword
+            rememberPassword: resolvedRememberPassword,
+            sessionMode: options?.expectedMode ?? sessionMode,
+            sessionPanelBase: normalizeApiBase(options?.expectedPanelBase || get().sessionPanelBase)
           });
           apiClient.setConfig({ apiBase: resolvedBase, managementKey: resolvedKey });
 
@@ -111,6 +166,8 @@ export const useAuthStore = create<AuthStoreState>()(
             apiBase,
             managementKey,
             rememberPassword,
+            sessionMode: credentials.sessionMode ?? get().sessionMode,
+            sessionPanelBase: normalizeApiBase(credentials.sessionPanelBase || get().sessionPanelBase),
             connectionStatus: 'connected',
             connectionError: null
           });
@@ -145,6 +202,8 @@ export const useAuthStore = create<AuthStoreState>()(
           managementKey: '',
           serverVersion: null,
           serverBuildDate: null,
+          sessionMode: '',
+          sessionPanelBase: '',
           connectionStatus: 'disconnected',
           connectionError: null
         });
@@ -213,7 +272,9 @@ export const useAuthStore = create<AuthStoreState>()(
         ...(state.rememberPassword ? { managementKey: state.managementKey } : {}),
         rememberPassword: state.rememberPassword,
         serverVersion: state.serverVersion,
-        serverBuildDate: state.serverBuildDate
+        serverBuildDate: state.serverBuildDate,
+        sessionMode: state.sessionMode,
+        sessionPanelBase: state.sessionPanelBase
       })
     }
   )

--- a/apps/web/src/stores/useUsageServiceStore.ts
+++ b/apps/web/src/stores/useUsageServiceStore.ts
@@ -2,12 +2,23 @@ import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { obfuscatedStorage } from '@/services/storage/secureStorage';
 import { normalizeUsageServiceBase } from '@/services/api/usageService';
+import type { PanelHostMode } from '@/hooks/usePanelFeatureAvailability';
+
+export interface UsageServiceStoreContext {
+  panelBase?: string;
+  panelHostMode?: PanelHostMode;
+}
 
 export interface UsageServiceStoreState {
   enabled: boolean;
   serviceBase: string;
+  panelBase: string;
+  panelHostMode: PanelHostMode | '';
   revision: number;
-  setUsageServiceConfig: (config: { enabled: boolean; serviceBase: string }) => void;
+  setUsageServiceConfig: (
+    config: { enabled: boolean; serviceBase: string },
+    context?: UsageServiceStoreContext
+  ) => void;
   clearUsageServiceConfig: () => void;
 }
 
@@ -16,16 +27,28 @@ export const useUsageServiceStore = create<UsageServiceStoreState>()(
     (set) => ({
       enabled: false,
       serviceBase: '',
+      panelBase: '',
+      panelHostMode: '',
       revision: 0,
-      setUsageServiceConfig: ({ enabled, serviceBase }) => {
+      setUsageServiceConfig: ({ enabled, serviceBase }, context) => {
         set((state) => ({
           enabled,
           serviceBase: enabled ? normalizeUsageServiceBase(serviceBase) : '',
+          panelBase: context?.panelBase
+            ? normalizeUsageServiceBase(context.panelBase)
+            : state.panelBase,
+          panelHostMode: context?.panelHostMode ?? state.panelHostMode,
           revision: state.revision + 1,
         }));
       },
       clearUsageServiceConfig: () =>
-        set((state) => ({ enabled: false, serviceBase: '', revision: state.revision + 1 })),
+        set((state) => ({
+          enabled: false,
+          serviceBase: '',
+          panelBase: '',
+          panelHostMode: '',
+          revision: state.revision + 1,
+        })),
     }),
     {
       name: 'cli-proxy-usage-service',
@@ -44,6 +67,8 @@ export const useUsageServiceStore = create<UsageServiceStoreState>()(
       partialize: (state) => ({
         enabled: state.enabled,
         serviceBase: state.serviceBase,
+        panelBase: state.panelBase,
+        panelHostMode: state.panelHostMode,
       }),
     }
   )

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -3,11 +3,15 @@
  * 基于原项目 src/modules/login.js 和 src/core/connection.js
  */
 
+export type AuthSessionMode = 'manager_embedded' | 'external_panel';
+
 // 登录凭据
 export interface LoginCredentials {
   apiBase: string;
   managementKey: string;
   rememberPassword?: boolean;
+  sessionMode?: AuthSessionMode;
+  sessionPanelBase?: string;
 }
 
 // 认证状态


### PR DESCRIPTION
## Summary
Fix runtime feature gating across Docker-hosted and CPA-hosted panel modes.

## Changes
- Centralize frontend feature availability for Manager Server and CPA panel modes.
- Gate sidebar entries, direct routes, monitoring actions, model prices, server Codex inspection, and logs.
- Add session/runtime metadata to prevent stale cross-mode state reuse.
- Restrict generic Manager Server CPA proxy routes to admin-key auth only.

## Testing
- npm --workspace apps/web run type-check
- npm --workspace apps/web run lint
- npm --workspace apps/web run test
- npm run build
- go test ./...