### PR TITLE
ci(release): publish container images to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+      - '*-alpha*'
+      - '*-beta*'
+      - '*-rc*'
 
 jobs:
   build-and-release:
@@ -64,6 +67,16 @@ jobs:
           : > release-notes.md
           git log --pretty=format:"- %h %s" "${range}" >> release-notes.md
 
+      - name: Detect release type
+        id: release_type
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -72,7 +85,7 @@ jobs:
             dist/native/*
           body_path: release-notes.md
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.release_type.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,9 +94,11 @@ jobs:
 
     permissions:
       contents: read
+      packages: write
 
     env:
       DOCKERHUB_IMAGE: seakee/cpa-manager-plus
+      GHCR_IMAGE: ghcr.io/seakee/cpa-manager-plus
 
     steps:
       - name: Checkout code
@@ -95,26 +110,64 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Validate DockerHub configuration
+      - name: Detect Docker release type
+        id: release_type
         run: |
           set -euo pipefail
-          if [ -z "${DOCKERHUB_USERNAME}" ]; then
-            echo "DOCKERHUB_USERNAME secret is required" >&2
-            exit 1
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "semver=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "semver=false" >> "${GITHUB_OUTPUT}"
           fi
-          if [ -z "${DOCKERHUB_TOKEN}" ]; then
-            echo "DOCKERHUB_TOKEN secret is required" >&2
-            exit 1
+
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "stable=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "stable=false" >> "${GITHUB_OUTPUT}"
           fi
+
+      - name: Prepare Docker publish targets
+        id: docker_targets
+        run: |
+          set -euo pipefail
           if [ "${DOCKERHUB_IMAGE}" != "seakee/cpa-manager-plus" ]; then
             echo "Docker image name must be seakee/cpa-manager-plus" >&2
             exit 1
           fi
+
+          images="${GHCR_IMAGE}"
+          dockerhub_enabled=false
+          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            images="${images}"$'\n'"${DOCKERHUB_IMAGE}"
+            dockerhub_enabled=true
+          else
+            echo "::warning::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are not both configured; DockerHub publish will be skipped."
+          fi
+
+          if [ "${dockerhub_enabled}" = "true" ] && [ "${DOCKERHUB_IMAGE}" != "seakee/cpa-manager-plus" ]; then
+            echo "DockerHub image name must be seakee/cpa-manager-plus" >&2
+            exit 1
+          fi
+
+          {
+            echo "images<<EOF"
+            echo "${images}"
+            echo "EOF"
+            echo "dockerhub_enabled=${dockerhub_enabled}"
+          } >> "${GITHUB_OUTPUT}"
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to Docker Hub
+        if: steps.docker_targets.outputs.dockerhub_enabled == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -124,12 +177,18 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKERHUB_IMAGE }}
+          images: ${{ steps.docker_targets.outputs.images }}
           tags: |
             type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=semver,pattern={{version}},enable=${{ steps.release_type.outputs.semver == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ steps.release_type.outputs.stable == 'true' }}
+            type=raw,value=latest,enable=${{ steps.release_type.outputs.stable == 'true' }}
+          labels: |
+            org.opencontainers.image.title=CPA Manager Plus
+            org.opencontainers.image.description=CPA Manager Plus Manager Server container image
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.documentation=${{ github.server_url }}/${{ github.repository }}#readme
 
       - name: Build and push Manager Server image
         uses: docker/build-push-action@v6
@@ -144,6 +203,7 @@ jobs:
             VERSION=${{ github.ref_name }}
 
       - name: Update DockerHub overview
+        if: steps.docker_targets.outputs.dockerhub_enabled == 'true'
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ model -> repository -> service -> controller -> router
 
 ## Quick Start: Full Docker Mode
 
-### Docker Hub Image
+### Container Images
+
+Public multi-arch images are published to both registries:
+
+- Docker Hub: `seakee/cpa-manager-plus`
+- GitHub Container Registry: `ghcr.io/seakee/cpa-manager-plus`
 
 ```bash
 docker run -d \
@@ -129,7 +134,7 @@ On first setup, enter:
 
 You can read the generated admin key with `docker logs cpa-manager-plus`. After setup, the same entry URL uses the saved CPA connection from Manager Server SQLite. New browsers only need the admin key on the login page.
 
-The published image supports `linux/amd64` and `linux/arm64`. If your image is published under another Docker Hub namespace, replace `seakee/cpa-manager-plus:latest`.
+The published image supports `linux/amd64` and `linux/arm64`. Docker examples use Docker Hub by default. To pull from GitHub Container Registry instead, replace `seakee/cpa-manager-plus:latest` with `ghcr.io/seakee/cpa-manager-plus:latest`.
 
 ### Native Packages
 
@@ -193,6 +198,8 @@ Start:
 ```bash
 docker compose up -d
 ```
+
+To use GitHub Container Registry, replace the compose image with `ghcr.io/seakee/cpa-manager-plus:latest`.
 
 ### Linux Host CPA
 
@@ -388,13 +395,14 @@ go run ./cmd/cpa-manager-plus
 ## Build and Release
 
 - Vite builds a single-file `apps/web/dist/index.html`.
-- Tagging `vX.Y.Z` triggers `.github/workflows/release.yml`.
+- Tagging `vX.Y.Z` or a prerelease tag such as `vX.Y.Z-beta` triggers `.github/workflows/release.yml`.
 - The release workflow uploads `apps/web/dist/management.html`, native packages, and `checksums.txt` to GitHub Releases.
 - Native packages are published for `linux`, `darwin`, and `windows` on both `amd64` and `arm64`, with the management panel embedded.
-- The same workflow builds `Dockerfile.manager-server` and pushes `seakee/cpa-manager-plus`.
+- The same workflow builds `Dockerfile.manager-server` and pushes public images to Docker Hub and GitHub Container Registry.
 - The Docker image is published for `linux/amd64` and `linux/arm64`.
-- The workflow syncs `README.md` to the Docker Hub overview.
-- Required GitHub secrets:
+- The GitHub Container Registry image is `ghcr.io/seakee/cpa-manager-plus`; it uses the workflow `GITHUB_TOKEN` with `packages: write`.
+- The workflow syncs `README.md` to the Docker Hub overview when Docker Hub publishing is enabled.
+- Optional GitHub secrets for Docker Hub publishing:
   - `DOCKERHUB_USERNAME`
   - `DOCKERHUB_TOKEN`
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -101,7 +101,12 @@ model -> repository -> service -> controller -> router
 
 ## 快速开始：完整 Docker 方案
 
-### Docker Hub 镜像
+### 容器镜像
+
+公开多架构镜像会发布到两个仓库：
+
+- Docker Hub：`seakee/cpa-manager-plus`
+- GitHub Container Registry：`ghcr.io/seakee/cpa-manager-plus`
 
 ```bash
 docker run -d \
@@ -129,7 +134,7 @@ http://<host>:18317/management.html
 
 可通过 `docker logs cpa-manager-plus` 查看首次生成的管理员密钥。setup 完成后，同一入口地址会使用 Manager Server SQLite 中保存的 CPA 连接。新浏览器只需要在登录页填写管理员密钥。
 
-发布镜像支持 `linux/amd64` 和 `linux/arm64`。如果你的镜像发布在其他 Docker Hub 命名空间，把 `seakee/cpa-manager-plus:latest` 替换成实际镜像名。
+发布镜像支持 `linux/amd64` 和 `linux/arm64`。Docker 示例默认使用 Docker Hub。如果要从 GitHub Container Registry 拉取，把 `seakee/cpa-manager-plus:latest` 替换成 `ghcr.io/seakee/cpa-manager-plus:latest`。
 
 ### 原生运行包
 
@@ -193,6 +198,8 @@ volumes:
 ```bash
 docker compose up -d
 ```
+
+如果要使用 GitHub Container Registry，把 compose 中的镜像替换为 `ghcr.io/seakee/cpa-manager-plus:latest`。
 
 ### Linux 宿主机运行 CPA
 
@@ -388,13 +395,14 @@ go run ./cmd/cpa-manager-plus
 ## 构建与发布
 
 - Vite 输出单文件 `apps/web/dist/index.html`
-- 打 `vX.Y.Z` 标签会触发 `.github/workflows/release.yml`
+- 打 `vX.Y.Z` 或 `vX.Y.Z-beta` 这类预发布标签会触发 `.github/workflows/release.yml`
 - 发布流程会上传 `apps/web/dist/management.html`、原生运行包和 `checksums.txt` 到 GitHub Releases
 - 原生运行包会发布 `linux`、`darwin`、`windows` 的 `amd64` 和 `arm64` 版本，包内已内置管理面板
-- 同一个 workflow 会构建 `Dockerfile.manager-server` 并推送 `seakee/cpa-manager-plus`
+- 同一个 workflow 会构建 `Dockerfile.manager-server`，并把公开镜像推送到 Docker Hub 和 GitHub Container Registry
 - Docker 镜像会发布 `linux/amd64` 和 `linux/arm64`
-- workflow 会把 `README.md` 同步到 Docker Hub overview
-- 必需 GitHub secrets：
+- GitHub Container Registry 镜像是 `ghcr.io/seakee/cpa-manager-plus`，使用 workflow 自带的 `GITHUB_TOKEN` 和 `packages: write` 权限发布
+- 启用 Docker Hub 发布时，workflow 会把 `README.md` 同步到 Docker Hub overview
+- Docker Hub 发布的可选 GitHub secrets：
   - `DOCKERHUB_USERNAME`
   - `DOCKERHUB_TOKEN`
 


### PR DESCRIPTION
## Summary
Publish CPA Manager Plus container images to GitHub Container Registry while keeping Docker Hub publishing available when credentials are configured.

## Changes
- Add GHCR publishing with `packages: write` and `GITHUB_TOKEN` authentication.
- Keep Docker Hub publishing optional when Docker Hub secrets are configured.
- Mark prerelease tags as GitHub prereleases and avoid pushing `latest` for prerelease images.
- Add explicit OCI labels linking the image to this repository.
- Document Docker Hub and GHCR image usage in English and Chinese READMEs.

## Testing
- `git diff --check`
- YAML parsing for `.github/workflows/release.yml`
- `bash -n .github/workflows/release.yml`
- Local release-tag classification checks for `v0.1.0-beta`, `0525-beta`, and `v0.1.0`