### PR TITLE
✨ feat(dashboard): improve traffic and token charts

### DIFF
--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -496,6 +496,7 @@ export function DashboardPage() {
         <section className={styles.chartsRow}>
           <TrafficOverviewCard
             timeline={usageSummary.trafficTimeline}
+            trafficNowMs={usageSummary.summary?.window.now_ms}
             todayRequestHealthTimeline={usageSummary.todayRequestHealthTimeline}
             tokenMix={usageSummary.tokenMix}
             totalTokens={usageSummary.summary?.today.total_tokens}

--- a/apps/web/src/features/dashboard/components/TrafficOverviewCard.module.scss
+++ b/apps/web/src/features/dashboard/components/TrafficOverviewCard.module.scss
@@ -43,7 +43,7 @@
 }
 
 .activityCard {
-  .chartFrame {
+  .trafficChart {
     flex: 1 1 auto;
   }
 }
@@ -62,89 +62,157 @@
   }
 }
 
-.chartFrame {
+.trafficChart {
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 6px 20px 0 22px;
-  min-height: 0;
+  justify-content: center;
+  gap: 8px;
+  min-height: clamp(178px, 15vw, 208px);
+  padding: 4px 4px 0;
 }
 
-.yAxisLeft,
-.yAxisRight {
-  position: absolute;
-  top: 8px;
-  font-size: 11px;
-  color: var(--text-tertiary);
-}
-
-.yAxisLeft {
-  left: 0;
-}
-
-.yAxisRight {
-  right: 0;
-  color: #10b981;
-}
-
-.barChart {
+.trafficPlot {
+  position: relative;
   flex: 1 1 auto;
-  min-height: clamp(170px, 15vw, 208px);
+  min-height: 164px;
+  border-bottom: 1px solid var(--app-border);
+  overflow: hidden;
+}
+
+.trafficGridLines {
+  position: absolute;
+  inset: 8px 0 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  z-index: 0;
+  pointer-events: none;
+
+  span {
+    width: 100%;
+    height: 0;
+    border-top: 1px solid color-mix(in srgb, var(--app-border), transparent 42%);
+  }
+}
+
+.trafficBars {
+  position: absolute;
+  inset: 8px 0 6px;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(var(--bucket-count), minmax(0, 1fr));
+  align-items: end;
+  gap: 4px;
+  min-width: 0;
+}
+
+.trafficBucket {
+  position: relative;
   display: flex;
   align-items: flex-end;
-  gap: 4px;
-  padding: 16px 0 6px;
-  border-bottom: 1px solid var(--app-border);
-  position: relative;
+  justify-content: center;
+  height: 100%;
+  min-width: 0;
+  border-radius: 4px 4px 0 0;
+}
 
-  .barColumn {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    gap: 2px;
-    height: 100%;
-
-    .callBar {
-      height: calc(var(--calls-share) * 100%);
-      background: #3b82f6;
-      border-radius: 2px 2px 0 0;
-      min-height: 2px;
-      transition: height 0.3s ease;
-    }
-  }
-
-  .tokenLine {
+.trafficBucketPartial {
+  &::after {
+    content: '';
     position: absolute;
-    inset: 16px 0 6px;
-    width: 100%;
-    height: calc(100% - 22px);
-    overflow: visible;
+    inset: 0;
+    border-radius: 4px;
+    background: repeating-linear-gradient(
+      -45deg,
+      color-mix(in srgb, var(--app-surface-muted), transparent 30%) 0,
+      color-mix(in srgb, var(--app-surface-muted), transparent 30%) 2px,
+      transparent 2px,
+      transparent 5px
+    );
+    opacity: 0.32;
     pointer-events: none;
-
-    polyline {
-      fill: none;
-      stroke: #10b981;
-      stroke-width: 2.2;
-      vector-effect: non-scaling-stroke;
-    }
   }
 
-  .empty {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 13px;
-    color: var(--text-muted);
+  .trafficBar {
+    opacity: 0.62;
   }
 }
 
-.xAxis {
+.trafficBar {
+  width: 100%;
+  max-width: 34px;
+  height: max(var(--metric-min-height), calc(var(--metric-share) * 100%));
+  border-radius: 4px 4px 0 0;
+  transition: height 0.24s ease;
+}
+
+.tokensBar {
+  background: linear-gradient(180deg, #22c55e 0%, #10b981 100%);
+  box-shadow: 0 -1px 0 rgba(255, 255, 255, 0.28) inset;
+}
+
+.callsLineLayer {
+  position: absolute;
+  inset: 8px 0 6px;
+  z-index: 3;
+  width: 100%;
+  height: calc(100% - 14px);
+  overflow: visible;
+  pointer-events: none;
+
+  path {
+    fill: none;
+    stroke: #3b82f6;
+    stroke-width: 2.1;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    vector-effect: non-scaling-stroke;
+  }
+
+}
+
+.trafficYAxis {
+  position: absolute;
+  inset: 8px 0 auto;
+  z-index: 2;
   display: flex;
   justify-content: space-between;
-  padding: 0 4px;
-  span { font-size: 11px; color: var(--text-muted); }
+  pointer-events: none;
+
+  span {
+    color: var(--text-tertiary);
+    font-size: 11px;
+    line-height: 1;
+  }
+
+  span:last-child {
+    color: #3b82f6;
+  }
+}
+
+.trafficAxis {
+  display: grid;
+  grid-template-columns: repeat(var(--bucket-count), minmax(0, 1fr));
+  gap: 4px;
+  min-height: 14px;
+
+  span {
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+  }
+}
+
+.empty {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 13px;
+  color: var(--text-muted);
 }
 
 // 2. Request Health Timeline
@@ -295,9 +363,17 @@
 }
 
 .healthFuture {
-  background: transparent;
-  border: 1px dashed var(--app-border);
-  opacity: 0.55;
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      color-mix(in srgb, var(--app-surface-muted), transparent 30%) 0,
+      color-mix(in srgb, var(--app-surface-muted), transparent 30%) 2px,
+      transparent 2px,
+      transparent 5px
+    ),
+    color-mix(in srgb, var(--app-surface-muted), transparent 65%);
+  border: 1px solid color-mix(in srgb, var(--app-border), var(--text-muted) 38%);
+  opacity: 0.9;
 }
 
 .healthEmptyState {
@@ -337,156 +413,58 @@
   }
 }
 
-// 3. Doughnut
-.doughnutSection {
+// 3. Token rank
+.tokenRankSection {
   position: relative;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: center;
   flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
   min-height: 0;
-  padding: 0;
-  gap: 10px;
 }
 
-.doughnutChart {
-  width: min(100%, 210px);
-  aspect-ratio: 1;
-  position: relative;
-  align-self: center;
+.tokenSummary {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+  padding: 2px 2px 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--app-border), transparent 30%);
 
-  svg {
-    width: 100%;
-    height: 100%;
-    transform: rotate(-90deg);
+  span {
+    color: var(--text-tertiary);
+    font-size: 11px;
+    line-height: 1;
+    white-space: nowrap;
   }
-
-  .doughnutTrack,
-  .doughnutSegment {
-    fill: none;
-    stroke-width: 12;
-  }
-
-  .doughnutTrack {
-    stroke: var(--app-surface-muted);
-  }
-
-  .doughnutSegment {
-    stroke: var(--color);
-    stroke-dasharray: var(--dash);
-    stroke-dashoffset: var(--offset);
-    stroke-linecap: butt;
-    cursor: pointer;
-    outline: none;
-    transition:
-      opacity 0.18s ease,
-      stroke-width 0.18s ease,
-      filter 0.18s ease;
-
-    &:hover,
-    &:focus-visible {
-      filter: drop-shadow(0 3px 8px rgba(15, 23, 42, 0.18));
-      opacity: 0.92;
-      stroke-width: 13;
-    }
-  }
-
-  .doughnutSegmentActive {
-    filter: drop-shadow(0 3px 8px rgba(15, 23, 42, 0.18));
-    opacity: 0.92;
-    stroke-width: 13;
-  }
-
-  .doughnutCenter {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-
-    .centerLabel { font-size: 11px; color: var(--text-tertiary); }
-    .centerValue { font-size: 16px; font-weight: 700; color: var(--text-primary); }
-  }
-}
-
-.tokenTooltip {
-  position: absolute;
-  right: 4px;
-  bottom: 4px;
-  z-index: 2;
-  min-width: 112px;
-  padding: 8px 10px;
-  border: 1px solid var(--glass-border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--glass-bg), var(--app-bg) 20%);
-  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.16);
-  color: var(--text-primary);
-  pointer-events: none;
-  backdrop-filter: var(--glass-backdrop-filter);
 
   strong {
-    display: block;
-    margin-top: 5px;
-    font-size: 16px;
-    line-height: 1.1;
-  }
-
-  > span:last-child {
-    display: block;
-    margin-top: 3px;
-    color: var(--text-tertiary);
-    font-size: 12px;
-    font-weight: 600;
+    min-width: 0;
+    color: var(--text-primary);
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 
-.tokenTooltipLabel {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  color: var(--text-tertiary);
-  font-size: 12px;
-  line-height: 1;
-  white-space: nowrap;
-
-  i {
-    width: 8px;
-    height: 8px;
-    flex: 0 0 auto;
-    border-radius: 2px;
-  }
-}
-
-.tokenEmptyState {
-  position: absolute;
-  inset: 0;
+.tokenRankList {
   display: grid;
-  place-items: center;
-  color: var(--text-tertiary);
-  font-size: 12px;
-}
-
-.tokenBreakdownList {
-  display: grid;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
 }
 
-.tokenBreakdownRow {
+.tokenRankRow {
   appearance: none;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
   min-width: 0;
-  min-height: 28px;
-  padding: 5px 7px;
+  padding: 7px;
   border: 1px solid transparent;
   border-radius: 7px;
   background: transparent;
@@ -506,18 +484,27 @@
   }
 }
 
-.tokenBreakdownRowActive {
+.tokenRankRowActive {
   border-color: var(--app-border);
   background: color-mix(in srgb, var(--app-surface-muted), transparent 35%);
 }
 
-.tokenBreakdownLeft {
+.tokenRankHeader {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.tokenRankIdentity {
   display: inline-flex;
   align-items: center;
   gap: 7px;
   min-width: 0;
+  color: var(--text-secondary);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 650;
 
   span {
     min-width: 0;
@@ -527,36 +514,54 @@
   }
 }
 
-.tokenBreakdownSwatch {
+.tokenRankSwatch {
   width: 8px;
   height: 8px;
   flex: 0 0 auto;
   border-radius: 2px;
 }
 
-.tokenBreakdownValue {
-  color: var(--text-primary);
-  font-size: 12px;
-  font-weight: 750;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.tokenBreakdownShare {
-  min-width: 42px;
+.tokenRankMeta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
   color: var(--text-tertiary);
   font-size: 11px;
   font-weight: 650;
   font-variant-numeric: tabular-nums;
-  text-align: right;
   white-space: nowrap;
+
+  strong {
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 750;
+  }
 }
 
-@media (max-width: 480px) {
-  .doughnutChart {
-    width: min(100%, 240px);
-    justify-self: center;
-  }
+.tokenRankTrack {
+  display: block;
+  height: 7px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--app-surface-muted), transparent 18%);
+}
+
+.tokenRankBar {
+  display: block;
+  width: calc(var(--rank-share) * 100%);
+  height: 100%;
+  min-width: 0;
+  border-radius: inherit;
+  background: var(--rank-color);
+  transition: width 0.2s ease;
+}
+
+.tokenEmptyState {
+  display: grid;
+  min-height: 96px;
+  place-items: center;
+  color: var(--text-tertiary);
+  font-size: 12px;
 }
 
 @media (max-width: 1280px) and (min-width: 561px) {
@@ -576,17 +581,43 @@
     gap: 8px;
   }
 
-  .chartFrame {
-    padding-left: 0;
-    padding-right: 0;
+  .trafficChart {
+    gap: 8px;
+    min-height: 158px;
   }
 
-  .yAxisLeft,
-  .yAxisRight {
-    display: none;
+  .trafficBars {
+    gap: 2px;
   }
 
-  .xAxis span {
+  .trafficBar {
+    max-width: none;
+  }
+
+  .trafficPlot {
+    min-height: 146px;
+  }
+
+  .callsLineLayer {
+    path {
+      stroke-width: 1.8;
+    }
+
+  }
+
+  .trafficYAxis span {
+    font-size: 10px;
+  }
+
+  .trafficAxis {
+    gap: 2px;
+
+    span {
+      font-size: 10px;
+    }
+  }
+
+  .trafficAxis span {
     &:nth-child(even) {
       display: none;
     }
@@ -620,8 +651,4 @@
     font-size: 9px;
   }
 
-  .doughnutChart {
-    width: min(100%, 240px);
-    height: auto;
-  }
 }

--- a/apps/web/src/features/dashboard/components/TrafficOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/TrafficOverviewCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from 'react';
+import { useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {
   DashboardTodayRequestHealthTimeline,
@@ -7,19 +7,28 @@ import type {
   DashboardTrafficPoint,
 } from '@/services/api/usageService';
 import { formatCompactNumber } from '@/utils/usage';
+import {
+  buildCallsLinePath,
+  buildTrafficAxisTickIndexes,
+  buildVisibleTrafficTimeline,
+  getTrafficMetricShare,
+  isCurrentTrafficBucket,
+} from './trafficOverviewChartModel';
 import styles from './TrafficOverviewCard.module.scss';
 
 interface TrafficOverviewCardProps {
   timeline: DashboardTrafficPoint[];
+  trafficNowMs?: number | null;
   todayRequestHealthTimeline: DashboardTodayRequestHealthTimeline | null;
   tokenMix: DashboardTokenMixSegment[];
   totalTokens?: number;
   loading: boolean;
 }
 
-type ChartStyle = CSSProperties & Record<'--calls-share' | '--tokens-share', number>;
+type TrafficGridStyle = CSSProperties & Record<'--bucket-count', number>;
+type TrafficBarStyle = CSSProperties & Record<'--metric-share' | '--metric-min-height', number | string>;
+type TokenRankStyle = CSSProperties & Record<'--rank-share' | '--rank-color', number | string>;
 type HealthCellStyle = CSSProperties & Record<'--cell-intensity', number>;
-type DonutStyle = CSSProperties & Record<'--dash' | '--offset' | '--color', string>;
 
 const fallbackHealthBucketMs = 10 * 60 * 1000;
 
@@ -74,6 +83,7 @@ const buildHealthTitle = (
 
 export function TrafficOverviewCard({
   timeline,
+  trafficNowMs,
   todayRequestHealthTimeline,
   tokenMix,
   totalTokens: todayTotalTokens,
@@ -81,17 +91,16 @@ export function TrafficOverviewCard({
 }: TrafficOverviewCardProps) {
   const { t, i18n } = useTranslation();
   const [activeTokenSegment, setActiveTokenSegment] = useState<DashboardTokenMixSegment | null>(null);
-  const hasData = timeline.some((point) => point.calls > 0 || point.tokens > 0);
+  const visibleTimeline = buildVisibleTrafficTimeline(timeline, trafficNowMs);
+  const hasData = visibleTimeline.some((point) => point.calls > 0 || point.tokens > 0);
   const tokenMixTotal = tokenMix.reduce((acc, s) => acc + s.tokens, 0);
   const displayTotalTokens = todayTotalTokens ?? tokenMixTotal;
   const hasTokenMixData = tokenMix.some((segment) => segment.tokens > 0);
-  const tokenPolyline = timeline
-    .map((point, index) => {
-      const x = timeline.length <= 1 ? 50 : (index / (timeline.length - 1)) * 100;
-      const y = 100 - Math.max(0, Math.min(1, point.tokens_share)) * 100;
-      return `${x},${y}`;
-    })
-    .join(' ');
+  const rankedTokenMix = [...tokenMix].sort((left, right) => right.tokens - left.tokens);
+  const maxTokenMixTokens = rankedTokenMix.reduce((max, segment) => Math.max(max, segment.tokens), 0);
+  const trafficAxisTickIndexes = buildTrafficAxisTickIndexes(visibleTimeline.length);
+  const trafficGridStyle = { '--bucket-count': Math.max(visibleTimeline.length, 1) } as TrafficGridStyle;
+  const callsLinePath = buildCallsLinePath(visibleTimeline);
   const healthPoints = todayRequestHealthTimeline?.points ?? [];
   const healthBucketMs = todayRequestHealthTimeline?.bucket_ms || fallbackHealthBucketMs;
   const healthRowsPerHour = Math.max(1, Math.round((60 * 60 * 1000) / healthBucketMs));
@@ -119,43 +128,59 @@ export function TrafficOverviewCard({
             </span>
           </div>
         </div>
-        <div className={styles.chartFrame}>
-          <div className={styles.yAxisLeft}>{t('dashboard.traffic_calls')}</div>
-          <div className={styles.yAxisRight}>{t('dashboard.traffic_tokens')}</div>
-          <div className={styles.barChart}>
-            {timeline.map((point) => (
-              <div
-                key={point.bucket_ms}
-                className={styles.barColumn}
-                style={
-                  {
-                    '--calls-share': point.calls_share,
-                    '--tokens-share': point.tokens_share,
-                  } as ChartStyle
-                }
-                title={`${formatHour(point.bucket_ms, i18n.language)} · ${t('dashboard.traffic_calls')}: ${formatCompactNumber(point.calls)} · ${t('dashboard.traffic_tokens')}: ${formatCompactNumber(point.tokens)}`}
-              >
-                <div className={styles.callBar} />
-              </div>
-            ))}
-            {hasData && (
-              <svg className={styles.tokenLine} viewBox="0 0 100 100" preserveAspectRatio="none">
-                <polyline points={tokenPolyline} />
+        <div className={styles.trafficChart}>
+          <div className={styles.trafficPlot}>
+            <div className={styles.trafficGridLines} aria-hidden="true">
+              {Array.from({ length: 5 }, (_, index) => <span key={index} />)}
+            </div>
+            <div className={styles.trafficBars} style={trafficGridStyle}>
+              {visibleTimeline.map((point) => {
+                const share = getTrafficMetricShare(point, 'tokens');
+                return (
+                  <div
+                    key={point.bucket_ms}
+                    className={`${styles.trafficBucket} ${
+                      isCurrentTrafficBucket(point, trafficNowMs) ? styles.trafficBucketPartial : ''
+                    }`}
+                    title={`${formatHour(point.bucket_ms, i18n.language)} · ${t('dashboard.traffic_calls')}: ${formatCompactNumber(point.calls)} · ${t('dashboard.traffic_tokens')}: ${formatCompactNumber(point.tokens)}`}
+                  >
+                    <div
+                      className={`${styles.trafficBar} ${styles.tokensBar}`}
+                      style={
+                        {
+                          '--metric-share': share,
+                          '--metric-min-height': share > 0 ? '2px' : '0px',
+                        } as TrafficBarStyle
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            {hasData ? (
+              <svg className={styles.callsLineLayer} viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+                <path d={callsLinePath} />
               </svg>
-            )}
+            ) : null}
+            <div className={styles.trafficYAxis} aria-hidden="true">
+              <span>{t('dashboard.traffic_tokens')}</span>
+              <span>{t('dashboard.traffic_calls')}</span>
+            </div>
             {!hasData && !loading && (
               <div className={styles.empty}>{t('dashboard.no_traffic_data')}</div>
             )}
             {loading && !hasData && <div className={styles.empty}>...</div>}
           </div>
-        </div>
-        <div className={styles.xAxis}>
-          <span>00:00</span>
-          <span>04:00</span>
-          <span>08:00</span>
-          <span>12:00</span>
-          <span>16:00</span>
-          <span>20:00</span>
+          <div className={styles.trafficAxis} style={trafficGridStyle}>
+            {trafficAxisTickIndexes.map((index) => {
+              const point = visibleTimeline[index];
+              return point ? (
+                <span key={point.bucket_ms} style={{ gridColumn: index + 1 }}>
+                  {formatHour(point.bucket_ms, i18n.language)}
+                </span>
+              ) : null;
+            })}
+          </div>
         </div>
       </section>
 
@@ -238,104 +263,59 @@ export function TrafficOverviewCard({
         <div className={styles.cardHeader}>
           <h3>{t('dashboard.token_mix_today')}</h3>
         </div>
-        <div className={styles.doughnutSection}>
-          <div className={styles.doughnutChart}>
-            <svg viewBox="0 0 100 100">
-              <circle className={styles.doughnutTrack} cx="50" cy="50" r="35" />
-              {
-                tokenMix.reduce(
-                  (acc, segment) => {
-                    const startAngle = acc.currentAngle;
-                    const sweepAngle = segment.share * 360;
-                    acc.currentAngle += sweepAngle;
-
-                    const radius = 35;
-                    const circumference = 2 * Math.PI * radius;
-                    const offset = (startAngle / 360) * circumference;
-                    const length = segment.share * circumference;
-
-                    return {
-                      ...acc,
-                      elements: [
-                        ...acc.elements,
-                        <circle
-                          key={segment.key}
-                          cx="50"
-                          cy="50"
-                          r={radius}
-                          fill="none"
-                          className={`${styles.doughnutSegment} ${
-                            activeTokenSegment?.key === segment.key ? styles.doughnutSegmentActive : ''
-                          }`}
-                          style={
-                            {
-                              '--dash': `${length} ${circumference}`,
-                              '--offset': `${-offset}`,
-                              '--color': tokenColorMap[segment.key] || '#ccc',
-                            } as DonutStyle
-                          }
-                          tabIndex={0}
-                          role="img"
-                          aria-label={`${t(tokenLabelMap[segment.key] || segment.key)} ${formatCompactNumber(segment.tokens)} ${(segment.share * 100).toFixed(1)}%`}
-                          onMouseEnter={() => setActiveTokenSegment(segment)}
-                          onMouseLeave={() => setActiveTokenSegment(null)}
-                          onFocus={() => setActiveTokenSegment(segment)}
-                          onBlur={() => setActiveTokenSegment(null)}
-                        />,
-                      ],
-                    };
-                  },
-                  { currentAngle: 0, elements: [] as ReactNode[] }
-                ).elements
-              }
-            </svg>
-            <div className={styles.doughnutCenter}>
-              <span className={styles.centerLabel}>{t('dashboard.total_tokens')}</span>
-              <span className={styles.centerValue}>{formatCompactNumber(displayTotalTokens)}</span>
+        <div className={styles.tokenRankSection}>
+          <div className={styles.tokenSummary}>
+            <span>{t('dashboard.total_tokens')}</span>
+            <strong>{loading && !hasTokenMixData ? '...' : formatCompactNumber(displayTotalTokens)}</strong>
+          </div>
+          {hasTokenMixData ? (
+            <div className={styles.tokenRankList}>
+              {rankedTokenMix.map((segment) => (
+                <button
+                  type="button"
+                  key={segment.key}
+                  className={`${styles.tokenRankRow} ${
+                    activeTokenSegment?.key === segment.key ? styles.tokenRankRowActive : ''
+                  }`}
+                  onMouseEnter={() => setActiveTokenSegment(segment)}
+                  onMouseLeave={() => setActiveTokenSegment(null)}
+                  onFocus={() => setActiveTokenSegment(segment)}
+                  onBlur={() => setActiveTokenSegment(null)}
+                  aria-label={`${t(tokenLabelMap[segment.key] || segment.key)} ${formatCompactNumber(segment.tokens)} ${(segment.share * 100).toFixed(1)}%`}
+                >
+                  <span className={styles.tokenRankHeader}>
+                    <span className={styles.tokenRankIdentity}>
+                      <i
+                        className={styles.tokenRankSwatch}
+                        style={{ background: tokenColorMap[segment.key] || '#ccc' }}
+                        aria-hidden="true"
+                      />
+                      <span>{t(tokenLabelMap[segment.key] || segment.key)}</span>
+                    </span>
+                    <span className={styles.tokenRankMeta}>
+                      <strong>{formatCompactNumber(segment.tokens)}</strong>
+                      <span>{(segment.share * 100).toFixed(1)}%</span>
+                    </span>
+                  </span>
+                  <span className={styles.tokenRankTrack}>
+                    <span
+                      className={styles.tokenRankBar}
+                      style={
+                        {
+                          '--rank-share': maxTokenMixTokens > 0 ? segment.tokens / maxTokenMixTokens : 0,
+                          '--rank-color': tokenColorMap[segment.key] || '#ccc',
+                        } as TokenRankStyle
+                      }
+                    />
+                  </span>
+                </button>
+              ))}
             </div>
-            {!hasTokenMixData ? (
-              <div className={styles.tokenEmptyState}>
-                {loading ? '...' : t('dashboard.no_token_mix_data')}
-              </div>
-            ) : null}
-            {activeTokenSegment ? (
-              <div className={styles.tokenTooltip}>
-                <span className={styles.tokenTooltipLabel}>
-                  <i style={{ background: tokenColorMap[activeTokenSegment.key] || '#ccc' }} />
-                  {t(tokenLabelMap[activeTokenSegment.key] || activeTokenSegment.key)}
-                </span>
-                <strong>{formatCompactNumber(activeTokenSegment.tokens)}</strong>
-                <span>{(activeTokenSegment.share * 100).toFixed(1)}%</span>
-              </div>
-            ) : null}
-          </div>
-          <div className={styles.tokenBreakdownList}>
-            {tokenMix.map((segment) => (
-              <button
-                type="button"
-                key={segment.key}
-                className={`${styles.tokenBreakdownRow} ${
-                  activeTokenSegment?.key === segment.key ? styles.tokenBreakdownRowActive : ''
-                }`}
-                onMouseEnter={() => setActiveTokenSegment(segment)}
-                onMouseLeave={() => setActiveTokenSegment(null)}
-                onFocus={() => setActiveTokenSegment(segment)}
-                onBlur={() => setActiveTokenSegment(null)}
-                aria-label={`${t(tokenLabelMap[segment.key] || segment.key)} ${formatCompactNumber(segment.tokens)} ${(segment.share * 100).toFixed(1)}%`}
-              >
-                <span className={styles.tokenBreakdownLeft}>
-                  <i
-                    className={styles.tokenBreakdownSwatch}
-                    style={{ background: tokenColorMap[segment.key] || '#ccc' }}
-                    aria-hidden="true"
-                  />
-                  <span>{t(tokenLabelMap[segment.key] || segment.key)}</span>
-                </span>
-                <span className={styles.tokenBreakdownValue}>{formatCompactNumber(segment.tokens)}</span>
-                <span className={styles.tokenBreakdownShare}>{(segment.share * 100).toFixed(1)}%</span>
-              </button>
-            ))}
-          </div>
+          ) : (
+            <div className={styles.tokenEmptyState}>
+              {loading ? '...' : t('dashboard.no_token_mix_data')}
+            </div>
+          )}
         </div>
       </section>
     </div>

--- a/apps/web/src/features/dashboard/components/trafficOverviewChartModel.test.ts
+++ b/apps/web/src/features/dashboard/components/trafficOverviewChartModel.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { DashboardTrafficPoint } from '@/services/api/usageService';
+import {
+  buildCallsLinePath,
+  buildCallsLinePoints,
+  buildTrafficAxisTickIndexes,
+  buildVisibleTrafficTimeline,
+  getTrafficPointX,
+  getTrafficMetricShare,
+  isCurrentTrafficBucket,
+} from './trafficOverviewChartModel';
+
+const point = (hour: number, calls = 0, tokens = 0): DashboardTrafficPoint => ({
+  bucket_ms: Date.UTC(2026, 0, 1, hour, 0, 0),
+  calls,
+  tokens,
+  success: calls,
+  failure: 0,
+  calls_share: calls > 0 ? calls / 10 : 0,
+  tokens_share: tokens > 0 ? tokens / 100 : 0,
+  failure_rate: 0,
+});
+
+describe('trafficOverviewChartModel', () => {
+  it('starts visible traffic at the first used bucket and stops at the elapsed bucket', () => {
+    const timeline = [
+      point(0),
+      point(1),
+      point(2, 4, 20),
+      point(3),
+      point(4, 2, 50),
+      point(5),
+      point(6),
+    ];
+
+    expect(buildVisibleTrafficTimeline(timeline, point(5).bucket_ms).map((item) => item.bucket_ms)).toEqual([
+      point(2).bucket_ms,
+      point(3).bucket_ms,
+      point(4).bucket_ms,
+      point(5).bucket_ms,
+    ]);
+  });
+
+  it('keeps elapsed empty buckets when there is no traffic yet', () => {
+    const timeline = [point(0), point(1), point(2), point(3)];
+
+    expect(buildVisibleTrafficTimeline(timeline, point(2).bucket_ms)).toHaveLength(3);
+  });
+
+  it('builds evenly distributed axis tick indexes', () => {
+    expect(buildTrafficAxisTickIndexes(10)).toEqual([0, 2, 4, 5, 7, 9]);
+    expect(buildTrafficAxisTickIndexes(3)).toEqual([0, 1, 2]);
+  });
+
+  it('clamps metric shares for chart bars', () => {
+    const row = { ...point(7, 20, 200), calls_share: 1.8, tokens_share: -0.2 };
+
+    expect(getTrafficMetricShare(row, 'calls')).toBe(1);
+    expect(getTrafficMetricShare(row, 'tokens')).toBe(0);
+  });
+
+  it('marks only the current elapsed bucket as partial', () => {
+    const row = point(12, 2, 10);
+
+    expect(isCurrentTrafficBucket(row, Date.UTC(2026, 0, 1, 12, 30, 0))).toBe(true);
+    expect(isCurrentTrafficBucket(row, Date.UTC(2026, 0, 1, 13, 0, 0))).toBe(false);
+    expect(isCurrentTrafficBucket(row, null)).toBe(false);
+  });
+
+  it('places line points at bucket centers', () => {
+    expect(getTrafficPointX(0, 4)).toBe(12.5);
+    expect(getTrafficPointX(3, 4)).toBe(87.5);
+    expect(getTrafficPointX(0, 1)).toBe(50);
+  });
+
+  it('builds a linear calls path without curve commands', () => {
+    const rows = [point(7, 2, 10), point(8, 6, 80), point(9, 3, 30)];
+    const path = buildCallsLinePath(rows);
+    const points = buildCallsLinePoints(rows);
+
+    expect(path).toBe('M 16.667 80 L 50 40 L 83.333 70');
+    expect(path).not.toContain('C');
+    expect(points.map((item) => item.bucketMs)).toEqual(rows.map((item) => item.bucket_ms));
+  });
+});

--- a/apps/web/src/features/dashboard/components/trafficOverviewChartModel.ts
+++ b/apps/web/src/features/dashboard/components/trafficOverviewChartModel.ts
@@ -1,0 +1,94 @@
+import type { DashboardTrafficPoint } from '@/services/api/usageService';
+
+export type TrafficMetric = 'calls' | 'tokens';
+
+export interface TrafficLinePoint {
+  bucketMs: number;
+  x: number;
+  y: number;
+}
+
+const hasTraffic = (point: DashboardTrafficPoint) => point.calls > 0 || point.tokens > 0;
+
+const clampShare = (value: number) => Math.max(0, Math.min(1, value));
+
+const formatCoord = (value: number) =>
+  Number.isInteger(value) ? String(value) : value.toFixed(3).replace(/\.?0+$/, '');
+
+const findLastElapsedIndex = (timeline: DashboardTrafficPoint[], nowMs?: number | null) => {
+  if (typeof nowMs !== 'number' || !Number.isFinite(nowMs)) {
+    return timeline.length - 1;
+  }
+
+  for (let index = timeline.length - 1; index >= 0; index -= 1) {
+    if (timeline[index].bucket_ms <= nowMs) {
+      return index;
+    }
+  }
+
+  return -1;
+};
+
+export const buildVisibleTrafficTimeline = (
+  timeline: DashboardTrafficPoint[],
+  nowMs?: number | null
+) => {
+  if (timeline.length === 0) {
+    return [];
+  }
+
+  const lastElapsedIndex = findLastElapsedIndex(timeline, nowMs);
+  const endIndex = Math.max(0, lastElapsedIndex);
+  const firstDataIndex = timeline.findIndex((point, index) => index <= endIndex && hasTraffic(point));
+
+  if (firstDataIndex < 0) {
+    return timeline.slice(0, endIndex + 1);
+  }
+
+  return timeline.slice(firstDataIndex, endIndex + 1);
+};
+
+export const buildTrafficAxisTickIndexes = (pointCount: number, maxTicks = 6) => {
+  if (pointCount <= 0) {
+    return [];
+  }
+  if (pointCount <= maxTicks) {
+    return Array.from({ length: pointCount }, (_, index) => index);
+  }
+
+  const tickCount = Math.max(2, maxTicks);
+  const indexes = new Set<number>();
+  for (let index = 0; index < tickCount; index += 1) {
+    indexes.add(Math.round((index * (pointCount - 1)) / (tickCount - 1)));
+  }
+
+  return Array.from(indexes).sort((left, right) => left - right);
+};
+
+export const getTrafficMetricShare = (point: DashboardTrafficPoint, metric: TrafficMetric) =>
+  clampShare(metric === 'calls' ? point.calls_share : point.tokens_share);
+
+export const getTrafficPointX = (index: number, pointCount: number) =>
+  pointCount <= 0 ? 0 : ((index + 0.5) / pointCount) * 100;
+
+export const buildCallsLinePoints = (timeline: DashboardTrafficPoint[]): TrafficLinePoint[] =>
+  timeline.map((point, index) => ({
+    bucketMs: point.bucket_ms,
+    x: getTrafficPointX(index, timeline.length),
+    y: 100 - getTrafficMetricShare(point, 'calls') * 100,
+  }));
+
+export const buildCallsLinePath = (timeline: DashboardTrafficPoint[]) =>
+  buildCallsLinePoints(timeline)
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${formatCoord(point.x)} ${formatCoord(point.y)}`)
+    .join(' ');
+
+export const isCurrentTrafficBucket = (
+  point: DashboardTrafficPoint,
+  nowMs?: number | null,
+  bucketMs = 60 * 60 * 1000
+) =>
+  typeof nowMs === 'number' &&
+  Number.isFinite(nowMs) &&
+  nowMs >= point.bucket_ms &&
+  nowMs < point.bucket_ms + bucketMs;


### PR DESCRIPTION
## Summary
Improve the dashboard traffic and token composition charts for clearer daily monitoring.

## Changes
- Start the traffic trend at the first active bucket and stop at the elapsed bucket.
- Show token volume as bars with a linear call trend overlay and clearer current/future bucket styling.
- Replace the token mix donut with compact ranked token bars.
- Add chart model helpers and focused coverage for timeline trimming, axis ticks, and call line generation.

## Testing
- npm --workspace apps/web run test -- src/features/dashboard/components/trafficOverviewChartModel.test.ts
- npm --workspace apps/web run type-check
- ./node_modules/.bin/sass --no-source-map apps/web/src/features/dashboard/components/TrafficOverviewCard.module.scss