### PR TITLE
feat(web): persist UI page preferences

### DIFF
--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -35,7 +35,7 @@ import {
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 import { isFileLogsAvailable } from '@/features/logs/logFeatureAvailability';
-import { LANGUAGE_LABEL_KEYS, LANGUAGE_ORDER } from '@/utils/constants';
+import { LANGUAGE_LABEL_KEYS, LANGUAGE_ORDER, STORAGE_KEY_SIDEBAR } from '@/utils/constants';
 import { isSupportedLanguage } from '@/utils/language';
 import type { Theme } from '@/types';
 
@@ -182,7 +182,13 @@ export function MainLayout() {
   const setLanguage = useLanguageStore((state) => state.setLanguage);
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY_SIDEBAR) === 'true';
+    } catch {
+      return false;
+    }
+  });
   const [languageMenuOpen, setLanguageMenuOpen] = useState(false);
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -488,7 +494,15 @@ export function MainLayout() {
                   setSidebarOpen((prev) => !prev);
                   return;
                 }
-                setSidebarCollapsed((prev) => !prev);
+                setSidebarCollapsed((prev) => {
+                  const next = !prev;
+                  try {
+                    localStorage.setItem(STORAGE_KEY_SIDEBAR, String(next));
+                  } catch {
+                    /* ignore storage failures */
+                  }
+                  return next;
+                });
               }}
               title={mobileSidebarToggleLabel}
               aria-label={mobileSidebarToggleLabel}

--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -15,6 +15,7 @@ import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
 import type { QuotaConfig, QuotaSortMode } from './quotaConfigs';
+import type { QuotaSectionViewMode } from '@/features/quota/quotaPageUiState';
 import { useGridColumns } from './useGridColumns';
 import { IconRefreshCw } from '@/components/ui/icons';
 import styles from '@/features/quota/QuotaPage.module.scss';
@@ -22,8 +23,6 @@ import styles from '@/features/quota/QuotaPage.module.scss';
 type QuotaUpdater<T> = T | ((prev: T) => T);
 
 type QuotaSetter<T> = (updater: QuotaUpdater<T>) => void;
-
-type ViewMode = 'paged' | 'all';
 
 const MAX_ITEMS_PER_PAGE = 25;
 const MAX_SHOW_ALL_THRESHOLD = 30;
@@ -109,6 +108,8 @@ interface QuotaSectionProps<TState extends QuotaStatusState, TData> {
   disabled: boolean;
   searchQuery?: string;
   sortMode?: QuotaSortMode;
+  viewMode?: QuotaSectionViewMode;
+  onViewModeChange?: (viewMode: QuotaSectionViewMode) => void;
 }
 
 export function QuotaSection<TState extends QuotaStatusState, TData>({
@@ -117,7 +118,9 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   loading,
   disabled,
   searchQuery = '',
-  sortMode = 'default'
+  sortMode = 'default',
+  viewMode,
+  onViewModeChange
 }: QuotaSectionProps<TState, TData>) {
   const { t } = useTranslation();
   const resolvedTheme: ResolvedTheme = useThemeStore((state) => state.resolvedTheme);
@@ -128,8 +131,19 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
   /* Removed useRef */
   const [columns, gridRef] = useGridColumns(380); // Min card width 380px matches SCSS
-  const [viewMode, setViewMode] = useState<ViewMode>('paged');
+  const [internalViewMode, setInternalViewMode] = useState<QuotaSectionViewMode>('paged');
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
+  const resolvedViewMode = viewMode ?? internalViewMode;
+  const setViewMode = useCallback(
+    (nextViewMode: QuotaSectionViewMode) => {
+      if (onViewModeChange) {
+        onViewModeChange(nextViewMode);
+      } else {
+        setInternalViewMode(nextViewMode);
+      }
+    },
+    [onViewModeChange]
+  );
 
   const filteredFiles = useMemo(() => files.filter((file) => config.filterFn(file)), [
     files,
@@ -193,7 +207,8 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   }, [config, filteredFiles, normalizedSearchQuery, quota, sortMode, t]);
 
   const showAllAllowed = displayFiles.length <= MAX_SHOW_ALL_THRESHOLD;
-  const effectiveViewMode: ViewMode = viewMode === 'all' && !showAllAllowed ? 'paged' : viewMode;
+  const effectiveViewMode: QuotaSectionViewMode =
+    resolvedViewMode === 'all' && !showAllAllowed ? 'paged' : resolvedViewMode;
 
   const {
     pageSize,
@@ -209,7 +224,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
   useEffect(() => {
     if (showAllAllowed) return;
-    if (viewMode !== 'all') return;
+    if (resolvedViewMode !== 'all') return;
 
     let cancelled = false;
     queueMicrotask(() => {
@@ -221,7 +236,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     return () => {
       cancelled = true;
     };
-  }, [showAllAllowed, viewMode]);
+  }, [resolvedViewMode, setViewMode, showAllAllowed]);
 
   // Update page size based on view mode and columns
   useEffect(() => {

--- a/apps/web/src/features/authFiles/AuthFilesPage.authJsonPaste.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.authJsonPaste.test.tsx
@@ -135,6 +135,8 @@ vi.mock('@/features/authFiles/hooks/useAuthFilesStatusBarCache', () => ({
 
 vi.mock('@/features/authFiles/uiState', () => ({
   normalizeAuthFilesSortMode: (value: string) => (value === 'default' ? 'default' : null),
+  normalizeAuthFilesViewMode: (value: string) =>
+    value === 'diagram' || value === 'list' ? value : null,
   readAuthFilesUiState: () => null,
   readPersistedAuthFilesCompactMode: () => null,
   writeAuthFilesUiState: vi.fn(),

--- a/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
@@ -143,6 +143,8 @@ vi.mock('@/features/authFiles/hooks/useAuthFilesStatusBarCache', () => ({
 
 vi.mock('@/features/authFiles/uiState', () => ({
   normalizeAuthFilesSortMode: (value: string) => (value === 'default' ? 'default' : null),
+  normalizeAuthFilesViewMode: (value: string) =>
+    value === 'diagram' || value === 'list' ? value : null,
   readAuthFilesUiState: () => null,
   readPersistedAuthFilesCompactMode: () => null,
   writeAuthFilesUiState: vi.fn(),

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -67,6 +67,7 @@ import {
 } from '@/features/authFiles/model/authFilesPageModel';
 import {
   normalizeAuthFilesSortMode,
+  normalizeAuthFilesViewMode,
   readAuthFilesUiState,
   readPersistedAuthFilesCompactMode,
   writeAuthFilesUiState,
@@ -245,6 +246,10 @@ export function AuthFilesPage() {
       if (persistedSortMode) {
         setSortMode(persistedSortMode);
       }
+      const persistedViewMode = normalizeAuthFilesViewMode(persisted.viewMode);
+      if (persistedViewMode) {
+        setViewMode(persistedViewMode);
+      }
     }
 
     setUiStateHydrated(true);
@@ -265,6 +270,7 @@ export function AuthFilesPage() {
       regularPageSize: pageSizeByMode.regular,
       compactPageSize: pageSizeByMode.compact,
       sortMode,
+      viewMode,
     });
     writePersistedAuthFilesCompactMode(compactMode);
   }, [
@@ -279,6 +285,7 @@ export function AuthFilesPage() {
     search,
     sortMode,
     uiStateHydrated,
+    viewMode,
   ]);
 
   useEffect(() => {

--- a/apps/web/src/features/authFiles/uiState.test.ts
+++ b/apps/web/src/features/authFiles/uiState.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAuthFilesSortMode, normalizeAuthFilesViewMode } from './uiState';
+
+describe('authFiles uiState', () => {
+  it('normalizes persisted sort modes', () => {
+    expect(normalizeAuthFilesSortMode('default')).toBe('default');
+    expect(normalizeAuthFilesSortMode('priority')).toBe('priority-desc');
+    expect(normalizeAuthFilesSortMode('bad')).toBeNull();
+  });
+
+  it('normalizes persisted view modes', () => {
+    expect(normalizeAuthFilesViewMode('diagram')).toBe('diagram');
+    expect(normalizeAuthFilesViewMode('list')).toBe('list');
+    expect(normalizeAuthFilesViewMode('bad')).toBeNull();
+  });
+});

--- a/apps/web/src/features/authFiles/uiState.ts
+++ b/apps/web/src/features/authFiles/uiState.ts
@@ -10,6 +10,7 @@ export const AUTH_FILES_SORT_MODES = [
 ] as const;
 
 export type AuthFilesSortMode = (typeof AUTH_FILES_SORT_MODES)[number];
+export type AuthFilesViewMode = 'diagram' | 'list';
 
 export type AuthFilesUiState = {
   filter?: string;
@@ -23,6 +24,7 @@ export type AuthFilesUiState = {
   regularPageSize?: number;
   compactPageSize?: number;
   sortMode?: AuthFilesSortMode;
+  viewMode?: AuthFilesViewMode;
 };
 
 const AUTH_FILES_UI_STATE_KEY = 'authFilesPage.uiState';
@@ -41,6 +43,9 @@ export const normalizeAuthFilesSortMode = (value: unknown): AuthFilesSortMode | 
   if (typeof value !== 'string') return null;
   return LEGACY_AUTH_FILES_SORT_MODE_MAP[value] ?? null;
 };
+
+export const normalizeAuthFilesViewMode = (value: unknown): AuthFilesViewMode | null =>
+  value === 'diagram' || value === 'list' ? value : null;
 
 const readAuthFilesUiStateFromStorage = (
   storage: Pick<Storage, 'getItem'> | null | undefined

--- a/apps/web/src/features/monitoring/ModelPricesPage.tsx
+++ b/apps/web/src/features/monitoring/ModelPricesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
@@ -21,6 +21,10 @@ import {
   type ModelPriceFilter,
   type PriceDraft,
 } from '@/features/monitoring/model/modelPricesPageModel';
+import {
+  readModelPricesPageUiState,
+  writeModelPricesPageUiState,
+} from './modelPricesPageUiState';
 import styles from './ModelPricesPage.module.scss';
 
 const FILTERS: ModelPriceFilter[] = ['all', 'missing', 'candidates', 'saved'];
@@ -38,8 +42,9 @@ export function ModelPricesPage() {
   const featureAvailability = usePanelFeatureAvailability();
   const { usage, loading, modelPrices, setModelPrices, syncModelPrices, usageServiceAvailable } =
     useUsageData();
-  const [search, setSearch] = useState('');
-  const [filter, setFilter] = useState<ModelPriceFilter>('all');
+  const initialUiState = useRef(readModelPricesPageUiState());
+  const [search, setSearch] = useState(() => initialUiState.current.search);
+  const [filter, setFilter] = useState<ModelPriceFilter>(() => initialUiState.current.filter);
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState<ModelPriceSyncResponse | null>(null);
   const [selectedCandidates, setSelectedCandidates] = useState<Record<string, string>>({});
@@ -71,6 +76,10 @@ export function ModelPricesPage() {
     }),
     [summary]
   );
+
+  useEffect(() => {
+    writeModelPricesPageUiState({ search, filter });
+  }, [filter, search]);
 
   const handleSync = async () => {
     if (syncModels.length === 0) {

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -113,7 +113,6 @@ import styles from './MonitoringCenterPage.module.scss';
 export { AccountExpandedDetails, AccountOverviewCard };
 
 const DEFAULT_ACCOUNT_PAGE_SIZE = ACCOUNT_OVERVIEW_TABLE_PAGE_SIZE_OPTIONS[0];
-const DEFAULT_REALTIME_PAGE_SIZE = 10;
 const MAX_USAGE_IMPORT_FILE_SIZE = 64 * 1024 * 1024;
 const EMPTY_STATUS_BAR_DATA: StatusBarData = {
   blocks: [],
@@ -130,19 +129,47 @@ export function MonitoringCenterPage() {
   const showNotification = useNotificationStore((state) => state.showNotification);
   const showConfirmation = useNotificationStore((state) => state.showConfirmation);
   const requestMonitoringAvailability = useRequestMonitoringAvailability();
-  const [timeRange, setTimeRange] = useState<MonitoringTimeRange>('today');
-  const [customStartInput, setCustomStartInput] = useState(getTodayStartInputValue);
-  const [customEndInput, setCustomEndInput] = useState(getCurrentInputValue);
-  const [customDraftStartInput, setCustomDraftStartInput] = useState(getTodayStartInputValue);
-  const [customDraftEndInput, setCustomDraftEndInput] = useState(getCurrentInputValue);
-  const [searchInput, setSearchInput] = useState('');
-  const [autoRefreshMs, setAutoRefreshMs] = useState('5000');
-  const [selectedAccount, setSelectedAccount] = useState('all');
-  const [selectedProvider, setSelectedProvider] = useState('all');
-  const [selectedModel, setSelectedModel] = useState('all');
-  const [selectedChannel, setSelectedChannel] = useState('all');
-  const [selectedApiKeyHash, setSelectedApiKeyHash] = useState('all');
-  const [selectedStatus, setSelectedStatus] = useState<StatusFilter>('all');
+  const initialAccountOverviewUiState = useRef(readAccountOverviewUiState());
+  const initialMonitoringCenterUiState = useRef(readMonitoringCenterUiState());
+  const [timeRange, setTimeRange] = useState<MonitoringTimeRange>(
+    initialMonitoringCenterUiState.current.timeRange
+  );
+  const [customStartInput, setCustomStartInput] = useState(
+    () => initialMonitoringCenterUiState.current.customStartInput || getTodayStartInputValue()
+  );
+  const [customEndInput, setCustomEndInput] = useState(
+    () => initialMonitoringCenterUiState.current.customEndInput || getCurrentInputValue()
+  );
+  const [customDraftStartInput, setCustomDraftStartInput] = useState(
+    () => initialMonitoringCenterUiState.current.customStartInput || getTodayStartInputValue()
+  );
+  const [customDraftEndInput, setCustomDraftEndInput] = useState(
+    () => initialMonitoringCenterUiState.current.customEndInput || getCurrentInputValue()
+  );
+  const [searchInput, setSearchInput] = useState(
+    () => initialMonitoringCenterUiState.current.searchInput
+  );
+  const [autoRefreshMs, setAutoRefreshMs] = useState(
+    () => initialMonitoringCenterUiState.current.autoRefreshMs
+  );
+  const [selectedAccount, setSelectedAccount] = useState(
+    () => initialMonitoringCenterUiState.current.selectedAccount
+  );
+  const [selectedProvider, setSelectedProvider] = useState(
+    () => initialMonitoringCenterUiState.current.selectedProvider
+  );
+  const [selectedModel, setSelectedModel] = useState(
+    () => initialMonitoringCenterUiState.current.selectedModel
+  );
+  const [selectedChannel, setSelectedChannel] = useState(
+    () => initialMonitoringCenterUiState.current.selectedChannel
+  );
+  const [selectedApiKeyHash, setSelectedApiKeyHash] = useState(
+    () => initialMonitoringCenterUiState.current.selectedApiKeyHash
+  );
+  const [selectedStatus, setSelectedStatus] = useState<StatusFilter>(
+    () => initialMonitoringCenterUiState.current.selectedStatus
+  );
   const [expandedAccounts, setExpandedAccounts] = useState<Record<string, boolean>>({});
   const [expandedApiKeys, setExpandedApiKeys] = useState<Record<string, boolean>>({});
   const [focusedAccount, setFocusedAccount] = useState<string | null>(null);
@@ -152,8 +179,6 @@ export function MonitoringCenterPage() {
   const [accountQuotaStates, setAccountQuotaStates] = useState<Record<string, AccountQuotaState>>(
     {}
   );
-  const initialAccountOverviewUiState = useRef(readAccountOverviewUiState());
-  const initialMonitoringCenterUiState = useRef(readMonitoringCenterUiState());
   const [activeDataTab, setActiveDataTab] = useState<MonitoringDataTab>(
     initialMonitoringCenterUiState.current.activeDataTab
   );
@@ -173,9 +198,13 @@ export function MonitoringCenterPage() {
   }));
   const [accountStatusUpdating, setAccountStatusUpdating] = useState<Record<string, boolean>>({});
   const [apiKeyPage, setApiKeyPage] = useState(1);
-  const [apiKeyPageSize, setApiKeyPageSize] = useState<number>(DEFAULT_ACCOUNT_PAGE_SIZE);
+  const [apiKeyPageSize, setApiKeyPageSize] = useState<number>(
+    initialMonitoringCenterUiState.current.apiKeyPageSize
+  );
   const [realtimePage, setRealtimePage] = useState(1);
-  const [realtimePageSize, setRealtimePageSize] = useState(DEFAULT_REALTIME_PAGE_SIZE);
+  const [realtimePageSize, setRealtimePageSize] = useState(
+    initialMonitoringCenterUiState.current.realtimePageSize
+  );
   const focusSnapshotRef = useRef<FocusSnapshot | null>(null);
   const previousAccountPageResetStateRef = useRef<AccountOverviewPageResetState | null>(null);
   const accountQuotaStatesRef = useRef<Record<string, AccountQuotaState>>({});
@@ -349,8 +378,38 @@ export function MonitoringCenterPage() {
   }, [accountOverviewMode, accountPageByMode.card, accountPageSizeByMode.card, accountSort]);
 
   useEffect(() => {
-    writeMonitoringCenterUiState({ activeDataTab });
-  }, [activeDataTab]);
+    writeMonitoringCenterUiState({
+      activeDataTab,
+      timeRange,
+      customStartInput,
+      customEndInput,
+      searchInput,
+      autoRefreshMs,
+      selectedAccount,
+      selectedProvider,
+      selectedModel,
+      selectedChannel,
+      selectedApiKeyHash,
+      selectedStatus,
+      apiKeyPageSize,
+      realtimePageSize,
+    });
+  }, [
+    activeDataTab,
+    apiKeyPageSize,
+    autoRefreshMs,
+    customEndInput,
+    customStartInput,
+    realtimePageSize,
+    searchInput,
+    selectedAccount,
+    selectedApiKeyHash,
+    selectedChannel,
+    selectedModel,
+    selectedProvider,
+    selectedStatus,
+    timeRange,
+  ]);
 
   const providerOptions = useMemo(
     () => buildProviderOptions(filteredRows, selectedProvider, t),

--- a/apps/web/src/features/monitoring/modelPricesPageUiState.test.ts
+++ b/apps/web/src/features/monitoring/modelPricesPageUiState.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  MODEL_PRICES_PAGE_UI_STATE_STORAGE_KEY,
+  getDefaultModelPricesPageUiState,
+  normalizeModelPriceFilter,
+  normalizeModelPricesPageUiState,
+  readModelPricesPageUiState,
+  writeModelPricesPageUiState,
+} from './modelPricesPageUiState';
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+const createMemoryStorage = (): StorageLike => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+describe('modelPricesPageUiState', () => {
+  let storage: StorageLike;
+
+  beforeEach(() => {
+    storage = createMemoryStorage();
+    (globalThis as { window?: unknown }).window = { localStorage: storage };
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it('normalizes filter values', () => {
+    expect(normalizeModelPriceFilter('missing')).toBe('missing');
+    expect(normalizeModelPriceFilter('candidates')).toBe('candidates');
+    expect(normalizeModelPriceFilter('bad')).toBe('all');
+  });
+
+  it('normalizes page state from arbitrary input', () => {
+    expect(normalizeModelPricesPageUiState(null)).toEqual(getDefaultModelPricesPageUiState());
+    expect(
+      normalizeModelPricesPageUiState({
+        search: 'gpt',
+        filter: 'saved',
+      })
+    ).toEqual({
+      search: 'gpt',
+      filter: 'saved',
+    });
+    expect(
+      normalizeModelPricesPageUiState({
+        search: 123,
+        filter: 'unknown',
+      })
+    ).toEqual(getDefaultModelPricesPageUiState());
+  });
+
+  it('persists and reads ui state via localStorage', () => {
+    writeModelPricesPageUiState({ search: 'claude', filter: 'missing' });
+    expect(JSON.parse(storage.getItem(MODEL_PRICES_PAGE_UI_STATE_STORAGE_KEY) ?? '{}')).toEqual({
+      search: 'claude',
+      filter: 'missing',
+    });
+    expect(readModelPricesPageUiState()).toEqual({ search: 'claude', filter: 'missing' });
+  });
+
+  it('returns defaults when stored payload is invalid JSON', () => {
+    storage.setItem(MODEL_PRICES_PAGE_UI_STATE_STORAGE_KEY, '{not json');
+    expect(readModelPricesPageUiState()).toEqual(getDefaultModelPricesPageUiState());
+  });
+});

--- a/apps/web/src/features/monitoring/modelPricesPageUiState.ts
+++ b/apps/web/src/features/monitoring/modelPricesPageUiState.ts
@@ -1,0 +1,67 @@
+import type { ModelPriceFilter } from './model/modelPricesPageModel';
+
+export type ModelPricesPageUiState = {
+  search: string;
+  filter: ModelPriceFilter;
+};
+
+export const MODEL_PRICES_PAGE_UI_STATE_STORAGE_KEY = 'modelPricesPage.uiState';
+
+const MODEL_PRICE_FILTER_SET = new Set<ModelPriceFilter>([
+  'all',
+  'missing',
+  'candidates',
+  'saved',
+]);
+
+export const getDefaultModelPricesPageUiState = (): ModelPricesPageUiState => ({
+  search: '',
+  filter: 'all',
+});
+
+export const normalizeModelPriceFilter = (value: unknown): ModelPriceFilter =>
+  typeof value === 'string' && MODEL_PRICE_FILTER_SET.has(value as ModelPriceFilter)
+    ? (value as ModelPriceFilter)
+    : 'all';
+
+export const normalizeModelPricesPageUiState = (value: unknown): ModelPricesPageUiState => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return getDefaultModelPricesPageUiState();
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    search: typeof record.search === 'string' ? record.search : '',
+    filter: normalizeModelPriceFilter(record.filter),
+  };
+};
+
+export const readModelPricesPageUiState = (): ModelPricesPageUiState => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return getDefaultModelPricesPageUiState();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(MODEL_PRICES_PAGE_UI_STATE_STORAGE_KEY);
+    if (raw) {
+      return normalizeModelPricesPageUiState(JSON.parse(raw));
+    }
+  } catch {
+    // Ignore storage failures and fall back to defaults.
+  }
+
+  return getDefaultModelPricesPageUiState();
+};
+
+export const writeModelPricesPageUiState = (state: ModelPricesPageUiState) => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(
+      MODEL_PRICES_PAGE_UI_STATE_STORAGE_KEY,
+      JSON.stringify(normalizeModelPricesPageUiState(state))
+    );
+  } catch {
+    // Ignore storage failures and keep runtime state only.
+  }
+};

--- a/apps/web/src/features/monitoring/monitoringCenterUiState.test.ts
+++ b/apps/web/src/features/monitoring/monitoringCenterUiState.test.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_MONITORING_DATA_TAB,
   MONITORING_CENTER_UI_STATE_STORAGE_KEY,
+  getDefaultMonitoringCenterUiState,
   normalizeMonitoringCenterUiState,
+  normalizeMonitoringAutoRefreshMs,
   normalizeMonitoringDataTab,
+  normalizeMonitoringStatusFilter,
+  normalizeMonitoringTimeRange,
   readMonitoringCenterUiState,
   writeMonitoringCenterUiState,
 } from './monitoringCenterUiState';
@@ -61,30 +65,79 @@ describe('monitoringCenterUiState', () => {
     expect(normalizeMonitoringDataTab('realtime')).toBe('realtime');
   });
 
+  it('normalizes persisted filter fields', () => {
+    expect(normalizeMonitoringTimeRange('30d')).toBe('30d');
+    expect(normalizeMonitoringTimeRange('bad')).toBe('today');
+    expect(normalizeMonitoringStatusFilter('failed')).toBe('failed');
+    expect(normalizeMonitoringStatusFilter('bad')).toBe('all');
+    expect(normalizeMonitoringAutoRefreshMs(30000)).toBe('30000');
+    expect(normalizeMonitoringAutoRefreshMs('123')).toBe('5000');
+  });
+
   it('normalizes ui state from arbitrary input', () => {
-    expect(normalizeMonitoringCenterUiState(null)).toEqual({
-      activeDataTab: DEFAULT_MONITORING_DATA_TAB,
-    });
+    expect(normalizeMonitoringCenterUiState(null)).toEqual(getDefaultMonitoringCenterUiState());
     expect(normalizeMonitoringCenterUiState({ activeDataTab: 'realtime' })).toEqual({
+      ...getDefaultMonitoringCenterUiState(),
       activeDataTab: 'realtime',
     });
-    expect(normalizeMonitoringCenterUiState({ activeDataTab: 'nope' })).toEqual({
+    expect(
+      normalizeMonitoringCenterUiState({
+        activeDataTab: 'nope',
+        timeRange: 'custom',
+        customStartInput: '2026-05-01T00:00',
+        customEndInput: '2026-05-02T00:00',
+        searchInput: 'gpt',
+        autoRefreshMs: '60000',
+        selectedAccount: 'account@example.com',
+        selectedProvider: 'codex',
+        selectedModel: 'gpt-5',
+        selectedChannel: 'default',
+        selectedApiKeyHash: 'hash',
+        selectedStatus: 'failed',
+        apiKeyPageSize: 50,
+        realtimePageSize: 150,
+      })
+    ).toEqual({
+      ...getDefaultMonitoringCenterUiState(),
       activeDataTab: DEFAULT_MONITORING_DATA_TAB,
+      timeRange: 'custom',
+      customStartInput: '2026-05-01T00:00',
+      customEndInput: '2026-05-02T00:00',
+      searchInput: 'gpt',
+      autoRefreshMs: '60000',
+      selectedAccount: 'account@example.com',
+      selectedProvider: 'codex',
+      selectedModel: 'gpt-5',
+      selectedChannel: 'default',
+      selectedApiKeyHash: 'hash',
+      selectedStatus: 'failed',
+      apiKeyPageSize: 50,
+      realtimePageSize: 150,
     });
   });
 
   it('persists and reads ui state via localStorage', () => {
-    writeMonitoringCenterUiState({ activeDataTab: 'apiKeys' });
-    expect(JSON.parse(storage.getItem(MONITORING_CENTER_UI_STATE_STORAGE_KEY) ?? '{}')).toEqual({
+    writeMonitoringCenterUiState({
       activeDataTab: 'apiKeys',
+      selectedProvider: 'claude',
+      apiKeyPageSize: 20,
     });
-    expect(readMonitoringCenterUiState()).toEqual({ activeDataTab: 'apiKeys' });
+    expect(JSON.parse(storage.getItem(MONITORING_CENTER_UI_STATE_STORAGE_KEY) ?? '{}')).toEqual({
+      ...getDefaultMonitoringCenterUiState(),
+      activeDataTab: 'apiKeys',
+      selectedProvider: 'claude',
+      apiKeyPageSize: 20,
+    });
+    expect(readMonitoringCenterUiState()).toEqual({
+      ...getDefaultMonitoringCenterUiState(),
+      activeDataTab: 'apiKeys',
+      selectedProvider: 'claude',
+      apiKeyPageSize: 20,
+    });
   });
 
   it('returns defaults when stored payload is invalid JSON', () => {
     storage.setItem(MONITORING_CENTER_UI_STATE_STORAGE_KEY, '{not json');
-    expect(readMonitoringCenterUiState()).toEqual({
-      activeDataTab: DEFAULT_MONITORING_DATA_TAB,
-    });
+    expect(readMonitoringCenterUiState()).toEqual(getDefaultMonitoringCenterUiState());
   });
 });

--- a/apps/web/src/features/monitoring/monitoringCenterUiState.ts
+++ b/apps/web/src/features/monitoring/monitoringCenterUiState.ts
@@ -1,4 +1,6 @@
 export type MonitoringDataTab = 'accounts' | 'apiKeys' | 'realtime';
+export type MonitoringCenterTimeRange = 'today' | '7d' | '14d' | '30d' | 'all' | 'custom';
+export type MonitoringCenterStatusFilter = 'all' | 'success' | 'failed';
 
 export const MONITORING_DATA_TABS: readonly MonitoringDataTab[] = [
   'accounts',
@@ -7,34 +9,136 @@ export const MONITORING_DATA_TABS: readonly MonitoringDataTab[] = [
 ] as const;
 
 export const DEFAULT_MONITORING_DATA_TAB: MonitoringDataTab = 'accounts';
+export const DEFAULT_MONITORING_TIME_RANGE: MonitoringCenterTimeRange = 'today';
+export const DEFAULT_MONITORING_AUTO_REFRESH_MS = '5000';
+export const DEFAULT_MONITORING_TABLE_PAGE_SIZE = 12;
+export const DEFAULT_MONITORING_REALTIME_PAGE_SIZE = 10;
 
 export const MONITORING_CENTER_UI_STATE_STORAGE_KEY = 'monitoring.centerUiState';
 
 export type MonitoringCenterUiState = {
   activeDataTab: MonitoringDataTab;
+  timeRange: MonitoringCenterTimeRange;
+  customStartInput: string;
+  customEndInput: string;
+  searchInput: string;
+  autoRefreshMs: string;
+  selectedAccount: string;
+  selectedProvider: string;
+  selectedModel: string;
+  selectedChannel: string;
+  selectedApiKeyHash: string;
+  selectedStatus: MonitoringCenterStatusFilter;
+  apiKeyPageSize: number;
+  realtimePageSize: number;
 };
 
 const TAB_SET = new Set<MonitoringDataTab>(MONITORING_DATA_TABS);
+const TIME_RANGE_SET = new Set<MonitoringCenterTimeRange>([
+  'today',
+  '7d',
+  '14d',
+  '30d',
+  'all',
+  'custom',
+]);
+const STATUS_FILTER_SET = new Set<MonitoringCenterStatusFilter>(['all', 'success', 'failed']);
+const AUTO_REFRESH_MS_SET = new Set(['0', '5000', '10000', '30000', '60000', '300000']);
+const TABLE_PAGE_SIZE_OPTIONS = [12, 20, 50, 100] as const;
+const REALTIME_PAGE_SIZE_OPTIONS = [10, 50, 100, 150, 300] as const;
 
 export const normalizeMonitoringDataTab = (value: unknown): MonitoringDataTab =>
   typeof value === 'string' && TAB_SET.has(value as MonitoringDataTab)
     ? (value as MonitoringDataTab)
     : DEFAULT_MONITORING_DATA_TAB;
 
+export const normalizeMonitoringTimeRange = (value: unknown): MonitoringCenterTimeRange =>
+  typeof value === 'string' && TIME_RANGE_SET.has(value as MonitoringCenterTimeRange)
+    ? (value as MonitoringCenterTimeRange)
+    : DEFAULT_MONITORING_TIME_RANGE;
+
+export const normalizeMonitoringStatusFilter = (value: unknown): MonitoringCenterStatusFilter =>
+  typeof value === 'string' && STATUS_FILTER_SET.has(value as MonitoringCenterStatusFilter)
+    ? (value as MonitoringCenterStatusFilter)
+    : 'all';
+
+export const normalizeMonitoringAutoRefreshMs = (value: unknown): string => {
+  const stringValue = typeof value === 'number' ? String(value) : value;
+  return typeof stringValue === 'string' && AUTO_REFRESH_MS_SET.has(stringValue)
+    ? stringValue
+    : DEFAULT_MONITORING_AUTO_REFRESH_MS;
+};
+
+const normalizeString = (value: unknown, fallback = ''): string =>
+  typeof value === 'string' ? value : fallback;
+
+const normalizeSelectValue = (value: unknown): string => {
+  const normalized = normalizeString(value, 'all').trim();
+  return normalized || 'all';
+};
+
+const normalizePageSize = (
+  value: unknown,
+  options: readonly number[],
+  fallback: number
+): number => {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  return typeof parsed === 'number' && options.includes(parsed) ? parsed : fallback;
+};
+
+export const getDefaultMonitoringCenterUiState = (): MonitoringCenterUiState => ({
+  activeDataTab: DEFAULT_MONITORING_DATA_TAB,
+  timeRange: DEFAULT_MONITORING_TIME_RANGE,
+  customStartInput: '',
+  customEndInput: '',
+  searchInput: '',
+  autoRefreshMs: DEFAULT_MONITORING_AUTO_REFRESH_MS,
+  selectedAccount: 'all',
+  selectedProvider: 'all',
+  selectedModel: 'all',
+  selectedChannel: 'all',
+  selectedApiKeyHash: 'all',
+  selectedStatus: 'all',
+  apiKeyPageSize: DEFAULT_MONITORING_TABLE_PAGE_SIZE,
+  realtimePageSize: DEFAULT_MONITORING_REALTIME_PAGE_SIZE,
+});
+
 export const normalizeMonitoringCenterUiState = (value: unknown): MonitoringCenterUiState => {
+  const defaults = getDefaultMonitoringCenterUiState();
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return { activeDataTab: DEFAULT_MONITORING_DATA_TAB };
+    return defaults;
   }
 
   const record = value as Record<string, unknown>;
   return {
     activeDataTab: normalizeMonitoringDataTab(record.activeDataTab),
+    timeRange: normalizeMonitoringTimeRange(record.timeRange),
+    customStartInput: normalizeString(record.customStartInput),
+    customEndInput: normalizeString(record.customEndInput),
+    searchInput: normalizeString(record.searchInput),
+    autoRefreshMs: normalizeMonitoringAutoRefreshMs(record.autoRefreshMs),
+    selectedAccount: normalizeSelectValue(record.selectedAccount),
+    selectedProvider: normalizeSelectValue(record.selectedProvider),
+    selectedModel: normalizeSelectValue(record.selectedModel),
+    selectedChannel: normalizeSelectValue(record.selectedChannel),
+    selectedApiKeyHash: normalizeSelectValue(record.selectedApiKeyHash),
+    selectedStatus: normalizeMonitoringStatusFilter(record.selectedStatus),
+    apiKeyPageSize: normalizePageSize(
+      record.apiKeyPageSize,
+      TABLE_PAGE_SIZE_OPTIONS,
+      defaults.apiKeyPageSize
+    ),
+    realtimePageSize: normalizePageSize(
+      record.realtimePageSize,
+      REALTIME_PAGE_SIZE_OPTIONS,
+      defaults.realtimePageSize
+    ),
   };
 };
 
 export const readMonitoringCenterUiState = (): MonitoringCenterUiState => {
   if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return { activeDataTab: DEFAULT_MONITORING_DATA_TAB };
+    return getDefaultMonitoringCenterUiState();
   }
 
   try {
@@ -46,10 +150,10 @@ export const readMonitoringCenterUiState = (): MonitoringCenterUiState => {
     // Ignore storage failures and fall back to defaults.
   }
 
-  return { activeDataTab: DEFAULT_MONITORING_DATA_TAB };
+  return getDefaultMonitoringCenterUiState();
 };
 
-export const writeMonitoringCenterUiState = (state: MonitoringCenterUiState) => {
+export const writeMonitoringCenterUiState = (state: Partial<MonitoringCenterUiState>) => {
   if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
     return;
   }

--- a/apps/web/src/features/quota/QuotaPage.tsx
+++ b/apps/web/src/features/quota/QuotaPage.tsx
@@ -2,7 +2,7 @@
  * Quota management page - coordinates the three quota sections.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { useAuthStore } from '@/stores';
@@ -20,17 +20,27 @@ import {
 } from '@/components/quota';
 import type { QuotaSortMode } from '@/components/quota/quotaConfigs';
 import type { AuthFileItem } from '@/types';
+import {
+  readQuotaPageUiState,
+  writeQuotaPageUiState,
+  type QuotaSectionType,
+  type QuotaSectionViewMode,
+} from './quotaPageUiState';
 import styles from './QuotaPage.module.scss';
 
 export function QuotaPage() {
   const { t } = useTranslation();
   const connectionStatus = useAuthStore((state) => state.connectionStatus);
+  const initialUiState = useRef(readQuotaPageUiState());
 
   const [files, setFiles] = useState<AuthFileItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortMode, setSortMode] = useState<QuotaSortMode>('default');
+  const [searchQuery, setSearchQuery] = useState(() => initialUiState.current.searchQuery);
+  const [sortMode, setSortMode] = useState<QuotaSortMode>(() => initialUiState.current.sortMode);
+  const [sectionViewModes, setSectionViewModes] = useState(() => ({
+    ...initialUiState.current.sectionViewModes,
+  }));
 
   const disableControls = connectionStatus !== 'connected';
   const sortOptions = useMemo(
@@ -77,6 +87,30 @@ export function QuotaPage() {
     loadConfig();
   }, [loadFiles, loadConfig]);
 
+  useEffect(() => {
+    writeQuotaPageUiState({
+      searchQuery,
+      sortMode,
+      sectionViewModes,
+    });
+  }, [searchQuery, sectionViewModes, sortMode]);
+
+  const getSectionViewMode = useCallback(
+    (sectionType: QuotaSectionType): QuotaSectionViewMode =>
+      sectionViewModes[sectionType] ?? 'paged',
+    [sectionViewModes]
+  );
+
+  const setSectionViewMode = useCallback(
+    (sectionType: QuotaSectionType, viewMode: QuotaSectionViewMode) => {
+      setSectionViewModes((current) => ({
+        ...current,
+        [sectionType]: viewMode,
+      }));
+    },
+    []
+  );
+
   return (
     <div className={styles.container}>
       {error && <div className={styles.errorBox}>{error}</div>}
@@ -114,6 +148,8 @@ export function QuotaPage() {
         disabled={disableControls}
         searchQuery={searchQuery}
         sortMode={sortMode}
+        viewMode={getSectionViewMode(CODEX_CONFIG.type)}
+        onViewModeChange={(viewMode) => setSectionViewMode(CODEX_CONFIG.type, viewMode)}
       />
       <QuotaSection
         config={CLAUDE_CONFIG}
@@ -122,6 +158,8 @@ export function QuotaPage() {
         disabled={disableControls}
         searchQuery={searchQuery}
         sortMode={sortMode}
+        viewMode={getSectionViewMode(CLAUDE_CONFIG.type)}
+        onViewModeChange={(viewMode) => setSectionViewMode(CLAUDE_CONFIG.type, viewMode)}
       />
       <QuotaSection
         config={ANTIGRAVITY_CONFIG}
@@ -130,6 +168,8 @@ export function QuotaPage() {
         disabled={disableControls}
         searchQuery={searchQuery}
         sortMode={sortMode}
+        viewMode={getSectionViewMode(ANTIGRAVITY_CONFIG.type)}
+        onViewModeChange={(viewMode) => setSectionViewMode(ANTIGRAVITY_CONFIG.type, viewMode)}
       />
       <QuotaSection
         config={GEMINI_CLI_CONFIG}
@@ -138,6 +178,8 @@ export function QuotaPage() {
         disabled={disableControls}
         searchQuery={searchQuery}
         sortMode={sortMode}
+        viewMode={getSectionViewMode(GEMINI_CLI_CONFIG.type)}
+        onViewModeChange={(viewMode) => setSectionViewMode(GEMINI_CLI_CONFIG.type, viewMode)}
       />
       <QuotaSection
         config={KIMI_CONFIG}
@@ -146,6 +188,8 @@ export function QuotaPage() {
         disabled={disableControls}
         searchQuery={searchQuery}
         sortMode={sortMode}
+        viewMode={getSectionViewMode(KIMI_CONFIG.type)}
+        onViewModeChange={(viewMode) => setSectionViewMode(KIMI_CONFIG.type, viewMode)}
       />
     </div>
   );

--- a/apps/web/src/features/quota/quotaPageUiState.test.ts
+++ b/apps/web/src/features/quota/quotaPageUiState.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  QUOTA_PAGE_UI_STATE_STORAGE_KEY,
+  getDefaultQuotaPageUiState,
+  normalizeQuotaPageUiState,
+  normalizeQuotaSectionType,
+  normalizeQuotaSectionViewMode,
+  normalizeQuotaSortMode,
+  readQuotaPageUiState,
+  writeQuotaPageUiState,
+} from './quotaPageUiState';
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+const createMemoryStorage = (): StorageLike => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+describe('quotaPageUiState', () => {
+  let storage: StorageLike;
+
+  beforeEach(() => {
+    storage = createMemoryStorage();
+    (globalThis as { window?: unknown }).window = { localStorage: storage };
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it('normalizes enum-like fields', () => {
+    expect(normalizeQuotaSortMode('plan-desc')).toBe('plan-desc');
+    expect(normalizeQuotaSortMode('unknown')).toBe('default');
+    expect(normalizeQuotaSectionViewMode('all')).toBe('all');
+    expect(normalizeQuotaSectionViewMode('bad')).toBe('paged');
+    expect(normalizeQuotaSectionType('gemini-cli')).toBe('gemini-cli');
+    expect(normalizeQuotaSectionType('bad')).toBeNull();
+  });
+
+  it('normalizes page state and drops unknown sections', () => {
+    expect(normalizeQuotaPageUiState(null)).toEqual(getDefaultQuotaPageUiState());
+    expect(
+      normalizeQuotaPageUiState({
+        searchQuery: 'pro',
+        sortMode: 'name-asc',
+        sectionViewModes: {
+          codex: 'all',
+          claude: 'bad',
+          unknown: 'all',
+        },
+      })
+    ).toEqual({
+      searchQuery: 'pro',
+      sortMode: 'name-asc',
+      sectionViewModes: {
+        codex: 'all',
+        claude: 'paged',
+      },
+    });
+  });
+
+  it('persists and reads page state via localStorage', () => {
+    writeQuotaPageUiState({
+      searchQuery: 'plus',
+      sortMode: 'plan-desc',
+      sectionViewModes: {
+        codex: 'all',
+        kimi: 'paged',
+      },
+    });
+
+    expect(JSON.parse(storage.getItem(QUOTA_PAGE_UI_STATE_STORAGE_KEY) ?? '{}')).toEqual({
+      searchQuery: 'plus',
+      sortMode: 'plan-desc',
+      sectionViewModes: {
+        codex: 'all',
+        kimi: 'paged',
+      },
+    });
+    expect(readQuotaPageUiState()).toEqual({
+      searchQuery: 'plus',
+      sortMode: 'plan-desc',
+      sectionViewModes: {
+        codex: 'all',
+        kimi: 'paged',
+      },
+    });
+  });
+
+  it('returns defaults when stored payload is invalid JSON', () => {
+    storage.setItem(QUOTA_PAGE_UI_STATE_STORAGE_KEY, '{not json');
+    expect(readQuotaPageUiState()).toEqual(getDefaultQuotaPageUiState());
+  });
+});

--- a/apps/web/src/features/quota/quotaPageUiState.ts
+++ b/apps/web/src/features/quota/quotaPageUiState.ts
@@ -1,0 +1,102 @@
+import type { QuotaSortMode } from '@/components/quota/quotaConfigs';
+
+export type QuotaSectionType = 'antigravity' | 'claude' | 'codex' | 'gemini-cli' | 'kimi';
+export type QuotaSectionViewMode = 'paged' | 'all';
+
+export type QuotaPageUiState = {
+  searchQuery: string;
+  sortMode: QuotaSortMode;
+  sectionViewModes: Partial<Record<QuotaSectionType, QuotaSectionViewMode>>;
+};
+
+export const QUOTA_PAGE_UI_STATE_STORAGE_KEY = 'quotaPage.uiState';
+
+const QUOTA_SORT_MODE_SET = new Set<QuotaSortMode>([
+  'default',
+  'name-asc',
+  'plan-desc',
+  'plan-asc',
+]);
+const QUOTA_SECTION_TYPE_SET = new Set<QuotaSectionType>([
+  'antigravity',
+  'claude',
+  'codex',
+  'gemini-cli',
+  'kimi',
+]);
+
+export const getDefaultQuotaPageUiState = (): QuotaPageUiState => ({
+  searchQuery: '',
+  sortMode: 'default',
+  sectionViewModes: {},
+});
+
+export const normalizeQuotaSortMode = (value: unknown): QuotaSortMode =>
+  typeof value === 'string' && QUOTA_SORT_MODE_SET.has(value as QuotaSortMode)
+    ? (value as QuotaSortMode)
+    : 'default';
+
+export const normalizeQuotaSectionViewMode = (value: unknown): QuotaSectionViewMode =>
+  value === 'all' ? 'all' : 'paged';
+
+export const normalizeQuotaSectionType = (value: unknown): QuotaSectionType | null =>
+  typeof value === 'string' && QUOTA_SECTION_TYPE_SET.has(value as QuotaSectionType)
+    ? (value as QuotaSectionType)
+    : null;
+
+const normalizeSectionViewModes = (
+  value: unknown
+): Partial<Record<QuotaSectionType, QuotaSectionViewMode>> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  const result: Partial<Record<QuotaSectionType, QuotaSectionViewMode>> = {};
+  Object.entries(value as Record<string, unknown>).forEach(([key, mode]) => {
+    const sectionType = normalizeQuotaSectionType(key);
+    if (!sectionType) return;
+    result[sectionType] = normalizeQuotaSectionViewMode(mode);
+  });
+  return result;
+};
+
+export const normalizeQuotaPageUiState = (value: unknown): QuotaPageUiState => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return getDefaultQuotaPageUiState();
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    searchQuery: typeof record.searchQuery === 'string' ? record.searchQuery : '',
+    sortMode: normalizeQuotaSortMode(record.sortMode),
+    sectionViewModes: normalizeSectionViewModes(record.sectionViewModes),
+  };
+};
+
+export const readQuotaPageUiState = (): QuotaPageUiState => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return getDefaultQuotaPageUiState();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(QUOTA_PAGE_UI_STATE_STORAGE_KEY);
+    if (raw) {
+      return normalizeQuotaPageUiState(JSON.parse(raw));
+    }
+  } catch {
+    // Ignore storage failures and fall back to defaults.
+  }
+
+  return getDefaultQuotaPageUiState();
+};
+
+export const writeQuotaPageUiState = (state: QuotaPageUiState) => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(
+      QUOTA_PAGE_UI_STATE_STORAGE_KEY,
+      JSON.stringify(normalizeQuotaPageUiState(state))
+    );
+  } catch {
+    // Ignore storage failures and keep runtime state only.
+  }
+};


### PR DESCRIPTION
## Summary
Persist browser-backed UI preferences across monitoring, quota, model pricing, auth files, and layout navigation.

## Changes
- Restore monitoring filters, tabs, page sizes, and refresh preferences from local storage.
- Persist auth files, quota, and model price UI state with validation helpers and tests.
- Remember the desktop sidebar collapsed state using the existing sidebar storage key.

## Testing
- npm --workspace apps/web run type-check
- npm --workspace apps/web run test -- src/features/monitoring/monitoringCenterUiState.test.ts src/features/quota/quotaPageUiState.test.ts src/features/monitoring/modelPricesPageUiState.test.ts src/features/authFiles/uiState.test.ts src/features/authFiles/AuthFilesPage.authJsonPaste.test.tsx src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx