### PR TITLE
fix(manager-server): sync setup bootstrap state

### DIFF
--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -116,7 +116,7 @@ func TestServerCompatPanelPathOverridesEmbeddedPanel(t *testing.T) {
 func TestServerCompatSetupConfigAndEnvLock(t *testing.T) {
 	cpa := testutil.NewCPAMock(t)
 	cfg := testutil.NewConfig(t)
-	handler, _ := newCompatHandler(t, cfg, nil)
+	handler, db := newCompatHandler(t, cfg, nil)
 
 	setupBody := `{"cpaBaseUrl":"` + cpa.URL() + `","managementKey":"management-key","requestMonitoringEnabled":false,"ensureUsageStatisticsEnabled":false}`
 	setupRR := testutil.Request(t, handler, http.MethodPost, "/setup", setupBody, testutil.AdminKey)
@@ -133,6 +133,13 @@ func TestServerCompatSetupConfigAndEnvLock(t *testing.T) {
 	testutil.DecodeJSON(t, infoRR, &info)
 	if !info.Configured {
 		t.Fatalf("configured = false after setup")
+	}
+	state, ok, err := db.LoadBootstrapState(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("load bootstrap state ok=%v err=%v", ok, err)
+	}
+	if !state.ProjectInitialized || !state.AdminReady || !state.DataKeyReady || state.Status != "ready" {
+		t.Fatalf("bootstrap state after setup = %#v", state)
 	}
 
 	configRR := testutil.Request(t, handler, http.MethodGet, "/usage-service/config", "", testutil.AdminKey)
@@ -160,6 +167,33 @@ func TestServerCompatSetupConfigAndEnvLock(t *testing.T) {
 	testutil.RequireStatus(t, conflictRR, http.StatusConflict)
 	if !strings.Contains(conflictRR.Body.String(), `"code":"connection_env_managed"`) {
 		t.Fatalf("conflict body = %s", conflictRR.Body.String())
+	}
+}
+
+func TestServerCompatInfoIgnoresStaleUninitializedBootstrapState(t *testing.T) {
+	cpa := testutil.NewCPAMock(t)
+	setup := &store.Setup{CPAUpstreamURL: cpa.URL(), ManagementKey: "management-key", Queue: "usage", PopSide: "right"}
+	handler, db := newCompatHandler(t, testutil.NewConfig(t), setup)
+	if err := db.SaveBootstrapState(context.Background(), store.BootstrapState{
+		Version:            1,
+		Status:             "fresh",
+		AdminReady:         true,
+		ProjectInitialized: false,
+		DataKeyReady:       true,
+	}); err != nil {
+		t.Fatalf("save stale bootstrap state: %v", err)
+	}
+
+	infoRR := testutil.Request(t, handler, http.MethodGet, "/usage-service/info", "", "")
+	testutil.RequireStatus(t, infoRR, http.StatusOK)
+	var info struct {
+		Configured         bool `json:"configured"`
+		ProjectInitialized bool `json:"projectInitialized"`
+		SetupRequired      bool `json:"setupRequired"`
+	}
+	testutil.DecodeJSON(t, infoRR, &info)
+	if !info.Configured || !info.ProjectInitialized || info.SetupRequired {
+		t.Fatalf("info response = %#v", info)
 	}
 }
 

--- a/apps/manager-server/internal/service/setup/service.go
+++ b/apps/manager-server/internal/service/setup/service.go
@@ -37,13 +37,13 @@ type InfoResult struct {
 	Service            string `json:"service"`
 	Mode               string `json:"mode"`
 	StartedAt          int64  `json:"startedAt"`
-	Configured          bool   `json:"configured"`
-	AdminReady          bool   `json:"adminReady"`
-	ProjectInitialized  bool   `json:"projectInitialized"`
-	SetupRequired       bool   `json:"setupRequired"`
-	MigrationStatus     string `json:"migrationStatus,omitempty"`
-	DataKeyReady        bool   `json:"dataKeyReady"`
-	HasHistoricalData   bool   `json:"hasHistoricalData"`
+	Configured         bool   `json:"configured"`
+	AdminReady         bool   `json:"adminReady"`
+	ProjectInitialized bool   `json:"projectInitialized"`
+	SetupRequired      bool   `json:"setupRequired"`
+	MigrationStatus    string `json:"migrationStatus,omitempty"`
+	DataKeyReady       bool   `json:"dataKeyReady"`
+	HasHistoricalData  bool   `json:"hasHistoricalData"`
 }
 
 type Service struct {
@@ -80,20 +80,20 @@ func (s *Service) Info(ctx context.Context) (InfoResult, error) {
 		return InfoResult{}, err
 	}
 	projectInitialized := ok && setup.CPAUpstreamURL != "" && setup.ManagementKey != ""
-	if bootstrapStateOK {
+	if bootstrapStateOK && !projectInitialized {
 		projectInitialized = bootstrapState.ProjectInitialized
 	}
 	return InfoResult{
 		Service:            s.serviceID,
 		Mode:               "embedded",
 		StartedAt:          s.startedAt,
-		Configured:          projectInitialized,
-		AdminReady:          adminReady,
-		ProjectInitialized:  projectInitialized,
-		SetupRequired:       adminReady && !projectInitialized,
-		MigrationStatus:     bootstrapState.Status,
-		DataKeyReady:        bootstrapState.DataKeyReady,
-		HasHistoricalData:   bootstrapState.HasHistoricalData,
+		Configured:         projectInitialized,
+		AdminReady:         adminReady,
+		ProjectInitialized: projectInitialized,
+		SetupRequired:      adminReady && !projectInitialized,
+		MigrationStatus:    bootstrapState.Status,
+		DataKeyReady:       bootstrapState.DataKeyReady,
+		HasHistoricalData:  bootstrapState.HasHistoricalData,
 	}, nil
 }
 
@@ -185,12 +185,32 @@ func (s *Service) Setup(ctx context.Context, req Request, _ string) (Result, err
 	if err := s.store.SaveManagerConfig(ctx, managerCfg); err != nil {
 		return Result{}, err
 	}
+	if err := s.markBootstrapReady(ctx); err != nil {
+		return Result{}, err
+	}
 	if requestMonitoringEnabled {
 		_ = s.collector.Start(context.Background(), managerCfg)
 	} else {
 		_ = s.collector.Stop(context.Background())
 	}
 	return Result{OK: true, Upstream: setup.CPAUpstreamURL}, nil
+}
+
+func (s *Service) markBootstrapReady(ctx context.Context) error {
+	state, ok, err := s.store.LoadBootstrapState(ctx)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		state = store.BootstrapState{Version: 1}
+	} else if state.Version == 0 {
+		state.Version = 1
+	}
+	state.Status = "ready"
+	state.AdminReady = true
+	state.ProjectInitialized = true
+	state.DataKeyReady = true
+	return s.store.SaveBootstrapState(ctx, state)
 }
 
 func setupDiffers(existing store.Setup, req Request) bool {


### PR DESCRIPTION
## Summary
Fix Docker setup status reporting so a completed setup does not show the initialization page again on the next visit.

## Cause
`/usage-service/info` could let stale `bootstrap_state_v1.ProjectInitialized=false` override the persisted CPA setup and manager config.

## Solution
- Prefer resolved setup configuration over stale bootstrap state in `/usage-service/info`.
- Mark bootstrap state as ready after successful `/setup`.
- Add regression tests for stale bootstrap state and setup synchronization.

## Testing
- `go test ./internal/service/setup ./internal/httpapi`
- `go test ./...`