### PR TITLE
fix(monitoring): resolve masked usage sources

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
@@ -108,7 +108,7 @@ describe('MonitoringCenterPage account card', () => {
         },
         t
       ).primary
-    ).toBe('openai');
+    ).toBe('relay.example.com');
     expect(
       buildRealtimeSourceDisplay(
         {
@@ -117,7 +117,7 @@ describe('MonitoringCenterPage account card', () => {
         },
         t
       ).meta
-    ).toBe('Host: relay.example.com');
+    ).toBe('Provider: openai');
 
     expect(
       buildRealtimeSourceDisplay(
@@ -128,6 +128,24 @@ describe('MonitoringCenterPage account card', () => {
         t
       ).meta
     ).toBe('alice@example.com');
+  });
+
+  it('prefers resolved hosts over generic provider labels', () => {
+    const display = buildRealtimeSourceDisplay(
+      {
+        account: '',
+        accountMasked: '',
+        authLabel: '',
+        channel: 'codex',
+        channelHost: 'api.freemodel.dev',
+        provider: 'codex',
+        sourceMasked: 'm:fe_o...c68c',
+      },
+      t
+    );
+
+    expect(display.primary).toBe('api.freemodel.dev');
+    expect(display.meta).toBe('Provider: codex');
   });
 
   it('renders bulk action buttons for mixed account auth state', () => {

--- a/apps/web/src/features/monitoring/realtimeSourceDisplay.ts
+++ b/apps/web/src/features/monitoring/realtimeSourceDisplay.ts
@@ -6,6 +6,20 @@ const hasReadableRealtimeValue = (value: string | null | undefined) => {
   return Boolean(trimmed) && trimmed !== '-';
 };
 
+const GENERIC_PROVIDER_LABELS = new Set([
+  'codex',
+  'openai',
+  'openai-compatibility',
+  'gemini',
+  'claude',
+  'vertex',
+]);
+
+const isGenericProviderLabel = (value: string) =>
+  GENERIC_PROVIDER_LABELS.has(value.trim().toLowerCase());
+
+const firstReadable = (...values: string[]) => values.find(hasReadableRealtimeValue)?.trim() || '';
+
 export const buildRealtimeSourceDisplay = (
   row: Pick<
     MonitoringEventRow,
@@ -26,7 +40,15 @@ export const buildRealtimeSourceDisplay = (
     .find(hasReadableRealtimeValue)
     ?.trim();
   const source = hasReadableRealtimeValue(row.sourceMasked) ? row.sourceMasked.trim() : '';
-  const primary = channel || provider || host || account || source || '-';
+  const primary = firstReadable(
+    channel && !isGenericProviderLabel(channel) ? channel : '',
+    host,
+    source,
+    provider && !isGenericProviderLabel(provider) ? provider : '',
+    account || '',
+    channel,
+    provider
+  ) || '-';
   const metaCandidate = [
     { value: provider, label: t('monitoring.filter_provider') },
     { value: host, label: t('monitoring.column_host') },

--- a/apps/web/src/utils/sourceResolver.test.ts
+++ b/apps/web/src/utils/sourceResolver.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSourceInfoMap, resolveSourceDisplay } from './sourceResolver';
+
+describe('source resolver', () => {
+  it('resolves CPA masked Codex API key sources to readable base URL hosts', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: 'sk-1234567890abcdef',
+          baseUrl: 'https://api.first.example/v1',
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('m:sk-1...cdef', '', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('api.first.example');
+    expect(resolved.type).toBe('codex');
+    expect(resolved.identityKey).toBe('codex:0');
+  });
+
+  it('distinguishes multiple keys from the same base URL without exposing raw keys', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: 'sk-111111111111aaaa',
+          baseUrl: 'https://api.same.example/v1',
+        },
+        {
+          apiKey: 'sk-222222222222bbbb',
+          baseUrl: 'https://api.same.example/v1',
+        },
+      ],
+    });
+
+    const first = resolveSourceDisplay('m:sk-1...aaaa', '', sourceInfoMap, new Map());
+    const second = resolveSourceDisplay('m:sk-2...bbbb', '', sourceInfoMap, new Map());
+
+    expect(first.displayName).toBe('api.same.example #1');
+    expect(second.displayName).toBe('api.same.example #2');
+    expect(first.displayName).not.toContain('111111111111');
+    expect(second.displayName).not.toContain('222222222222');
+  });
+
+  it('uses explicit provider names before base URL fallbacks for OpenAI compatible providers', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      openaiCompatibility: [
+        {
+          name: 'Primary Gateway',
+          baseUrl: 'https://api.openai-compatible.example/v1',
+          apiKeyEntries: [{ apiKey: 'sk-openai1234567890' }],
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('m:sk-o...7890', '', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('Primary Gateway');
+    expect(resolved.type).toBe('openai');
+  });
+
+  it('distinguishes OpenAI compatible providers that share the same base URL', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      openaiCompatibility: [
+        {
+          name: '',
+          baseUrl: 'https://relay.same.example/v1',
+          apiKeyEntries: [{ apiKey: 'sk-openai111111aaaa' }],
+        },
+        {
+          name: '',
+          baseUrl: 'https://relay.same.example/v1',
+          apiKeyEntries: [{ apiKey: 'sk-openai222222bbbb' }],
+        },
+      ],
+    });
+
+    const first = resolveSourceDisplay('m:sk-o...aaaa', '', sourceInfoMap, new Map());
+    const second = resolveSourceDisplay('m:sk-o...bbbb', '', sourceInfoMap, new Map());
+
+    expect(first.displayName).toBe('relay.same.example #1');
+    expect(second.displayName).toBe('relay.same.example #2');
+    expect(first.type).toBe('openai');
+    expect(second.type).toBe('openai');
+  });
+
+  it('distinguishes multiple keys under one OpenAI compatible provider', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      openaiCompatibility: [
+        {
+          name: '',
+          baseUrl: 'https://relay.keys.example/v1',
+          apiKeyEntries: [
+            { apiKey: 'sk-openai111111aaaa' },
+            { apiKey: 'sk-openai222222bbbb' },
+          ],
+        },
+      ],
+    });
+
+    const first = resolveSourceDisplay('m:sk-o...aaaa', '', sourceInfoMap, new Map());
+    const second = resolveSourceDisplay('m:sk-o...bbbb', '', sourceInfoMap, new Map());
+
+    expect(first.displayName).toBe('relay.keys.example #1');
+    expect(second.displayName).toBe('relay.keys.example #2');
+  });
+
+  it('prefers OpenAI compatible key metadata when provider and key auth indices overlap', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      openaiCompatibility: [
+        {
+          name: 'Shared Relay',
+          baseUrl: 'https://relay.auth.example/v1',
+          authIndex: 'same-auth',
+          apiKeyEntries: [{ apiKey: 'sk-openai111111aaaa', authIndex: 'same-auth' }],
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('', 'same-auth', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('Shared Relay');
+    expect(resolved.identityKey).toBe('openai:0:0');
+  });
+
+  it('does not echo unsafe m-prefixed raw secrets as source fallback', () => {
+    const sourceInfoMap = buildSourceInfoMap({});
+
+    const resolved = resolveSourceDisplay('m:sk-realsecret', '', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toMatch(/^k:/);
+    expect(resolved.displayName).not.toContain('sk-realsecret');
+  });
+
+  it('resolves legacy UI-masked usage source IDs without treating them as raw secrets', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: 'sk-1234567890abcdef',
+          baseUrl: 'https://api.first.example/v1',
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('m:sk******ef', '', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('api.first.example');
+    expect(resolved.type).toBe('codex');
+  });
+
+  it('keeps raw source fallback when no provider candidate matches', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: 'sk-1234567890abcdef',
+          baseUrl: 'https://api.first.example/v1',
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('m:sk-x...zzzz', '', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('m:sk-x...zzzz');
+    expect(resolved.identityKey).toBe('source:m:sk-x...zzzz');
+  });
+});

--- a/apps/web/src/utils/sourceResolver.ts
+++ b/apps/web/src/utils/sourceResolver.ts
@@ -1,6 +1,6 @@
 import type { GeminiKeyConfig, OpenAIProviderConfig, ProviderKeyConfig } from '@/types';
 import type { CredentialInfo, SourceInfo } from '@/types/sourceInfo';
-import { buildCandidateUsageSourceIds, normalizeAuthIndex } from '@/utils/usage';
+import { buildCandidateUsageSourceIds, normalizeAuthIndex, normalizeUsageSourceId } from '@/utils/usage';
 
 export interface SourceInfoMapInput {
   geminiApiKeys?: GeminiKeyConfig[];
@@ -17,7 +17,7 @@ export interface SourceInfoMap {
   bySource: Map<string, SourceInfoEntry | null>;
 }
 
-const buildProviderIdentityKey = (type: string, index: number) => `${type}:${index}`;
+const buildProviderIdentityKey = (type: string, index: number | string) => `${type}:${index}`;
 
 const registerIdentity = (
   map: Map<string, SourceInfoEntry | null>,
@@ -39,6 +39,84 @@ const registerIdentity = (
 const formatRawSourceDisplayName = (source: string) => {
   if (!source) return '-';
   return source.startsWith('t:') ? source.slice(2) : source;
+};
+
+const extractHost = (baseUrl: string | undefined) => {
+  const trimmed = String(baseUrl || '').trim();
+  if (!trimmed) return '';
+
+  try {
+    return new URL(trimmed).host || trimmed;
+  } catch {
+    return trimmed.replace(/^https?:\/\//i, '').split('/')[0] || trimmed;
+  }
+};
+
+const buildProviderDisplayNames = (
+  items: Array<{ prefix?: string; name?: string; baseUrl?: string }>,
+  fallbackLabel: string
+) => {
+  const hostCounts = new Map<string, number>();
+
+  items.forEach((item) => {
+    if (item.prefix?.trim()) return;
+    if (item.name?.trim()) return;
+    const host = extractHost(item.baseUrl);
+    if (!host) return;
+    hostCounts.set(host, (hostCounts.get(host) || 0) + 1);
+  });
+
+  const hostOrdinals = new Map<string, number>();
+  return items.map((item, index) => {
+    const prefix = item.prefix?.trim();
+    if (prefix) return prefix;
+
+    const name = item.name?.trim();
+    if (name) return name;
+
+    const host = extractHost(item.baseUrl);
+    if (!host) return `${fallbackLabel} #${index + 1}`;
+    if ((hostCounts.get(host) || 0) <= 1) return host;
+
+    const ordinal = (hostOrdinals.get(host) || 0) + 1;
+    hostOrdinals.set(host, ordinal);
+    return `${host} #${ordinal}`;
+  });
+};
+
+const disambiguateDuplicateNames = (names: string[]) => {
+  const counts = new Map<string, number>();
+  names.forEach((name) => {
+    counts.set(name, (counts.get(name) || 0) + 1);
+  });
+
+  const ordinals = new Map<string, number>();
+  return names.map((name) => {
+    if ((counts.get(name) || 0) <= 1) return name;
+    const ordinal = (ordinals.get(name) || 0) + 1;
+    ordinals.set(name, ordinal);
+    return `${name} #${ordinal}`;
+  });
+};
+
+const buildOpenAIKeyDisplayNameMap = (providers: OpenAIProviderConfig[]) => {
+  const entries: Array<{ key: string; name: string }> = [];
+
+  providers.forEach((provider, providerIndex) => {
+    (provider.apiKeyEntries || []).forEach((_entry, entryIndex) => {
+      entries.push({
+        key: `${providerIndex}:${entryIndex}`,
+        name:
+          provider.prefix?.trim() ||
+          provider.name?.trim() ||
+          extractHost(provider.baseUrl) ||
+          `OpenAI #${providerIndex + 1}`,
+      });
+    });
+  });
+
+  const displayNames = disambiguateDuplicateNames(entries.map((entry) => entry.name));
+  return new Map(entries.map((entry, index) => [entry.key, displayNames[index] || entry.name]));
 };
 
 export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
@@ -71,10 +149,11 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
   ];
 
   providers.forEach(({ items, type, label }) => {
+    const displayNames = buildProviderDisplayNames(items, label);
     items.forEach((item, index) => {
       registerProvider(
         {
-          displayName: item.prefix?.trim() || `${label} #${index + 1}`,
+          displayName: displayNames[index] || `${label} #${index + 1}`,
           type,
           identityKey: buildProviderIdentityKey(type, index),
         },
@@ -84,25 +163,42 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
     });
   });
 
-  (input.openaiCompatibility || []).forEach((provider, providerIndex) => {
-    const candidates = new Set<string>();
-    const authIndices: Array<unknown> = [provider.authIndex];
+  const openaiProviders = input.openaiCompatibility || [];
+  const openaiProviderDisplayNames = buildProviderDisplayNames(openaiProviders, 'OpenAI');
+  const openaiKeyDisplayNames = buildOpenAIKeyDisplayNameMap(openaiProviders);
 
-    buildCandidateUsageSourceIds({ prefix: provider.prefix }).forEach((id) => candidates.add(id));
-    (provider.apiKeyEntries || []).forEach((entry) => {
-      authIndices.push(entry.authIndex);
-      buildCandidateUsageSourceIds({ apiKey: entry.apiKey }).forEach((id) => candidates.add(id));
-    });
+  openaiProviders.forEach((provider, providerIndex) => {
+    const entryAuthIndexKeys = new Set(
+      (provider.apiKeyEntries || [])
+        .map((entry) => normalizeAuthIndex(entry.authIndex))
+        .filter(Boolean)
+    );
+    const providerAuthIndex = normalizeAuthIndex(provider.authIndex);
+    const providerEntry = {
+      displayName: openaiProviderDisplayNames[providerIndex] || `OpenAI #${providerIndex + 1}`,
+      type: 'openai',
+      identityKey: buildProviderIdentityKey('openai', providerIndex),
+    };
 
     registerProvider(
-      {
-        displayName: provider.prefix?.trim() || provider.name || `OpenAI #${providerIndex + 1}`,
-        type: 'openai',
-        identityKey: buildProviderIdentityKey('openai', providerIndex),
-      },
-      authIndices,
-      candidates
+      providerEntry,
+      providerAuthIndex && !entryAuthIndexKeys.has(providerAuthIndex) ? [providerAuthIndex] : [],
+      buildCandidateUsageSourceIds({ prefix: provider.prefix })
     );
+
+    (provider.apiKeyEntries || []).forEach((entry, entryIndex) => {
+      registerProvider(
+        {
+          displayName:
+            openaiKeyDisplayNames.get(`${providerIndex}:${entryIndex}`) ||
+            providerEntry.displayName,
+          type: 'openai',
+          identityKey: buildProviderIdentityKey('openai', `${providerIndex}:${entryIndex}`),
+        },
+        [entry.authIndex],
+        buildCandidateUsageSourceIds({ apiKey: entry.apiKey })
+      );
+    });
   });
 
   return { byAuthIndex, bySource };
@@ -114,7 +210,7 @@ export function resolveSourceDisplay(
   sourceInfoMap: SourceInfoMap,
   authFileMap: Map<string, CredentialInfo>
 ): SourceInfo {
-  const source = sourceRaw.trim();
+  const source = normalizeUsageSourceId(sourceRaw);
   const authIndexKey = normalizeAuthIndex(authIndex);
 
   if (authIndexKey) {

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -1,13 +1,91 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildCandidateUsageSourceIds,
   calculateCost,
   collectUsageDetails,
   collectUsageDetailsWithEndpoint,
   compatibleCachedTokens,
   extractTotalTokens,
+  normalizeUsageSourceId,
 } from './usage';
 import { maskSensitiveText } from './format';
+
+describe('usage source candidates', () => {
+  it('includes the masked source emitted by CPA for raw upstream keys', () => {
+    expect(buildCandidateUsageSourceIds({ apiKey: 'sk-1234567890abcdef' })).toContain(
+      'm:sk-1...cdef'
+    );
+  });
+
+  it('aligns short secret masking with the backend source contract', () => {
+    expect(buildCandidateUsageSourceIds({ apiKey: 'sk-12345' })).toContain('m:****');
+  });
+
+  it('preserves already-normalized masked usage event sources', () => {
+    const usageData = {
+      apis: {
+        'POST /v1/responses': {
+          models: {
+            'gpt-5.5': {
+              details: [
+                {
+                  timestamp: '2026-05-26T10:00:00Z',
+                  source: 'm:sk-1...cdef',
+                  auth_index: '',
+                  tokens: {},
+                  failed: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(collectUsageDetails(usageData)[0].source).toBe('m:sk-1...cdef');
+  });
+
+  it('does not trust text-prefixed raw API key sources', () => {
+    const sourceId = buildCandidateUsageSourceIds({ prefix: 'codex' })[0];
+    expect(sourceId).toBe('t:codex');
+
+    const usageData = {
+      apis: {
+        'POST /v1/responses': {
+          models: {
+            'gpt-5.5': {
+              details: [
+                {
+                  timestamp: '2026-05-26T10:00:00Z',
+                  source: 't:sk-1234567890abcdef',
+                  auth_index: '',
+                  tokens: {},
+                  failed: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const normalized = collectUsageDetails(usageData)[0].source;
+    expect(normalized).toMatch(/^k:/);
+    expect(normalized).not.toContain('sk-1234567890abcdef');
+  });
+
+  it('does not trust abnormal masked sources that contain raw secrets', () => {
+    const normalized = normalizeUsageSourceId('m:sk-realsecret');
+
+    expect(normalized).toMatch(/^k:/);
+    expect(normalized).not.toContain('sk-realsecret');
+  });
+
+  it('preserves legacy UI-masked source IDs when no raw secret is present', () => {
+    expect(normalizeUsageSourceId('m:sk******ef')).toBe('m:sk******ef');
+  });
+});
 
 describe('usage detail collection', () => {
   it('copies project id snapshots into normalized usage details', () => {

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -86,6 +86,7 @@ const USAGE_SOURCE_PREFIX_TEXT = 't:';
 const KEY_LIKE_TOKEN_REGEX =
   /(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{6,}|ghp_[A-Za-z0-9]{6,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{6,}|pk_[A-Za-z0-9]{6,}|rk_[A-Za-z0-9]{6,})/;
 const MASKED_TOKEN_HINT_REGEX = /^[^\s]{1,24}(\*{2,}|\.{3})[^\s]{1,24}$/;
+const BACKEND_MASKED_SOURCE_REGEX = /^m:(\*{4}|[^\s/\\]{4}\.\.\.[^\s/\\]{4})$/;
 
 const keyFingerprintCache = new Map<string, string>();
 const usageDetailsCache = new WeakMap<object, UsageDetail[]>();
@@ -202,6 +203,14 @@ const extractRawSecretFromText = (text: string): string | null => {
   return bearerValue && looksLikeRawSecret(bearerValue) ? bearerValue : null;
 };
 
+export function maskUsageSecretSource(secret: string): string {
+  const trimmed = String(secret || '').trim();
+  if (!trimmed) return '';
+
+  if (trimmed.length <= 8) return '****';
+  return `${trimmed.slice(0, 4)}...${trimmed.slice(-4)}`;
+}
+
 export function normalizeUsageSourceId(
   value: unknown,
   masker: (val: string) => string = maskApiKey
@@ -210,6 +219,20 @@ export function normalizeUsageSourceId(
     typeof value === 'string' ? value : value === null || value === undefined ? '' : String(value);
   const trimmed = raw.trim();
   if (!trimmed) return '';
+  if (trimmed.startsWith(USAGE_SOURCE_PREFIX_KEY)) return trimmed;
+  if (trimmed.startsWith(USAGE_SOURCE_PREFIX_MASKED)) {
+    if (BACKEND_MASKED_SOURCE_REGEX.test(trimmed)) return trimmed;
+    const maskedValue = trimmed.slice(USAGE_SOURCE_PREFIX_MASKED.length).trim();
+    const extracted = extractRawSecretFromText(maskedValue) || extractRawSecretFromText(trimmed);
+    return extracted
+      ? `${USAGE_SOURCE_PREFIX_KEY}${fnv1a64Hex(extracted)}`
+      : trimmed;
+  }
+  if (trimmed.startsWith(USAGE_SOURCE_PREFIX_TEXT)) {
+    const textSource = trimmed.slice(USAGE_SOURCE_PREFIX_TEXT.length).trim();
+    const extracted = extractRawSecretFromText(textSource);
+    return extracted ? `${USAGE_SOURCE_PREFIX_KEY}${fnv1a64Hex(extracted)}` : trimmed;
+  }
 
   const extracted = extractRawSecretFromText(trimmed);
   if (extracted) return `${USAGE_SOURCE_PREFIX_KEY}${fnv1a64Hex(extracted)}`;
@@ -230,6 +253,8 @@ export function buildCandidateUsageSourceIds(input: {
   const apiKey = input.apiKey?.trim();
   if (apiKey) {
     result.push(normalizeUsageSourceId(apiKey));
+    result.push(`${USAGE_SOURCE_PREFIX_MASKED}${maskUsageSecretSource(apiKey)}`);
+    result.push(`${USAGE_SOURCE_PREFIX_MASKED}${maskApiKey(apiKey)}`);
     result.push(`${USAGE_SOURCE_PREFIX_TEXT}${maskApiKey(apiKey)}`);
   }
 


### PR DESCRIPTION
## Summary

Fixes #39.

This PR makes request monitoring resolve CPA masked API-key usage sources back to readable provider labels instead of falling back to raw `m:...` source strings.

CPA usage events can contain already-normalized masked sources such as `m:sk-1...cdef`. The web client previously generated source candidates from raw provider keys using hash/text forms and the UI mask form, but did not generate the CPA masked source form, so Codex/OpenAI-compatible upstreams often displayed as `m:sk-...` in monitoring tables and summaries.

## Changes

- Preserve already-normalized usage source IDs with `k:`, `m:`, and `t:` prefixes instead of normalizing them again.
- Add a CPA-compatible masked source candidate for configured API keys using the first/last character pattern emitted by CPA usage events.
- Keep the existing UI mask candidate for compatibility with older/other data shapes.
- Resolve provider display names with this priority:
  - explicit prefix
  - explicit OpenAI-compatible provider name
  - base URL host
  - provider fallback label
- Distinguish multiple configured keys on the same host as `host #1`, `host #2`, etc.
- Add regression coverage for Codex and OpenAI-compatible masked source resolution, duplicate host disambiguation, unmatched fallbacks, and already-normalized usage sources.

## Security

The resolver only generates masked source IDs and display labels. It does not display or persist raw API keys. Tests assert that raw key middle sections are not exposed in duplicate-host labels.

## Validation

- `npm --workspace apps/web run test -- src/utils/usage.test.ts src/utils/sourceResolver.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run manager-server:test`
