### PR TITLE
fix(monitoring): refine realtime latency display

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -1241,28 +1241,37 @@
   line-height: 1.25;
 }
 
-.realtimeMetricLine,
 .realtimeTimeLine,
 .realtimeTpsCell {
   white-space: nowrap;
 }
 
-.realtimeMetricLine {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
+.realtimeLatencyColumn {
+  text-align: center !important;
 }
 
-.realtimeMetricLabel {
-  color: var(--monitor-muted);
+.realtimeLatencyHeader {
+  display: inline-grid;
+  grid-template-columns: minmax(42px, 1fr) 10px minmax(42px, 1fr);
+  align-items: center;
+  justify-content: center;
+  width: 118px;
+  font-size: 12px;
+  line-height: 1.25;
+  text-transform: none;
+  white-space: nowrap;
 }
 
-.realtimeMetricValue {
-  color: inherit;
-}
-
-.realtimeMetricTtft {
-  color: var(--monitor-ink);
+.realtimeMetricCell {
+  display: inline-grid;
+  grid-template-columns: minmax(48px, 1fr) 10px minmax(48px, 1fr);
+  align-items: center;
+  justify-content: center;
+  width: 118px;
+  min-width: 118px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .realtimeTpsColumn {
@@ -1280,10 +1289,46 @@
 }
 
 .realtimeTimeLine {
-  width: 82px;
-  font-size: 11px;
+  width: 92px;
+  font-size: 12px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  line-height: 1.35;
+  line-height: 1.3;
+}
+
+.realtimeMetricText {
+  color: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+}
+
+.realtimeMetricLeft {
+  min-width: 0;
+  text-align: right;
+}
+
+.realtimeMetricRight {
+  min-width: 0;
+  text-align: left;
+}
+
+.realtimeMetricText.goodText {
+  color: var(--monitor-green);
+}
+
+.realtimeMetricText.warnText {
+  color: var(--monitor-amber);
+}
+
+.realtimeMetricText.badText {
+  color: var(--monitor-red);
+}
+
+.realtimeMetricSeparator {
+  color: var(--monitor-line);
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: center;
 }
 
 .logTypeCell {

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MonitoringEventRow } from '@/features/monitoring/hooks/useMonitoringData';
 import { RealtimeEventsPanel } from './RealtimeEventsPanel';
 
-const t = ((key: string, options?: Record<string, string>) => {
+const t = ((key: string) => {
   const messages: Record<string, string> = {
     'common.loading': 'Loading',
     'common.copy': 'Copy',
@@ -33,9 +33,6 @@ const t = ((key: string, options?: Record<string, string>) => {
     'monitoring.this_call_usage': 'Usage',
     'monitoring.ttft_short': 'TTFT',
   };
-  if (key === 'monitoring.resolved_model_label') {
-    return `Resolved ${options?.model ?? ''}`.trim();
-  }
   return messages[key] ?? key;
 }) as unknown as TFunction;
 
@@ -156,11 +153,15 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('<th>Effort</th>');
     expect(markup).toContain('>TPS</th>');
     expect(markup).toContain('medium');
+    expect(markup).toContain('client-gpt');
+    expect(markup).toContain('gpt-5.4');
+    expect(markup).not.toContain('Resolved');
+    expect(markup).not.toContain('POST /v1/chat/completions');
     expect(markup).toContain('Failed');
-    expect(markup).toContain('TTFT');
-    expect(markup).toContain('500ms');
+    expect(markup).toMatch(/TTFT<\/span><span class="[^"]+">｜<\/span><span class="[^"]+">Elapsed/);
+    expect(markup).toContain('500 ms');
     expect(markup).toContain('Elapsed');
-    expect(markup).toContain('1.5s');
+    expect(markup).toContain('1.5 s');
     expect(markup).toContain('20');
     expect(markup).toContain('I 10 · O 20 · C 5');
     expect(markup).not.toContain('Read 4');
@@ -180,7 +181,7 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('<th>Effort</th>');
     expect(markup).toContain('>TPS</th>');
     expect(markup).toContain('Success');
-    expect(markup).toContain('TTFT');
+    expect(markup).toMatch(/TTFT<\/span><span class="[^"]+">｜<\/span><span class="[^"]+">Elapsed/);
     expect(markup).toContain(expectedDate);
     expect(markup).toContain(expectedTime);
     expect(markup).toContain('I 10 · O 20 · C 5');
@@ -191,12 +192,31 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).not.toContain('HTTP');
   });
 
-  it('hides ttft latency details when ttft is missing', () => {
+  it('renders a ttft placeholder when ttft is missing', () => {
     const markup = renderPanel(baseRow({ ttftMs: null }));
 
     expect(markup).toContain('>TPS</th>');
-    expect(markup).not.toContain('TTFT');
-    expect(markup).not.toContain('TTFT --');
+    expect(markup).toMatch(/TTFT<\/span><span class="[^"]+">｜<\/span><span class="[^"]+">Elapsed/);
+    expect(markup).not.toContain('500 ms');
+    expect(markup).toContain('1.5 s');
+    expect(markup).toMatch(
+      /--<\/span><span class="[^"]+">｜<\/span><span class="[^"]*realtimeMetricText[^"]*realtimeMetricRight[^"]*">1\.5 s<\/span>/
+    );
+  });
+
+  it('keeps latency warning and error tone classes on plain text metrics', () => {
+    const warningMarkup = renderPanel(baseRow({ latencyMs: 20_000, ttftMs: 1_000 }));
+    const errorMarkup = renderPanel(baseRow({ latencyMs: 35_000, ttftMs: 1_000 }));
+
+    expect(warningMarkup).toMatch(/class="[^"]*realtimeMetricText[^"]*warnText[^"]*"/);
+    expect(errorMarkup).toMatch(/class="[^"]*realtimeMetricText[^"]*badText[^"]*"/);
+  });
+
+  it('colors normal millisecond and second metrics green for both ttft and elapsed time', () => {
+    const markup = renderPanel(baseRow({ latencyMs: 470, ttftMs: 120 }));
+
+    expect(markup).toMatch(/class="[^"]*realtimeMetricText[^"]*realtimeMetricLeft[^"]*goodText[^"]*">120 ms/);
+    expect(markup).toMatch(/class="[^"]*realtimeMetricText[^"]*realtimeMetricRight[^"]*goodText[^"]*">470 ms/);
   });
 
   it('renders residual cached tokens even when they equal cache read tokens', () => {

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -61,11 +61,6 @@ export type RealtimeEventsPanelActionsProps = {
 
 const REALTIME_PAGE_SIZE_OPTIONS = [10, 50, 100, 150, 300] as const;
 
-const buildRealtimeMetaText = (row: MonitoringEventRow) => {
-  const text = `${row.endpointMethod} ${row.endpointPath}`.trim();
-  return maskSensitiveText(text || '-');
-};
-
 const formatOptionalText = (value: string | null | undefined) => {
   const trimmed = String(value || '').trim();
   return trimmed || '-';
@@ -103,10 +98,21 @@ const formatRealtimeCompactDuration = (value: number | null | undefined, locale:
     }
   };
 
-  if (parsed < 1000) return `${formatNumber(Math.round(parsed), 0)}ms`;
+  if (parsed < 1000) return `${formatNumber(Math.round(parsed), 0)} ms`;
 
   const seconds = parsed / 1000;
-  return `${formatNumber(seconds, seconds < 10 ? 2 : 1)}s`;
+  return `${formatNumber(seconds, seconds < 10 ? 2 : 1)} s`;
+};
+
+const getRealtimeDurationToneClass = (value: number | null | undefined) => {
+  if (value === null || value === undefined) return undefined;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+
+  if (parsed >= 30000) return styles.badText;
+  if (parsed >= 15000) return styles.warnText;
+  return styles.goodText;
 };
 
 const formatRealtimeDateParts = (timestampMs: number, locale: string) => {
@@ -231,7 +237,17 @@ export function RealtimeEventsPanel({
               <th>{t('monitoring.column_success_rate')}</th>
               <th>{t('monitoring.total_calls')}</th>
               <th className={styles.realtimeTpsColumn}>{t('monitoring.column_output_tps')}</th>
-              <th>{t('monitoring.column_latency')}</th>
+              <th className={styles.realtimeLatencyColumn}>
+                <span className={styles.realtimeLatencyHeader}>
+                  <span className={styles.realtimeMetricLeft}>
+                    {t('monitoring.ttft_short')}
+                  </span>
+                  <span className={styles.realtimeMetricSeparator}>｜</span>
+                  <span className={styles.realtimeMetricRight}>
+                    {t('monitoring.elapsed_short')}
+                  </span>
+                </span>
+              </th>
               <th>{t('monitoring.column_time')}</th>
               <th>{t('monitoring.this_call_usage')}</th>
               <th>{t('monitoring.this_call_cost')}</th>
@@ -250,13 +266,9 @@ export function RealtimeEventsPanel({
                 ? `${tooltipIdPrefix}-failure-tooltip-${row.id}`
                 : undefined;
               const timeParts = formatRealtimeDateParts(row.timestampMs, locale);
-              const latencyToneClass =
-                row.latencyMs !== null && row.latencyMs >= 30000
-                  ? styles.badText
-                  : row.latencyMs !== null && row.latencyMs >= 15000
-                    ? styles.warnText
-                    : undefined;
               const hasTtftMs = row.ttftMs !== null && row.ttftMs !== undefined;
+              const ttftToneClass = getRealtimeDurationToneClass(row.ttftMs);
+              const latencyToneClass = getRealtimeDurationToneClass(row.latencyMs);
               return (
                 <tr key={row.id} className={row.failed ? styles.logRowFailed : undefined}>
                   <td>
@@ -271,11 +283,8 @@ export function RealtimeEventsPanel({
                     <div className={styles.primaryCell}>
                       <span className={styles.monoCell}>{row.model}</span>
                       {showResolvedModel ? (
-                        <small className={styles.monoCell}>
-                          {t('monitoring.resolved_model_label', { model: row.resolvedModel })}
-                        </small>
+                        <small className={styles.monoCell}>{row.resolvedModel}</small>
                       ) : null}
-                      <small className={styles.monoCell}>{buildRealtimeMetaText(row)}</small>
                     </div>
                   </td>
                   <td>
@@ -369,34 +378,30 @@ export function RealtimeEventsPanel({
                       {formatTokensPerSecond(row.tokensPerSecond, locale)}
                     </span>
                   </td>
-                  <td>
+                  <td className={styles.realtimeLatencyColumn}>
                     <div className={styles.realtimeMetricCell}>
-                      {hasTtftMs ? (
-                        <span
-                          className={`${styles.realtimeMetricLine} ${styles.realtimeMetricTtft}`}
-                        >
-                          <span className={styles.realtimeMetricLabel}>
-                            {t('monitoring.ttft_short')}
-                          </span>
-                          <span className={styles.realtimeMetricValue}>
-                            {formatRealtimeCompactDuration(row.ttftMs, locale)}
-                          </span>
-                        </span>
-                      ) : null}
                       <span
                         className={[
-                          styles.realtimeMetricLine,
+                          styles.realtimeMetricText,
+                          styles.realtimeMetricLeft,
+                          ttftToneClass,
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                      >
+                        {hasTtftMs ? formatRealtimeCompactDuration(row.ttftMs, locale) : '--'}
+                      </span>
+                      <span className={styles.realtimeMetricSeparator}>｜</span>
+                      <span
+                        className={[
+                          styles.realtimeMetricText,
+                          styles.realtimeMetricRight,
                           latencyToneClass,
                         ]
                           .filter(Boolean)
                           .join(' ')}
                       >
-                        <span className={styles.realtimeMetricLabel}>
-                          {t('monitoring.elapsed_short')}
-                        </span>
-                        <span className={styles.realtimeMetricValue}>
-                          {formatRealtimeCompactDuration(row.latencyMs, locale)}
-                        </span>
+                        {formatRealtimeCompactDuration(row.latencyMs, locale)}
                       </span>
                     </div>
                   </td>


### PR DESCRIPTION
## Summary
Refine the realtime monitoring latency display for clearer alignment and status coloring.

## Changes
- Align TTFT and elapsed values around a centered separator.
- Show actual resolved model names without endpoint noise in the model column.
- Apply good/warn/bad coloring to both TTFT and elapsed values.
- Increase time display readability and update focused tests.

## Testing
- npm --workspace apps/web run test -- src/features/monitoring/components/RealtimeEventsPanel.test.tsx
- npm run type-check