### PR TITLE
Fix dashboard and monitoring source labels

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/aggregate.go
+++ b/apps/manager-server/internal/repository/usageevent/aggregate.go
@@ -38,13 +38,20 @@ type ModelStat struct {
 
 // RecentFailure holds the columns required to display a recent failure entry.
 type RecentFailure struct {
-	TimestampMS int64
-	Model       string
-	APIKeyHash  string
-	SourceHash  string
-	AuthIndex   string
-	Endpoint    string
-	LatencyMS   sql.NullInt64
+	TimestampMS           int64
+	Model                 string
+	APIKeyHash            string
+	Source                string
+	SourceHash            string
+	AuthIndex             string
+	Endpoint              string
+	LatencyMS             sql.NullInt64
+	AccountSnapshot       string
+	AuthLabelSnapshot     string
+	AuthProviderSnapshot  string
+	AuthProjectIDSnapshot string
+	FailStatusCode        sql.NullInt64
+	FailSummary           string
 }
 
 const aggregateSQL = `select
@@ -202,13 +209,20 @@ func (r *repository) ModelStatsBetween(ctx context.Context, fromMs, toMs int64) 
 const recentFailuresSQL = `select
 	timestamp_ms, model,
 	coalesce(api_key_hash, ''),
+	coalesce(source, ''),
 	coalesce(source_hash, ''),
 	coalesce(auth_index, ''),
 	coalesce(endpoint, ''),
-	latency_ms
+	latency_ms,
+	coalesce(account_snapshot, ''),
+	coalesce(auth_label_snapshot, ''),
+	coalesce(auth_provider_snapshot, ''),
+	coalesce(auth_project_id_snapshot, ''),
+	fail_status_code,
+	coalesce(fail_summary, '')
 from usage_events
 where failed = 1 and timestamp_ms >= ? and timestamp_ms < ?
-order by timestamp_ms desc
+order by timestamp_ms desc, id desc
 limit ?`
 
 // RecentFailuresBetween returns the most recent failed events.
@@ -229,10 +243,17 @@ func (r *repository) RecentFailuresBetween(ctx context.Context, fromMs, toMs int
 			&rf.TimestampMS,
 			&rf.Model,
 			&rf.APIKeyHash,
+			&rf.Source,
 			&rf.SourceHash,
 			&rf.AuthIndex,
 			&rf.Endpoint,
 			&rf.LatencyMS,
+			&rf.AccountSnapshot,
+			&rf.AuthLabelSnapshot,
+			&rf.AuthProviderSnapshot,
+			&rf.AuthProjectIDSnapshot,
+			&rf.FailStatusCode,
+			&rf.FailSummary,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -41,28 +41,36 @@ type HourlyPoint struct {
 }
 
 type ChannelModelStat struct {
-	AuthIndex           string
-	Model               string
-	BillingModel        string
-	Calls               int64
-	SuccessCalls        int64
-	FailureCalls        int64
-	InputTokens         int64
-	OutputTokens        int64
-	CachedTokens        int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
-	TotalTokens         int64
-	AvgLatencyMS        sql.NullFloat64
+	AuthIndex            string
+	Source               string
+	AccountSnapshot      string
+	AuthLabelSnapshot    string
+	AuthProviderSnapshot string
+	Model                string
+	BillingModel         string
+	Calls                int64
+	SuccessCalls         int64
+	FailureCalls         int64
+	InputTokens          int64
+	OutputTokens         int64
+	CachedTokens         int64
+	CacheReadTokens      int64
+	CacheCreationTokens  int64
+	TotalTokens          int64
+	AvgLatencyMS         sql.NullFloat64
 }
 
 type FailureSourceStat struct {
-	SourceHash   string
-	AuthIndex    string
-	Calls        int64
-	FailureCalls int64
-	LastSeenMS   int64
-	AvgLatencyMS sql.NullFloat64
+	Source               string
+	SourceHash           string
+	AuthIndex            string
+	AccountSnapshot      string
+	AuthLabelSnapshot    string
+	AuthProviderSnapshot string
+	Calls                int64
+	FailureCalls         int64
+	LastSeenMS           int64
+	AvgLatencyMS         sql.NullFloat64
 }
 
 type TaskBucket struct {
@@ -301,6 +309,10 @@ func (r *repository) ChannelModelStatsWithFilter(ctx context.Context, filter Ana
 	where, args := analyticsWhere(filter)
 	rows, err := r.db.QueryContext(ctx, `select
 	coalesce(auth_index, ''),
+	coalesce(max(source), ''),
+	coalesce(max(account_snapshot), ''),
+	coalesce(max(auth_label_snapshot), ''),
+	coalesce(max(auth_provider_snapshot), ''),
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
 	count(*),
@@ -326,6 +338,10 @@ order by count(*) desc`, args...)
 		var stat ChannelModelStat
 		if err := rows.Scan(
 			&stat.AuthIndex,
+			&stat.Source,
+			&stat.AccountSnapshot,
+			&stat.AuthLabelSnapshot,
+			&stat.AuthProviderSnapshot,
 			&stat.Model,
 			&stat.BillingModel,
 			&stat.Calls,
@@ -349,8 +365,12 @@ order by count(*) desc`, args...)
 func (r *repository) FailureSourcesWithFilter(ctx context.Context, filter AnalyticsFilter) ([]FailureSourceStat, error) {
 	where, args := analyticsWhere(filter)
 	rows, err := r.db.QueryContext(ctx, `select
+	coalesce(max(source), ''),
 	coalesce(source_hash, ''),
 	coalesce(auth_index, ''),
+	coalesce(max(account_snapshot), ''),
+	coalesce(max(auth_label_snapshot), ''),
+	coalesce(max(auth_provider_snapshot), ''),
 	count(*),
 	sum(case when failed = 1 then 1 else 0 end),
 	max(timestamp_ms),
@@ -367,7 +387,18 @@ order by sum(case when failed = 1 then 1 else 0 end) desc, max(timestamp_ms) des
 	stats := make([]FailureSourceStat, 0)
 	for rows.Next() {
 		var stat FailureSourceStat
-		if err := rows.Scan(&stat.SourceHash, &stat.AuthIndex, &stat.Calls, &stat.FailureCalls, &stat.LastSeenMS, &stat.AvgLatencyMS); err != nil {
+		if err := rows.Scan(
+			&stat.Source,
+			&stat.SourceHash,
+			&stat.AuthIndex,
+			&stat.AccountSnapshot,
+			&stat.AuthLabelSnapshot,
+			&stat.AuthProviderSnapshot,
+			&stat.Calls,
+			&stat.FailureCalls,
+			&stat.LastSeenMS,
+			&stat.AvgLatencyMS,
+		); err != nil {
 			return nil, err
 		}
 		stats = append(stats, stat)
@@ -448,10 +479,17 @@ func (r *repository) RecentFailuresWithFilter(ctx context.Context, filter Analyt
 	timestamp_ms,
 	model,
 	coalesce(api_key_hash, ''),
+	coalesce(source, ''),
 	coalesce(source_hash, ''),
 	coalesce(auth_index, ''),
 	coalesce(endpoint, ''),
-	latency_ms
+	latency_ms,
+	coalesce(account_snapshot, ''),
+	coalesce(auth_label_snapshot, ''),
+	coalesce(auth_provider_snapshot, ''),
+	coalesce(auth_project_id_snapshot, ''),
+	fail_status_code,
+	coalesce(fail_summary, '')
 from usage_events `+where+`
 and failed = 1
 order by timestamp_ms desc, id desc
@@ -468,10 +506,17 @@ limit ?`, args...)
 			&failure.TimestampMS,
 			&failure.Model,
 			&failure.APIKeyHash,
+			&failure.Source,
 			&failure.SourceHash,
 			&failure.AuthIndex,
 			&failure.Endpoint,
 			&failure.LatencyMS,
+			&failure.AccountSnapshot,
+			&failure.AuthLabelSnapshot,
+			&failure.AuthProviderSnapshot,
+			&failure.AuthProjectIDSnapshot,
+			&failure.FailStatusCode,
+			&failure.FailSummary,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -133,36 +133,51 @@ type ModelCostRank struct {
 }
 
 type ChannelHealth struct {
-	AuthIndex        string   `json:"auth_index"`
-	Calls            int64    `json:"calls"`
-	Failures         int64    `json:"failures"`
-	FailureRate      float64  `json:"failure_rate"`
-	SuccessRate      float64  `json:"success_rate"`
-	Tokens           int64    `json:"tokens"`
-	Cost             float64  `json:"cost"`
-	AverageLatencyMS *float64 `json:"average_latency_ms"`
-	Tone             string   `json:"tone"`
+	AuthIndex            string   `json:"auth_index"`
+	Source               string   `json:"source,omitempty"`
+	AccountSnapshot      string   `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot    string   `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot string   `json:"auth_provider_snapshot,omitempty"`
+	Calls                int64    `json:"calls"`
+	Failures             int64    `json:"failures"`
+	FailureRate          float64  `json:"failure_rate"`
+	SuccessRate          float64  `json:"success_rate"`
+	Tokens               int64    `json:"tokens"`
+	Cost                 float64  `json:"cost"`
+	AverageLatencyMS     *float64 `json:"average_latency_ms"`
+	Tone                 string   `json:"tone"`
 }
 
 type FailureSource struct {
-	SourceHash       string   `json:"source_hash"`
-	AuthIndex        string   `json:"auth_index"`
-	Calls            int64    `json:"calls"`
-	Failures         int64    `json:"failures"`
-	FailureRate      float64  `json:"failure_rate"`
-	LastSeenMS       int64    `json:"last_seen_ms"`
-	AverageLatencyMS *float64 `json:"average_latency_ms"`
-	Tone             string   `json:"tone"`
+	Source               string   `json:"source,omitempty"`
+	SourceHash           string   `json:"source_hash"`
+	AuthIndex            string   `json:"auth_index"`
+	AccountSnapshot      string   `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot    string   `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot string   `json:"auth_provider_snapshot,omitempty"`
+	Calls                int64    `json:"calls"`
+	Failures             int64    `json:"failures"`
+	FailureRate          float64  `json:"failure_rate"`
+	LastSeenMS           int64    `json:"last_seen_ms"`
+	AverageLatencyMS     *float64 `json:"average_latency_ms"`
+	Tone                 string   `json:"tone"`
 }
 
 type RecentFailure struct {
-	TimestampMS int64  `json:"timestamp_ms"`
-	Model       string `json:"model"`
-	APIKeyHash  string `json:"api_key_hash"`
-	SourceHash  string `json:"source_hash"`
-	AuthIndex   string `json:"auth_index"`
-	Endpoint    string `json:"endpoint"`
-	DurationMS  *int64 `json:"duration_ms"`
+	TimestampMS           int64  `json:"timestamp_ms"`
+	Model                 string `json:"model"`
+	APIKeyHash            string `json:"api_key_hash"`
+	Source                string `json:"source,omitempty"`
+	SourceHash            string `json:"source_hash"`
+	AuthIndex             string `json:"auth_index"`
+	AccountSnapshot       string `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot     string `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot  string `json:"auth_provider_snapshot,omitempty"`
+	AuthProjectIDSnapshot string `json:"auth_project_id_snapshot,omitempty"`
+	Endpoint              string `json:"endpoint"`
+	DurationMS            *int64 `json:"duration_ms"`
+	FailStatusCode        *int64 `json:"fail_status_code,omitempty"`
+	FailSummary           string `json:"fail_summary,omitempty"`
 }
 
 type SummaryResponse struct {
@@ -489,9 +504,16 @@ func buildChannelHealth(stats []store.ChannelModelStat, prices map[string]store.
 		}
 		entry := grouped[authIndex]
 		if entry == nil {
-			entry = &accumulator{row: ChannelHealth{AuthIndex: authIndex}}
+			entry = &accumulator{row: ChannelHealth{
+				AuthIndex:            authIndex,
+				Source:               stat.Source,
+				AccountSnapshot:      stat.AccountSnapshot,
+				AuthLabelSnapshot:    stat.AuthLabelSnapshot,
+				AuthProviderSnapshot: stat.AuthProviderSnapshot,
+			}}
 			grouped[authIndex] = entry
 		}
+		fillChannelHealthSnapshots(&entry.row, stat)
 		entry.row.Calls += stat.Calls
 		entry.row.Failures += stat.FailureCalls
 		entry.row.Tokens += stat.TotalTokens
@@ -540,14 +562,18 @@ func buildFailureSources(stats []store.FailureSourceStat, limit int) []FailureSo
 			tone = "bad"
 		}
 		rows = append(rows, FailureSource{
-			SourceHash:       stat.SourceHash,
-			AuthIndex:        stat.AuthIndex,
-			Calls:            stat.Calls,
-			Failures:         stat.FailureCalls,
-			FailureRate:      failureRate,
-			LastSeenMS:       stat.LastSeenMS,
-			AverageLatencyMS: nullableFloat(stat.AvgLatencyMS.Valid, stat.AvgLatencyMS.Float64),
-			Tone:             tone,
+			Source:               stat.Source,
+			SourceHash:           stat.SourceHash,
+			AuthIndex:            stat.AuthIndex,
+			AccountSnapshot:      stat.AccountSnapshot,
+			AuthLabelSnapshot:    stat.AuthLabelSnapshot,
+			AuthProviderSnapshot: stat.AuthProviderSnapshot,
+			Calls:                stat.Calls,
+			Failures:             stat.FailureCalls,
+			FailureRate:          failureRate,
+			LastSeenMS:           stat.LastSeenMS,
+			AverageLatencyMS:     nullableFloat(stat.AvgLatencyMS.Valid, stat.AvgLatencyMS.Float64),
+			Tone:                 tone,
 		})
 	}
 	if limit > 0 && len(rows) > limit {
@@ -556,17 +582,39 @@ func buildFailureSources(stats []store.FailureSourceStat, limit int) []FailureSo
 	return rows
 }
 
+func fillChannelHealthSnapshots(row *ChannelHealth, stat store.ChannelModelStat) {
+	if row.Source == "" {
+		row.Source = stat.Source
+	}
+	if row.AccountSnapshot == "" {
+		row.AccountSnapshot = stat.AccountSnapshot
+	}
+	if row.AuthLabelSnapshot == "" {
+		row.AuthLabelSnapshot = stat.AuthLabelSnapshot
+	}
+	if row.AuthProviderSnapshot == "" {
+		row.AuthProviderSnapshot = stat.AuthProviderSnapshot
+	}
+}
+
 func buildRecentFailures(failures []store.RecentFailure) []RecentFailure {
 	result := make([]RecentFailure, 0, len(failures))
 	for _, failure := range failures {
 		result = append(result, RecentFailure{
-			TimestampMS: failure.TimestampMS,
-			Model:       failure.Model,
-			APIKeyHash:  failure.APIKeyHash,
-			SourceHash:  failure.SourceHash,
-			AuthIndex:   failure.AuthIndex,
-			Endpoint:    failure.Endpoint,
-			DurationMS:  nullableInt(failure.LatencyMS.Valid, failure.LatencyMS.Int64),
+			TimestampMS:           failure.TimestampMS,
+			Model:                 failure.Model,
+			APIKeyHash:            failure.APIKeyHash,
+			Source:                failure.Source,
+			SourceHash:            failure.SourceHash,
+			AuthIndex:             failure.AuthIndex,
+			AccountSnapshot:       failure.AccountSnapshot,
+			AuthLabelSnapshot:     failure.AuthLabelSnapshot,
+			AuthProviderSnapshot:  failure.AuthProviderSnapshot,
+			AuthProjectIDSnapshot: failure.AuthProjectIDSnapshot,
+			Endpoint:              failure.Endpoint,
+			DurationMS:            nullableInt(failure.LatencyMS.Valid, failure.LatencyMS.Int64),
+			FailStatusCode:        nullableInt(failure.FailStatusCode.Valid, failure.FailStatusCode.Int64),
+			FailSummary:           failure.FailSummary,
 		})
 	}
 	return result

--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -94,6 +94,12 @@ func TestSummaryAggregatesCostsAndWindows(t *testing.T) {
 		resp.RecentFailures[0].DurationMS == nil || *resp.RecentFailures[0].DurationMS != 200 {
 		t.Fatalf("recent failures = %#v", resp.RecentFailures)
 	}
+	if resp.RecentFailures[0].Source != "user@example.com" ||
+		resp.RecentFailures[0].FailSummary != "upstream rate limit" ||
+		resp.RecentFailures[0].FailStatusCode == nil ||
+		*resp.RecentFailures[0].FailStatusCode != 429 {
+		t.Fatalf("recent failure details = %#v", resp.RecentFailures[0])
+	}
 	if len(resp.TrafficTimeline) != 24 || resp.TrafficTimeline[0].Calls != 3 ||
 		resp.TrafficTimeline[0].Tokens != 1_750_100 ||
 		math.Abs(resp.TrafficTimeline[0].FailureRate-(1.0/3.0)) > 0.000001 {
@@ -129,9 +135,17 @@ func TestSummaryAggregatesCostsAndWindows(t *testing.T) {
 		resp.ChannelHealth[0].Failures != 1 || resp.ChannelHealth[0].Tone != "bad" {
 		t.Fatalf("channel health = %#v", resp.ChannelHealth)
 	}
+	if resp.ChannelHealth[0].Source != "user@example.com" ||
+		resp.ChannelHealth[0].AccountSnapshot != "user@example.com" {
+		t.Fatalf("channel health display snapshots = %#v", resp.ChannelHealth[0])
+	}
 	if len(resp.FailureSources) != 1 || resp.FailureSources[0].SourceHash != "source-hash" ||
 		resp.FailureSources[0].Failures != 1 {
 		t.Fatalf("failure sources = %#v", resp.FailureSources)
+	}
+	if resp.FailureSources[0].Source != "user@example.com" ||
+		resp.FailureSources[0].AccountSnapshot != "user@example.com" {
+		t.Fatalf("failure source display snapshots = %#v", resp.FailureSources[0])
 	}
 }
 
@@ -219,6 +233,7 @@ func dashboardEvent(
 		Source:          "user@example.com",
 		SourceHash:      "source-hash",
 		APIKeyHash:      "api-key-hash",
+		AccountSnapshot: "user@example.com",
 		InputTokens:     inputTokens,
 		OutputTokens:    outputTokens,
 		ReasoningTokens: reasoningTokens,
@@ -227,6 +242,8 @@ func dashboardEvent(
 		TotalTokens:     totalTokens,
 		LatencyMS:       latencyMS,
 		Failed:          failed,
+		FailStatusCode:  429,
+		FailSummary:     "upstream rate limit",
 		CreatedAtMS:     timestampMS,
 	}
 }

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -142,22 +142,30 @@ type ModelStat struct {
 }
 
 type ChannelShareRow struct {
-	AuthIndex    string   `json:"auth_index"`
-	Calls        int64    `json:"calls"`
-	Success      int64    `json:"success"`
-	Failure      int64    `json:"failure"`
-	Tokens       int64    `json:"tokens"`
-	Cost         float64  `json:"cost"`
-	AvgLatencyMS *float64 `json:"average_latency_ms"`
+	AuthIndex            string   `json:"auth_index"`
+	Source               string   `json:"source,omitempty"`
+	AccountSnapshot      string   `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot    string   `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot string   `json:"auth_provider_snapshot,omitempty"`
+	Calls                int64    `json:"calls"`
+	Success              int64    `json:"success"`
+	Failure              int64    `json:"failure"`
+	Tokens               int64    `json:"tokens"`
+	Cost                 float64  `json:"cost"`
+	AvgLatencyMS         *float64 `json:"average_latency_ms"`
 }
 
 type FailureSourceRow struct {
-	SourceHash   string   `json:"source_hash"`
-	AuthIndex    string   `json:"auth_index"`
-	Calls        int64    `json:"calls"`
-	Failure      int64    `json:"failure"`
-	LastSeenMS   int64    `json:"last_seen_ms"`
-	AvgLatencyMS *float64 `json:"average_latency_ms"`
+	Source               string   `json:"source,omitempty"`
+	SourceHash           string   `json:"source_hash"`
+	AuthIndex            string   `json:"auth_index"`
+	AccountSnapshot      string   `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot    string   `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot string   `json:"auth_provider_snapshot,omitempty"`
+	Calls                int64    `json:"calls"`
+	Failure              int64    `json:"failure"`
+	LastSeenMS           int64    `json:"last_seen_ms"`
+	AvgLatencyMS         *float64 `json:"average_latency_ms"`
 }
 
 type TaskBucketRow struct {
@@ -183,13 +191,20 @@ type TaskBucketRow struct {
 }
 
 type RecentFailure struct {
-	TimestampMS int64  `json:"timestamp_ms"`
-	Model       string `json:"model"`
-	APIKeyHash  string `json:"api_key_hash"`
-	SourceHash  string `json:"source_hash"`
-	AuthIndex   string `json:"auth_index"`
-	Endpoint    string `json:"endpoint"`
-	DurationMS  *int64 `json:"duration_ms"`
+	TimestampMS           int64  `json:"timestamp_ms"`
+	Model                 string `json:"model"`
+	APIKeyHash            string `json:"api_key_hash"`
+	Source                string `json:"source,omitempty"`
+	SourceHash            string `json:"source_hash"`
+	AuthIndex             string `json:"auth_index"`
+	AccountSnapshot       string `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot     string `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot  string `json:"auth_provider_snapshot,omitempty"`
+	AuthProjectIDSnapshot string `json:"auth_project_id_snapshot,omitempty"`
+	Endpoint              string `json:"endpoint"`
+	DurationMS            *int64 `json:"duration_ms"`
+	FailStatusCode        *int64 `json:"fail_status_code,omitempty"`
+	FailSummary           string `json:"fail_summary,omitempty"`
 }
 
 type EventsResponse struct {
@@ -538,9 +553,16 @@ func buildChannelShare(stats []store.ChannelModelStat, prices map[string]store.M
 		}
 		entry := grouped[authIndex]
 		if entry == nil {
-			entry = &accumulator{row: ChannelShareRow{AuthIndex: authIndex}}
+			entry = &accumulator{row: ChannelShareRow{
+				AuthIndex:            authIndex,
+				Source:               stat.Source,
+				AccountSnapshot:      stat.AccountSnapshot,
+				AuthLabelSnapshot:    stat.AuthLabelSnapshot,
+				AuthProviderSnapshot: stat.AuthProviderSnapshot,
+			}}
 			grouped[authIndex] = entry
 		}
+		fillChannelShareSnapshots(&entry.row, stat)
 		entry.row.Calls += stat.Calls
 		entry.row.Success += stat.SuccessCalls
 		entry.row.Failure += stat.FailureCalls
@@ -566,15 +588,34 @@ func buildFailureSources(stats []store.FailureSourceStat) []FailureSourceRow {
 	result := make([]FailureSourceRow, 0, len(stats))
 	for _, stat := range stats {
 		result = append(result, FailureSourceRow{
-			SourceHash:   stat.SourceHash,
-			AuthIndex:    stat.AuthIndex,
-			Calls:        stat.Calls,
-			Failure:      stat.FailureCalls,
-			LastSeenMS:   stat.LastSeenMS,
-			AvgLatencyMS: nullableFloat(stat.AvgLatencyMS.Valid, stat.AvgLatencyMS.Float64),
+			Source:               stat.Source,
+			SourceHash:           stat.SourceHash,
+			AuthIndex:            stat.AuthIndex,
+			AccountSnapshot:      stat.AccountSnapshot,
+			AuthLabelSnapshot:    stat.AuthLabelSnapshot,
+			AuthProviderSnapshot: stat.AuthProviderSnapshot,
+			Calls:                stat.Calls,
+			Failure:              stat.FailureCalls,
+			LastSeenMS:           stat.LastSeenMS,
+			AvgLatencyMS:         nullableFloat(stat.AvgLatencyMS.Valid, stat.AvgLatencyMS.Float64),
 		})
 	}
 	return result
+}
+
+func fillChannelShareSnapshots(row *ChannelShareRow, stat store.ChannelModelStat) {
+	if row.Source == "" {
+		row.Source = stat.Source
+	}
+	if row.AccountSnapshot == "" {
+		row.AccountSnapshot = stat.AccountSnapshot
+	}
+	if row.AuthLabelSnapshot == "" {
+		row.AuthLabelSnapshot = stat.AuthLabelSnapshot
+	}
+	if row.AuthProviderSnapshot == "" {
+		row.AuthProviderSnapshot = stat.AuthProviderSnapshot
+	}
 }
 
 func buildTaskBuckets(buckets []store.TaskBucket) []TaskBucketRow {
@@ -609,13 +650,20 @@ func buildRecentFailures(failures []store.RecentFailure) []RecentFailure {
 	result := make([]RecentFailure, 0, len(failures))
 	for _, failure := range failures {
 		result = append(result, RecentFailure{
-			TimestampMS: failure.TimestampMS,
-			Model:       failure.Model,
-			APIKeyHash:  failure.APIKeyHash,
-			SourceHash:  failure.SourceHash,
-			AuthIndex:   failure.AuthIndex,
-			Endpoint:    failure.Endpoint,
-			DurationMS:  nullableInt(failure.LatencyMS.Valid, failure.LatencyMS.Int64),
+			TimestampMS:           failure.TimestampMS,
+			Model:                 failure.Model,
+			APIKeyHash:            failure.APIKeyHash,
+			Source:                failure.Source,
+			SourceHash:            failure.SourceHash,
+			AuthIndex:             failure.AuthIndex,
+			AccountSnapshot:       failure.AccountSnapshot,
+			AuthLabelSnapshot:     failure.AuthLabelSnapshot,
+			AuthProviderSnapshot:  failure.AuthProviderSnapshot,
+			AuthProjectIDSnapshot: failure.AuthProjectIDSnapshot,
+			Endpoint:              failure.Endpoint,
+			DurationMS:            nullableInt(failure.LatencyMS.Valid, failure.LatencyMS.Int64),
+			FailStatusCode:        nullableInt(failure.FailStatusCode.Valid, failure.FailStatusCode.Int64),
+			FailSummary:           failure.FailSummary,
 		})
 	}
 	return result

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -284,6 +284,10 @@ func TestAnalyticsUsesResolvedModelPricingInAggregates(t *testing.T) {
 		math.Abs(resp.ChannelShare[0].Cost-3) > 0.000001 {
 		t.Fatalf("channel share = %#v", resp.ChannelShare)
 	}
+	if resp.ChannelShare[0].Source != "user@example.com" ||
+		resp.ChannelShare[0].AccountSnapshot != "user@example.com" {
+		t.Fatalf("channel share snapshots = %#v", resp.ChannelShare[0])
+	}
 }
 
 func TestAnalyticsAppliesFilters(t *testing.T) {
@@ -480,6 +484,7 @@ func monitoringEvent(
 		Source:          "user@example.com",
 		SourceHash:      sourceHash,
 		APIKeyHash:      "api-key-" + authIndex,
+		AccountSnapshot: "user@example.com",
 		InputTokens:     inputTokens,
 		OutputTokens:    outputTokens,
 		ReasoningTokens: reasoningTokens,

--- a/apps/manager-server/internal/store/aggregation_test.go
+++ b/apps/manager-server/internal/store/aggregation_test.go
@@ -76,6 +76,10 @@ func TestAggregateBetween(t *testing.T) {
 	if len(failures) != 1 || failures[0].Model != "gpt-b" || failures[0].TimestampMS != 1_500 {
 		t.Fatalf("failures = %#v", failures)
 	}
+	if failures[0].Source != "user@example.com" || failures[0].FailSummary != "upstream rate limit" ||
+		!failures[0].FailStatusCode.Valid || failures[0].FailStatusCode.Int64 != 429 {
+		t.Fatalf("failure detail fields = %#v", failures[0])
+	}
 
 	buckets, err := db.BucketTimelineBetween(context.Background(), 1_000, 2_000, 500)
 	if err != nil {
@@ -120,6 +124,8 @@ func aggregationEvent(
 		TotalTokens:     totalTokens,
 		LatencyMS:       latencyMS,
 		Failed:          failed,
+		FailStatusCode:  429,
+		FailSummary:     "upstream rate limit",
 		CreatedAtMS:     timestampMS,
 	}
 }

--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -12,11 +12,17 @@ import {
 import { useAuthStore, useConfigStore, useModelsStore } from '@/stores';
 import { apiKeysApi, providersApi, authFilesApi } from '@/services/api';
 import { logsApi, type ErrorLogFile } from '@/services/api/logs';
-import { usageServiceApi, type ApiKeyAlias, type UsageServiceStatus } from '@/services/api/usageService';
+import {
+  usageServiceApi,
+  type ApiKeyAlias,
+  type UsageServiceStatus,
+} from '@/services/api/usageService';
 import { useHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { loadMonitoringMetaPayload } from '@/features/monitoring/services/monitoringMetaService';
 import { buildMonitoringAuthMetaMap } from '@/features/monitoring/model/authMeta';
+import { buildAuthFileMapFromMeta } from '@/features/monitoring/model/sourceDisplay';
 import type { MonitoringChannelMeta } from '@/features/monitoring/model/types';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import type { AuthFileItem } from '@/types/authFile';
 import { VersionCard } from './components/VersionCard';
 import { UsageMetricsCard } from './components/UsageMetricsCard';
@@ -211,6 +217,18 @@ export function DashboardPage() {
     () => buildMonitoringAuthMetaMap(displayMeta.authFiles),
     [displayMeta.authFiles]
   );
+  const authFileMap = useMemo(() => buildAuthFileMapFromMeta(authMetaMap), [authMetaMap]);
+  const sourceInfoMap = useMemo(
+    () =>
+      buildSourceInfoMap({
+        geminiApiKeys: config?.geminiApiKeys || [],
+        claudeApiKeys: config?.claudeApiKeys || [],
+        codexApiKeys: config?.codexApiKeys || [],
+        vertexApiKeys: config?.vertexApiKeys || [],
+        openaiCompatibility: config?.openaiCompatibility || [],
+      }),
+    [config]
+  );
   const channelByAuthIndex = useMemo(() => {
     const map = new Map<string, MonitoringChannelMeta>();
     displayMeta.channels.forEach((channel) => {
@@ -247,13 +265,14 @@ export function DashboardPage() {
     setCollectorLoading(true);
     setErrorLogsLoading(true);
 
-    const [collectorResult, logsResult, managerConfigResult, metaResult, aliasesResult] = await Promise.allSettled([
-      usageServiceApi.getStatus(usageServiceBase, managementKey),
-      logsApi.fetchErrorLogs(),
-      usageServiceApi.getManagerConfig(usageServiceBase, managementKey),
-      loadMonitoringMetaPayload(config),
-      usageServiceApi.getApiKeyAliases(usageServiceBase, managementKey),
-    ]);
+    const [collectorResult, logsResult, managerConfigResult, metaResult, aliasesResult] =
+      await Promise.allSettled([
+        usageServiceApi.getStatus(usageServiceBase, managementKey),
+        logsApi.fetchErrorLogs(),
+        usageServiceApi.getManagerConfig(usageServiceBase, managementKey),
+        loadMonitoringMetaPayload(config),
+        usageServiceApi.getApiKeyAliases(usageServiceBase, managementKey),
+      ]);
 
     if (collectorResult.status === 'fulfilled') {
       setCollectorStatus(collectorResult.value);
@@ -442,7 +461,11 @@ export function DashboardPage() {
             <span className={styles.date}>{formattedDate}</span>
           </div>
           <div className={styles.headerActions}>
-            <button className={styles.actionBtn} onClick={refreshDashboard} title={t('common.refresh')}>
+            <button
+              className={styles.actionBtn}
+              onClick={refreshDashboard}
+              title={t('common.refresh')}
+            >
               <IconRefreshCw size={16} />
               <span>{t('common.refresh')}</span>
             </button>
@@ -476,9 +499,7 @@ export function DashboardPage() {
       {/* 3. Today's Overview (Metrics Cards) */}
       {usageSummary.enabled && (
         <section className={styles.metricsRow}>
-          <h2 className={styles.sectionTitle}>
-            {t('dashboard.today_overview_usage_service')}
-          </h2>
+          <h2 className={styles.sectionTitle}>{t('dashboard.today_overview_usage_service')}</h2>
           <UsageMetricsCard
             summary={usageSummary.summary}
             topModels={usageSummary.topModels}
@@ -522,6 +543,8 @@ export function DashboardPage() {
             recentFailures={usageSummary.recentFailures}
             channelHealth={usageSummary.channelHealth}
             authMetaMap={authMetaMap}
+            authFileMap={authFileMap}
+            sourceInfoMap={sourceInfoMap}
             channelByAuthIndex={channelByAuthIndex}
             apiKeyAliasMap={apiKeyAliasMap}
           />
@@ -575,8 +598,12 @@ export function DashboardPage() {
                 </span>
               </div>
               <div className={styles.configItem}>
-                <span className={styles.configLabel}>{t('basic_settings.logging_to_file_enable')}</span>
-                <span className={`${styles.configValue} ${config.loggingToFile ? styles.on : styles.off}`}>
+                <span className={styles.configLabel}>
+                  {t('basic_settings.logging_to_file_enable')}
+                </span>
+                <span
+                  className={`${styles.configValue} ${config.loggingToFile ? styles.on : styles.off}`}
+                >
                   {config.loggingToFile ? t('common.enabled') : t('common.disabled')}
                 </span>
               </div>

--- a/apps/web/src/features/dashboard/components/HealthAlertsCard.module.scss
+++ b/apps/web/src/features/dashboard/components/HealthAlertsCard.module.scss
@@ -15,13 +15,19 @@
     align-items: center;
     gap: 10px;
     min-width: 0;
-    h3 { font-size: 16px; font-weight: 600; margin: 0; }
+    h3 {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0;
+    }
     .moreBtn {
       color: var(--color-primary);
       font-size: 12px;
       font-weight: 600;
       cursor: pointer;
-      &:hover { text-decoration: underline; }
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 
@@ -43,9 +49,15 @@
       border-radius: 50%;
       background: #ccc;
 
-      &.good { background: #10b981; }
-      &.warn { background: #f59e0b; }
-      &.bad { background: #ef4444; }
+      &.good {
+        background: #10b981;
+      }
+      &.warn {
+        background: #f59e0b;
+      }
+      &.bad {
+        background: #ef4444;
+      }
     }
 
     .label {
@@ -57,9 +69,18 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .value { font-weight: 600; color: var(--text-primary); }
-    .count { font-weight: 600; color: #ef4444; }
-    .percent { font-size: 11px; color: var(--text-tertiary); }
+    .value {
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .count {
+      font-weight: 600;
+      color: #ef4444;
+    }
+    .percent {
+      font-size: 11px;
+      color: var(--text-tertiary);
+    }
   }
 
   // Failure Item special styling
@@ -70,14 +91,21 @@
     flex-direction: column;
     gap: 4px;
 
-    &:last-child { border-bottom: none; }
+    &:last-child {
+      border-bottom: none;
+    }
 
     .failureMeta {
       display: flex;
       justify-content: space-between;
       font-size: 11px;
-      .time { color: var(--text-tertiary); }
-      .model { font-weight: 600; color: var(--text-secondary); }
+      .time {
+        color: var(--text-tertiary);
+      }
+      .model {
+        font-weight: 600;
+        color: var(--text-secondary);
+      }
     }
 
     .failureDetail {
@@ -88,11 +116,73 @@
       font-size: 12px;
       color: var(--text-tertiary);
 
-      span:first-child {
+      > span:first-child:not(.failureSourceWithTooltip) {
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+
+      .failureSourceWithTooltip {
+        position: relative;
+        display: inline-flex;
+        min-width: 0;
+        max-width: 100%;
+        overflow: visible;
+        cursor: help;
+
+        &:hover,
+        &:focus-visible {
+          .failureTooltip {
+            opacity: 1;
+            pointer-events: auto;
+            transform: translateY(-6px);
+          }
+        }
+      }
+
+      .failureSourceText {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .failureTooltip {
+        position: absolute;
+        left: 0;
+        bottom: calc(100% + 8px);
+        z-index: 20;
+        display: flex;
+        width: max-content;
+        max-width: min(280px, 70vw);
+        flex-direction: column;
+        gap: 6px;
+        padding: 8px 10px;
+        border: 1px solid var(--app-border);
+        border-radius: var(--app-radius-sm);
+        background: var(--bg-primary);
+        box-shadow: var(--app-shadow-md);
+        color: var(--text-primary);
+        font-size: 11px;
+        line-height: 1.45;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(-2px);
+        transition:
+          opacity 0.14s ease,
+          transform 0.14s ease;
+        white-space: normal;
+      }
+
+      .failureTooltipStatus {
+        font-weight: 700;
+        color: var(--error-color);
+      }
+
+      .failureTooltipBody {
+        color: var(--text-secondary);
+        word-break: break-word;
       }
     }
   }

--- a/apps/web/src/features/dashboard/components/HealthAlertsCard.tsx
+++ b/apps/web/src/features/dashboard/components/HealthAlertsCard.tsx
@@ -1,11 +1,15 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type {
-  DashboardChannelHealth,
-  DashboardRecentFailure,
-} from '@/services/api/usageService';
+import type { DashboardChannelHealth, DashboardRecentFailure } from '@/services/api/usageService';
+import type { CredentialInfo } from '@/types/sourceInfo';
 import type { MonitoringAuthMeta, MonitoringChannelMeta } from '@/features/monitoring/model/types';
-import { formatDurationMs, normalizeAuthIndex } from '@/utils/usage';
+import {
+  buildMonitoringSourceDisplay,
+  type MonitoringSourceDisplay,
+} from '@/features/monitoring/model/sourceDisplay';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
+import { maskSensitiveText, truncateText } from '@/utils/format';
+import { formatDurationMs } from '@/utils/usage';
 import styles from './HealthAlertsCard.module.scss';
 
 interface HealthAlertsCardProps {
@@ -13,21 +17,19 @@ interface HealthAlertsCardProps {
   recentFailures: DashboardRecentFailure[];
   channelHealth: DashboardChannelHealth[];
   authMetaMap: Map<string, MonitoringAuthMeta>;
+  authFileMap: Map<string, CredentialInfo>;
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>;
   channelByAuthIndex: Map<string, MonitoringChannelMeta>;
   apiKeyAliasMap: Map<string, string>;
 }
-
-const shortHash = (value: string) => {
-  const trimmed = value.trim();
-  if (!trimmed) return '-';
-  return trimmed.length <= 12 ? trimmed : `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
-};
 
 export function HealthAlertsCard({
   loading,
   recentFailures,
   channelHealth,
   authMetaMap,
+  authFileMap,
+  sourceInfoMap,
   channelByAuthIndex,
   apiKeyAliasMap,
 }: HealthAlertsCardProps) {
@@ -42,96 +44,89 @@ export function HealthAlertsCard({
     [i18n.language]
   );
 
-  const resolveAuthMeta = (authIndex: string | undefined) => {
-    const normalized = normalizeAuthIndex(authIndex) ?? '';
-    if (!normalized || normalized === '-') return {};
-
-    const authMeta = authMetaMap.get(normalized);
-    const channelMeta =
-      channelByAuthIndex.get(normalized) ||
-      (authMeta?.authIndex ? channelByAuthIndex.get(authMeta.authIndex) : undefined);
-
-    return { normalized, authMeta, channelMeta };
-  };
-
-  const resolveAuthDisplay = (authIndex: string | undefined, fallback = '') => {
-    const { normalized, authMeta, channelMeta } = resolveAuthMeta(authIndex);
-    if (!normalized) return fallback;
-
-    return (
-      channelMeta?.name ||
-      authMeta?.label ||
-      authMeta?.account ||
-      authMeta?.provider ||
-      fallback ||
-      normalized
-    );
-  };
-
-  const resolveChannelBaseDisplay = (channel: DashboardChannelHealth) => {
-    const record = channel as DashboardChannelHealth & {
-      auth_label?: string;
-      account?: string;
-      channel?: string;
-    };
-    const { normalized, authMeta, channelMeta } = resolveAuthMeta(channel.auth_index);
-    const base =
-      record.channel?.trim() ||
-      channelMeta?.name ||
-      record.auth_label?.trim() ||
-      authMeta?.label ||
-      record.account?.trim() ||
-      authMeta?.account ||
-      authMeta?.provider ||
-      normalized ||
-      channel.auth_index;
-
-    const suffixCandidates = [
-      record.auth_label,
-      record.account,
-      authMeta?.label,
-      authMeta?.account,
-      authMeta?.provider,
-      normalized ? `#${shortHash(normalized)}` : '',
-    ]
-      .map((item) => item?.trim())
-      .filter((item): item is string => Boolean(item && item !== '-' && item !== base));
-    const suffix = Array.from(new Set(suffixCandidates))[0] || '';
-    const title = [base, suffix, normalized || channel.auth_index].filter(Boolean).join(' · ');
-
-    return { base, suffix, title };
+  const sourceDisplayContext = {
+    authMetaMap,
+    authFileMap,
+    sourceInfoMap,
+    channelByAuthIndex,
+    apiKeyAliasMap,
   };
 
   const channelRows = channelHealth.slice(0, 5).map((channel, index) => ({
     channel,
     key: `${channel.auth_index}-${index}`,
-    display: resolveChannelBaseDisplay(channel),
+    display: buildMonitoringSourceDisplay(
+      {
+        source: channel.source,
+        authIndex: channel.auth_index,
+        accountSnapshot: channel.account_snapshot,
+        authLabelSnapshot: channel.auth_label_snapshot,
+        authProviderSnapshot: channel.auth_provider_snapshot,
+        authLabel: channel.auth_label,
+        account: channel.account,
+        channel: channel.channel,
+      },
+      sourceDisplayContext
+    ),
   }));
   const channelNameCounts = channelRows.reduce((map, row) => {
-    map.set(row.display.base, (map.get(row.display.base) ?? 0) + 1);
+    map.set(row.display.primary, (map.get(row.display.primary) ?? 0) + 1);
     return map;
   }, new Map<string, number>());
 
-  const resolveRecentFailureDisplay = (failure: DashboardRecentFailure) => {
-    const record = failure as DashboardRecentFailure & {
-      auth_label?: string;
-      account?: string;
-      channel?: string;
-      api_key_alias?: string;
-      source?: string;
-    };
-    const apiKeyAlias = apiKeyAliasMap.get((failure.api_key_hash || '').toLowerCase());
-    return (
-      record.channel?.trim() ||
-      record.auth_label?.trim() ||
-      record.account?.trim() ||
-      resolveAuthDisplay(failure.auth_index) ||
-      record.api_key_alias?.trim() ||
-      apiKeyAlias ||
-      record.source?.trim() ||
-      shortHash(failure.source_hash || failure.api_key_hash)
+  const buildRecentFailureDisplay = (failure: DashboardRecentFailure) =>
+    buildMonitoringSourceDisplay(
+      {
+        source: failure.source,
+        sourceHash: failure.source_hash,
+        apiKeyHash: failure.api_key_hash,
+        authIndex: failure.auth_index,
+        accountSnapshot: failure.account_snapshot,
+        authLabelSnapshot: failure.auth_label_snapshot,
+        authProviderSnapshot: failure.auth_provider_snapshot,
+        channel: failure.channel,
+        authLabel: failure.auth_label,
+        account: failure.account,
+        apiKeyAlias: failure.api_key_alias,
+      },
+      sourceDisplayContext
     );
+
+  const buildFailureTooltip = (failure: DashboardRecentFailure) => {
+    const statusCode = failure.fail_status_code;
+    const summary = maskSensitiveText(failure.fail_summary || '');
+    if (!statusCode && !summary) return null;
+    const statusText = statusCode ? `${t('monitoring.fail_status_code_short')} ${statusCode}` : '';
+    const compactSummary = summary ? truncateText(summary, 160) : '';
+    return {
+      statusText,
+      summary: compactSummary,
+      title: [statusText, compactSummary].filter(Boolean).join(' · '),
+    };
   };
+
+  const renderFailureName = (
+    display: MonitoringSourceDisplay,
+    tooltip: ReturnType<typeof buildFailureTooltip>
+  ) => (
+    <span
+      className={tooltip ? styles.failureSourceWithTooltip : undefined}
+      tabIndex={tooltip ? 0 : undefined}
+      title={tooltip ? undefined : display.title}
+    >
+      <span className={styles.failureSourceText}>{display.primary}</span>
+      {tooltip ? (
+        <span role="tooltip" className={styles.failureTooltip}>
+          {tooltip.statusText ? (
+            <span className={styles.failureTooltipStatus}>{tooltip.statusText}</span>
+          ) : null}
+          {tooltip.summary ? (
+            <span className={styles.failureTooltipBody}>{tooltip.summary}</span>
+          ) : null}
+        </span>
+      ) : null}
+    </span>
+  );
 
   return (
     <>
@@ -142,13 +137,13 @@ export function HealthAlertsCard({
         </div>
         <div className={styles.list}>
           {channelRows.map(({ channel, key, display }) => {
-            const isDuplicateName = (channelNameCounts.get(display.base) ?? 0) > 1;
+            const isDuplicateName = (channelNameCounts.get(display.primary) ?? 0) > 1;
             const label =
               channel.auth_index === '-'
                 ? t('dashboard.health_unlinked_channel')
-                : isDuplicateName && display.suffix
-                  ? `${display.base} · ${display.suffix}`
-                  : display.base;
+                : isDuplicateName && display.meta
+                  ? `${display.primary} · ${display.meta}`
+                  : display.primary;
 
             return (
               <div key={key} className={styles.listItem}>
@@ -164,7 +159,9 @@ export function HealthAlertsCard({
             );
           })}
           {channelHealth.length === 0 ? (
-            <div className={styles.empty}>{loading ? '...' : t('dashboard.no_channel_health_data')}</div>
+            <div className={styles.empty}>
+              {loading ? '...' : t('dashboard.no_channel_health_data')}
+            </div>
           ) : null}
         </div>
       </section>
@@ -175,22 +172,31 @@ export function HealthAlertsCard({
           <h3>{t('dashboard.recent_failed_requests')}</h3>
         </div>
         <div className={styles.list}>
-          {recentFailures.slice(0, 3).map((failure) => (
-            <div key={`${failure.timestamp_ms}-${failure.source_hash}-${failure.model}`} className={styles.failureItem}>
-              <div className={styles.failureMeta}>
-                <span className={styles.time}>{new Date(failure.timestamp_ms).toLocaleTimeString(i18n.language)}</span>
-                <span className={styles.model}>{failure.model}</span>
+          {recentFailures.slice(0, 3).map((failure) => {
+            const display = buildRecentFailureDisplay(failure);
+            const tooltip = buildFailureTooltip(failure);
+            return (
+              <div
+                key={`${failure.timestamp_ms}-${failure.source_hash}-${failure.model}`}
+                className={styles.failureItem}
+              >
+                <div className={styles.failureMeta}>
+                  <span className={styles.time}>
+                    {new Date(failure.timestamp_ms).toLocaleTimeString(i18n.language)}
+                  </span>
+                  <span className={styles.model}>{failure.model}</span>
+                </div>
+                <div className={styles.failureDetail}>
+                  {renderFailureName(display, tooltip)}
+                  <span>{formatDurationMs(failure.duration_ms, { locale: i18n.language })}</span>
+                </div>
               </div>
-              <div className={styles.failureDetail}>
-                <span title={[failure.auth_index, failure.source_hash, failure.api_key_hash].filter(Boolean).join(' · ')}>
-                  {resolveRecentFailureDisplay(failure)}
-                </span>
-                <span>{formatDurationMs(failure.duration_ms, { locale: i18n.language })}</span>
-              </div>
-            </div>
-          ))}
+            );
+          })}
           {recentFailures.length === 0 ? (
-            <div className={styles.empty}>{loading ? '...' : t('dashboard.no_recent_failures')}</div>
+            <div className={styles.empty}>
+              {loading ? '...' : t('dashboard.no_recent_failures')}
+            </div>
           ) : null}
         </div>
       </section>

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -356,9 +356,7 @@ export function useMonitoringData({
       if (cancelled) return;
       setEventsPageState((previous) => {
         const base =
-          previous.scopeKey === eventsScopeKey
-            ? previous
-            : createEventsPageState(eventsScopeKey);
+          previous.scopeKey === eventsScopeKey ? previous : createEventsPageState(eventsScopeKey);
         if (base.lastPageKey === pageKey) return base;
         return {
           scopeKey: eventsScopeKey,
@@ -396,9 +394,7 @@ export function useMonitoringData({
     if (!nextBeforeMs) return;
     setEventsPageState((previous) => {
       const base =
-        previous.scopeKey === eventsScopeKey
-          ? previous
-          : createEventsPageState(eventsScopeKey);
+        previous.scopeKey === eventsScopeKey ? previous : createEventsPageState(eventsScopeKey);
       if (base.loadingMore) return base;
       return { ...base, beforeMs: nextBeforeMs, loadingMore: true };
     });
@@ -477,9 +473,15 @@ export function useMonitoringData({
   const channelRows = useMemo(
     () =>
       analyticsData?.channel_share
-        ? buildChannelRowsFromAnalytics(analyticsData.channel_share, authMetaMap, channelByAuthIndex)
+        ? buildChannelRowsFromAnalytics(
+            analyticsData.channel_share,
+            authMetaMap,
+            authFileMap,
+            sourceInfoMap,
+            channelByAuthIndex
+          )
         : buildChannelRows(statsRows),
-    [analyticsData, authMetaMap, channelByAuthIndex, statsRows]
+    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
   const modelRows = useMemo(
     () =>
@@ -494,10 +496,12 @@ export function useMonitoringData({
         ? buildFailureSourceRowsFromAnalytics(
             analyticsData.failure_sources,
             authMetaMap,
+            authFileMap,
+            sourceInfoMap,
             channelByAuthIndex
           )
         : buildFailureSourceRows(statsRows),
-    [analyticsData, authMetaMap, channelByAuthIndex, statsRows]
+    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
   const taskBuckets = useMemo(
     () =>
@@ -518,10 +522,12 @@ export function useMonitoringData({
         ? buildFailureRowsFromAnalytics(
             analyticsData.recent_failures,
             authMetaMap,
+            authFileMap,
+            sourceInfoMap,
             channelByAuthIndex
           )
         : buildFailureRows(statsRows),
-    [analyticsData, authMetaMap, channelByAuthIndex, statsRows]
+    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
 
   const metadata = useMemo<MonitoringMetadata>(() => {

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import type { MonitoringAnalyticsEventRow } from '@/services/api/usageService';
-import { buildUsageDetailsFromAnalyticsEvents } from './analyticsAdapters';
+import type {
+  MonitoringAnalyticsChannelShareRow,
+  MonitoringAnalyticsEventRow,
+} from '@/services/api/usageService';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
+import {
+  buildChannelRowsFromAnalytics,
+  buildFailureRowsFromAnalytics,
+  buildFailureSourceRowsFromAnalytics,
+  buildUsageDetailsFromAnalyticsEvents,
+} from './analyticsAdapters';
 
 describe('buildUsageDetailsFromAnalyticsEvents', () => {
   it('maps resolved model and auth project snapshots into usage details', () => {
@@ -90,5 +99,150 @@ describe('buildUsageDetailsFromAnalyticsEvents', () => {
     expect(details[0].tokens.cached_tokens).toBe(5);
     expect(details[0].tokens.cache_read_tokens).toBe(4);
     expect(details[0].tokens.cache_creation_tokens).toBe(1);
+  });
+});
+
+describe('analytics failure source display', () => {
+  const authMetaMap = new Map([
+    [
+      'auth-1',
+      {
+        authIndex: 'auth-1',
+        label: 'Team Auth',
+        account: 'alice@example.com',
+        provider: 'codex',
+        status: 'active',
+        disabled: false,
+        unavailable: false,
+        runtimeOnly: false,
+        planType: 'pro',
+        updatedAt: '',
+      },
+    ],
+  ]);
+  const authFileMap = new Map([['auth-1', { name: 'Team Auth', type: 'codex' }]]);
+  const sourceInfoMap = buildSourceInfoMap({});
+  const channelByAuthIndex = new Map([
+    [
+      'auth-1',
+      {
+        key: 'relay:0',
+        name: 'Production Relay',
+        baseUrl: 'https://relay.example.com/v1',
+        host: 'relay.example.com',
+        disabled: false,
+        authIndices: ['auth-1'],
+        modelNames: [],
+      },
+    ],
+  ]);
+
+  it('uses channel metadata for channel share rows when auth metadata exists', () => {
+    const rows = buildChannelRowsFromAnalytics(
+      [
+        {
+          auth_index: 'auth-1',
+          source: 'm:sk-a...zzzz',
+          account_snapshot: 'snapshot@example.com',
+          auth_label_snapshot: 'Snapshot Auth',
+          auth_provider_snapshot: 'codex',
+          calls: 10,
+          success: 8,
+          failure: 2,
+          tokens: 1000,
+          cost: 0.12,
+          average_latency_ms: 120,
+        },
+      ],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex
+    );
+
+    expect(rows[0].label).toBe('Production Relay');
+    expect(rows[0].host).toBe('relay.example.com');
+    expect(rows[0].authLabels).toEqual(['Team Auth']);
+  });
+
+  it('uses channel share snapshots when current auth metadata is missing', () => {
+    const rows = buildChannelRowsFromAnalytics(
+      [
+        {
+          auth_index: 'legacy-auth',
+          source: 'm:sk-a...zzzz',
+          account_snapshot: 'legacy@example.com',
+          auth_label_snapshot: 'Legacy Auth',
+          auth_provider_snapshot: 'codex',
+          calls: 4,
+          success: 3,
+          failure: 1,
+          tokens: 500,
+          cost: 0.04,
+          average_latency_ms: 200,
+        } satisfies MonitoringAnalyticsChannelShareRow,
+      ],
+      new Map(),
+      new Map(),
+      sourceInfoMap,
+      new Map()
+    );
+
+    expect(rows[0].label).toBe('Legacy Auth');
+    expect(rows[0].provider).toBe('codex');
+    expect(rows[0].label).not.toBe('legacy-auth');
+  });
+
+  it('uses readable account metadata for recent failures instead of hashes', () => {
+    const rows = buildFailureRowsFromAnalytics(
+      [
+        {
+          timestamp_ms: Date.UTC(2026, 4, 20, 1, 2, 3),
+          model: 'gpt-test',
+          api_key_hash: 'api-key-hash',
+          source: 'm:sk-a...zzzz',
+          source_hash: 'source-hash',
+          auth_index: 'auth-1',
+          account_snapshot: 'snapshot@example.com',
+          auth_label_snapshot: 'Snapshot Auth',
+          auth_provider_snapshot: 'codex',
+          endpoint: 'POST /v1/chat/completions',
+          duration_ms: 123,
+          fail_status_code: 429,
+          fail_summary: 'rate limit exceeded',
+        },
+      ],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex
+    );
+
+    expect(rows[0].source).toBe('Team Auth');
+    expect(rows[0].channel).toBe('Production Relay');
+    expect(rows[0].source).not.toBe('source-hash');
+  });
+
+  it('uses readable source labels for failure source rows', () => {
+    const rows = buildFailureSourceRowsFromAnalytics(
+      [
+        {
+          source_hash: 'source-hash',
+          auth_index: 'auth-1',
+          calls: 10,
+          failure: 2,
+          last_seen_ms: Date.UTC(2026, 4, 20, 1, 2, 3),
+          average_latency_ms: 120,
+        },
+      ],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex
+    );
+
+    expect(rows[0].label).toBe('Team Auth');
+    expect(rows[0].channel).toBe('Production Relay');
+    expect(rows[0].label).not.toBe('source-hash');
   });
 });

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -16,6 +16,7 @@ import { buildSourceInfoMap, resolveSourceDisplay } from '@/utils/sourceResolver
 import { normalizeAuthIndex, type UsageDetailWithEndpoint } from '@/utils/usage';
 import { joinUnique, maskAuthIndex, maskEmailLike, readString } from './base';
 import { buildDayLabel, buildHourLabel, buildLocalDayKey, padNumber } from './range';
+import { buildMonitoringSourceDisplay } from './sourceDisplay';
 import type {
   MonitoringAuthMeta,
   MonitoringChannelMeta,
@@ -208,6 +209,8 @@ const resolveChannelMeta = (
 export const buildChannelRowsFromAnalytics = (
   rows: MonitoringAnalyticsChannelShareRow[],
   authMetaMap: Map<string, MonitoringAuthMeta>,
+  authFileMap: Map<string, CredentialInfo>,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
   channelByAuthIndex: Map<string, MonitoringChannelMeta>
 ): MonitoringChannelRow[] =>
   rows
@@ -218,12 +221,22 @@ export const buildChannelRowsFromAnalytics = (
         authMetaMap,
         channelByAuthIndex
       );
-      const label = channelMeta?.name || authMeta?.provider || authIndex;
+      const display = buildMonitoringSourceDisplay(
+        {
+          source: row.source,
+          authIndex,
+          accountSnapshot: row.account_snapshot,
+          authLabelSnapshot: row.auth_label_snapshot,
+          authProviderSnapshot: row.auth_provider_snapshot,
+        },
+        { authMetaMap, authFileMap, sourceInfoMap, channelByAuthIndex }
+      );
+      const label = display.primary;
       return {
         id: authIndex,
         label,
-        host: channelMeta?.host || '-',
-        provider: authMeta?.provider || '-',
+        host: display.channelHost,
+        provider: display.provider,
         planTypes: authMeta?.planType && authMeta.planType !== '-' ? [authMeta.planType] : [],
         disabled: channelMeta?.disabled || authMeta?.disabled || false,
         authCount: authIndex === '-' ? 0 : 1,
@@ -234,7 +247,9 @@ export const buildChannelRowsFromAnalytics = (
         totalTokens: row.tokens,
         totalCost: row.cost,
         averageLatencyMs: row.average_latency_ms,
-        authLabels: authMeta?.label ? [authMeta.label] : [],
+        authLabels: [authMeta?.label || row.auth_label_snapshot || display.sourceLabel].filter(
+          (value): value is string => Boolean(value)
+        ),
       } satisfies MonitoringChannelRow;
     })
     .sort((left, right) => right.requests - left.requests);
@@ -242,18 +257,26 @@ export const buildChannelRowsFromAnalytics = (
 export const buildFailureSourceRowsFromAnalytics = (
   rows: MonitoringAnalyticsFailureSourceRow[],
   authMetaMap: Map<string, MonitoringAuthMeta>,
+  authFileMap: Map<string, CredentialInfo>,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
   channelByAuthIndex: Map<string, MonitoringChannelMeta>
 ): MonitoringFailureSourceRow[] =>
   rows.map((row) => {
-    const { authMeta, channelMeta } = resolveChannelMeta(
-      row.auth_index || '-',
-      authMetaMap,
-      channelByAuthIndex
+    const display = buildMonitoringSourceDisplay(
+      {
+        source: row.source,
+        sourceHash: row.source_hash,
+        authIndex: row.auth_index,
+        accountSnapshot: row.account_snapshot,
+        authLabelSnapshot: row.auth_label_snapshot,
+        authProviderSnapshot: row.auth_provider_snapshot,
+      },
+      { authMetaMap, authFileMap, sourceInfoMap, channelByAuthIndex }
     );
     return {
       id: `${row.source_hash || '-'}::${row.auth_index || '-'}`,
-      label: shortHashLabel(row.source_hash),
-      channel: channelMeta?.name || authMeta?.provider || row.auth_index || '-',
+      label: display.sourceMasked || display.primary,
+      channel: display.channel,
       failures: row.failure,
       totalRequests: row.calls,
       failureRate: row.calls > 0 ? row.failure / row.calls : 0,
@@ -303,22 +326,31 @@ export const buildTaskBucketsFromAnalytics = (
 export const buildFailureRowsFromAnalytics = (
   rows: MonitoringAnalyticsRecentFailure[],
   authMetaMap: Map<string, MonitoringAuthMeta>,
+  authFileMap: Map<string, CredentialInfo>,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
   channelByAuthIndex: Map<string, MonitoringChannelMeta>
 ): MonitoringFailureRow[] =>
   rows.map((row) => {
     const authIndex = normalizeAuthIndex(row.auth_index) ?? '-';
-    const { authMeta, channelMeta } = resolveChannelMeta(
-      authIndex,
-      authMetaMap,
-      channelByAuthIndex
+    const display = buildMonitoringSourceDisplay(
+      {
+        source: row.source,
+        sourceHash: row.source_hash,
+        apiKeyHash: row.api_key_hash,
+        authIndex,
+        accountSnapshot: row.account_snapshot,
+        authLabelSnapshot: row.auth_label_snapshot,
+        authProviderSnapshot: row.auth_provider_snapshot,
+      },
+      { authMetaMap, authFileMap, sourceInfoMap, channelByAuthIndex }
     );
     return {
       id: `${row.timestamp_ms}-${row.source_hash}-${row.api_key_hash}-${row.model}`,
       timestampMs: row.timestamp_ms,
       timestamp: new Date(row.timestamp_ms).toISOString(),
       model: row.model,
-      source: shortHashLabel(row.source_hash || row.api_key_hash),
-      channel: channelMeta?.name || authMeta?.provider || '-',
+      source: display.sourceMasked || display.primary,
+      channel: display.channel,
       authIndex: maskAuthIndex(authIndex),
       latencyMs: row.duration_ms,
     };

--- a/apps/web/src/features/monitoring/model/sourceDisplay.ts
+++ b/apps/web/src/features/monitoring/model/sourceDisplay.ts
@@ -1,0 +1,183 @@
+import type { CredentialInfo } from '@/types/sourceInfo';
+import { buildSourceInfoMap, resolveSourceDisplay } from '@/utils/sourceResolver';
+import { normalizeAuthIndex } from '@/utils/usage';
+import { maskEmailLike, readString } from './base';
+import type { MonitoringAuthMeta, MonitoringChannelMeta } from './types';
+
+const GENERIC_PROVIDER_LABELS = new Set([
+  'codex',
+  'openai',
+  'openai-compatibility',
+  'gemini',
+  'claude',
+  'vertex',
+]);
+
+const hasReadableValue = (value: string | null | undefined) => {
+  const trimmed = readString(value);
+  return Boolean(trimmed) && trimmed !== '-';
+};
+
+export const isGenericMonitoringProviderLabel = (value: string) =>
+  GENERIC_PROVIDER_LABELS.has(value.trim().toLowerCase());
+
+const firstReadable = (...values: Array<string | null | undefined>) =>
+  values.find(hasReadableValue)?.trim() || '';
+
+export type MonitoringSourceDisplayInput = {
+  source?: string | null;
+  sourceHash?: string | null;
+  apiKeyHash?: string | null;
+  authIndex?: unknown;
+  accountSnapshot?: string | null;
+  authLabelSnapshot?: string | null;
+  authProviderSnapshot?: string | null;
+  channel?: string | null;
+  authLabel?: string | null;
+  account?: string | null;
+  apiKeyAlias?: string | null;
+};
+
+export type MonitoringSourceDisplayContext = {
+  authMetaMap: Map<string, MonitoringAuthMeta>;
+  authFileMap?: Map<string, CredentialInfo>;
+  sourceInfoMap?: ReturnType<typeof buildSourceInfoMap>;
+  channelByAuthIndex: Map<string, MonitoringChannelMeta>;
+  apiKeyAliasMap?: Map<string, string>;
+};
+
+export type MonitoringSourceDisplay = {
+  primary: string;
+  meta: string;
+  title: string;
+  sourceLabel: string;
+  sourceMasked: string;
+  account: string;
+  accountMasked: string;
+  authIndex: string;
+  channel: string;
+  channelHost: string;
+  provider: string;
+  fallbackId: string;
+};
+
+const shortHash = (value: string | null | undefined) => {
+  const trimmed = readString(value);
+  if (!trimmed) return '-';
+  return trimmed.length <= 12 ? trimmed : `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+};
+
+export const buildAuthFileMapFromMeta = (
+  authMetaMap: Map<string, MonitoringAuthMeta>
+): Map<string, CredentialInfo> => {
+  const map = new Map<string, CredentialInfo>();
+  authMetaMap.forEach((meta, authIndex) => {
+    map.set(authIndex, {
+      name: meta.label || meta.account || authIndex,
+      type: meta.provider || '',
+    });
+  });
+  return map;
+};
+
+export const buildMonitoringSourceDisplay = (
+  input: MonitoringSourceDisplayInput,
+  context: MonitoringSourceDisplayContext
+): MonitoringSourceDisplay => {
+  const authIndex = normalizeAuthIndex(input.authIndex) ?? '-';
+  const authMeta = authIndex === '-' ? undefined : context.authMetaMap.get(authIndex);
+  const channelMeta =
+    authIndex === '-'
+      ? undefined
+      : context.channelByAuthIndex.get(authIndex) ||
+        (authMeta?.authIndex ? context.channelByAuthIndex.get(authMeta.authIndex) : undefined);
+  const sourceInfoMap = context.sourceInfoMap ?? buildSourceInfoMap({});
+  const authFileMap = context.authFileMap ?? buildAuthFileMapFromMeta(context.authMetaMap);
+  const sourceMeta = resolveSourceDisplay(
+    readString(input.source),
+    authIndex,
+    sourceInfoMap,
+    authFileMap
+  );
+  const apiKeyHash = readString(input.apiKeyHash).toLowerCase();
+  const apiKeyAlias = firstReadable(
+    input.apiKeyAlias,
+    apiKeyHash ? context.apiKeyAliasMap?.get(apiKeyHash) : ''
+  );
+  const snapshotAccount = readString(input.accountSnapshot);
+  const snapshotLabel = readString(input.authLabelSnapshot);
+  const snapshotProvider = readString(input.authProviderSnapshot);
+  const explicitChannel = readString(input.channel);
+  const explicitLabel = readString(input.authLabel);
+  const explicitAccount = readString(input.account);
+
+  const account = firstReadable(
+    authMeta?.account,
+    explicitAccount,
+    snapshotAccount,
+    explicitLabel,
+    snapshotLabel
+  );
+  const sourceLabel = firstReadable(
+    authMeta?.label,
+    explicitLabel,
+    snapshotLabel,
+    account,
+    sourceMeta.displayName
+  );
+  const provider = firstReadable(authMeta?.provider, snapshotProvider, sourceMeta.type);
+  const channel = firstReadable(channelMeta?.name, explicitChannel, provider);
+  const channelHost = firstReadable(channelMeta?.host);
+  const sourceMasked = maskEmailLike(sourceLabel || sourceMeta.displayName);
+  const accountMasked = maskEmailLike(account || sourceLabel);
+  const fallbackId = shortHash(input.sourceHash || input.apiKeyHash || authIndex);
+  const primary =
+    firstReadable(
+      channel && !isGenericMonitoringProviderLabel(channel) ? channel : '',
+      channelHost,
+      sourceMasked,
+      provider && !isGenericMonitoringProviderLabel(provider) ? provider : '',
+      accountMasked,
+      apiKeyAlias,
+      channel,
+      provider,
+      fallbackId
+    ) || '-';
+  const meta = firstReadable(
+    provider && provider !== primary ? provider : '',
+    channelHost && channelHost !== primary ? channelHost : '',
+    accountMasked && accountMasked !== primary ? accountMasked : '',
+    sourceMasked && sourceMasked !== primary ? sourceMasked : '',
+    apiKeyAlias && apiKeyAlias !== primary ? apiKeyAlias : ''
+  );
+  const title = Array.from(
+    new Set(
+      [
+        primary,
+        meta,
+        sourceMasked,
+        accountMasked,
+        channelHost,
+        provider,
+        authIndex !== '-' ? `#${shortHash(authIndex)}` : '',
+        readString(input.sourceHash),
+        readString(input.apiKeyHash),
+      ].filter(hasReadableValue)
+    )
+  ).join(' · ');
+
+  return {
+    primary,
+    meta,
+    title,
+    sourceLabel: sourceLabel || primary,
+    sourceMasked: sourceMasked || primary,
+    account: account || sourceLabel || primary,
+    accountMasked: accountMasked || sourceMasked || primary,
+    authIndex,
+    channel: channel || '-',
+    channelHost: channelHost || '-',
+    provider: provider || '-',
+    fallbackId,
+  };
+};

--- a/apps/web/src/features/monitoring/realtimeSourceDisplay.ts
+++ b/apps/web/src/features/monitoring/realtimeSourceDisplay.ts
@@ -1,22 +1,11 @@
 import type { TFunction } from 'i18next';
 import type { MonitoringEventRow } from '@/features/monitoring/hooks/useMonitoringData';
+import { isGenericMonitoringProviderLabel } from '@/features/monitoring/model/sourceDisplay';
 
 const hasReadableRealtimeValue = (value: string | null | undefined) => {
   const trimmed = String(value || '').trim();
   return Boolean(trimmed) && trimmed !== '-';
 };
-
-const GENERIC_PROVIDER_LABELS = new Set([
-  'codex',
-  'openai',
-  'openai-compatibility',
-  'gemini',
-  'claude',
-  'vertex',
-]);
-
-const isGenericProviderLabel = (value: string) =>
-  GENERIC_PROVIDER_LABELS.has(value.trim().toLowerCase());
 
 const firstReadable = (...values: string[]) => values.find(hasReadableRealtimeValue)?.trim() || '';
 
@@ -40,15 +29,16 @@ export const buildRealtimeSourceDisplay = (
     .find(hasReadableRealtimeValue)
     ?.trim();
   const source = hasReadableRealtimeValue(row.sourceMasked) ? row.sourceMasked.trim() : '';
-  const primary = firstReadable(
-    channel && !isGenericProviderLabel(channel) ? channel : '',
-    host,
-    source,
-    provider && !isGenericProviderLabel(provider) ? provider : '',
-    account || '',
-    channel,
-    provider
-  ) || '-';
+  const primary =
+    firstReadable(
+      channel && !isGenericMonitoringProviderLabel(channel) ? channel : '',
+      host,
+      source,
+      provider && !isGenericMonitoringProviderLabel(provider) ? provider : '',
+      account || '',
+      channel,
+      provider
+    ) || '-';
   const metaCandidate = [
     { value: provider, label: t('monitoring.filter_provider') },
     { value: host, label: t('monitoring.column_host') },

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -371,6 +371,10 @@ export interface DashboardChannelHealth {
   auth_label?: string;
   account?: string;
   channel?: string;
+  source?: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
   calls: number;
   failures: number;
   failure_rate: number;
@@ -388,6 +392,9 @@ export interface DashboardFailureSource {
   account?: string;
   channel?: string;
   source?: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
   calls: number;
   failures: number;
   failure_rate: number;
@@ -407,8 +414,14 @@ export interface DashboardRecentFailure {
   channel?: string;
   api_key_alias?: string;
   source?: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
+  auth_project_id_snapshot?: string;
   endpoint: string;
   duration_ms: number | null;
+  fail_status_code?: number | null;
+  fail_summary?: string;
 }
 
 export interface DashboardSummaryResponse {
@@ -537,6 +550,10 @@ export interface MonitoringAnalyticsModelStat {
 
 export interface MonitoringAnalyticsChannelShareRow {
   auth_index: string;
+  source?: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
   calls: number;
   success: number;
   failure: number;
@@ -546,8 +563,12 @@ export interface MonitoringAnalyticsChannelShareRow {
 }
 
 export interface MonitoringAnalyticsFailureSourceRow {
+  source?: string;
   source_hash: string;
   auth_index: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
   calls: number;
   failure: number;
   last_seen_ms: number;
@@ -580,10 +601,17 @@ export interface MonitoringAnalyticsRecentFailure {
   timestamp_ms: number;
   model: string;
   api_key_hash: string;
+  source?: string;
   source_hash: string;
   auth_index: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
+  auth_project_id_snapshot?: string;
   endpoint: string;
   duration_ms: number | null;
+  fail_status_code?: number | null;
+  fail_summary?: string;
 }
 
 export interface MonitoringAnalyticsEventRow {


### PR DESCRIPTION
## Summary
- Expose safe source/account/provider/failure summary metadata from dashboard and monitoring APIs.
- Normalize dashboard health, recent failures, and monitoring analytics source labels through a shared frontend resolver.
- Add hover details for recent dashboard failures without exposing raw failure bodies or raw JSON.

## Tests
- npm --workspace apps/web run test -- src/features/monitoring/model/analyticsAdapters.test.ts src/features/monitoring/MonitoringCenterPage.test.tsx
- npm run type-check
- npm run lint
- go test ./internal/repository/usageevent ./internal/store ./internal/service/dashboard ./internal/service/monitoring
- go test ./...