### PR TITLE
fix(monitoring): stabilize scope-filtered realtime data

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -18,6 +18,7 @@ type AnalyticsFilter struct {
 	SearchQuery       string
 	SearchAPIKeyHash  string
 	Models            []string
+	Accounts          []string
 	AuthIndices       []string
 	APIKeyHashes      []string
 	SourceHashes      []string
@@ -694,6 +695,7 @@ func analyticsWhere(filter AnalyticsFilter) (string, []any) {
 		}
 	}
 	addInCondition("model", filter.Models)
+	addAccountCondition(filter.Accounts, &conditions, &args)
 	addInCondition("auth_index", filter.AuthIndices)
 	addInCondition("api_key_hash", filter.APIKeyHashes)
 	addInCondition("source_hash", filter.SourceHashes)
@@ -708,6 +710,26 @@ func analyticsWhere(filter AnalyticsFilter) (string, []any) {
 	}
 
 	return "where " + strings.Join(conditions, " and "), args
+}
+
+func addAccountCondition(values []string, conditions *[]string, args *[]any) {
+	normalized := normalizeLowerFilterValues(values)
+	if len(normalized) == 0 {
+		return
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(normalized)), ",")
+	accountConditions := []string{
+		fmt.Sprintf("lower(coalesce(account_snapshot, '')) in (%s)", placeholders),
+		fmt.Sprintf("lower(coalesce(auth_label_snapshot, '')) in (%s)", placeholders),
+		fmt.Sprintf("lower(coalesce(source, '')) in (%s)", placeholders),
+		fmt.Sprintf("lower(coalesce(auth_index, '')) in (%s)", placeholders),
+	}
+	*conditions = append(*conditions, "("+strings.Join(accountConditions, " or ")+")")
+	for range accountConditions {
+		for _, value := range normalized {
+			*args = append(*args, value)
+		}
+	}
 }
 
 func normalizeFilterValues(values []string) []string {
@@ -725,4 +747,12 @@ func normalizeFilterValues(values []string) []string {
 		result = append(result, trimmed)
 	}
 	return result
+}
+
+func normalizeLowerFilterValues(values []string) []string {
+	normalized := normalizeFilterValues(values)
+	for index, value := range normalized {
+		normalized[index] = strings.ToLower(value)
+	}
+	return normalized
 }

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -37,6 +37,7 @@ type Request struct {
 
 type Filters struct {
 	Models            []string `json:"models"`
+	Accounts          []string `json:"accounts"`
 	AuthIndices       []string `json:"auth_indices"`
 	APIKeyHashes      []string `json:"api_key_hashes"`
 	SourceHashes      []string `json:"source_hashes"`
@@ -380,6 +381,7 @@ func buildFilter(req Request) store.AnalyticsFilter {
 		SearchQuery:       req.SearchQuery,
 		SearchAPIKeyHash:  req.SearchAPIKeyHash,
 		Models:            req.Filters.Models,
+		Accounts:          req.Filters.Accounts,
 		AuthIndices:       req.Filters.AuthIndices,
 		APIKeyHashes:      req.Filters.APIKeyHashes,
 		SourceHashes:      req.Filters.SourceHashes,

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -446,6 +446,62 @@ func TestAnalyticsAppliesFailedOnlyFilter(t *testing.T) {
 	}
 }
 
+func TestAnalyticsAppliesAccountFallbackFilter(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_200_000_000)
+	toMS := fromMS + 60*60*1000
+
+	alice := monitoringEvent("account-alice", fromMS+1_000, "gpt-a", "auth-a", "source-a", false, 10, 5, 0, 0, 15, nil)
+	alice.AccountSnapshot = "alice@example.com"
+	alice.AuthLabelSnapshot = "Alice Auth"
+	alice.Source = "alice-source"
+	bob := monitoringEvent("account-bob", fromMS+2_000, "gpt-b", "auth-b", "source-b", false, 10, 5, 0, 0, 15, nil)
+	bob.AccountSnapshot = "bob@example.com"
+	bob.AuthLabelSnapshot = "Bob Auth"
+	bob.Source = "bob-source"
+
+	if _, err := db.InsertEvents(ctx, []usage.Event{alice, bob}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Filters: Filters{
+			Accounts: []string{"alice@example.com"},
+		},
+		Include: Include{Summary: true, EventsPage: &EventsPage{Limit: 10}},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if resp.Summary == nil || resp.Summary.TotalCalls != 1 || resp.Summary.SuccessCalls != 1 {
+		t.Fatalf("summary = %#v", resp.Summary)
+	}
+	if resp.Events == nil || len(resp.Events.Items) != 1 || resp.Events.Items[0].EventHash != "account-alice" {
+		t.Fatalf("events = %#v", resp.Events)
+	}
+
+	resp, err = New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Filters: Filters{
+			Accounts: []string{"Alice Auth"},
+		},
+		Include: Include{Summary: true, EventsPage: &EventsPage{Limit: 10}},
+	})
+	if err != nil {
+		t.Fatalf("analytics auth label account filter: %v", err)
+	}
+	if resp.Summary == nil || resp.Summary.TotalCalls != 1 {
+		t.Fatalf("auth label summary = %#v", resp.Summary)
+	}
+	if resp.Events == nil || len(resp.Events.Items) != 1 || resp.Events.Items[0].EventHash != "account-alice" {
+		t.Fatalf("auth label events = %#v", resp.Events)
+	}
+}
+
 func newMonitoringTestStore(t *testing.T) *store.Store {
 	t.Helper()
 	db, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -301,6 +301,8 @@ export function MonitoringCenterPage() {
     eventsHasMore,
     eventsLoadingMore,
     lastRefreshedAt: monitoringLastRefreshedAt,
+    isTransitioningScope: monitoringScopeTransitioning,
+    hasPresentationSnapshot: hasMonitoringPresentationSnapshot,
     refreshMeta,
     loadMoreEvents,
   } = useMonitoringData({
@@ -355,8 +357,10 @@ export function MonitoringCenterPage() {
         : requestMonitoringAvailability.reason === 'manager_mismatch'
           ? t('monitoring.request_monitoring_manager_mismatch_body')
           : t('monitoring.request_monitoring_not_configured_body');
+  const monitoringBlockingLoading =
+    monitoringLoading && (!monitoringScopeTransitioning || !hasMonitoringPresentationSnapshot);
   const overallLoading =
-    usageLoading || monitoringLoading || requestMonitoringAvailability.checking;
+    usageLoading || monitoringBlockingLoading || requestMonitoringAvailability.checking;
   const combinedError = monitoringUnavailable
     ? monitoringError
     : [usageError, monitoringError].filter(Boolean).join('；');
@@ -527,13 +531,21 @@ export function MonitoringCenterPage() {
         accountPageResetState
       )
     ) {
+      if (monitoringScopeTransitioning && hasMonitoringPresentationSnapshot) {
+        return;
+      }
       resetCurrentAccountPage();
       setApiKeyPage(1);
       setRealtimePage(1);
     }
 
     previousAccountPageResetStateRef.current = accountPageResetState;
-  }, [accountPageResetState, resetCurrentAccountPage]);
+  }, [
+    accountPageResetState,
+    hasMonitoringPresentationSnapshot,
+    monitoringScopeTransitioning,
+    resetCurrentAccountPage,
+  ]);
 
   useEffect(() => {
     if (
@@ -1150,7 +1162,11 @@ export function MonitoringCenterPage() {
   return (
     <div className={styles.page}>
       <MonitoringStatusHeader
-        showLoadingOverlay={overallLoading && filteredRows.length === 0}
+        showLoadingOverlay={
+          overallLoading &&
+          filteredRows.length === 0 &&
+          (!monitoringScopeTransitioning || !hasMonitoringPresentationSnapshot)
+        }
         monitoringUnavailable={monitoringUnavailable}
         monitoringUnavailableTitle={monitoringUnavailableTitle}
         monitoringUnavailableBody={monitoringUnavailableBody}

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
@@ -19,6 +19,7 @@ export interface UseMonitoringAnalyticsParams {
   fromMs?: number | null;
   toMs?: number | null;
   nowMs?: number;
+  dataScopeKey?: string;
   searchQuery?: string;
   searchApiKeyHash?: string;
   filters?: MonitoringAnalyticsFilters;
@@ -36,6 +37,7 @@ export interface UseMonitoringAnalyticsReturn {
   loading: boolean;
   error: string;
   data: MonitoringAnalyticsResponse | null;
+  dataStale: boolean;
   lastRefreshedAt: Date | null;
   serviceBase: string;
   unavailableReason: RequestMonitoringUnavailableReason | '';
@@ -53,6 +55,7 @@ export function useMonitoringAnalytics({
   fromMs,
   toMs,
   nowMs,
+  dataScopeKey,
   searchQuery,
   searchApiKeyHash,
   filters,
@@ -63,6 +66,7 @@ export function useMonitoringAnalytics({
   const managementKey = useAuthStore((state) => state.managementKey);
   const availability = useRequestMonitoringAvailability();
   const [data, setData] = useState<MonitoringAnalyticsResponse | null>(null);
+  const [dataScopeStateKey, setDataScopeStateKey] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [lastRefreshedAt, setLastRefreshedAt] = useState<Date | null>(null);
@@ -114,6 +118,7 @@ export function useMonitoringAnalytics({
   }, [eventsPageKey, filtersKey, fromMs, includeKey, nowMs, searchApiKeyHash, searchQuery, toMs]);
 
   const requestKey = useMemo(() => (request ? stableJson(request) : ''), [request]);
+  const activeDataScopeKey = dataScopeKey || requestKey;
   const serviceBase = availability.serviceBase;
   const enabled = availability.available && Boolean(serviceBase) && Boolean(request);
 
@@ -122,6 +127,7 @@ export function useMonitoringAnalytics({
       if (!enabled || !request || !serviceBase) {
         requestIdRef.current += 1;
         setData(null);
+        setDataScopeStateKey('');
         setLastRefreshedAt(null);
         setLoading(false);
         return;
@@ -145,9 +151,14 @@ export function useMonitoringAnalytics({
       setError('');
 
       try {
-        const response = await monitoringAnalyticsApi.getAnalytics(serviceBase, managementKey, request);
+        const response = await monitoringAnalyticsApi.getAnalytics(
+          serviceBase,
+          managementKey,
+          request
+        );
         if (requestIdRef.current !== requestId) return;
         setData(response);
+        setDataScopeStateKey(activeDataScopeKey);
         setLastRefreshedAt(new Date());
       } catch (err) {
         if (requestIdRef.current !== requestId) return;
@@ -158,7 +169,7 @@ export function useMonitoringAnalytics({
         }
       }
     },
-    [enabled, managementKey, request, requestKey, serviceBase, throttleMs]
+    [activeDataScopeKey, enabled, managementKey, request, requestKey, serviceBase, throttleMs]
   );
 
   useEffect(() => {
@@ -168,12 +179,16 @@ export function useMonitoringAnalytics({
     void refresh({ force: true });
   }, [availability.checking, refresh]);
 
+  const dataStale = Boolean(dataScopeKey && data && dataScopeStateKey !== activeDataScopeKey);
+  const scopedData = dataScopeKey || dataScopeStateKey === activeDataScopeKey ? data : null;
+
   return useMemo(
     () => ({
       enabled,
       loading: availability.checking || loading,
       error,
-      data,
+      data: scopedData,
+      dataStale,
       lastRefreshedAt,
       serviceBase,
       unavailableReason: availability.reason,
@@ -182,12 +197,13 @@ export function useMonitoringAnalytics({
     [
       availability.checking,
       availability.reason,
-      data,
       enabled,
       error,
+      dataStale,
       lastRefreshedAt,
       loading,
       refresh,
+      scopedData,
       serviceBase,
     ]
   );

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -5,9 +5,14 @@ import {
   buildApiKeyDisplayMap,
   buildMonitoringEventsScopeKey,
   buildMonitoringAuthMetaMap,
+  buildMonitoringSummary,
   buildRangeFilteredRows,
+  buildScopeFilteredRows,
   mergeMonitoringEventsPageItems,
+  resolveMonitoringDisplayEventItems,
+  resolveMonitoringPresentationSnapshot,
   type MonitoringEventRow,
+  type MonitoringPresentationSnapshot,
 } from './useMonitoringData';
 import type { MonitoringAnalyticsEventRow } from '@/services/api/usageService';
 import { sha256Hex } from '@/utils/apiKeyHash';
@@ -59,6 +64,26 @@ const createMonitoringEventRow = (
   taskKey: overrides.taskKey ?? 'task-1',
   searchText: overrides.searchText ?? 'amount myth resend',
 });
+
+const createPresentationSnapshot = (id: string): MonitoringPresentationSnapshot => {
+  const row = createMonitoringEventRow({ id });
+  return {
+    summary: buildMonitoringSummary([row]),
+    timeline: [{ label: id, requests: 1, tokens: row.totalTokens, cost: row.totalCost }],
+    timelineGranularity: 'hour',
+    hourlyDistribution: [],
+    modelShareRows: [],
+    channelRows: [],
+    modelRows: [],
+    failureSourceRows: [],
+    taskBuckets: [],
+    recentFailures: [],
+    filteredRows: [row],
+    eventsHasMore: id.includes('more'),
+    eventsLoadingMore: false,
+    lastRefreshedAt: new Date(1_768_759_000_000),
+  };
+};
 
 describe('buildAccountRows', () => {
   it('keeps raw auth indices for account-level auth file linking', () => {
@@ -212,6 +237,47 @@ describe('buildRangeFilteredRows', () => {
   });
 });
 
+describe('buildScopeFilteredRows', () => {
+  it('applies failed-only status filtering to realtime rows locally', () => {
+    const rows = [
+      createMonitoringEventRow({ id: 'success-row', failed: false }),
+      createMonitoringEventRow({ id: 'failed-row', failed: true }),
+    ];
+
+    expect(buildScopeFilteredRows(rows, { status: 'failed' }).map((row) => row.id)).toEqual([
+      'failed-row',
+    ]);
+  });
+
+  it('matches account focus against account and fallback display fields', () => {
+    const rows = [
+      createMonitoringEventRow({
+        id: 'alice-row',
+        account: 'alice@example.com',
+        authLabel: 'Alice Auth',
+      }),
+      createMonitoringEventRow({
+        id: 'legacy-row',
+        account: '',
+        authLabel: 'Legacy Auth',
+        source: 'legacy-source',
+      }),
+      createMonitoringEventRow({
+        id: 'bob-row',
+        account: 'bob@example.com',
+        authLabel: 'Bob Auth',
+      }),
+    ];
+
+    expect(
+      buildScopeFilteredRows(rows, { account: 'alice@example.com' }).map((row) => row.id)
+    ).toEqual(['alice-row']);
+    expect(buildScopeFilteredRows(rows, { account: 'Legacy Auth' }).map((row) => row.id)).toEqual([
+      'legacy-row',
+    ]);
+  });
+});
+
 describe('buildMonitoringEventsScopeKey', () => {
   it('keeps moving ranges stable when only the end time changes', () => {
     const first = buildMonitoringEventsScopeKey(
@@ -299,5 +365,145 @@ describe('mergeMonitoringEventsPageItems', () => {
     expect(
       mergeMonitoringEventsPageItems(previous, nextPage, null).map((item) => item.event_hash)
     ).toEqual(['event-3', 'event-2', 'event-1']);
+  });
+});
+
+describe('resolveMonitoringDisplayEventItems', () => {
+  const createAnalyticsEvent = (
+    eventHash: string,
+    timestampMs: number
+  ): MonitoringAnalyticsEventRow => ({
+    event_hash: eventHash,
+    timestamp_ms: timestampMs,
+    model: 'gpt-4.1',
+    endpoint: 'POST /v1/chat/completions',
+    method: 'POST',
+    path: '/v1/chat/completions',
+    auth_index: 'auth-1',
+    source: 'source-1',
+    source_hash: 'source-hash-1',
+    api_key_hash: 'api-key-hash-1',
+    account_snapshot: 'alice@example.com',
+    auth_label_snapshot: 'alice.json',
+    auth_provider_snapshot: 'codex',
+    input_tokens: 10,
+    output_tokens: 5,
+    cached_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+    reasoning_tokens: 0,
+    total_tokens: 15,
+    latency_ms: 1200,
+    ttft_ms: 200,
+    failed: false,
+  });
+
+  it('reuses persisted page items while the analytics response has no new event page', () => {
+    const eventsPageItems = [createAnalyticsEvent('event-1', 1_768_759_000_000)];
+
+    const first = resolveMonitoringDisplayEventItems({
+      analyticsData: null,
+      currentPageItems: null,
+      eventsPageItems,
+      eventsBeforeMs: null,
+      dataStale: false,
+    });
+    const second = resolveMonitoringDisplayEventItems({
+      analyticsData: null,
+      currentPageItems: null,
+      eventsPageItems,
+      eventsBeforeMs: null,
+      dataStale: false,
+    });
+
+    expect(first).toBe(eventsPageItems);
+    expect(second).toBe(eventsPageItems);
+  });
+
+  it('keeps stale transitions on existing page items without creating a new array', () => {
+    const eventsPageItems = [createAnalyticsEvent('event-1', 1_768_759_000_000)];
+    const analyticsItems = [createAnalyticsEvent('event-2', 1_768_759_001_000)];
+
+    expect(
+      resolveMonitoringDisplayEventItems({
+        analyticsData: { events: { items: analyticsItems } },
+        currentPageItems: analyticsItems,
+        eventsPageItems,
+        eventsBeforeMs: null,
+        dataStale: true,
+      })
+    ).toBe(eventsPageItems);
+  });
+
+  it('reuses persisted page items after the same analytics page has been absorbed', () => {
+    const analyticsItems = [
+      createAnalyticsEvent('event-2', 1_768_759_001_000),
+      createAnalyticsEvent('event-1', 1_768_759_000_000),
+    ];
+    const eventsPageItems = [
+      createAnalyticsEvent('event-2', 1_768_759_001_000),
+      createAnalyticsEvent('event-1', 1_768_759_000_000),
+    ];
+
+    expect(
+      resolveMonitoringDisplayEventItems({
+        analyticsData: { events: { items: analyticsItems } },
+        currentPageItems: analyticsItems,
+        eventsPageItems,
+        eventsBeforeMs: null,
+        dataStale: false,
+      })
+    ).toBe(eventsPageItems);
+  });
+});
+
+describe('resolveMonitoringPresentationSnapshot', () => {
+  it('keeps the last stable presentation while a new uncached scope is loading', () => {
+    const computed = createPresentationSnapshot('computed-empty-transition');
+    const stable = createPresentationSnapshot('stable-all');
+    const result = resolveMonitoringPresentationSnapshot({
+      computedSnapshot: computed,
+      scopeKey: 'failed',
+      dataStale: true,
+      cachedSnapshots: new Map(),
+      lastStableSnapshot: stable,
+    });
+
+    expect(result.snapshot).toBe(stable);
+    expect(result.hasPresentationSnapshot).toBe(true);
+    expect(result.usingSnapshotFallback).toBe(true);
+  });
+
+  it('prefers a cached target scope presentation over the last stable scope', () => {
+    const computed = createPresentationSnapshot('computed-transition');
+    const stable = createPresentationSnapshot('stable-all');
+    const cachedFailed = createPresentationSnapshot('cached-failed');
+    const result = resolveMonitoringPresentationSnapshot({
+      computedSnapshot: computed,
+      scopeKey: 'failed',
+      dataStale: true,
+      cachedSnapshots: new Map([['failed', cachedFailed]]),
+      lastStableSnapshot: stable,
+    });
+
+    expect(result.snapshot).toBe(cachedFailed);
+    expect(result.hasPresentationSnapshot).toBe(true);
+    expect(result.usingSnapshotFallback).toBe(true);
+  });
+
+  it('returns the computed presentation for fresh data', () => {
+    const computed = createPresentationSnapshot('computed-fresh');
+    const stable = createPresentationSnapshot('stable-all');
+    const result = resolveMonitoringPresentationSnapshot({
+      computedSnapshot: computed,
+      scopeKey: 'all',
+      dataStale: false,
+      cachedSnapshots: new Map([['all', stable]]),
+      lastStableSnapshot: stable,
+    });
+
+    expect(result.snapshot).toBe(computed);
+    expect(result.hasPresentationSnapshot).toBe(true);
+    expect(result.usingSnapshotFallback).toBe(false);
   });
 });

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -37,6 +37,7 @@ import { buildEventRows } from '../model/eventRows';
 import {
   buildMonitoringSummary,
   buildRangeFilteredRows,
+  buildScopeFilteredRows,
   shouldIncludeInStats,
 } from '../model/rowBuilders';
 import type {
@@ -83,10 +84,13 @@ export {
   buildApiKeyRows,
   buildMonitoringSummary,
   buildRangeFilteredRows,
+  buildScopeFilteredRows,
   buildRealtimeMonitorRows,
 } from '../model/rowBuilders';
 
 const MONITORING_EVENTS_PAGE_LIMIT = 500;
+const MONITORING_PRESENTATION_CACHE_LIMIT = 24;
+const EMPTY_MONITORING_ANALYTICS_EVENT_ROWS: MonitoringAnalyticsEventRow[] = [];
 
 interface MonitoringEventsPageState {
   scopeKey: string;
@@ -95,6 +99,35 @@ interface MonitoringEventsPageState {
   hasMore: boolean;
   loadingMore: boolean;
   lastPageKey: string;
+}
+
+export type MonitoringPresentationSnapshot = Pick<
+  UseMonitoringDataReturn,
+  | 'summary'
+  | 'timeline'
+  | 'timelineGranularity'
+  | 'hourlyDistribution'
+  | 'modelShareRows'
+  | 'channelRows'
+  | 'modelRows'
+  | 'failureSourceRows'
+  | 'taskBuckets'
+  | 'recentFailures'
+  | 'filteredRows'
+  | 'eventsHasMore'
+  | 'eventsLoadingMore'
+  | 'lastRefreshedAt'
+>;
+
+export interface MonitoringPresentationSnapshotResolution {
+  snapshot: MonitoringPresentationSnapshot;
+  hasPresentationSnapshot: boolean;
+  usingSnapshotFallback: boolean;
+}
+
+interface MonitoringPresentationSnapshotStore {
+  cachedSnapshots: Map<string, MonitoringPresentationSnapshot>;
+  lastStableSnapshot: MonitoringPresentationSnapshot | null;
 }
 
 const createEventsPageState = (scopeKey = ''): MonitoringEventsPageState => ({
@@ -157,6 +190,66 @@ export const mergeMonitoringEventsPageItems = (
   return mergeAnalyticsEventItems(pageItems, previousItems);
 };
 
+export const resolveMonitoringDisplayEventItems = ({
+  analyticsData,
+  currentPageItems,
+  eventsPageItems,
+  eventsBeforeMs,
+  dataStale,
+}: {
+  analyticsData: { events?: { items: MonitoringAnalyticsEventRow[] } } | null;
+  currentPageItems: MonitoringAnalyticsEventRow[] | null;
+  eventsPageItems: MonitoringAnalyticsEventRow[];
+  eventsBeforeMs: number | null;
+  dataStale: boolean;
+}): MonitoringAnalyticsEventRow[] => {
+  if (dataStale) {
+    return eventsPageItems.length > 0
+      ? eventsPageItems
+      : (analyticsData?.events?.items ?? EMPTY_MONITORING_ANALYTICS_EVENT_ROWS);
+  }
+
+  if (!currentPageItems) {
+    return eventsPageItems;
+  }
+
+  const existingEventHashes = new Set(eventsPageItems.map((item) => item.event_hash));
+  if (currentPageItems.every((item) => existingEventHashes.has(item.event_hash))) {
+    return eventsPageItems;
+  }
+
+  return mergeMonitoringEventsPageItems(eventsPageItems, currentPageItems, eventsBeforeMs);
+};
+
+export const resolveMonitoringPresentationSnapshot = ({
+  computedSnapshot,
+  scopeKey,
+  dataStale,
+  cachedSnapshots,
+  lastStableSnapshot,
+}: {
+  computedSnapshot: MonitoringPresentationSnapshot;
+  scopeKey: string;
+  dataStale: boolean;
+  cachedSnapshots: ReadonlyMap<string, MonitoringPresentationSnapshot>;
+  lastStableSnapshot: MonitoringPresentationSnapshot | null;
+}): MonitoringPresentationSnapshotResolution => {
+  if (!dataStale) {
+    return {
+      snapshot: computedSnapshot,
+      hasPresentationSnapshot: true,
+      usingSnapshotFallback: false,
+    };
+  }
+
+  const snapshot = cachedSnapshots.get(scopeKey) ?? lastStableSnapshot;
+  return {
+    snapshot: snapshot ?? computedSnapshot,
+    hasPresentationSnapshot: Boolean(snapshot),
+    usingSnapshotFallback: Boolean(snapshot),
+  };
+};
+
 export function useMonitoringData({
   usage,
   config,
@@ -176,6 +269,11 @@ export function useMonitoringData({
   const [eventsPageState, setEventsPageState] = useState<MonitoringEventsPageState>(() =>
     createEventsPageState()
   );
+  const [presentationSnapshotStore, setPresentationSnapshotStore] =
+    useState<MonitoringPresentationSnapshotStore>(() => ({
+      cachedSnapshots: new Map(),
+      lastStableSnapshot: null,
+    }));
 
   const analyticsBounds = useMemo(() => {
     const bounds = getRangeBounds(timeRange, analyticsNowMs, customTimeRange);
@@ -321,6 +419,7 @@ export function useMonitoringData({
     fromMs: analyticsBounds?.startMs,
     toMs: analyticsBounds?.endMs,
     nowMs: analyticsNowMs,
+    dataScopeKey: eventsScopeKey,
     searchQuery,
     searchApiKeyHash,
     filters: analyticsFilters,
@@ -340,9 +439,28 @@ export function useMonitoringData({
     throttleMs: 1_000,
   });
   const analyticsData = analytics.data;
+  const currentAnalyticsData = analytics.dataStale ? null : analyticsData;
+  const displayEventItems = useMemo(
+    () =>
+      resolveMonitoringDisplayEventItems({
+        analyticsData,
+        currentPageItems: currentAnalyticsData?.events?.items ?? null,
+        eventsPageItems: eventItems,
+        eventsBeforeMs,
+        dataStale: analytics.dataStale,
+      }),
+    [
+      analytics.dataStale,
+      analyticsData,
+      currentAnalyticsData?.events?.items,
+      eventItems,
+      eventsBeforeMs,
+    ]
+  );
+  const displayEventsHasMore = currentAnalyticsData?.events?.has_more ?? eventsHasMore;
 
   useEffect(() => {
-    const page = analyticsData?.events;
+    const page = currentAnalyticsData?.events;
     if (!page) return;
     const requestBeforeMs = eventsBeforeMs;
     const pageKey = buildEventsPageKey(
@@ -371,7 +489,7 @@ export function useMonitoringData({
     return () => {
       cancelled = true;
     };
-  }, [analyticsData?.events, eventsScopeKey, eventsBeforeMs]);
+  }, [currentAnalyticsData?.events, eventsScopeKey, eventsBeforeMs]);
 
   useEffect(() => {
     if (analytics.error) {
@@ -390,7 +508,7 @@ export function useMonitoringData({
 
   const loadMoreEvents = useCallback(() => {
     if (analytics.loading || eventsLoadingMore || !eventsHasMore) return;
-    const nextBeforeMs = analyticsData?.events?.next_before_ms;
+    const nextBeforeMs = currentAnalyticsData?.events?.next_before_ms;
     if (!nextBeforeMs) return;
     setEventsPageState((previous) => {
       const base =
@@ -399,7 +517,7 @@ export function useMonitoringData({
       return { ...base, beforeMs: nextBeforeMs, loadingMore: true };
     });
   }, [
-    analyticsData?.events?.next_before_ms,
+    currentAnalyticsData?.events?.next_before_ms,
     analytics.loading,
     eventsScopeKey,
     eventsHasMore,
@@ -408,7 +526,7 @@ export function useMonitoringData({
 
   const allRows = useMemo(() => {
     const details = analyticsData
-      ? buildUsageDetailsFromAnalyticsEvents(eventItems)
+      ? buildUsageDetailsFromAnalyticsEvents(displayEventItems)
       : collectUsageDetailsWithEndpoint(usage);
     return buildEventRows(
       details,
@@ -425,110 +543,206 @@ export function useMonitoringData({
     authMetaMap,
     channelByAuthIndex,
     analyticsData,
-    eventItems,
+    displayEventItems,
     modelPrices,
     sourceInfoMap,
     usage,
   ]);
 
-  const filteredRows = useMemo(
+  const rangeFilteredRows = useMemo(
     () =>
       buildRangeFilteredRows(allRows, timeRange, customTimeRange, searchQuery, searchApiKeyHash),
     [allRows, customTimeRange, searchApiKeyHash, searchQuery, timeRange]
+  );
+  const filteredRows = useMemo(
+    () => buildScopeFilteredRows(rangeFilteredRows, scopeFilters),
+    [rangeFilteredRows, scopeFilters]
   );
   const statsRows = useMemo(() => filteredRows.filter(shouldIncludeInStats), [filteredRows]);
 
   const summary = useMemo(
     () =>
-      analyticsData?.summary
-        ? buildSummaryFromAnalytics(analyticsData.summary)
+      currentAnalyticsData?.summary
+        ? buildSummaryFromAnalytics(currentAnalyticsData.summary)
         : buildMonitoringSummary(statsRows),
-    [analyticsData, statsRows]
+    [currentAnalyticsData, statsRows]
   );
   const timelineData = useMemo(
     () =>
-      analyticsData?.timeline
+      currentAnalyticsData?.timeline
         ? {
             granularity:
-              analyticsData.granularity === 'hour' ? ('hour' as const) : ('day' as const),
-            points: buildTimelineFromAnalytics(analyticsData.timeline, analyticsData.granularity),
+              currentAnalyticsData.granularity === 'hour' ? ('hour' as const) : ('day' as const),
+            points: buildTimelineFromAnalytics(
+              currentAnalyticsData.timeline,
+              currentAnalyticsData.granularity
+            ),
           }
         : buildTimeline(statsRows, timeRange, customTimeRange),
-    [analyticsData, customTimeRange, statsRows, timeRange]
+    [currentAnalyticsData, customTimeRange, statsRows, timeRange]
   );
   const hourlyDistribution = useMemo(
     () =>
-      analyticsData?.hourly_distribution
-        ? buildHourlyDistributionFromAnalytics(analyticsData.hourly_distribution)
+      currentAnalyticsData?.hourly_distribution
+        ? buildHourlyDistributionFromAnalytics(currentAnalyticsData.hourly_distribution)
         : buildHourlyDistribution(statsRows),
-    [analyticsData, statsRows]
+    [currentAnalyticsData, statsRows]
   );
   const modelShareRows = useMemo(
     () =>
-      analyticsData?.model_share
-        ? buildModelShareRowsFromAnalytics(analyticsData.model_share, analyticsData.model_stats)
+      currentAnalyticsData?.model_share
+        ? buildModelShareRowsFromAnalytics(
+            currentAnalyticsData.model_share,
+            currentAnalyticsData.model_stats
+          )
         : buildModelShareRows(statsRows),
-    [analyticsData, statsRows]
+    [currentAnalyticsData, statsRows]
   );
   const channelRows = useMemo(
     () =>
-      analyticsData?.channel_share
+      currentAnalyticsData?.channel_share
         ? buildChannelRowsFromAnalytics(
-            analyticsData.channel_share,
+            currentAnalyticsData.channel_share,
             authMetaMap,
             authFileMap,
             sourceInfoMap,
             channelByAuthIndex
           )
         : buildChannelRows(statsRows),
-    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
+    [currentAnalyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
   const modelRows = useMemo(
     () =>
-      analyticsData?.model_stats
-        ? buildModelRowsFromAnalytics(analyticsData.model_stats)
+      currentAnalyticsData?.model_stats
+        ? buildModelRowsFromAnalytics(currentAnalyticsData.model_stats)
         : buildModelRows(statsRows),
-    [analyticsData, statsRows]
+    [currentAnalyticsData, statsRows]
   );
   const failureSourceRows = useMemo(
     () =>
-      analyticsData?.failure_sources
+      currentAnalyticsData?.failure_sources
         ? buildFailureSourceRowsFromAnalytics(
-            analyticsData.failure_sources,
+            currentAnalyticsData.failure_sources,
             authMetaMap,
             authFileMap,
             sourceInfoMap,
             channelByAuthIndex
           )
         : buildFailureSourceRows(statsRows),
-    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
+    [currentAnalyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
   const taskBuckets = useMemo(
     () =>
-      analyticsData?.task_buckets
+      currentAnalyticsData?.task_buckets
         ? buildTaskBucketsFromAnalytics(
-            analyticsData.task_buckets,
+            currentAnalyticsData.task_buckets,
             authMetaMap,
             authFileMap,
             sourceInfoMap,
             channelByAuthIndex
           )
         : buildTaskBuckets(statsRows),
-    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
+    [currentAnalyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
   const recentFailures = useMemo(
     () =>
-      analyticsData?.recent_failures
+      currentAnalyticsData?.recent_failures
         ? buildFailureRowsFromAnalytics(
-            analyticsData.recent_failures,
+            currentAnalyticsData.recent_failures,
             authMetaMap,
             authFileMap,
             sourceInfoMap,
             channelByAuthIndex
           )
         : buildFailureRows(statsRows),
-    [analyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
+    [currentAnalyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
+
+  const computedPresentationSnapshot = useMemo<MonitoringPresentationSnapshot>(
+    () => ({
+      summary,
+      timeline: timelineData.points,
+      timelineGranularity: timelineData.granularity,
+      hourlyDistribution,
+      modelShareRows,
+      channelRows,
+      modelRows,
+      failureSourceRows,
+      taskBuckets,
+      recentFailures,
+      filteredRows,
+      eventsHasMore: displayEventsHasMore,
+      eventsLoadingMore,
+      lastRefreshedAt: analytics.lastRefreshedAt,
+    }),
+    [
+      analytics.lastRefreshedAt,
+      channelRows,
+      displayEventsHasMore,
+      eventsLoadingMore,
+      failureSourceRows,
+      filteredRows,
+      hourlyDistribution,
+      modelRows,
+      modelShareRows,
+      recentFailures,
+      summary,
+      taskBuckets,
+      timelineData.granularity,
+      timelineData.points,
+    ]
+  );
+
+  useEffect(() => {
+    if (analytics.dataStale) return;
+
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setPresentationSnapshotStore((previous) => {
+        if (
+          previous.lastStableSnapshot === computedPresentationSnapshot &&
+          previous.cachedSnapshots.get(eventsScopeKey) === computedPresentationSnapshot
+        ) {
+          return previous;
+        }
+
+        const cachedSnapshots = new Map(previous.cachedSnapshots);
+        cachedSnapshots.set(eventsScopeKey, computedPresentationSnapshot);
+        while (cachedSnapshots.size > MONITORING_PRESENTATION_CACHE_LIMIT) {
+          const oldestKey = cachedSnapshots.keys().next().value;
+          if (oldestKey === undefined) break;
+          cachedSnapshots.delete(oldestKey);
+        }
+        return {
+          cachedSnapshots,
+          lastStableSnapshot: computedPresentationSnapshot,
+        };
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [analytics.dataStale, computedPresentationSnapshot, eventsScopeKey]);
+
+  const presentationResolution = useMemo(
+    () =>
+      resolveMonitoringPresentationSnapshot({
+        computedSnapshot: computedPresentationSnapshot,
+        scopeKey: eventsScopeKey,
+        dataStale: analytics.dataStale,
+        cachedSnapshots: presentationSnapshotStore.cachedSnapshots,
+        lastStableSnapshot: presentationSnapshotStore.lastStableSnapshot,
+      }),
+    [
+      analytics.dataStale,
+      computedPresentationSnapshot,
+      eventsScopeKey,
+      presentationSnapshotStore.cachedSnapshots,
+      presentationSnapshotStore.lastStableSnapshot,
+    ]
+  );
+  const presentationSnapshot = presentationResolution.snapshot;
 
   const metadata = useMemo<MonitoringMetadata>(() => {
     const planTypes = Array.from(
@@ -556,22 +770,24 @@ export function useMonitoringData({
     error: [error, analytics.error].filter(Boolean).join('；'),
     authFiles,
     channels,
-    summary,
+    summary: presentationSnapshot.summary,
     metadata,
     statusChips,
-    timeline: timelineData.points,
-    timelineGranularity: timelineData.granularity,
-    hourlyDistribution,
-    modelShareRows,
-    channelRows,
-    modelRows,
-    failureSourceRows,
-    taskBuckets,
-    recentFailures,
-    filteredRows,
-    eventsHasMore,
-    eventsLoadingMore,
-    lastRefreshedAt: analytics.lastRefreshedAt,
+    timeline: presentationSnapshot.timeline,
+    timelineGranularity: presentationSnapshot.timelineGranularity,
+    hourlyDistribution: presentationSnapshot.hourlyDistribution,
+    modelShareRows: presentationSnapshot.modelShareRows,
+    channelRows: presentationSnapshot.channelRows,
+    modelRows: presentationSnapshot.modelRows,
+    failureSourceRows: presentationSnapshot.failureSourceRows,
+    taskBuckets: presentationSnapshot.taskBuckets,
+    recentFailures: presentationSnapshot.recentFailures,
+    filteredRows: presentationSnapshot.filteredRows,
+    eventsHasMore: presentationSnapshot.eventsHasMore,
+    eventsLoadingMore: presentationSnapshot.eventsLoadingMore,
+    lastRefreshedAt: presentationSnapshot.lastRefreshedAt,
+    isTransitioningScope: analytics.dataStale,
+    hasPresentationSnapshot: presentationResolution.hasPresentationSnapshot,
     refreshMeta,
     loadMoreEvents,
   };

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/services/api/usageService';
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import {
+  buildAnalyticsFilters,
   buildChannelRowsFromAnalytics,
   buildFailureRowsFromAnalytics,
   buildFailureSourceRowsFromAnalytics,
@@ -99,6 +100,55 @@ describe('buildUsageDetailsFromAnalyticsEvents', () => {
     expect(details[0].tokens.cached_tokens).toBe(5);
     expect(details[0].tokens.cache_read_tokens).toBe(4);
     expect(details[0].tokens.cache_creation_tokens).toBe(1);
+  });
+});
+
+describe('buildAnalyticsFilters', () => {
+  it('maps failed-only status and known accounts into backend filters', () => {
+    const filters = buildAnalyticsFilters(
+      {
+        account: 'alice@example.com',
+        status: 'failed',
+      },
+      new Map([
+        [
+          'auth-1',
+          {
+            authIndex: 'auth-1',
+            label: 'Alice',
+            account: 'alice@example.com',
+            provider: 'codex',
+            status: 'active',
+            disabled: false,
+            unavailable: false,
+            runtimeOnly: false,
+            planType: 'pro',
+            updatedAt: '',
+          },
+        ],
+      ]),
+      []
+    );
+
+    expect(filters).toMatchObject({
+      auth_indices: ['auth-1'],
+      failed_only: true,
+    });
+    expect(filters.accounts).toBeUndefined();
+  });
+
+  it('falls back to account snapshot filters when auth metadata cannot resolve an account', () => {
+    const filters = buildAnalyticsFilters(
+      {
+        account: 'legacy@example.com',
+      },
+      new Map(),
+      []
+    );
+
+    expect(filters).toEqual({
+      accounts: ['legacy@example.com'],
+    });
   });
 });
 

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -73,12 +73,13 @@ export const buildAnalyticsFilters = (
   let authIndices: Set<string> | null = null;
   if (isActiveFilterValue(scopeFilters.account)) {
     const account = scopeFilters.account!.trim();
-    authIndices = addAuthIndexConstraint(
-      authIndices,
-      Array.from(authMetaMap.entries())
-        .filter(([, meta]) => meta.account === account)
-        .map(([authIndex]) => authIndex)
-    );
+    const accountAuthIndices = Array.from(authMetaMap.entries())
+      .filter(([, meta]) => meta.account === account)
+      .map(([authIndex]) => authIndex);
+    authIndices = addAuthIndexConstraint(authIndices, accountAuthIndices);
+    if (accountAuthIndices.length === 0) {
+      filters.accounts = [account];
+    }
   }
   if (isActiveFilterValue(scopeFilters.provider)) {
     const provider = scopeFilters.provider!.trim();

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -7,6 +7,7 @@ import type {
   MonitoringCustomTimeRange,
   MonitoringEventRow,
   MonitoringRealtimeRow,
+  MonitoringScopeFilters,
   MonitoringSummary,
   MonitoringTimeRange,
 } from './types';
@@ -67,6 +68,72 @@ export const buildRangeFilteredRows = (
   });
 };
 
+const isActiveScopeFilterValue = (value: string | null | undefined) =>
+  Boolean(value && value.trim() && value !== 'all');
+
+const normalizeScopeValue = (value: string | null | undefined) =>
+  String(value || '')
+    .trim()
+    .toLowerCase();
+
+export const buildScopeFilteredRows = (
+  rows: MonitoringEventRow[],
+  scopeFilters?: MonitoringScopeFilters
+) => {
+  if (!scopeFilters) return rows;
+
+  const account = normalizeScopeValue(scopeFilters.account);
+  const provider = normalizeScopeValue(scopeFilters.provider);
+  const model = normalizeScopeValue(scopeFilters.model);
+  const channel = normalizeScopeValue(scopeFilters.channel);
+  const apiKeyHash = normalizeScopeValue(scopeFilters.apiKeyHash);
+  const status = scopeFilters.status;
+
+  return rows.filter((row) => {
+    if (isActiveScopeFilterValue(scopeFilters.account)) {
+      const rowAccountValues = [
+        row.account,
+        row.accountMasked,
+        row.authLabel,
+        row.source,
+        row.sourceMasked,
+        row.authIndex,
+      ].map(normalizeScopeValue);
+      if (!rowAccountValues.includes(account)) return false;
+    }
+
+    if (
+      isActiveScopeFilterValue(scopeFilters.provider) &&
+      normalizeScopeValue(row.provider) !== provider
+    ) {
+      return false;
+    }
+
+    if (isActiveScopeFilterValue(scopeFilters.model) && normalizeScopeValue(row.model) !== model) {
+      return false;
+    }
+
+    if (
+      isActiveScopeFilterValue(scopeFilters.channel) &&
+      normalizeScopeValue(row.channel) !== channel
+    ) {
+      return false;
+    }
+
+    if (
+      isActiveScopeFilterValue(scopeFilters.apiKeyHash) &&
+      normalizeScopeValue(row.apiKeyHash) !== apiKeyHash
+    ) {
+      return false;
+    }
+
+    if (status === 'failed' && !row.failed) return false;
+    if (status === 'success' && row.failed) return false;
+
+    return true;
+  });
+};
+
 const buildRecentPattern = (rows: MonitoringEventRow[], limit = 10) =>
   rows
     .slice()
@@ -84,10 +151,7 @@ export const buildMonitoringSummary = (rows: MonitoringEventRow[]): MonitoringSu
   const reasoningTokens = rows.reduce((sum, row) => sum + row.reasoningTokens, 0);
   const cachedTokens = rows.reduce((sum, row) => sum + row.cachedTokens, 0);
   const cacheReadTokens = rows.reduce((sum, row) => sum + (row.cacheReadTokens ?? 0), 0);
-  const cacheCreationTokens = rows.reduce(
-    (sum, row) => sum + (row.cacheCreationTokens ?? 0),
-    0
-  );
+  const cacheCreationTokens = rows.reduce((sum, row) => sum + (row.cacheCreationTokens ?? 0), 0);
   const totalTokens = rows.reduce((sum, row) => sum + row.totalTokens, 0);
   const totalCost = rows.reduce((sum, row) => sum + row.totalCost, 0);
 
@@ -358,8 +422,8 @@ export const buildApiKeyRows = (rows: MonitoringEventRow[]): MonitoringApiKeyRow
   rows.forEach((row) => {
     const hasKnownApiKey = Boolean(
       row.apiKeyHash ||
-        (row.apiKeyLabel && row.apiKeyLabel !== '-') ||
-        (row.apiKeyMasked && row.apiKeyMasked !== '-')
+      (row.apiKeyLabel && row.apiKeyLabel !== '-') ||
+      (row.apiKeyMasked && row.apiKeyMasked !== '-')
     );
     const apiKeyGroupKey = hasKnownApiKey
       ? row.apiKeyHash || row.apiKeyLabel || row.apiKeyMasked

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -361,6 +361,8 @@ export interface UseMonitoringDataReturn {
   eventsHasMore: boolean;
   eventsLoadingMore: boolean;
   lastRefreshedAt: Date | null;
+  isTransitioningScope: boolean;
+  hasPresentationSnapshot: boolean;
   refreshMeta: (showLoading?: boolean) => Promise<void>;
   loadMoreEvents: () => void;
 }

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -449,6 +449,7 @@ export interface DashboardSummaryParams {
 
 export interface MonitoringAnalyticsFilters {
   models?: string[];
+  accounts?: string[];
   auth_indices?: string[];
   api_key_hashes?: string[];
   source_hashes?: string[];


### PR DESCRIPTION
## Summary
Fix monitoring scope transitions for failed-only filtering and focused account views.

## Cause
Scope changes could briefly render empty or stale event state while analytics data was refreshing.
A later stabilization pass also introduced unstable event item references that could trigger repeated renders.

## Solution
- Add account fallback filtering for manager-server monitoring analytics.
- Apply local monitoring scope filters consistently in the web UI.
- Cache stable presentation snapshots during scope transitions.
- Reuse absorbed event page arrays to avoid render loops and page lockups.
- Add regression coverage for filtering, analytics adapters, snapshot fallback, and stable event item reuse.

## Testing
- [x] npm run type-check
- [x] npm run lint
- [x] npm --workspace apps/web run test -- src/features/monitoring/hooks/useMonitoringData.test.ts src/features/monitoring/model/analyticsAdapters.test.ts
- [x] npm run test
- [x] npm run build
- [x] cd apps/manager-server && go test ./...
