### PR TITLE
Expose Codex provider priority ordering in the manager UI

### DIFF
--- a/apps/web/src/components/providers/CodexSection/CodexSection.test.tsx
+++ b/apps/web/src/components/providers/CodexSection/CodexSection.test.tsx
@@ -83,15 +83,15 @@ describe('CodexSection', () => {
     clickButton(sortButton);
 
     const firstAscendingRow = getRows(renderer)[0];
-    expect(getText(firstAscendingRow)).toContain('https://low.example.com/v1');
+    expect(getText(firstAscendingRow)).toContain('https://unset.example.com/v1');
 
     const [editLowButton, deleteLowButton] = firstAscendingRow.findAllByType(Button);
     clickButton(editLowButton);
     clickButton(deleteLowButton);
     toggleSwitch(firstAscendingRow.findByType(ToggleSwitch), false);
 
-    expect(onEdit).toHaveBeenLastCalledWith(0);
-    expect(onDelete).toHaveBeenLastCalledWith(0);
-    expect(onToggle).toHaveBeenLastCalledWith(0, false);
+    expect(onEdit).toHaveBeenLastCalledWith(2);
+    expect(onDelete).toHaveBeenLastCalledWith(2);
+    expect(onToggle).toHaveBeenLastCalledWith(2, false);
   });
 });

--- a/apps/web/src/components/providers/CodexSection/CodexSection.test.tsx
+++ b/apps/web/src/components/providers/CodexSection/CodexSection.test.tsx
@@ -1,0 +1,97 @@
+import { act } from 'react';
+import { create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import { Button } from '@/components/ui/Button';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import type { ProviderKeyConfig } from '@/types';
+import { CodexSection } from './CodexSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const getRows = (renderer: ReactTestRenderer) =>
+  renderer.root.findAll((node) => node.type === 'div' && node.props.className === 'item-row');
+
+const getText = (node: ReactTestInstance): string =>
+  node.children.map((child) => (typeof child === 'string' ? child : getText(child))).join('');
+
+const clickButton = (button: ReactTestInstance) => {
+  const onClick = button.props.onClick as (() => void) | undefined;
+  if (!onClick) throw new Error('Button click handler not found');
+
+  act(() => {
+    onClick();
+  });
+};
+
+const toggleSwitch = (toggle: ReactTestInstance, value: boolean) => {
+  const onChange = toggle.props.onChange as ((value: boolean) => void) | undefined;
+  if (!onChange) throw new Error('Toggle change handler not found');
+
+  act(() => {
+    onChange(value);
+  });
+};
+
+describe('CodexSection', () => {
+  it('keeps sorted row actions mapped to original config indexes', () => {
+    const configs: ProviderKeyConfig[] = [
+      { apiKey: 'low-key', baseUrl: 'https://low.example.com/v1', priority: 1 },
+      { apiKey: 'high-key', baseUrl: 'https://high.example.com/v1', priority: 9 },
+      { apiKey: 'unset-key', baseUrl: 'https://unset.example.com/v1' },
+    ];
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const onToggle = vi.fn();
+    let renderer!: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        <CodexSection
+          configs={configs}
+          usageByProvider={new Map()}
+          loading={false}
+          disableControls={false}
+          isSwitching={false}
+          onAdd={() => {}}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onToggle={onToggle}
+        />
+      );
+    });
+
+    const firstDescendingRow = getRows(renderer)[0];
+    expect(getText(firstDescendingRow)).toContain('https://high.example.com/v1');
+
+    const [editHighButton, deleteHighButton] = firstDescendingRow.findAllByType(Button);
+    clickButton(editHighButton);
+    clickButton(deleteHighButton);
+    toggleSwitch(firstDescendingRow.findByType(ToggleSwitch), false);
+
+    expect(onEdit).toHaveBeenLastCalledWith(1);
+    expect(onDelete).toHaveBeenLastCalledWith(1);
+    expect(onToggle).toHaveBeenLastCalledWith(1, false);
+
+    const sortButton = renderer.root
+      .findAllByType(Button)
+      .find((button) => button.props['aria-label'] === 'ai_providers.sort_descending');
+    if (!sortButton) throw new Error('Sort button not found');
+    clickButton(sortButton);
+
+    const firstAscendingRow = getRows(renderer)[0];
+    expect(getText(firstAscendingRow)).toContain('https://low.example.com/v1');
+
+    const [editLowButton, deleteLowButton] = firstAscendingRow.findAllByType(Button);
+    clickButton(editLowButton);
+    clickButton(deleteLowButton);
+    toggleSwitch(firstAscendingRow.findByType(ToggleSwitch), false);
+
+    expect(onEdit).toHaveBeenLastCalledWith(0);
+    expect(onDelete).toHaveBeenLastCalledWith(0);
+    expect(onToggle).toHaveBeenLastCalledWith(0, false);
+  });
+});

--- a/apps/web/src/components/providers/CodexSection/CodexSection.tsx
+++ b/apps/web/src/components/providers/CodexSection/CodexSection.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useMemo } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { IconChevronDown, IconChevronUp } from '@/components/ui/icons';
 import iconCodex from '@/assets/icons/codex.svg';
 import type { ProviderKeyConfig } from '@/types';
 import { maskApiKey } from '@/utils/format';
@@ -17,6 +18,11 @@ import {
   hasDisableAllModelsRule,
   type ProviderRecentUsageMap,
 } from '../utils';
+import {
+  sortCodexConfigsByPriority,
+  type CodexProviderSortDirection,
+  type IndexedCodexProviderConfig,
+} from './sort';
 
 interface CodexSectionProps {
   configs: ProviderKeyConfig[];
@@ -44,6 +50,7 @@ export function CodexSection({
   const { t } = useTranslation();
   const actionsDisabled = disableControls || loading || isSwitching;
   const toggleDisabled = disableControls || loading || isSwitching;
+  const [sortDirection, setSortDirection] = useState<CodexProviderSortDirection>('desc');
 
   const statusBarCache = useMemo(() => {
     const cache = new Map<string, ReturnType<typeof statusBarDataFromRecentRequests>>();
@@ -62,6 +69,52 @@ export function CodexSection({
     return cache;
   }, [configs, usageByProvider]);
 
+  const sortedConfigs = useMemo(
+    () => sortCodexConfigsByPriority(configs, sortDirection),
+    [configs, sortDirection]
+  );
+
+  const toggleSortDirection = () => {
+    setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+  };
+
+  const renderHeaderActions = () => (
+    <div className={styles.cardHeaderActions}>
+      <div className={styles.sortControls}>
+        <span className={styles.sortLabel}>{t('ai_providers.sort_by_priority')}</span>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={toggleSortDirection}
+          className={styles.sortDirectionButton}
+          disabled={actionsDisabled}
+          title={
+            sortDirection === 'asc'
+              ? t('ai_providers.sort_ascending')
+              : t('ai_providers.sort_descending')
+          }
+          aria-label={
+            sortDirection === 'asc'
+              ? t('ai_providers.sort_ascending')
+              : t('ai_providers.sort_descending')
+          }
+        >
+          <span className={styles.sortDirectionIcon}>
+            {sortDirection === 'asc' ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />}
+          </span>
+          <span>
+            {sortDirection === 'asc'
+              ? t('ai_providers.sort_asc_short')
+              : t('ai_providers.sort_desc_short')}
+          </span>
+        </Button>
+      </div>
+      <Button size="sm" onClick={onAdd} disabled={actionsDisabled}>
+        {t('ai_providers.codex_add_button')}
+      </Button>
+    </div>
+  );
+
   return (
     <>
       <Card
@@ -71,31 +124,27 @@ export function CodexSection({
             {t('ai_providers.codex_title')}
           </span>
         }
-        extra={
-          <Button size="sm" onClick={onAdd} disabled={actionsDisabled}>
-            {t('ai_providers.codex_add_button')}
-          </Button>
-        }
+        extra={renderHeaderActions()}
       >
-        <ProviderList<ProviderKeyConfig>
-          items={configs}
+        <ProviderList<IndexedCodexProviderConfig>
+          items={sortedConfigs}
           loading={loading}
-          keyField={(item, index) => getProviderConfigKey(item, index)}
+          keyField={(item) => getProviderConfigKey(item.config, item.originalIndex)}
           emptyTitle={t('ai_providers.codex_empty_title')}
           emptyDescription={t('ai_providers.codex_empty_desc')}
-          onEdit={(_, index) => onEdit(index)}
-          onDelete={(_, index) => onDelete(index)}
+          onEdit={(item) => onEdit(item.originalIndex)}
+          onDelete={(item) => onDelete(item.originalIndex)}
           actionsDisabled={actionsDisabled}
-          getRowDisabled={(item) => hasDisableAllModelsRule(item.excludedModels)}
-          renderExtraActions={(item, index) => (
+          getRowDisabled={(item) => hasDisableAllModelsRule(item.config.excludedModels)}
+          renderExtraActions={(item) => (
             <ToggleSwitch
               label={t('ai_providers.config_toggle_label')}
-              checked={!hasDisableAllModelsRule(item.excludedModels)}
+              checked={!hasDisableAllModelsRule(item.config.excludedModels)}
               disabled={toggleDisabled}
-              onChange={(value) => void onToggle(index, value)}
+              onChange={(value) => void onToggle(item.originalIndex, value)}
             />
           )}
-          renderContent={(item, index) => {
+          renderContent={({ config: item, originalIndex }) => {
             const stats = getProviderTotalStats(
               usageByProvider,
               'codex',
@@ -106,7 +155,7 @@ export function CodexSection({
             const configDisabled = hasDisableAllModelsRule(item.excludedModels);
             const excludedModels = item.excludedModels ?? [];
             const statusData =
-              statusBarCache.get(getProviderConfigKey(item, index)) ||
+              statusBarCache.get(getProviderConfigKey(item, originalIndex)) ||
               statusBarDataFromRecentRequests([]);
 
             return (
@@ -142,8 +191,12 @@ export function CodexSection({
                 )}
                 {item.websockets !== undefined && (
                   <div className={styles.fieldRow}>
-                    <span className={styles.fieldLabel}>{t('ai_providers.codex_websockets_label')}:</span>
-                    <span className={styles.fieldValue}>{item.websockets ? t('common.yes') : t('common.no')}</span>
+                    <span className={styles.fieldLabel}>
+                      {t('ai_providers.codex_websockets_label')}:
+                    </span>
+                    <span className={styles.fieldValue}>
+                      {item.websockets ? t('common.yes') : t('common.no')}
+                    </span>
                   </div>
                 )}
                 {headerEntries.length > 0 && (
@@ -182,7 +235,10 @@ export function CodexSection({
                     </div>
                     <div className={styles.modelTagList}>
                       {excludedModels.map((model) => (
-                        <span key={model} className={`${styles.modelTag} ${styles.excludedModelTag}`}>
+                        <span
+                          key={model}
+                          className={`${styles.modelTag} ${styles.excludedModelTag}`}
+                        >
                           <span className={styles.modelName}>{model}</span>
                         </span>
                       ))}

--- a/apps/web/src/components/providers/CodexSection/sort.test.ts
+++ b/apps/web/src/components/providers/CodexSection/sort.test.ts
@@ -11,19 +11,19 @@ describe('sortCodexConfigsByPriority', () => {
     { apiKey: 'lowest', baseUrl: 'https://lowest.example.com/v1', priority: -1 },
   ];
 
-  it('sorts known priorities high to low by default and keeps original indexes', () => {
+  it('sorts priorities high to low by default and treats missing priority as 0', () => {
     expect(sortCodexConfigsByPriority(configs).map((item) => item.originalIndex)).toEqual([
-      2, 3, 0, 4, 1,
+      2, 3, 0, 1, 4,
     ]);
   });
 
-  it('sorts known priorities low to high when requested and leaves missing priorities last', () => {
+  it('sorts priorities low to high when requested and treats missing priority as 0', () => {
     expect(sortCodexConfigsByPriority(configs, 'asc').map((item) => item.originalIndex)).toEqual([
-      4, 0, 2, 3, 1,
+      4, 1, 0, 2, 3,
     ]);
   });
 
-  it('preserves the source list order for equal or missing priorities', () => {
+  it('preserves the source list order for equal effective priorities', () => {
     const tiedConfigs: ProviderKeyConfig[] = [
       { apiKey: 'a', priority: 2 },
       { apiKey: 'b', priority: 2 },

--- a/apps/web/src/components/providers/CodexSection/sort.test.ts
+++ b/apps/web/src/components/providers/CodexSection/sort.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderKeyConfig } from '@/types';
+import { sortCodexConfigsByPriority } from './sort';
+
+describe('sortCodexConfigsByPriority', () => {
+  const configs: ProviderKeyConfig[] = [
+    { apiKey: 'first', baseUrl: 'https://first.example.com/v1', priority: 3 },
+    { apiKey: 'unset', baseUrl: 'https://unset.example.com/v1' },
+    { apiKey: 'highest', baseUrl: 'https://highest.example.com/v1', priority: 10 },
+    { apiKey: 'also-highest', baseUrl: 'https://also-highest.example.com/v1', priority: 10 },
+    { apiKey: 'lowest', baseUrl: 'https://lowest.example.com/v1', priority: -1 },
+  ];
+
+  it('sorts known priorities high to low by default and keeps original indexes', () => {
+    expect(sortCodexConfigsByPriority(configs).map((item) => item.originalIndex)).toEqual([
+      2, 3, 0, 4, 1,
+    ]);
+  });
+
+  it('sorts known priorities low to high when requested and leaves missing priorities last', () => {
+    expect(sortCodexConfigsByPriority(configs, 'asc').map((item) => item.originalIndex)).toEqual([
+      4, 0, 2, 3, 1,
+    ]);
+  });
+
+  it('preserves the source list order for equal or missing priorities', () => {
+    const tiedConfigs: ProviderKeyConfig[] = [
+      { apiKey: 'a', priority: 2 },
+      { apiKey: 'b', priority: 2 },
+      { apiKey: 'c' },
+      { apiKey: 'd' },
+    ];
+
+    expect(sortCodexConfigsByPriority(tiedConfigs).map((item) => item.config.apiKey)).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ]);
+  });
+});

--- a/apps/web/src/components/providers/CodexSection/sort.ts
+++ b/apps/web/src/components/providers/CodexSection/sort.ts
@@ -9,7 +9,7 @@ export interface IndexedCodexProviderConfig {
 
 const getPriority = (config: ProviderKeyConfig) => {
   const priority = config.priority;
-  return typeof priority === 'number' && Number.isFinite(priority) ? priority : undefined;
+  return typeof priority === 'number' && Number.isFinite(priority) ? priority : 0;
 };
 
 export const sortCodexConfigsByPriority = (
@@ -21,19 +21,9 @@ export const sortCodexConfigsByPriority = (
   return [...indexed].sort((left, right) => {
     const leftPriority = getPriority(left.config);
     const rightPriority = getPriority(right.config);
-    const leftKnown = leftPriority !== undefined;
-    const rightKnown = rightPriority !== undefined;
 
-    if (leftKnown || rightKnown) {
-      if (!leftKnown) return 1;
-      if (!rightKnown) return -1;
-
-      const diff =
-        direction === 'desc'
-          ? (rightPriority ?? 0) - (leftPriority ?? 0)
-          : (leftPriority ?? 0) - (rightPriority ?? 0);
-      if (diff !== 0) return diff;
-    }
+    const diff = direction === 'desc' ? rightPriority - leftPriority : leftPriority - rightPriority;
+    if (diff !== 0) return diff;
 
     // Codex entries do not have stable provider names, so ties keep source order.
     return left.originalIndex - right.originalIndex;

--- a/apps/web/src/components/providers/CodexSection/sort.ts
+++ b/apps/web/src/components/providers/CodexSection/sort.ts
@@ -1,0 +1,41 @@
+import type { ProviderKeyConfig } from '@/types';
+
+export type CodexProviderSortDirection = 'asc' | 'desc';
+
+export interface IndexedCodexProviderConfig {
+  config: ProviderKeyConfig;
+  originalIndex: number;
+}
+
+const getPriority = (config: ProviderKeyConfig) => {
+  const priority = config.priority;
+  return typeof priority === 'number' && Number.isFinite(priority) ? priority : undefined;
+};
+
+export const sortCodexConfigsByPriority = (
+  configs: ProviderKeyConfig[],
+  direction: CodexProviderSortDirection = 'desc'
+): IndexedCodexProviderConfig[] => {
+  const indexed = configs.map((config, originalIndex) => ({ config, originalIndex }));
+
+  return [...indexed].sort((left, right) => {
+    const leftPriority = getPriority(left.config);
+    const rightPriority = getPriority(right.config);
+    const leftKnown = leftPriority !== undefined;
+    const rightKnown = rightPriority !== undefined;
+
+    if (leftKnown || rightKnown) {
+      if (!leftKnown) return 1;
+      if (!rightKnown) return -1;
+
+      const diff =
+        direction === 'desc'
+          ? (rightPriority ?? 0) - (leftPriority ?? 0)
+          : (leftPriority ?? 0) - (rightPriority ?? 0);
+      if (diff !== 0) return diff;
+    }
+
+    // Codex entries do not have stable provider names, so ties keep source order.
+    return left.originalIndex - right.originalIndex;
+  });
+};

--- a/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
+++ b/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
@@ -113,6 +113,19 @@ $openai-toolbar-control-height: 36px;
   }
 }
 
+.sortLabel {
+  display: inline-flex;
+  align-items: center;
+  height: $openai-toolbar-control-height;
+  padding: 0 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--surface-subtle);
+  color: var(--text-primary);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
 // 排序方向按钮
 .sortDirectionButton:global(.btn.btn-secondary) {
   flex: 0 0 74px;


### PR DESCRIPTION
Adds priority-based sorting to the Codex provider configs, with a UI toggle for ascending/descending order. Known priorities sort before missing values; equal/missing priorities keep source order. Includes helper and component regression tests plus the Codex section UI update.