### PR TITLE
fix(manager-server): add monitoring filter aggregates

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -18,6 +18,7 @@ type AnalyticsFilter struct {
 	SearchQuery       string
 	SearchAPIKeyHash  string
 	Models            []string
+	Providers         []string
 	Accounts          []string
 	AuthIndices       []string
 	APIKeyHashes      []string
@@ -72,6 +73,53 @@ type FailureSourceStat struct {
 	FailureCalls         int64
 	LastSeenMS           int64
 	AvgLatencyMS         sql.NullFloat64
+}
+
+type AccountModelStat struct {
+	AccountSnapshot      string
+	AuthLabelSnapshot    string
+	AuthProviderSnapshot string
+	AuthIndex            string
+	Source               string
+	SourceHash           string
+	Model                string
+	BillingModel         string
+	Calls                int64
+	SuccessCalls         int64
+	FailureCalls         int64
+	InputTokens          int64
+	OutputTokens         int64
+	CachedTokens         int64
+	CacheReadTokens      int64
+	CacheCreationTokens  int64
+	TotalTokens          int64
+	LastSeenMS           int64
+	AvgLatencyMS         sql.NullFloat64
+	LatencySamples       int64
+}
+
+type APIKeyModelStat struct {
+	APIKeyHash           string
+	AccountSnapshot      string
+	AuthLabelSnapshot    string
+	AuthProviderSnapshot string
+	AuthIndex            string
+	Source               string
+	SourceHash           string
+	Model                string
+	BillingModel         string
+	Calls                int64
+	SuccessCalls         int64
+	FailureCalls         int64
+	InputTokens          int64
+	OutputTokens         int64
+	CachedTokens         int64
+	CacheReadTokens      int64
+	CacheCreationTokens  int64
+	TotalTokens          int64
+	LastSeenMS           int64
+	AvgLatencyMS         sql.NullFloat64
+	LatencySamples       int64
 }
 
 type TaskBucket struct {
@@ -313,7 +361,7 @@ func (r *repository) ChannelModelStatsWithFilter(ctx context.Context, filter Ana
 	coalesce(max(source), ''),
 	coalesce(max(account_snapshot), ''),
 	coalesce(max(auth_label_snapshot), ''),
-	coalesce(max(auth_provider_snapshot), ''),
+	coalesce(nullif(max(auth_provider_snapshot), ''), max(provider), ''),
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
 	count(*),
@@ -371,7 +419,7 @@ func (r *repository) FailureSourcesWithFilter(ctx context.Context, filter Analyt
 	coalesce(auth_index, ''),
 	coalesce(max(account_snapshot), ''),
 	coalesce(max(auth_label_snapshot), ''),
-	coalesce(max(auth_provider_snapshot), ''),
+	coalesce(nullif(max(auth_provider_snapshot), ''), max(provider), ''),
 	count(*),
 	sum(case when failed = 1 then 1 else 0 end),
 	max(timestamp_ms),
@@ -399,6 +447,134 @@ order by sum(case when failed = 1 then 1 else 0 end) desc, max(timestamp_ms) des
 			&stat.FailureCalls,
 			&stat.LastSeenMS,
 			&stat.AvgLatencyMS,
+		); err != nil {
+			return nil, err
+		}
+		stats = append(stats, stat)
+	}
+	return stats, rows.Err()
+}
+
+func (r *repository) AccountModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]AccountModelStat, error) {
+	where, args := analyticsWhere(filter)
+	rows, err := r.db.QueryContext(ctx, `select
+	coalesce(account_snapshot, ''),
+	coalesce(auth_label_snapshot, ''),
+	coalesce(nullif(auth_provider_snapshot, ''), provider, ''),
+	coalesce(auth_index, ''),
+	coalesce(max(source), ''),
+	coalesce(source_hash, ''),
+	model,
+	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	count(*),
+	sum(case when failed = 0 then 1 else 0 end),
+	sum(case when failed = 1 then 1 else 0 end),
+	coalesce(sum(input_tokens), 0),
+	coalesce(sum(output_tokens), 0),
+	coalesce(sum(`+compatCachedExpr+`), 0),
+	coalesce(sum(cache_read_tokens), 0),
+	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(total_tokens), 0),
+	max(timestamp_ms),
+	avg(nullif(latency_ms, 0)),
+	count(nullif(latency_ms, 0))
+from usage_events `+where+`
+group by account_snapshot, auth_label_snapshot, coalesce(nullif(auth_provider_snapshot, ''), provider, ''), auth_index, source_hash, model, billing_model
+order by max(timestamp_ms) desc, count(*) desc`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	stats := make([]AccountModelStat, 0)
+	for rows.Next() {
+		var stat AccountModelStat
+		if err := rows.Scan(
+			&stat.AccountSnapshot,
+			&stat.AuthLabelSnapshot,
+			&stat.AuthProviderSnapshot,
+			&stat.AuthIndex,
+			&stat.Source,
+			&stat.SourceHash,
+			&stat.Model,
+			&stat.BillingModel,
+			&stat.Calls,
+			&stat.SuccessCalls,
+			&stat.FailureCalls,
+			&stat.InputTokens,
+			&stat.OutputTokens,
+			&stat.CachedTokens,
+			&stat.CacheReadTokens,
+			&stat.CacheCreationTokens,
+			&stat.TotalTokens,
+			&stat.LastSeenMS,
+			&stat.AvgLatencyMS,
+			&stat.LatencySamples,
+		); err != nil {
+			return nil, err
+		}
+		stats = append(stats, stat)
+	}
+	return stats, rows.Err()
+}
+
+func (r *repository) APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error) {
+	where, args := analyticsWhere(filter)
+	rows, err := r.db.QueryContext(ctx, `select
+	coalesce(api_key_hash, ''),
+	coalesce(account_snapshot, ''),
+	coalesce(auth_label_snapshot, ''),
+	coalesce(nullif(auth_provider_snapshot, ''), provider, ''),
+	coalesce(auth_index, ''),
+	coalesce(max(source), ''),
+	coalesce(source_hash, ''),
+	model,
+	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	count(*),
+	sum(case when failed = 0 then 1 else 0 end),
+	sum(case when failed = 1 then 1 else 0 end),
+	coalesce(sum(input_tokens), 0),
+	coalesce(sum(output_tokens), 0),
+	coalesce(sum(`+compatCachedExpr+`), 0),
+	coalesce(sum(cache_read_tokens), 0),
+	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(total_tokens), 0),
+	max(timestamp_ms),
+	avg(nullif(latency_ms, 0)),
+	count(nullif(latency_ms, 0))
+from usage_events `+where+`
+group by api_key_hash, account_snapshot, auth_label_snapshot, coalesce(nullif(auth_provider_snapshot, ''), provider, ''), auth_index, source_hash, model, billing_model
+order by max(timestamp_ms) desc, count(*) desc`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	stats := make([]APIKeyModelStat, 0)
+	for rows.Next() {
+		var stat APIKeyModelStat
+		if err := rows.Scan(
+			&stat.APIKeyHash,
+			&stat.AccountSnapshot,
+			&stat.AuthLabelSnapshot,
+			&stat.AuthProviderSnapshot,
+			&stat.AuthIndex,
+			&stat.Source,
+			&stat.SourceHash,
+			&stat.Model,
+			&stat.BillingModel,
+			&stat.Calls,
+			&stat.SuccessCalls,
+			&stat.FailureCalls,
+			&stat.InputTokens,
+			&stat.OutputTokens,
+			&stat.CachedTokens,
+			&stat.CacheReadTokens,
+			&stat.CacheCreationTokens,
+			&stat.TotalTokens,
+			&stat.LastSeenMS,
+			&stat.AvgLatencyMS,
+			&stat.LatencySamples,
 		); err != nil {
 			return nil, err
 		}
@@ -487,7 +663,7 @@ func (r *repository) RecentFailuresWithFilter(ctx context.Context, filter Analyt
 	latency_ms,
 	coalesce(account_snapshot, ''),
 	coalesce(auth_label_snapshot, ''),
-	coalesce(auth_provider_snapshot, ''),
+	coalesce(nullif(auth_provider_snapshot, ''), provider, ''),
 	coalesce(auth_project_id_snapshot, ''),
 	fail_status_code,
 	coalesce(fail_summary, '')
@@ -551,7 +727,7 @@ func (r *repository) EventsPageWithFilter(ctx context.Context, filter AnalyticsF
 	coalesce(api_key_hash, ''),
 	coalesce(account_snapshot, ''),
 	coalesce(auth_label_snapshot, ''),
-	coalesce(auth_provider_snapshot, ''),
+	coalesce(nullif(auth_provider_snapshot, ''), provider, ''),
 	coalesce(auth_project_id_snapshot, ''),
 	coalesce(reasoning_effort, ''),
 	input_tokens,
@@ -695,6 +871,7 @@ func analyticsWhere(filter AnalyticsFilter) (string, []any) {
 		}
 	}
 	addInCondition("model", filter.Models)
+	addProviderCondition(filter.Providers, &conditions, &args)
 	addAccountCondition(filter.Accounts, &conditions, &args)
 	addInCondition("auth_index", filter.AuthIndices)
 	addInCondition("api_key_hash", filter.APIKeyHashes)
@@ -710,6 +887,24 @@ func analyticsWhere(filter AnalyticsFilter) (string, []any) {
 	}
 
 	return "where " + strings.Join(conditions, " and "), args
+}
+
+func addProviderCondition(values []string, conditions *[]string, args *[]any) {
+	normalized := normalizeLowerFilterValues(values)
+	if len(normalized) == 0 {
+		return
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(normalized)), ",")
+	providerConditions := []string{
+		fmt.Sprintf("lower(coalesce(provider, '')) in (%s)", placeholders),
+		fmt.Sprintf("lower(coalesce(auth_provider_snapshot, '')) in (%s)", placeholders),
+	}
+	*conditions = append(*conditions, "("+strings.Join(providerConditions, " or ")+")")
+	for range providerConditions {
+		for _, value := range normalized {
+			*args = append(*args, value)
+		}
+	}
 }
 
 func addAccountCondition(values []string, conditions *[]string, args *[]any) {

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -26,6 +26,8 @@ type Repository interface {
 	HourlyDistributionWithFilter(ctx context.Context, filter AnalyticsFilter) ([]HourlyPoint, error)
 	ChannelModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]ChannelModelStat, error)
 	FailureSourcesWithFilter(ctx context.Context, filter AnalyticsFilter) ([]FailureSourceStat, error)
+	AccountModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]AccountModelStat, error)
+	APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error)
 	TaskBucketsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]TaskBucket, error)
 	RecentFailuresWithFilter(ctx context.Context, filter AnalyticsFilter, limit int) ([]RecentFailure, error)
 	EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, limit int) (EventsPage, error)

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -37,6 +37,7 @@ type Request struct {
 
 type Filters struct {
 	Models            []string `json:"models"`
+	Providers         []string `json:"providers"`
 	Accounts          []string `json:"accounts"`
 	AuthIndices       []string `json:"auth_indices"`
 	APIKeyHashes      []string `json:"api_key_hashes"`
@@ -54,6 +55,9 @@ type Include struct {
 	ChannelShare       bool        `json:"channel_share"`
 	ModelStats         bool        `json:"model_stats"`
 	FailureSources     bool        `json:"failure_sources"`
+	AccountStats       bool        `json:"account_stats"`
+	APIKeyStats        bool        `json:"api_key_stats"`
+	FilterOptions      bool        `json:"filter_options"`
 	TaskBuckets        bool        `json:"task_buckets"`
 	RecentFailures     int         `json:"recent_failures"`
 	EventsPage         *EventsPage `json:"events_page"`
@@ -75,6 +79,9 @@ type Response struct {
 	ModelStats         []ModelStat        `json:"model_stats,omitempty"`
 	ChannelShare       []ChannelShareRow  `json:"channel_share,omitempty"`
 	FailureSources     []FailureSourceRow `json:"failure_sources,omitempty"`
+	AccountStats       []AccountStatRow   `json:"account_stats,omitempty"`
+	APIKeyStats        []APIKeyStatRow    `json:"api_key_stats,omitempty"`
+	FilterOptions      *FilterOptions     `json:"filter_options,omitempty"`
 	TaskBuckets        []TaskBucketRow    `json:"task_buckets,omitempty"`
 	RecentFailures     []RecentFailure    `json:"recent_failures,omitempty"`
 	Events             *EventsResponse    `json:"events,omitempty"`
@@ -167,6 +174,78 @@ type FailureSourceRow struct {
 	Failure              int64    `json:"failure"`
 	LastSeenMS           int64    `json:"last_seen_ms"`
 	AvgLatencyMS         *float64 `json:"average_latency_ms"`
+}
+
+type AccountStatRow struct {
+	ID                   string                `json:"id"`
+	AccountSnapshot      string                `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot    string                `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot string                `json:"auth_provider_snapshot,omitempty"`
+	AuthIndices          []string              `json:"auth_indices,omitempty"`
+	Sources              []string              `json:"sources,omitempty"`
+	SourceHashes         []string              `json:"source_hashes,omitempty"`
+	Calls                int64                 `json:"calls"`
+	SuccessCalls         int64                 `json:"success_calls"`
+	FailureCalls         int64                 `json:"failure_calls"`
+	SuccessRate          float64               `json:"success_rate"`
+	InputTokens          int64                 `json:"input_tokens"`
+	OutputTokens         int64                 `json:"output_tokens"`
+	CachedTokens         int64                 `json:"cached_tokens"`
+	CacheReadTokens      int64                 `json:"cache_read_tokens"`
+	CacheCreationTokens  int64                 `json:"cache_creation_tokens"`
+	TotalTokens          int64                 `json:"total_tokens"`
+	Cost                 float64               `json:"cost"`
+	AvgLatencyMS         *float64              `json:"average_latency_ms"`
+	LastSeenMS           int64                 `json:"last_seen_ms"`
+	Models               []AccountModelStatRow `json:"models,omitempty"`
+}
+
+type AccountModelStatRow struct {
+	Model               string  `json:"model"`
+	Calls               int64   `json:"calls"`
+	SuccessCalls        int64   `json:"success_calls"`
+	FailureCalls        int64   `json:"failure_calls"`
+	SuccessRate         float64 `json:"success_rate"`
+	InputTokens         int64   `json:"input_tokens"`
+	OutputTokens        int64   `json:"output_tokens"`
+	CachedTokens        int64   `json:"cached_tokens"`
+	CacheReadTokens     int64   `json:"cache_read_tokens"`
+	CacheCreationTokens int64   `json:"cache_creation_tokens"`
+	TotalTokens         int64   `json:"total_tokens"`
+	Cost                float64 `json:"cost"`
+	LastSeenMS          int64   `json:"last_seen_ms"`
+}
+
+type APIKeyStatRow struct {
+	ID                   string                `json:"id"`
+	APIKeyHash           string                `json:"api_key_hash"`
+	AccountSnapshot      string                `json:"account_snapshot,omitempty"`
+	AuthLabelSnapshot    string                `json:"auth_label_snapshot,omitempty"`
+	AuthProviderSnapshot string                `json:"auth_provider_snapshot,omitempty"`
+	AuthIndices          []string              `json:"auth_indices,omitempty"`
+	Sources              []string              `json:"sources,omitempty"`
+	SourceHashes         []string              `json:"source_hashes,omitempty"`
+	Calls                int64                 `json:"calls"`
+	SuccessCalls         int64                 `json:"success_calls"`
+	FailureCalls         int64                 `json:"failure_calls"`
+	SuccessRate          float64               `json:"success_rate"`
+	InputTokens          int64                 `json:"input_tokens"`
+	OutputTokens         int64                 `json:"output_tokens"`
+	CachedTokens         int64                 `json:"cached_tokens"`
+	CacheReadTokens      int64                 `json:"cache_read_tokens"`
+	CacheCreationTokens  int64                 `json:"cache_creation_tokens"`
+	TotalTokens          int64                 `json:"total_tokens"`
+	Cost                 float64               `json:"cost"`
+	AvgLatencyMS         *float64              `json:"average_latency_ms"`
+	LastSeenMS           int64                 `json:"last_seen_ms"`
+	Models               []AccountModelStatRow `json:"models,omitempty"`
+}
+
+type FilterOptions struct {
+	AccountStats []AccountStatRow  `json:"account_stats,omitempty"`
+	APIKeyStats  []APIKeyStatRow   `json:"api_key_stats,omitempty"`
+	ChannelShare []ChannelShareRow `json:"channel_share,omitempty"`
+	ModelStats   []ModelStat       `json:"model_stats,omitempty"`
 }
 
 type TaskBucketRow struct {
@@ -338,6 +417,27 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		}
 		response.FailureSources = buildFailureSources(stats)
 	}
+	if req.Include.AccountStats {
+		stats, err := s.store.AccountModelStatsWithFilter(ctx, filter)
+		if err != nil {
+			return Response{}, err
+		}
+		response.AccountStats = buildAccountStats(stats, prices)
+	}
+	if req.Include.APIKeyStats {
+		stats, err := s.store.APIKeyModelStatsWithFilter(ctx, filter)
+		if err != nil {
+			return Response{}, err
+		}
+		response.APIKeyStats = buildAPIKeyStats(stats, prices)
+	}
+	if req.Include.FilterOptions {
+		options, err := s.filterOptions(ctx, filter, prices)
+		if err != nil {
+			return Response{}, err
+		}
+		response.FilterOptions = options
+	}
 	if req.Include.TaskBuckets {
 		response.TaskBuckets = buildTaskBuckets(taskBuckets)
 	}
@@ -381,6 +481,7 @@ func buildFilter(req Request) store.AnalyticsFilter {
 		SearchQuery:       req.SearchQuery,
 		SearchAPIKeyHash:  req.SearchAPIKeyHash,
 		Models:            req.Filters.Models,
+		Providers:         req.Filters.Providers,
 		Accounts:          req.Filters.Accounts,
 		AuthIndices:       req.Filters.AuthIndices,
 		APIKeyHashes:      req.Filters.APIKeyHashes,
@@ -389,6 +490,43 @@ func buildFilter(req Request) store.AnalyticsFilter {
 		FailedOnly:        req.Filters.FailedOnly,
 		ExcludeZeroTokens: req.Filters.ExcludeZeroTokens,
 	}
+}
+
+func (s *Service) filterOptions(ctx context.Context, filter store.AnalyticsFilter, prices map[string]store.ModelPrice) (*FilterOptions, error) {
+	optionFilter := filter
+	optionFilter.Models = nil
+	optionFilter.Providers = nil
+	optionFilter.Accounts = nil
+	optionFilter.AuthIndices = nil
+	optionFilter.APIKeyHashes = nil
+	optionFilter.SourceHashes = nil
+	optionFilter.IncludeFailed = true
+	optionFilter.FailedOnly = false
+	optionFilter.ExcludeZeroTokens = false
+
+	accountStats, err := s.store.AccountModelStatsWithFilter(ctx, optionFilter)
+	if err != nil {
+		return nil, err
+	}
+	apiKeyStats, err := s.store.APIKeyModelStatsWithFilter(ctx, optionFilter)
+	if err != nil {
+		return nil, err
+	}
+	channelStats, err := s.store.ChannelModelStatsWithFilter(ctx, optionFilter)
+	if err != nil {
+		return nil, err
+	}
+	modelStats, err := s.store.ModelStatsWithFilter(ctx, optionFilter, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FilterOptions{
+		AccountStats: buildAccountStats(accountStats, prices),
+		APIKeyStats:  buildAPIKeyStats(apiKeyStats, prices),
+		ChannelShare: buildChannelShare(channelStats, prices),
+		ModelStats:   buildModelStats(modelStats, prices),
+	}, nil
 }
 
 func normalizeGranularity(input string, fromMS int64, toMS int64) string {
@@ -605,6 +743,183 @@ func buildFailureSources(stats []store.FailureSourceStat) []FailureSourceRow {
 	return result
 }
 
+type accountStatAccumulator struct {
+	row            AccountStatRow
+	authIndices    map[string]struct{}
+	sources        map[string]struct{}
+	sourceHashes   map[string]struct{}
+	models         map[string]*AccountModelStatRow
+	latencySum     float64
+	latencySamples int64
+}
+
+type apiKeyStatAccumulator struct {
+	row            APIKeyStatRow
+	authIndices    map[string]struct{}
+	sources        map[string]struct{}
+	sourceHashes   map[string]struct{}
+	models         map[string]*AccountModelStatRow
+	latencySum     float64
+	latencySamples int64
+}
+
+func buildAccountStats(stats []store.AccountModelStat, prices map[string]store.ModelPrice) []AccountStatRow {
+	grouped := map[string]*accountStatAccumulator{}
+	for _, stat := range stats {
+		id := accountGroupKey(stat.AccountSnapshot, stat.AuthLabelSnapshot, stat.Source, stat.AuthIndex)
+		entry := grouped[id]
+		if entry == nil {
+			entry = &accountStatAccumulator{
+				row: AccountStatRow{
+					ID:                   id,
+					AccountSnapshot:      stat.AccountSnapshot,
+					AuthLabelSnapshot:    stat.AuthLabelSnapshot,
+					AuthProviderSnapshot: stat.AuthProviderSnapshot,
+				},
+				authIndices:  map[string]struct{}{},
+				sources:      map[string]struct{}{},
+				sourceHashes: map[string]struct{}{},
+				models:       map[string]*AccountModelStatRow{},
+			}
+			grouped[id] = entry
+		}
+		fillAccountStatSnapshots(&entry.row, stat.AccountSnapshot, stat.AuthLabelSnapshot, stat.AuthProviderSnapshot)
+		addSetValue(entry.authIndices, stat.AuthIndex)
+		addSetValue(entry.sources, stat.Source)
+		addSetValue(entry.sourceHashes, stat.SourceHash)
+		cost := costForAccountModelStat(stat, prices)
+		addAccountTotals(
+			&entry.row.Calls,
+			&entry.row.SuccessCalls,
+			&entry.row.FailureCalls,
+			&entry.row.InputTokens,
+			&entry.row.OutputTokens,
+			&entry.row.CachedTokens,
+			&entry.row.CacheReadTokens,
+			&entry.row.CacheCreationTokens,
+			&entry.row.TotalTokens,
+			&entry.row.Cost,
+			stat.Calls,
+			stat.SuccessCalls,
+			stat.FailureCalls,
+			stat.InputTokens,
+			stat.OutputTokens,
+			stat.CachedTokens,
+			stat.CacheReadTokens,
+			stat.CacheCreationTokens,
+			stat.TotalTokens,
+			cost,
+		)
+		if stat.LastSeenMS > entry.row.LastSeenMS {
+			entry.row.LastSeenMS = stat.LastSeenMS
+		}
+		if stat.AvgLatencyMS.Valid && stat.LatencySamples > 0 {
+			entry.latencySum += stat.AvgLatencyMS.Float64 * float64(stat.LatencySamples)
+			entry.latencySamples += stat.LatencySamples
+		}
+		addAccountModelStat(entry.models, stat.Model, stat.Calls, stat.SuccessCalls, stat.FailureCalls, stat.InputTokens, stat.OutputTokens, stat.CachedTokens, stat.CacheReadTokens, stat.CacheCreationTokens, stat.TotalTokens, cost, stat.LastSeenMS)
+	}
+
+	result := make([]AccountStatRow, 0, len(grouped))
+	for _, entry := range grouped {
+		entry.row.SuccessRate = ratio(entry.row.SuccessCalls, entry.row.Calls)
+		entry.row.AuthIndices = sortedSetValues(entry.authIndices)
+		entry.row.Sources = sortedSetValues(entry.sources)
+		entry.row.SourceHashes = sortedSetValues(entry.sourceHashes)
+		entry.row.Models = sortedAccountModelStats(entry.models)
+		if entry.latencySamples > 0 {
+			value := entry.latencySum / float64(entry.latencySamples)
+			entry.row.AvgLatencyMS = &value
+		}
+		result = append(result, entry.row)
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].LastSeenMS > result[j].LastSeenMS ||
+			(result[i].LastSeenMS == result[j].LastSeenMS && result[i].Calls > result[j].Calls) ||
+			(result[i].LastSeenMS == result[j].LastSeenMS && result[i].Calls == result[j].Calls && result[i].Cost > result[j].Cost)
+	})
+	return result
+}
+
+func buildAPIKeyStats(stats []store.APIKeyModelStat, prices map[string]store.ModelPrice) []APIKeyStatRow {
+	grouped := map[string]*apiKeyStatAccumulator{}
+	for _, stat := range stats {
+		id := apiKeyGroupKey(stat.APIKeyHash, stat.SourceHash, stat.AuthIndex, stat.Source, stat.AuthProviderSnapshot)
+		entry := grouped[id]
+		if entry == nil {
+			entry = &apiKeyStatAccumulator{
+				row: APIKeyStatRow{
+					ID:                   id,
+					APIKeyHash:           stat.APIKeyHash,
+					AccountSnapshot:      stat.AccountSnapshot,
+					AuthLabelSnapshot:    stat.AuthLabelSnapshot,
+					AuthProviderSnapshot: stat.AuthProviderSnapshot,
+				},
+				authIndices:  map[string]struct{}{},
+				sources:      map[string]struct{}{},
+				sourceHashes: map[string]struct{}{},
+				models:       map[string]*AccountModelStatRow{},
+			}
+			grouped[id] = entry
+		}
+		fillAPIKeyStatSnapshots(&entry.row, stat.APIKeyHash, stat.AccountSnapshot, stat.AuthLabelSnapshot, stat.AuthProviderSnapshot)
+		addSetValue(entry.authIndices, stat.AuthIndex)
+		addSetValue(entry.sources, stat.Source)
+		addSetValue(entry.sourceHashes, stat.SourceHash)
+		cost := costForAPIKeyModelStat(stat, prices)
+		addAccountTotals(
+			&entry.row.Calls,
+			&entry.row.SuccessCalls,
+			&entry.row.FailureCalls,
+			&entry.row.InputTokens,
+			&entry.row.OutputTokens,
+			&entry.row.CachedTokens,
+			&entry.row.CacheReadTokens,
+			&entry.row.CacheCreationTokens,
+			&entry.row.TotalTokens,
+			&entry.row.Cost,
+			stat.Calls,
+			stat.SuccessCalls,
+			stat.FailureCalls,
+			stat.InputTokens,
+			stat.OutputTokens,
+			stat.CachedTokens,
+			stat.CacheReadTokens,
+			stat.CacheCreationTokens,
+			stat.TotalTokens,
+			cost,
+		)
+		if stat.LastSeenMS > entry.row.LastSeenMS {
+			entry.row.LastSeenMS = stat.LastSeenMS
+		}
+		if stat.AvgLatencyMS.Valid && stat.LatencySamples > 0 {
+			entry.latencySum += stat.AvgLatencyMS.Float64 * float64(stat.LatencySamples)
+			entry.latencySamples += stat.LatencySamples
+		}
+		addAccountModelStat(entry.models, stat.Model, stat.Calls, stat.SuccessCalls, stat.FailureCalls, stat.InputTokens, stat.OutputTokens, stat.CachedTokens, stat.CacheReadTokens, stat.CacheCreationTokens, stat.TotalTokens, cost, stat.LastSeenMS)
+	}
+
+	result := make([]APIKeyStatRow, 0, len(grouped))
+	for _, entry := range grouped {
+		entry.row.SuccessRate = ratio(entry.row.SuccessCalls, entry.row.Calls)
+		entry.row.AuthIndices = sortedSetValues(entry.authIndices)
+		entry.row.Sources = sortedSetValues(entry.sources)
+		entry.row.SourceHashes = sortedSetValues(entry.sourceHashes)
+		entry.row.Models = sortedAccountModelStats(entry.models)
+		if entry.latencySamples > 0 {
+			value := entry.latencySum / float64(entry.latencySamples)
+			entry.row.AvgLatencyMS = &value
+		}
+		result = append(result, entry.row)
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].LastSeenMS > result[j].LastSeenMS ||
+			(result[i].LastSeenMS == result[j].LastSeenMS && result[i].Calls > result[j].Calls) ||
+			(result[i].LastSeenMS == result[j].LastSeenMS && result[i].Calls == result[j].Calls && result[i].Cost > result[j].Cost)
+	})
+	return result
+}
+
 func fillChannelShareSnapshots(row *ChannelShareRow, stat store.ChannelModelStat) {
 	if row.Source == "" {
 		row.Source = stat.Source
@@ -618,6 +933,168 @@ func fillChannelShareSnapshots(row *ChannelShareRow, stat store.ChannelModelStat
 	if row.AuthProviderSnapshot == "" {
 		row.AuthProviderSnapshot = stat.AuthProviderSnapshot
 	}
+}
+
+func accountGroupKey(accountSnapshot, authLabelSnapshot, source, authIndex string) string {
+	if strings.TrimSpace(accountSnapshot) != "" {
+		return accountSnapshot
+	}
+	if strings.TrimSpace(authLabelSnapshot) != "" {
+		return authLabelSnapshot
+	}
+	if strings.TrimSpace(source) != "" {
+		return source
+	}
+	if strings.TrimSpace(authIndex) != "" {
+		return authIndex
+	}
+	return "-"
+}
+
+func apiKeyGroupKey(apiKeyHash, sourceHash, authIndex, source, provider string) string {
+	if strings.TrimSpace(apiKeyHash) != "" {
+		return strings.ToLower(strings.TrimSpace(apiKeyHash))
+	}
+	parts := []string{"unknown-client-api-key"}
+	for _, value := range []string{sourceHash, authIndex, source, provider} {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			trimmed = "-"
+		}
+		parts = append(parts, trimmed)
+	}
+	return strings.Join(parts, ":")
+}
+
+func fillAccountStatSnapshots(row *AccountStatRow, accountSnapshot, authLabelSnapshot, authProviderSnapshot string) {
+	if row.AccountSnapshot == "" {
+		row.AccountSnapshot = accountSnapshot
+	}
+	if row.AuthLabelSnapshot == "" {
+		row.AuthLabelSnapshot = authLabelSnapshot
+	}
+	if row.AuthProviderSnapshot == "" {
+		row.AuthProviderSnapshot = authProviderSnapshot
+	}
+}
+
+func fillAPIKeyStatSnapshots(row *APIKeyStatRow, apiKeyHash, accountSnapshot, authLabelSnapshot, authProviderSnapshot string) {
+	if row.APIKeyHash == "" {
+		row.APIKeyHash = apiKeyHash
+	}
+	if row.AccountSnapshot == "" {
+		row.AccountSnapshot = accountSnapshot
+	}
+	if row.AuthLabelSnapshot == "" {
+		row.AuthLabelSnapshot = authLabelSnapshot
+	}
+	if row.AuthProviderSnapshot == "" {
+		row.AuthProviderSnapshot = authProviderSnapshot
+	}
+}
+
+func addSetValue(values map[string]struct{}, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	values[trimmed] = struct{}{}
+}
+
+func sortedSetValues(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func addAccountTotals(
+	calls *int64,
+	successCalls *int64,
+	failureCalls *int64,
+	inputTokens *int64,
+	outputTokens *int64,
+	cachedTokens *int64,
+	cacheReadTokens *int64,
+	cacheCreationTokens *int64,
+	totalTokens *int64,
+	cost *float64,
+	addCalls int64,
+	addSuccessCalls int64,
+	addFailureCalls int64,
+	addInputTokens int64,
+	addOutputTokens int64,
+	addCachedTokens int64,
+	addCacheReadTokens int64,
+	addCacheCreationTokens int64,
+	addTotalTokens int64,
+	addCost float64,
+) {
+	*calls += addCalls
+	*successCalls += addSuccessCalls
+	*failureCalls += addFailureCalls
+	*inputTokens += addInputTokens
+	*outputTokens += addOutputTokens
+	*cachedTokens += addCachedTokens
+	*cacheReadTokens += addCacheReadTokens
+	*cacheCreationTokens += addCacheCreationTokens
+	*totalTokens += addTotalTokens
+	*cost += addCost
+}
+
+func addAccountModelStat(
+	models map[string]*AccountModelStatRow,
+	model string,
+	calls int64,
+	successCalls int64,
+	failureCalls int64,
+	inputTokens int64,
+	outputTokens int64,
+	cachedTokens int64,
+	cacheReadTokens int64,
+	cacheCreationTokens int64,
+	totalTokens int64,
+	cost float64,
+	lastSeenMS int64,
+) {
+	modelKey := model
+	if strings.TrimSpace(modelKey) == "" {
+		modelKey = "-"
+	}
+	entry := models[modelKey]
+	if entry == nil {
+		entry = &AccountModelStatRow{Model: modelKey}
+		models[modelKey] = entry
+	}
+	entry.Calls += calls
+	entry.SuccessCalls += successCalls
+	entry.FailureCalls += failureCalls
+	entry.InputTokens += inputTokens
+	entry.OutputTokens += outputTokens
+	entry.CachedTokens += cachedTokens
+	entry.CacheReadTokens += cacheReadTokens
+	entry.CacheCreationTokens += cacheCreationTokens
+	entry.TotalTokens += totalTokens
+	entry.Cost += cost
+	if lastSeenMS > entry.LastSeenMS {
+		entry.LastSeenMS = lastSeenMS
+	}
+	entry.SuccessRate = ratio(entry.SuccessCalls, entry.Calls)
+}
+
+func sortedAccountModelStats(models map[string]*AccountModelStatRow) []AccountModelStatRow {
+	result := make([]AccountModelStatRow, 0, len(models))
+	for _, model := range models {
+		result = append(result, *model)
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].Cost > result[j].Cost ||
+			(result[i].Cost == result[j].Cost && result[i].Calls > result[j].Calls) ||
+			(result[i].Cost == result[j].Cost && result[i].Calls == result[j].Calls && result[i].LastSeenMS > result[j].LastSeenMS)
+	})
+	return result
 }
 
 func buildTaskBuckets(buckets []store.TaskBucket) []TaskBucketRow {
@@ -731,6 +1208,34 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 }
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
+	model := stat.BillingModel
+	if model == "" {
+		model = stat.Model
+	}
+	return pricing.CostForModel(model, pricing.ModelTokens{
+		InputTokens:         stat.InputTokens,
+		OutputTokens:        stat.OutputTokens,
+		CachedTokens:        stat.CachedTokens,
+		CacheReadTokens:     stat.CacheReadTokens,
+		CacheCreationTokens: stat.CacheCreationTokens,
+	}, prices)
+}
+
+func costForAccountModelStat(stat store.AccountModelStat, prices map[string]store.ModelPrice) float64 {
+	model := stat.BillingModel
+	if model == "" {
+		model = stat.Model
+	}
+	return pricing.CostForModel(model, pricing.ModelTokens{
+		InputTokens:         stat.InputTokens,
+		OutputTokens:        stat.OutputTokens,
+		CachedTokens:        stat.CachedTokens,
+		CacheReadTokens:     stat.CacheReadTokens,
+		CacheCreationTokens: stat.CacheCreationTokens,
+	}, prices)
+}
+
+func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.ModelPrice) float64 {
 	model := stat.BillingModel
 	if model == "" {
 		model = stat.Model

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -345,6 +345,59 @@ func TestAnalyticsAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestAnalyticsAccountAndAPIKeyStatsUseFullFilteredScope(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_050_000_000)
+	toMS := fromMS + 60*60*1000
+
+	events := []usage.Event{
+		monitoringEvent("scope-a", fromMS+1_000, "gpt-a", "auth-1", "source-a", false, 10, 5, 0, 0, 15, nil),
+		monitoringEvent("scope-b", fromMS+2_000, "gpt-a", "auth-1", "source-a", false, 20, 6, 0, 0, 26, nil),
+		monitoringEvent("scope-c", fromMS+3_000, "gpt-b", "auth-1", "source-a", true, 1, 1, 0, 0, 2, nil),
+	}
+	for index := range events {
+		events[index].AccountSnapshot = "team@example.com"
+		events[index].AuthLabelSnapshot = "Team Account"
+		events[index].APIKeyHash = "client-key-hash"
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Include: Include{
+			Summary:      true,
+			AccountStats: true,
+			APIKeyStats:  true,
+			EventsPage:   &EventsPage{Limit: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if resp.Events == nil || len(resp.Events.Items) != 1 || !resp.Events.HasMore {
+		t.Fatalf("events page = %#v", resp.Events)
+	}
+	if resp.Summary == nil || resp.Summary.TotalCalls != 3 || resp.Summary.FailureCalls != 1 {
+		t.Fatalf("summary = %#v", resp.Summary)
+	}
+	if len(resp.AccountStats) != 1 || resp.AccountStats[0].Calls != 3 ||
+		resp.AccountStats[0].FailureCalls != 1 || resp.AccountStats[0].TotalTokens != 43 {
+		t.Fatalf("account stats = %#v", resp.AccountStats)
+	}
+	if len(resp.AccountStats[0].Models) != 2 {
+		t.Fatalf("account model stats = %#v", resp.AccountStats[0].Models)
+	}
+	if len(resp.APIKeyStats) != 1 || resp.APIKeyStats[0].APIKeyHash != "client-key-hash" ||
+		resp.APIKeyStats[0].Calls != 3 || resp.APIKeyStats[0].FailureCalls != 1 ||
+		resp.APIKeyStats[0].TotalTokens != 43 {
+		t.Fatalf("api key stats = %#v", resp.APIKeyStats)
+	}
+}
+
 func TestAnalyticsSearchMatchesResolvedModelAndProjectID(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()
@@ -499,6 +552,62 @@ func TestAnalyticsAppliesAccountFallbackFilter(t *testing.T) {
 	}
 	if resp.Events == nil || len(resp.Events.Items) != 1 || resp.Events.Items[0].EventHash != "account-alice" {
 		t.Fatalf("auth label events = %#v", resp.Events)
+	}
+}
+
+func TestAnalyticsFilterOptionsIgnoreActiveScopeFilters(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_300_000_000)
+	toMS := fromMS + 60*60*1000
+
+	alice := monitoringEvent("option-alice", fromMS+1_000, "gpt-a", "auth-a", "source-a", false, 10, 5, 0, 0, 15, nil)
+	alice.AccountSnapshot = "alice@example.com"
+	alice.AuthLabelSnapshot = "Alice Auth"
+	alice.AuthProviderSnapshot = "codex"
+	alice.APIKeyHash = "key-alice"
+	bob := monitoringEvent("option-bob", fromMS+2_000, "gpt-b", "auth-b", "source-b", false, 10, 5, 0, 0, 15, nil)
+	bob.AccountSnapshot = "bob@example.com"
+	bob.AuthLabelSnapshot = "Bob Auth"
+	bob.AuthProviderSnapshot = "gemini"
+	bob.APIKeyHash = "key-bob"
+
+	if _, err := db.InsertEvents(ctx, []usage.Event{alice, bob}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Filters: Filters{
+			Models:   []string{"gpt-a"},
+			Accounts: []string{"alice@example.com"},
+		},
+		Include: Include{
+			Summary:       true,
+			FilterOptions: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if resp.Summary == nil || resp.Summary.TotalCalls != 1 {
+		t.Fatalf("summary should respect active filters: %#v", resp.Summary)
+	}
+	if resp.FilterOptions == nil {
+		t.Fatal("filter options are nil")
+	}
+	if len(resp.FilterOptions.AccountStats) != 2 {
+		t.Fatalf("account filter options should ignore active account/model filters: %#v", resp.FilterOptions.AccountStats)
+	}
+	if len(resp.FilterOptions.APIKeyStats) != 2 {
+		t.Fatalf("api key filter options should ignore active account/model filters: %#v", resp.FilterOptions.APIKeyStats)
+	}
+	if len(resp.FilterOptions.ModelStats) != 2 {
+		t.Fatalf("model filter options should ignore active account/model filters: %#v", resp.FilterOptions.ModelStats)
+	}
+	if len(resp.FilterOptions.ChannelShare) != 2 {
+		t.Fatalf("channel/provider filter options should ignore active account/model filters: %#v", resp.FilterOptions.ChannelShare)
 	}
 }
 

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -45,6 +45,8 @@ type TimelinePoint = usageevent.TimelinePoint
 type HourlyPoint = usageevent.HourlyPoint
 type ChannelModelStat = usageevent.ChannelModelStat
 type FailureSourceStat = usageevent.FailureSourceStat
+type AccountModelStat = usageevent.AccountModelStat
+type APIKeyModelStat = usageevent.APIKeyModelStat
 type TaskBucket = usageevent.TaskBucket
 type EventPageItem = usageevent.EventPageItem
 type EventsPage = usageevent.EventsPage
@@ -265,6 +267,14 @@ func (s *Store) ChannelModelStatsWithFilter(ctx context.Context, filter Analytic
 
 func (s *Store) FailureSourcesWithFilter(ctx context.Context, filter AnalyticsFilter) ([]FailureSourceStat, error) {
 	return s.UsageEvents.FailureSourcesWithFilter(ctx, filter)
+}
+
+func (s *Store) AccountModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]AccountModelStat, error) {
+	return s.UsageEvents.AccountModelStatsWithFilter(ctx, filter)
+}
+
+func (s *Store) APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error) {
+	return s.UsageEvents.APIKeyModelStatsWithFilter(ctx, filter)
 }
 
 func (s *Store) TaskBucketsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]TaskBucket, error) {


### PR DESCRIPTION
## Summary
- Add provider-aware filters to monitoring analytics requests and repository queries.
- Add account and API key aggregate stats with per-model totals, cost, success rate, and latency.
- Add full filter option payloads so the UI can build stable candidates outside the current events page.

## Issues
Refs #70

## Testing
- go test ./internal/service/monitoring