### PR TITLE
fix(web): stabilize monitoring filter options

### DIFF
--- a/apps/web/src/components/ui/Select.module.scss
+++ b/apps/web/src/components/ui/Select.module.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  min-width: 0;
 }
 
 .wrapFullWidth {
@@ -16,6 +17,7 @@
   justify-content: space-between;
   gap: 8px;
   width: 100%;
+  min-width: 0;
   height: 40px;
   padding: 0 12px;
   border: 1px solid var(--app-input-border);
@@ -49,6 +51,8 @@
 }
 
 .triggerText {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -9,8 +9,6 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  buildAccountRows,
-  buildApiKeyRows,
   buildRealtimeMonitorRows,
   getRangeBounds,
   type MonitoringAccountRow,
@@ -70,15 +68,15 @@ import {
   buildAccountOptions,
   buildAccountOverviewColumns,
   buildAccountSortOptions,
-  buildApiKeyOptions,
+  buildApiKeyOptionsFromRows,
   buildApiKeyOverviewColumns,
   buildAuthFilesByAuthIndex,
   buildAccountQuotaErrorEntry,
-  buildChannelOptions,
-  buildModelOptions,
+  buildChannelOptionsFromValues,
+  buildModelOptionsFromValues,
   buildPaginationState,
   buildPrimarySummaryCards,
-  buildProviderOptions,
+  buildProviderOptionsFromValues,
   buildRealtimeLogRows,
   buildSecondarySummaryCards,
   buildStatusOptions,
@@ -297,6 +295,9 @@ export function MonitoringCenterPage() {
     error: monitoringError,
     authFiles,
     summary: monitoringSummary,
+    accountRows: monitoringAccountRows,
+    apiKeyRows: monitoringApiKeyRows,
+    filterOptions: monitoringFilterOptions,
     filteredRows,
     eventsHasMore,
     eventsLoadingMore,
@@ -416,30 +417,28 @@ export function MonitoringCenterPage() {
   ]);
 
   const providerOptions = useMemo(
-    () => buildProviderOptions(filteredRows, selectedProvider, t),
-    [filteredRows, selectedProvider, t]
+    () => buildProviderOptionsFromValues(monitoringFilterOptions.providers, selectedProvider, t),
+    [monitoringFilterOptions.providers, selectedProvider, t]
   );
 
-  const accountOptionRows = useMemo(() => buildAccountRows(filteredRows), [filteredRows]);
-
   const accountOptions = useMemo(
-    () => buildAccountOptions(accountOptionRows, selectedAccount, t),
-    [accountOptionRows, selectedAccount, t]
+    () => buildAccountOptions(monitoringFilterOptions.accountRows, selectedAccount, t),
+    [monitoringFilterOptions.accountRows, selectedAccount, t]
   );
 
   const modelOptions = useMemo(
-    () => buildModelOptions(filteredRows, selectedModel, t),
-    [filteredRows, selectedModel, t]
+    () => buildModelOptionsFromValues(monitoringFilterOptions.models, selectedModel, t),
+    [monitoringFilterOptions.models, selectedModel, t]
   );
 
   const channelOptions = useMemo(
-    () => buildChannelOptions(filteredRows, selectedChannel, t),
-    [filteredRows, selectedChannel, t]
+    () => buildChannelOptionsFromValues(monitoringFilterOptions.channels, selectedChannel, t),
+    [monitoringFilterOptions.channels, selectedChannel, t]
   );
 
   const apiKeyOptions = useMemo(
-    () => buildApiKeyOptions(filteredRows, selectedApiKeyHash, t),
-    [filteredRows, selectedApiKeyHash, t]
+    () => buildApiKeyOptionsFromRows(monitoringFilterOptions.apiKeyRows, selectedApiKeyHash, t),
+    [monitoringFilterOptions.apiKeyRows, selectedApiKeyHash, t]
   );
 
   const statusOptions = useMemo(() => buildStatusOptions(t), [t]);
@@ -462,8 +461,8 @@ export function MonitoringCenterPage() {
   );
 
   const scopedSummary = monitoringSummary;
-  const accountRows = useMemo(() => buildAccountRows(scopedRows), [scopedRows]);
-  const apiKeyRows = useMemo(() => buildApiKeyRows(scopedRows), [scopedRows]);
+  const accountRows = monitoringAccountRows;
+  const apiKeyRows = monitoringApiKeyRows;
   const accountStatusDataByRowId = useMemo(
     () => buildMonitoringAccountStatusDataMap(scopedRows, accountStatusBounds),
     [accountStatusBounds, scopedRows]
@@ -837,7 +836,9 @@ export function MonitoringCenterPage() {
   );
 
   const focusAccount = useCallback(
-    (account: string) => {
+    (row: MonitoringAccountRow) => {
+      const account = row.account;
+      const accountFilterValue = row.filterValue || row.account;
       if (focusedAccount === account) {
         restoreFocusSnapshot();
         return;
@@ -856,7 +857,7 @@ export function MonitoringCenterPage() {
       }
 
       setFocusedAccount(account);
-      setSelectedAccount(account);
+      setSelectedAccount(accountFilterValue);
     },
     [
       focusedAccount,

--- a/apps/web/src/features/monitoring/components/AccountOverviewPanel.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewPanel.tsx
@@ -83,7 +83,7 @@ type AccountOverviewPanelProps = {
   onAccountStatusToggle: (row: MonitoringAccountRow, enabled: boolean) => void | Promise<void>;
   onLoadAccountQuota: (account: string, force: boolean) => void | Promise<void>;
   onToggleExpanded: (rowId: string, account: string) => void;
-  onFocusAccount: (account: string) => void;
+  onFocusAccount: (row: MonitoringAccountRow) => void;
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
 };
@@ -408,7 +408,7 @@ export function AccountOverviewPanel({
                           <button
                             type="button"
                             className={styles.inlineActionButton}
-                            onClick={() => onFocusAccount(row.account)}
+                            onClick={() => onFocusAccount(row)}
                           >
                             <IconCrosshair size={13} aria-hidden="true" />
                             <span>
@@ -473,7 +473,7 @@ export function AccountOverviewPanel({
                 quotaState={accountQuotaStates[row.account]}
                 statusUpdating={accountStatusUpdating[row.id] === true}
                 onToggle={() => onToggleExpanded(row.id, row.account)}
-                onFocus={() => onFocusAccount(row.account)}
+                onFocus={() => onFocusAccount(row)}
                 onToggleEnabled={(enabled) => void onAccountStatusToggle(row, enabled)}
                 onRefreshQuota={() => void onLoadAccountQuota(row.account, true)}
               />

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -14,7 +14,12 @@ import {
   type MonitoringEventRow,
   type MonitoringPresentationSnapshot,
 } from './useMonitoringData';
+import {
+  buildAccountRowsFromAnalytics,
+  buildApiKeyRowsFromAnalytics,
+} from '../model/analyticsAdapters';
 import type { MonitoringAnalyticsEventRow } from '@/services/api/usageService';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { sha256Hex } from '@/utils/apiKeyHash';
 import type { AuthFileItem } from '@/types';
 
@@ -78,12 +83,156 @@ const createPresentationSnapshot = (id: string): MonitoringPresentationSnapshot 
     failureSourceRows: [],
     taskBuckets: [],
     recentFailures: [],
+    accountRows: buildAccountRows([row]),
+    apiKeyRows: buildApiKeyRows([row]),
+    filterOptions: {
+      accountRows: buildAccountRows([row]),
+      apiKeyRows: buildApiKeyRows([row]),
+      providers: [row.provider],
+      models: [row.model],
+      channels: [row.channel],
+    },
     filteredRows: [row],
     eventsHasMore: id.includes('more'),
     eventsLoadingMore: false,
     lastRefreshedAt: new Date(1_768_759_000_000),
   };
 };
+
+describe('analytics aggregate row adapters', () => {
+  const authMetaMap = buildMonitoringAuthMetaMap([
+    {
+      name: 'team.json',
+      provider: 'codex',
+      authIndex: 'auth-123456',
+      path: '/tmp/auths/team.json',
+      account: 'team@example.com',
+      label: 'Team Account',
+    },
+  ]);
+  const authFileMap = new Map();
+  const sourceInfoMap = buildSourceInfoMap({});
+  const channelByAuthIndex = new Map([
+    [
+      'auth-123456',
+      {
+        key: 'codex',
+        name: 'Codex',
+        baseUrl: 'https://api.openai.com',
+        host: 'api.openai.com',
+        disabled: false,
+        authIndices: ['auth-123456'],
+        modelNames: ['gpt-4.1'],
+      },
+    ],
+  ]);
+
+  it('builds account rows from full backend aggregates instead of event pages', () => {
+    const rows = buildAccountRowsFromAnalytics(
+      [
+        {
+          id: 'team@example.com',
+          account_snapshot: 'team@example.com',
+          auth_label_snapshot: 'Team Account',
+          auth_provider_snapshot: 'codex',
+          auth_indices: ['auth-123456'],
+          sources: ['team.json'],
+          source_hashes: ['source-hash'],
+          calls: 3,
+          success_calls: 2,
+          failure_calls: 1,
+          success_rate: 2 / 3,
+          input_tokens: 31,
+          output_tokens: 12,
+          cached_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          total_tokens: 43,
+          cost: 0.42,
+          average_latency_ms: 1200,
+          last_seen_ms: 1_768_759_000_000,
+          models: [
+            {
+              model: 'gpt-4.1',
+              calls: 3,
+              success_calls: 2,
+              failure_calls: 1,
+              success_rate: 2 / 3,
+              input_tokens: 31,
+              output_tokens: 12,
+              cached_tokens: 0,
+              cache_read_tokens: 0,
+              cache_creation_tokens: 0,
+              total_tokens: 43,
+              cost: 0.42,
+              last_seen_ms: 1_768_759_000_000,
+            },
+          ],
+        },
+      ],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      account: 'team@example.com',
+      totalCalls: 3,
+      failureCalls: 1,
+      totalTokens: 43,
+      totalCost: 0.42,
+    });
+    expect(rows[0].models[0]).toMatchObject({ model: 'gpt-4.1', totalCalls: 3 });
+  });
+
+  it('builds api key rows from full backend aggregates and keeps aliases', () => {
+    const rows = buildApiKeyRowsFromAnalytics(
+      [
+        {
+          id: 'client-key-hash',
+          api_key_hash: 'client-key-hash',
+          account_snapshot: 'team@example.com',
+          auth_label_snapshot: 'Team Account',
+          auth_provider_snapshot: 'codex',
+          auth_indices: ['auth-123456'],
+          sources: ['team.json'],
+          source_hashes: ['source-hash'],
+          calls: 3,
+          success_calls: 2,
+          failure_calls: 1,
+          success_rate: 2 / 3,
+          input_tokens: 31,
+          output_tokens: 12,
+          cached_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          total_tokens: 43,
+          cost: 0.42,
+          average_latency_ms: 1200,
+          last_seen_ms: 1_768_759_000_000,
+          models: [],
+        },
+      ],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex,
+      new Map([['client-key-hash', { label: 'Team Key', masked: 'sk********ey' }]])
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      apiKeyHash: 'client-key-hash',
+      apiKeyLabel: 'Team Key',
+      apiKeyMasked: 'sk********ey',
+      totalCalls: 3,
+      failureCalls: 1,
+      totalTokens: 43,
+    });
+  });
+});
 
 describe('buildAccountRows', () => {
   it('keeps raw auth indices for account-level auth file linking', () => {

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -21,9 +21,12 @@ import {
 } from '../model/chartBuilders';
 import {
   buildAnalyticsFilters,
+  buildAccountRowsFromAnalytics,
+  buildApiKeyRowsFromAnalytics,
   buildChannelRowsFromAnalytics,
   buildFailureRowsFromAnalytics,
   buildFailureSourceRowsFromAnalytics,
+  buildFilterOptionsFromAnalytics,
   buildHourlyDistributionFromAnalytics,
   buildModelRowsFromAnalytics,
   buildModelShareRowsFromAnalytics,
@@ -35,6 +38,8 @@ import {
 } from '../model/analyticsAdapters';
 import { buildEventRows } from '../model/eventRows';
 import {
+  buildAccountRows,
+  buildApiKeyRows,
   buildMonitoringSummary,
   buildRangeFilteredRows,
   buildScopeFilteredRows,
@@ -43,6 +48,7 @@ import {
 import type {
   MonitoringAuthMeta,
   MonitoringChannelMeta,
+  MonitoringFilterOptions,
   MonitoringMetadata,
   UseMonitoringDataParams,
   UseMonitoringDataReturn,
@@ -113,6 +119,9 @@ export type MonitoringPresentationSnapshot = Pick<
   | 'failureSourceRows'
   | 'taskBuckets'
   | 'recentFailures'
+  | 'accountRows'
+  | 'apiKeyRows'
+  | 'filterOptions'
   | 'filteredRows'
   | 'eventsHasMore'
   | 'eventsLoadingMore'
@@ -189,6 +198,11 @@ export const mergeMonitoringEventsPageItems = (
   }
   return mergeAnalyticsEventItems(pageItems, previousItems);
 };
+
+const uniqueOptionValues = (values: Array<string | null | undefined>) =>
+  Array.from(new Set(values.map((value) => String(value || '').trim()).filter(Boolean))).sort(
+    (left, right) => left.localeCompare(right)
+  );
 
 export const resolveMonitoringDisplayEventItems = ({
   analyticsData,
@@ -431,6 +445,9 @@ export function useMonitoringData({
       channel_share: true,
       model_stats: true,
       failure_sources: true,
+      account_stats: true,
+      api_key_stats: true,
+      filter_options: true,
       task_buckets: true,
       recent_failures: 8,
       events_page: { limit: MONITORING_EVENTS_PAGE_LIMIT, before_ms: eventsBeforeMs },
@@ -657,6 +674,74 @@ export function useMonitoringData({
         : buildFailureRows(statsRows),
     [currentAnalyticsData, authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap, statsRows]
   );
+  const accountRows = useMemo(
+    () =>
+      currentAnalyticsData?.account_stats
+        ? buildAccountRowsFromAnalytics(
+            currentAnalyticsData.account_stats,
+            authMetaMap,
+            authFileMap,
+            sourceInfoMap,
+            channelByAuthIndex
+          )
+        : buildAccountRows(filteredRows),
+    [currentAnalyticsData, authFileMap, authMetaMap, channelByAuthIndex, filteredRows, sourceInfoMap]
+  );
+  const apiKeyRows = useMemo(
+    () =>
+      currentAnalyticsData?.api_key_stats
+        ? buildApiKeyRowsFromAnalytics(
+            currentAnalyticsData.api_key_stats,
+            authMetaMap,
+            authFileMap,
+            sourceInfoMap,
+            channelByAuthIndex,
+            apiKeyDisplayMap
+          )
+        : buildApiKeyRows(filteredRows),
+    [
+      apiKeyDisplayMap,
+      currentAnalyticsData,
+      authFileMap,
+      authMetaMap,
+      channelByAuthIndex,
+      filteredRows,
+      sourceInfoMap,
+    ]
+  );
+  const fallbackFilterOptions = useMemo<MonitoringFilterOptions>(
+    () => ({
+      accountRows: buildAccountRows(rangeFilteredRows),
+      apiKeyRows: buildApiKeyRows(rangeFilteredRows),
+      providers: uniqueOptionValues(rangeFilteredRows.map((row) => row.provider)),
+      models: uniqueOptionValues(rangeFilteredRows.map((row) => row.model)),
+      channels: uniqueOptionValues(rangeFilteredRows.map((row) => row.channel)),
+    }),
+    [rangeFilteredRows]
+  );
+  const analyticsFilterOptions = currentAnalyticsData?.filter_options;
+  const filterOptions = useMemo(
+    () =>
+      analyticsFilterOptions
+        ? buildFilterOptionsFromAnalytics(
+            analyticsFilterOptions,
+            authMetaMap,
+            authFileMap,
+            sourceInfoMap,
+            channelByAuthIndex,
+            apiKeyDisplayMap
+          )
+        : fallbackFilterOptions,
+    [
+      apiKeyDisplayMap,
+      authFileMap,
+      authMetaMap,
+      channelByAuthIndex,
+      analyticsFilterOptions,
+      fallbackFilterOptions,
+      sourceInfoMap,
+    ]
+  );
 
   const computedPresentationSnapshot = useMemo<MonitoringPresentationSnapshot>(
     () => ({
@@ -670,6 +755,9 @@ export function useMonitoringData({
       failureSourceRows,
       taskBuckets,
       recentFailures,
+      accountRows,
+      apiKeyRows,
+      filterOptions,
       filteredRows,
       eventsHasMore: displayEventsHasMore,
       eventsLoadingMore,
@@ -677,10 +765,13 @@ export function useMonitoringData({
     }),
     [
       analytics.lastRefreshedAt,
+      accountRows,
+      apiKeyRows,
       channelRows,
       displayEventsHasMore,
       eventsLoadingMore,
       failureSourceRows,
+      filterOptions,
       filteredRows,
       hourlyDistribution,
       modelRows,
@@ -782,6 +873,9 @@ export function useMonitoringData({
     failureSourceRows: presentationSnapshot.failureSourceRows,
     taskBuckets: presentationSnapshot.taskBuckets,
     recentFailures: presentationSnapshot.recentFailures,
+    accountRows: presentationSnapshot.accountRows,
+    apiKeyRows: presentationSnapshot.apiKeyRows,
+    filterOptions: presentationSnapshot.filterOptions,
     filteredRows: presentationSnapshot.filteredRows,
     eventsHasMore: presentationSnapshot.eventsHasMore,
     eventsLoadingMore: presentationSnapshot.eventsLoadingMore,

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
@@ -6,9 +6,11 @@ import type {
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import {
   buildAnalyticsFilters,
+  buildMonitoringAccountFilterValue,
   buildChannelRowsFromAnalytics,
   buildFailureRowsFromAnalytics,
   buildFailureSourceRowsFromAnalytics,
+  buildFilterOptionsFromAnalytics,
   buildUsageDetailsFromAnalyticsEvents,
 } from './analyticsAdapters';
 
@@ -149,6 +151,331 @@ describe('buildAnalyticsFilters', () => {
     expect(filters).toEqual({
       accounts: ['legacy@example.com'],
     });
+  });
+
+  it('maps account filter tokens into exact backend identity filters', () => {
+    expect(
+      buildAnalyticsFilters(
+        {
+          account: buildMonitoringAccountFilterValue({
+            account: 'OpenAI Compatible',
+            authIndices: ['openai-auth'],
+          }),
+        },
+        new Map(),
+        []
+      )
+    ).toEqual({
+      auth_indices: ['openai-auth'],
+    });
+
+    expect(
+      buildAnalyticsFilters(
+        {
+          account: buildMonitoringAccountFilterValue({
+            account: 'OpenAI Compatible',
+            sourceHashes: ['source-hash'],
+          }),
+        },
+        new Map(),
+        []
+      )
+    ).toEqual({
+      source_hashes: ['source-hash'],
+    });
+
+    expect(
+      buildAnalyticsFilters(
+        {
+          account: buildMonitoringAccountFilterValue({
+            account: 'OpenAI Compatible',
+            apiKeyHashes: ['API-Key-Hash'],
+          }),
+        },
+        new Map(),
+        []
+      )
+    ).toEqual({
+      api_key_hashes: ['api-key-hash'],
+    });
+  });
+
+  it('falls back to provider filters when auth metadata cannot resolve a provider', () => {
+    const filters = buildAnalyticsFilters(
+      {
+        provider: 'legacy-provider',
+      },
+      new Map(),
+      []
+    );
+
+    expect(filters).toEqual({
+      providers: ['legacy-provider'],
+    });
+  });
+});
+
+describe('buildFilterOptionsFromAnalytics', () => {
+  it('maps backend option aggregates into stable dropdown candidates', () => {
+    const options = buildFilterOptionsFromAnalytics(
+      {
+        account_stats: [
+          {
+            id: 'alice@example.com',
+            account_snapshot: 'alice@example.com',
+            auth_label_snapshot: 'Alice Auth',
+            auth_provider_snapshot: 'codex',
+            auth_indices: ['auth-1'],
+            sources: ['alice.json'],
+            source_hashes: ['source-a'],
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+            last_seen_ms: 1,
+            models: [],
+          },
+          {
+            id: 'bob@example.com',
+            account_snapshot: 'bob@example.com',
+            auth_label_snapshot: 'Bob Auth',
+            auth_provider_snapshot: 'gemini',
+            auth_indices: ['auth-2'],
+            sources: ['bob.json'],
+            source_hashes: ['source-b'],
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+            last_seen_ms: 2,
+            models: [],
+          },
+        ],
+        api_key_stats: [
+          {
+            id: 'key-a',
+            api_key_hash: 'key-a',
+            account_snapshot: 'alice@example.com',
+            auth_label_snapshot: 'Alice Auth',
+            auth_provider_snapshot: 'codex',
+            auth_indices: ['auth-1'],
+            sources: ['alice.json'],
+            source_hashes: ['source-a'],
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+            last_seen_ms: 1,
+            models: [],
+          },
+        ],
+        channel_share: [
+          {
+            auth_index: 'auth-1',
+            auth_provider_snapshot: 'codex',
+            calls: 1,
+            success: 1,
+            failure: 0,
+            tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+          },
+          {
+            auth_index: 'auth-2',
+            auth_provider_snapshot: 'gemini',
+            calls: 1,
+            success: 1,
+            failure: 0,
+            tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+          },
+        ],
+        model_stats: [
+          {
+            model: 'gpt-a',
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+          },
+          {
+            model: 'gpt-b',
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+          },
+        ],
+      },
+      new Map([
+        [
+          'auth-1',
+          {
+            authIndex: 'auth-1',
+            label: 'Alice Auth',
+            account: 'alice@example.com',
+            provider: 'codex',
+            status: 'active',
+            disabled: false,
+            unavailable: false,
+            runtimeOnly: false,
+            planType: 'pro',
+            updatedAt: '',
+          },
+        ],
+      ]),
+      new Map(),
+      buildSourceInfoMap({}),
+      new Map([
+        [
+          'auth-1',
+          {
+            key: 'primary:0',
+            name: 'Primary Channel',
+            baseUrl: 'https://primary.example.com',
+            host: 'primary.example.com',
+            disabled: false,
+            authIndices: ['auth-1'],
+            modelNames: [],
+          },
+        ],
+      ]),
+      new Map([['key-a', { label: 'Key A', masked: 'sk********aa' }]])
+    );
+
+    expect(options.accountRows.map((row) => row.account).sort()).toEqual([
+      'alice@example.com',
+      'bob@example.com',
+    ]);
+    expect(options.apiKeyRows.map((row) => row.apiKeyLabel)).toEqual(['Key A']);
+    expect(options.providers).toEqual(['codex', 'gemini']);
+    expect(options.models).toEqual(['gpt-a', 'gpt-b']);
+    expect(options.channels).toEqual(['Primary Channel', 'gemini']);
+  });
+
+  it('uses auth or source identities for OpenAI-compatible account option rows', () => {
+    const options = buildFilterOptionsFromAnalytics(
+      {
+        account_stats: [
+          {
+            id: 'openai-provider',
+            account_snapshot: '',
+            auth_label_snapshot: '',
+            auth_provider_snapshot: 'openai',
+            auth_indices: ['openai-auth'],
+            sources: ['k:upstream-key'],
+            source_hashes: ['source-a'],
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+            last_seen_ms: 2,
+            models: [],
+          },
+          {
+            id: 'openai-provider-without-auth',
+            account_snapshot: '',
+            auth_label_snapshot: '',
+            auth_provider_snapshot: 'openai',
+            auth_indices: [],
+            sources: ['k:upstream-key-2'],
+            source_hashes: ['source-b'],
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+            last_seen_ms: 1,
+            models: [],
+          },
+        ],
+      },
+      new Map(),
+      new Map(),
+      buildSourceInfoMap({
+        openaiCompatibility: [
+          {
+            name: 'OpenAI Compatible',
+            baseUrl: 'https://compat.example.com',
+            apiKeyEntries: [{ apiKey: 'upstream-key', authIndex: 'openai-auth' }],
+          },
+        ],
+      }),
+      new Map([
+        [
+          'openai-auth',
+          {
+            key: 'openai:0',
+            name: 'OpenAI Compatible',
+            baseUrl: 'https://compat.example.com',
+            host: 'compat.example.com',
+            disabled: false,
+            authIndices: ['openai-auth'],
+            modelNames: [],
+          },
+        ],
+      ]),
+      new Map()
+    );
+
+    expect(options.accountRows.map((row) => row.filterValue)).toEqual([
+      'auth:openai-auth',
+      'source:source-b',
+    ]);
   });
 });
 

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -1,7 +1,10 @@
 import type {
+  MonitoringAnalyticsAccountStatRow,
+  MonitoringAnalyticsApiKeyStatRow,
   MonitoringAnalyticsChannelShareRow,
   MonitoringAnalyticsEventRow,
   MonitoringAnalyticsFailureSourceRow,
+  MonitoringAnalyticsFilterOptions,
   MonitoringAnalyticsFilters,
   MonitoringAnalyticsHourlyPoint,
   MonitoringAnalyticsModelShareRow,
@@ -14,15 +17,20 @@ import type {
 import type { CredentialInfo } from '@/types/sourceInfo';
 import { buildSourceInfoMap, resolveSourceDisplay } from '@/utils/sourceResolver';
 import { normalizeAuthIndex, type UsageDetailWithEndpoint } from '@/utils/usage';
-import { joinUnique, maskAuthIndex, maskEmailLike, readString } from './base';
+import { formatApiKeyHashLabel, joinUnique, maskAuthIndex, maskEmailLike, readString } from './base';
+import { sanitizeApiKeyDisplayText, type ApiKeyDisplayInfo } from './apiKeys';
 import { buildDayLabel, buildHourLabel, buildLocalDayKey, padNumber } from './range';
 import { buildMonitoringSourceDisplay } from './sourceDisplay';
 import type {
+  MonitoringAccountModelSpendRow,
+  MonitoringAccountRow,
+  MonitoringApiKeyRow,
   MonitoringAuthMeta,
   MonitoringChannelMeta,
   MonitoringChannelRow,
   MonitoringFailureRow,
   MonitoringFailureSourceRow,
+  MonitoringFilterOptions,
   MonitoringModelRow,
   MonitoringModelShareRow,
   MonitoringScopeFilters,
@@ -40,6 +48,185 @@ const shortHashLabel = (value: string) => {
   return trimmed.length <= 12 ? trimmed : `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
 };
 
+const uniqueReadableValues = (values: Array<string | null | undefined> = []) =>
+  Array.from(new Set(values.map(readString).filter((value) => value && value !== '-'))).sort();
+
+const firstReadableValue = (...values: Array<string | null | undefined>) =>
+  values.map(readString).find((value) => value && value !== '-') || '';
+
+const normalizeFilterText = (value: string | null | undefined) =>
+  readString(value).trim().toLowerCase();
+
+const ACCOUNT_FILTER_PREFIXES = {
+  auth: 'auth:',
+  source: 'source:',
+  apiKey: 'api-key:',
+  account: 'account:',
+} as const;
+
+const NO_MATCH_FILTER_VALUE = '__no_matching_filter_value__';
+
+export type MonitoringAccountFilterCriteria = {
+  accounts: string[];
+  authIndices: string[];
+  sourceHashes: string[];
+  apiKeyHashes: string[];
+};
+
+const normalizeAccountFilterValues = (values: Array<string | null | undefined> = []) =>
+  uniqueReadableValues(values).filter((value) => value !== '-');
+
+const normalizeAuthFilterValues = (values: Array<string | null | undefined> = []) =>
+  Array.from(
+    new Set(
+      values
+        .map((value) => normalizeAuthIndex(value))
+        .filter((value): value is string => Boolean(value && value !== '-'))
+    )
+  ).sort();
+
+const normalizeApiKeyHashValues = (values: Array<string | null | undefined> = []) =>
+  normalizeAccountFilterValues(values).map((value) => value.toLowerCase());
+
+const encodeAccountFilterValues = (values: string[]) =>
+  values.map((value) => encodeURIComponent(value)).join(',');
+
+const decodeAccountFilterValue = (value: string) => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const decodeAccountFilterValues = (value: string) =>
+  value
+    .split(',')
+    .map(decodeAccountFilterValue)
+    .map(readString)
+    .filter((item) => item && item !== '-');
+
+const buildAccountFilterToken = (prefix: string, values: string[]) =>
+  values.length > 0 ? `${prefix}${encodeAccountFilterValues(values)}` : '';
+
+export const buildMonitoringAccountFilterValue = ({
+  account,
+  authIndices,
+  sourceHashes,
+  apiKeyHashes,
+}: {
+  account?: string | null;
+  authIndices?: Array<string | null | undefined>;
+  sourceHashes?: Array<string | null | undefined>;
+  apiKeyHashes?: Array<string | null | undefined>;
+}) => {
+  const normalizedAuthIndices = normalizeAuthFilterValues(authIndices);
+  if (normalizedAuthIndices.length > 0) {
+    return buildAccountFilterToken(ACCOUNT_FILTER_PREFIXES.auth, normalizedAuthIndices);
+  }
+
+  const normalizedSourceHashes = normalizeAccountFilterValues(sourceHashes);
+  if (normalizedSourceHashes.length > 0) {
+    return buildAccountFilterToken(ACCOUNT_FILTER_PREFIXES.source, normalizedSourceHashes);
+  }
+
+  const normalizedApiKeyHashes = normalizeApiKeyHashValues(apiKeyHashes);
+  if (normalizedApiKeyHashes.length > 0) {
+    return buildAccountFilterToken(ACCOUNT_FILTER_PREFIXES.apiKey, normalizedApiKeyHashes);
+  }
+
+  const normalizedAccounts = normalizeAccountFilterValues([account]);
+  return buildAccountFilterToken(ACCOUNT_FILTER_PREFIXES.account, normalizedAccounts);
+};
+
+export const parseMonitoringAccountFilterValue = (
+  value: string | null | undefined
+): MonitoringAccountFilterCriteria => {
+  const text = readString(value);
+  const emptyCriteria: MonitoringAccountFilterCriteria = {
+    accounts: [],
+    authIndices: [],
+    sourceHashes: [],
+    apiKeyHashes: [],
+  };
+  if (!text || text === 'all') return emptyCriteria;
+
+  if (text.startsWith(ACCOUNT_FILTER_PREFIXES.auth)) {
+    return {
+      ...emptyCriteria,
+      authIndices: normalizeAuthFilterValues(
+        decodeAccountFilterValues(text.slice(ACCOUNT_FILTER_PREFIXES.auth.length))
+      ),
+    };
+  }
+
+  if (text.startsWith(ACCOUNT_FILTER_PREFIXES.source)) {
+    return {
+      ...emptyCriteria,
+      sourceHashes: normalizeAccountFilterValues(
+        decodeAccountFilterValues(text.slice(ACCOUNT_FILTER_PREFIXES.source.length))
+      ),
+    };
+  }
+
+  if (text.startsWith(ACCOUNT_FILTER_PREFIXES.apiKey)) {
+    return {
+      ...emptyCriteria,
+      apiKeyHashes: normalizeApiKeyHashValues(
+        decodeAccountFilterValues(text.slice(ACCOUNT_FILTER_PREFIXES.apiKey.length))
+      ),
+    };
+  }
+
+  if (text.startsWith(ACCOUNT_FILTER_PREFIXES.account)) {
+    return {
+      ...emptyCriteria,
+      accounts: normalizeAccountFilterValues([
+        decodeAccountFilterValue(text.slice(ACCOUNT_FILTER_PREFIXES.account.length)),
+      ]),
+    };
+  }
+
+  return {
+    ...emptyCriteria,
+    accounts: normalizeAccountFilterValues([text]),
+  };
+};
+
+const resolveFirstAuthIndex = (authIndices: string[] | undefined) =>
+  normalizeAuthIndex((authIndices || []).find((value) => readString(value))) ?? '-';
+
+const resolveAuthMetas = (
+  authIndices: string[] | undefined,
+  authMetaMap: Map<string, MonitoringAuthMeta>
+) =>
+  uniqueReadableValues(authIndices).flatMap((authIndex) => {
+    const normalized = normalizeAuthIndex(authIndex) ?? authIndex;
+    const meta = authMetaMap.get(normalized);
+    return meta ? [meta] : [];
+  });
+
+const buildModelSpendRowsFromAnalytics = (
+  rows: MonitoringAnalyticsAccountStatRow['models'] = []
+): MonitoringAccountModelSpendRow[] =>
+  rows
+    .map((row) => ({
+      model: row.model || '-',
+      totalCalls: row.calls,
+      successCalls: row.success_calls,
+      failureCalls: row.failure_calls,
+      successRate: row.success_rate,
+      inputTokens: row.input_tokens,
+      outputTokens: row.output_tokens,
+      cachedTokens: row.cached_tokens,
+      cacheReadTokens: row.cache_read_tokens ?? 0,
+      cacheCreationTokens: row.cache_creation_tokens ?? 0,
+      totalTokens: row.total_tokens,
+      totalCost: row.cost,
+      lastSeenAt: row.last_seen_ms,
+    }))
+    .sort((left, right) => right.totalCost - left.totalCost || right.totalCalls - left.totalCalls);
+
 const addAuthIndexConstraint = (
   current: Set<string> | null,
   values: Iterable<string>
@@ -48,6 +235,18 @@ const addAuthIndexConstraint = (
   if (next.size === 0) return current;
   if (current === null) return next;
   return new Set(Array.from(current).filter((value) => next.has(value)));
+};
+
+const addFilterValueConstraint = (
+  current: string[] | undefined,
+  values: Array<string | null | undefined>
+) => {
+  const next = normalizeAccountFilterValues(values);
+  if (next.length === 0) return current;
+  if (!current || current.length === 0) return next;
+  const nextSet = new Set(next);
+  const constrained = current.filter((value) => nextSet.has(value));
+  return constrained.length > 0 ? constrained : [NO_MATCH_FILTER_VALUE];
 };
 
 export const buildAnalyticsFilters = (
@@ -73,32 +272,59 @@ export const buildAnalyticsFilters = (
   let authIndices: Set<string> | null = null;
   if (isActiveFilterValue(scopeFilters.account)) {
     const account = scopeFilters.account!.trim();
-    const accountAuthIndices = Array.from(authMetaMap.entries())
-      .filter(([, meta]) => meta.account === account)
-      .map(([authIndex]) => authIndex);
-    authIndices = addAuthIndexConstraint(authIndices, accountAuthIndices);
-    if (accountAuthIndices.length === 0) {
-      filters.accounts = [account];
+    const accountCriteria = parseMonitoringAccountFilterValue(account);
+
+    authIndices = addAuthIndexConstraint(authIndices, accountCriteria.authIndices);
+    filters.source_hashes = addFilterValueConstraint(
+      filters.source_hashes,
+      accountCriteria.sourceHashes
+    );
+    filters.api_key_hashes = addFilterValueConstraint(
+      filters.api_key_hashes,
+      accountCriteria.apiKeyHashes
+    );
+
+    if (
+      accountCriteria.authIndices.length === 0 &&
+      accountCriteria.sourceHashes.length === 0 &&
+      accountCriteria.apiKeyHashes.length === 0
+    ) {
+      const legacyAccount = accountCriteria.accounts[0] || account;
+      const normalizedAccount = normalizeFilterText(legacyAccount);
+      const accountAuthIndices = Array.from(authMetaMap.entries())
+        .filter(([, meta]) => normalizeFilterText(meta.account) === normalizedAccount)
+        .map(([authIndex]) => authIndex);
+      authIndices = addAuthIndexConstraint(authIndices, accountAuthIndices);
+      if (accountAuthIndices.length === 0) {
+        filters.accounts =
+          accountCriteria.accounts.length > 0 ? accountCriteria.accounts : [account];
+      }
     }
   }
   if (isActiveFilterValue(scopeFilters.provider)) {
     const provider = scopeFilters.provider!.trim();
-    authIndices = addAuthIndexConstraint(
-      authIndices,
-      Array.from(authMetaMap.entries())
-        .filter(([, meta]) => meta.provider === provider)
-        .map(([authIndex]) => authIndex)
-    );
+    const normalizedProvider = normalizeFilterText(provider);
+    const providerAuthIndices = Array.from(authMetaMap.entries())
+      .filter(([, meta]) => normalizeFilterText(meta.provider) === normalizedProvider)
+      .map(([authIndex]) => authIndex);
+    authIndices = addAuthIndexConstraint(authIndices, providerAuthIndices);
+    if (providerAuthIndices.length === 0) {
+      filters.providers = [provider];
+    }
   }
   if (isActiveFilterValue(scopeFilters.channel)) {
     const channel = scopeFilters.channel!.trim();
-    authIndices = addAuthIndexConstraint(
-      authIndices,
-      channels.filter((item) => item.name === channel).flatMap((item) => item.authIndices)
-    );
+    const channelAuthIndices = channels
+      .filter((item) => item.name === channel)
+      .flatMap((item) => item.authIndices);
+    authIndices = addAuthIndexConstraint(authIndices, channelAuthIndices);
+    if (channelAuthIndices.length === 0 && !filters.providers?.includes(channel)) {
+      filters.providers = [...(filters.providers || []), channel];
+    }
   }
-  if (authIndices && authIndices.size > 0) {
-    filters.auth_indices = Array.from(authIndices).sort();
+  if (authIndices) {
+    filters.auth_indices =
+      authIndices.size > 0 ? Array.from(authIndices).sort() : ['__no_matching_auth_index__'];
   }
 
   return filters;
@@ -285,6 +511,222 @@ export const buildFailureSourceRowsFromAnalytics = (
       averageLatencyMs: row.average_latency_ms,
     };
   });
+
+export const buildAccountRowsFromAnalytics = (
+  rows: MonitoringAnalyticsAccountStatRow[],
+  authMetaMap: Map<string, MonitoringAuthMeta>,
+  authFileMap: Map<string, CredentialInfo>,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
+  channelByAuthIndex: Map<string, MonitoringChannelMeta>
+): MonitoringAccountRow[] =>
+  rows
+    .map((row) => {
+      const authIndex = resolveFirstAuthIndex(row.auth_indices);
+      const authMetas = resolveAuthMetas(row.auth_indices, authMetaMap);
+      const channelNames = uniqueReadableValues([
+        ...((row.auth_indices || []).map((value) => {
+          const normalized = normalizeAuthIndex(value) ?? value;
+          return channelByAuthIndex.get(normalized)?.name;
+        }) || []),
+        ...authMetas.map((meta) => meta.provider),
+      ]);
+      const display = buildMonitoringSourceDisplay(
+        {
+          source: row.sources?.[0],
+          sourceHash: row.source_hashes?.[0],
+          authIndex,
+          accountSnapshot: row.account_snapshot,
+          authLabelSnapshot: row.auth_label_snapshot,
+          authProviderSnapshot: row.auth_provider_snapshot,
+          channel: channelNames[0],
+        },
+        { authMetaMap, authFileMap, sourceInfoMap, channelByAuthIndex }
+      );
+      const account = firstReadableValue(display.account, row.account_snapshot, row.id);
+      const displayAccount = firstReadableValue(display.primary, account);
+      const authLabels = uniqueReadableValues([
+        ...authMetas.map((meta) => meta.label),
+        row.auth_label_snapshot,
+        display.sourceLabel,
+      ]);
+      const channels = uniqueReadableValues([...channelNames, display.channel]);
+
+      return {
+        id: account || row.id,
+        account,
+        displayAccount,
+        accountMasked: display.accountMasked || maskEmailLike(account),
+        authLabels,
+        authIndices: uniqueReadableValues(row.auth_indices),
+        channels,
+        totalCalls: row.calls,
+        successCalls: row.success_calls,
+        failureCalls: row.failure_calls,
+        successRate: row.success_rate,
+        inputTokens: row.input_tokens,
+        outputTokens: row.output_tokens,
+        cachedTokens: row.cached_tokens,
+        cacheReadTokens: row.cache_read_tokens ?? 0,
+        cacheCreationTokens: row.cache_creation_tokens ?? 0,
+        totalTokens: row.total_tokens,
+        totalCost: row.cost,
+        averageLatencyMs: row.average_latency_ms,
+        lastSeenAt: row.last_seen_ms,
+        recentPattern: [],
+        filterValue:
+          buildMonitoringAccountFilterValue({
+            account,
+            authIndices: row.auth_indices,
+            sourceHashes: row.source_hashes,
+          }) || account,
+        models: buildModelSpendRowsFromAnalytics(row.models),
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.lastSeenAt - left.lastSeenAt ||
+        right.totalCalls - left.totalCalls ||
+        right.totalCost - left.totalCost
+    );
+
+export const buildApiKeyRowsFromAnalytics = (
+  rows: MonitoringAnalyticsApiKeyStatRow[],
+  authMetaMap: Map<string, MonitoringAuthMeta>,
+  authFileMap: Map<string, CredentialInfo>,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
+  channelByAuthIndex: Map<string, MonitoringChannelMeta>,
+  apiKeyDisplayMap: Map<string, ApiKeyDisplayInfo>
+): MonitoringApiKeyRow[] =>
+  rows
+    .map((row) => {
+      const apiKeyHash = readString(row.api_key_hash).toLowerCase();
+      const authIndex = resolveFirstAuthIndex(row.auth_indices);
+      const authMetas = resolveAuthMetas(row.auth_indices, authMetaMap);
+      const channelNames = uniqueReadableValues([
+        ...((row.auth_indices || []).map((value) => {
+          const normalized = normalizeAuthIndex(value) ?? value;
+          return channelByAuthIndex.get(normalized)?.name;
+        }) || []),
+        ...authMetas.map((meta) => meta.provider),
+      ]);
+      const display = buildMonitoringSourceDisplay(
+        {
+          source: row.sources?.[0],
+          sourceHash: row.source_hashes?.[0],
+          apiKeyHash,
+          authIndex,
+          accountSnapshot: row.account_snapshot,
+          authLabelSnapshot: row.auth_label_snapshot,
+          authProviderSnapshot: row.auth_provider_snapshot,
+          channel: channelNames[0],
+        },
+        { authMetaMap, authFileMap, sourceInfoMap, channelByAuthIndex }
+      );
+      const apiKeyDisplay = apiKeyDisplayMap.get(apiKeyHash);
+      const fallbackApiKeyLabel = formatApiKeyHashLabel(apiKeyHash);
+      const apiKeyLabel = sanitizeApiKeyDisplayText(
+        apiKeyDisplay?.label || fallbackApiKeyLabel,
+        fallbackApiKeyLabel
+      );
+      const apiKeyMasked = sanitizeApiKeyDisplayText(
+        apiKeyDisplay?.masked || apiKeyLabel,
+        apiKeyLabel
+      );
+      const isUnknown = !apiKeyHash;
+
+      return {
+        id: apiKeyHash || row.id,
+        apiKeyHash,
+        apiKeyLabel: isUnknown ? '' : apiKeyLabel,
+        apiKeyMasked: isUnknown ? '' : apiKeyMasked,
+        isUnknown,
+        authLabels: uniqueReadableValues([
+          ...authMetas.map((meta) => meta.label),
+          row.auth_label_snapshot,
+          display.sourceLabel,
+        ]),
+        sourceLabels: uniqueReadableValues([...(row.sources || []), display.sourceMasked]),
+        channels: uniqueReadableValues([...channelNames, display.channel]),
+        totalCalls: row.calls,
+        successCalls: row.success_calls,
+        failureCalls: row.failure_calls,
+        successRate: row.success_rate,
+        inputTokens: row.input_tokens,
+        outputTokens: row.output_tokens,
+        cachedTokens: row.cached_tokens,
+        cacheReadTokens: row.cache_read_tokens ?? 0,
+        cacheCreationTokens: row.cache_creation_tokens ?? 0,
+        totalTokens: row.total_tokens,
+        totalCost: row.cost,
+        averageLatencyMs: row.average_latency_ms,
+        lastSeenAt: row.last_seen_ms,
+        models: buildModelSpendRowsFromAnalytics(row.models),
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.lastSeenAt - left.lastSeenAt ||
+        right.totalCalls - left.totalCalls ||
+        right.totalCost - left.totalCost
+    );
+
+export const buildFilterOptionsFromAnalytics = (
+  options: MonitoringAnalyticsFilterOptions | undefined,
+  authMetaMap: Map<string, MonitoringAuthMeta>,
+  authFileMap: Map<string, CredentialInfo>,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
+  channelByAuthIndex: Map<string, MonitoringChannelMeta>,
+  apiKeyDisplayMap: Map<string, ApiKeyDisplayInfo>
+): MonitoringFilterOptions => {
+  if (!options) {
+    return {
+      accountRows: [],
+      apiKeyRows: [],
+      providers: [],
+      models: [],
+      channels: [],
+    };
+  }
+
+  const resolveAuthIndex = (value: string | undefined) => normalizeAuthIndex(value) ?? value ?? '';
+  const resolveAuthMeta = (value: string | undefined) => authMetaMap.get(resolveAuthIndex(value));
+  const channelRows = options.channel_share || [];
+
+  return {
+    accountRows: buildAccountRowsFromAnalytics(
+      options.account_stats || [],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex
+    ),
+    apiKeyRows: buildApiKeyRowsFromAnalytics(
+      options.api_key_stats || [],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex,
+      apiKeyDisplayMap
+    ),
+    providers: uniqueReadableValues([
+      ...channelRows.map((row) => resolveAuthMeta(row.auth_index)?.provider),
+      ...channelRows.map((row) => row.auth_provider_snapshot),
+      ...(options.account_stats || []).map((row) => row.auth_provider_snapshot),
+      ...(options.api_key_stats || []).map((row) => row.auth_provider_snapshot),
+    ]),
+    models: uniqueReadableValues((options.model_stats || []).map((row) => row.model)),
+    channels: uniqueReadableValues(
+      channelRows.map((row) => {
+        const authIndex = resolveAuthIndex(row.auth_index);
+        return (
+          channelByAuthIndex.get(authIndex)?.name ||
+          resolveAuthMeta(row.auth_index)?.provider ||
+          row.auth_provider_snapshot
+        );
+      })
+    ),
+  };
+};
 
 export const buildTaskBucketsFromAnalytics = (
   rows: MonitoringAnalyticsTaskBucketRow[],

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -7,7 +7,15 @@ import {
   fetchXaiQuota,
 } from '@/utils/quota';
 import type { MonitoringAccountQuotaTarget } from '@/features/monitoring/accountOverviewQuotaTargets';
-import { requestAccountQuota } from './monitoringCenterPageModel';
+import type { MonitoringAccountRow, MonitoringApiKeyRow } from '@/features/monitoring/hooks/useMonitoringData';
+import {
+  buildAccountOptions,
+  buildApiKeyOptionsFromRows,
+  buildChannelOptionsFromValues,
+  buildModelOptionsFromValues,
+  buildProviderOptionsFromValues,
+  requestAccountQuota,
+} from './monitoringCenterPageModel';
 
 vi.mock('@/utils/quota', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/quota')>();
@@ -70,6 +78,106 @@ const createTarget = (
   },
   accountId: overrides.accountId ?? null,
   planType: overrides.planType ?? null,
+});
+
+const createAccountRow = (
+  account: string,
+  overrides: Partial<MonitoringAccountRow> = {}
+): MonitoringAccountRow => ({
+  id: account,
+  account,
+  displayAccount: account,
+  accountMasked: account,
+  authLabels: [],
+  authIndices: [],
+  channels: [],
+  totalCalls: 1,
+  successCalls: 1,
+  failureCalls: 0,
+  successRate: 1,
+  inputTokens: 1,
+  outputTokens: 1,
+  cachedTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 2,
+  totalCost: 0,
+  averageLatencyMs: null,
+  lastSeenAt: 1,
+  recentPattern: [],
+  models: [],
+  ...overrides,
+});
+
+const createApiKeyRow = (apiKeyHash: string, label: string): MonitoringApiKeyRow => ({
+  id: apiKeyHash,
+  apiKeyHash,
+  apiKeyLabel: label,
+  apiKeyMasked: label,
+  isUnknown: false,
+  authLabels: [],
+  sourceLabels: [],
+  channels: [],
+  totalCalls: 1,
+  successCalls: 1,
+  failureCalls: 0,
+  successRate: 1,
+  inputTokens: 1,
+  outputTokens: 1,
+  cachedTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 2,
+  totalCost: 0,
+  averageLatencyMs: null,
+  lastSeenAt: 1,
+  models: [],
+});
+
+describe('monitoringCenterPageModel filter options', () => {
+  it('keeps alternate candidates when a dynamic filter already has a selected value', () => {
+    expect(buildProviderOptionsFromValues(['codex', 'gemini'], 'codex', t).map((item) => item.value)).toEqual([
+      'all',
+      'codex',
+      'gemini',
+    ]);
+    expect(
+      buildAccountOptions(
+        [createAccountRow('alice@example.com'), createAccountRow('bob@example.com')],
+        'alice@example.com',
+        t
+      ).map((item) => item.value)
+    ).toEqual(['all', 'alice@example.com', 'bob@example.com']);
+    expect(buildModelOptionsFromValues(['gpt-a', 'gpt-b'], 'gpt-a', t).map((item) => item.value)).toEqual([
+      'all',
+      'gpt-a',
+      'gpt-b',
+    ]);
+    expect(
+      buildChannelOptionsFromValues(['Primary', 'Backup'], 'Primary', t).map((item) => item.value)
+    ).toEqual(['all', 'Backup', 'Primary']);
+    expect(
+      buildApiKeyOptionsFromRows(
+        [createApiKeyRow('key-a', 'Key A'), createApiKeyRow('key-b', 'Key B')],
+        'key-a',
+        t
+      ).map((item) => item.value)
+    ).toEqual(['all', 'key-a', 'key-b']);
+  });
+
+  it('uses account row filter values for account options', () => {
+    expect(
+      buildAccountOptions(
+        [
+          createAccountRow('OpenAI Compatible', {
+            filterValue: 'auth:openai-auth',
+          }),
+        ],
+        'auth:openai-auth',
+        t
+      ).map((item) => item.value)
+    ).toEqual(['all', 'auth:openai-auth']);
+  });
 });
 
 describe('monitoringCenterPageModel account quota', () => {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/types';
 import type {
   MonitoringAccountRow,
+  MonitoringApiKeyRow,
   MonitoringEventRow,
   MonitoringSummary,
 } from '@/features/monitoring/hooks/useMonitoringData';
@@ -131,11 +132,17 @@ export const buildProviderOptions = (
   rows: MonitoringEventRow[],
   selectedProvider: string,
   t: TFunction
+) => buildProviderOptionsFromValues(rows.map((row) => row.provider), selectedProvider, t);
+
+export const buildProviderOptionsFromValues = (
+  providers: string[],
+  selectedProvider: string,
+  t: TFunction
 ) =>
   ensureSelectedOption(
     [
       { value: 'all', label: t('monitoring.filter_all_providers') },
-      ...buildSortedValueOptions(rows.map((row) => row.provider)),
+      ...buildSortedValueOptions(providers),
     ],
     selectedProvider
   );
@@ -149,7 +156,9 @@ export const buildAccountOptions = (
     [
       { value: 'all', label: t('monitoring.filter_all_accounts') },
       ...Array.from(
-        new Map(rows.map((row) => [row.account, buildAccountOptionLabel(row)])).entries()
+        new Map(
+          rows.map((row) => [row.filterValue || row.account, buildAccountOptionLabel(row)])
+        ).entries()
       )
         .sort((left, right) => left[1].localeCompare(right[1]))
         .map(([value, label]) => ({ value, label })),
@@ -161,11 +170,17 @@ export const buildModelOptions = (
   rows: MonitoringEventRow[],
   selectedModel: string,
   t: TFunction
+) => buildModelOptionsFromValues(rows.map((row) => row.model), selectedModel, t);
+
+export const buildModelOptionsFromValues = (
+  models: string[],
+  selectedModel: string,
+  t: TFunction
 ) =>
   ensureSelectedOption(
     [
       { value: 'all', label: t('monitoring.filter_all_models') },
-      ...buildSortedValueOptions(rows.map((row) => row.model)),
+      ...buildSortedValueOptions(models),
     ],
     selectedModel
   );
@@ -174,13 +189,35 @@ export const buildChannelOptions = (
   rows: MonitoringEventRow[],
   selectedChannel: string,
   t: TFunction
+) => buildChannelOptionsFromValues(rows.map((row) => row.channel), selectedChannel, t);
+
+export const buildChannelOptionsFromValues = (
+  channels: string[],
+  selectedChannel: string,
+  t: TFunction
 ) =>
   ensureSelectedOption(
     [
       { value: 'all', label: t('monitoring.filter_all_channels') },
-      ...buildSortedValueOptions(rows.map((row) => row.channel)),
+      ...buildSortedValueOptions(channels),
     ],
     selectedChannel
+  );
+
+const buildApiKeyOptionsFromMap = (
+  optionMap: Map<string, string>,
+  selectedApiKeyHash: string,
+  t: TFunction
+) =>
+  ensureSelectedOption(
+    [
+      { value: 'all', label: t('monitoring.filter_all_api_keys') },
+      ...Array.from(optionMap.entries())
+        .sort((left, right) => left[1].localeCompare(right[1]))
+        .map(([value, label]) => ({ value, label })),
+    ],
+    selectedApiKeyHash,
+    selectedApiKeyHash
   );
 
 export const buildApiKeyOptions = (
@@ -194,16 +231,21 @@ export const buildApiKeyOptions = (
     optionMap.set(row.apiKeyHash, row.apiKeyLabel || row.apiKeyMasked || row.apiKeyHash);
   });
 
-  return ensureSelectedOption(
-    [
-      { value: 'all', label: t('monitoring.filter_all_api_keys') },
-      ...Array.from(optionMap.entries())
-        .sort((left, right) => left[1].localeCompare(right[1]))
-        .map(([value, label]) => ({ value, label })),
-    ],
-    selectedApiKeyHash,
-    selectedApiKeyHash
-  );
+  return buildApiKeyOptionsFromMap(optionMap, selectedApiKeyHash, t);
+};
+
+export const buildApiKeyOptionsFromRows = (
+  rows: MonitoringApiKeyRow[],
+  selectedApiKeyHash: string,
+  t: TFunction
+) => {
+  const optionMap = new Map<string, string>();
+  rows.forEach((row) => {
+    if (!row.apiKeyHash || optionMap.has(row.apiKeyHash)) return;
+    optionMap.set(row.apiKeyHash, row.apiKeyLabel || row.apiKeyMasked || row.apiKeyHash);
+  });
+
+  return buildApiKeyOptionsFromMap(optionMap, selectedApiKeyHash, t);
 };
 
 export const buildStatusOptions = (t: TFunction): MonitoringOption[] => [

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -1,5 +1,9 @@
 import { formatApiKeyHashLabel } from './base';
 import { sanitizeApiKeyDisplayText, shouldPreferApiKeyAlias } from './apiKeys';
+import {
+  buildMonitoringAccountFilterValue,
+  parseMonitoringAccountFilterValue,
+} from './analyticsAdapters';
 import { getRangeBounds } from './range';
 import type {
   MonitoringAccountRow,
@@ -82,7 +86,11 @@ export const buildScopeFilteredRows = (
 ) => {
   if (!scopeFilters) return rows;
 
-  const account = normalizeScopeValue(scopeFilters.account);
+  const accountCriteria = parseMonitoringAccountFilterValue(scopeFilters.account);
+  const account = normalizeScopeValue(accountCriteria.accounts[0] || scopeFilters.account);
+  const accountAuthIndices = new Set(accountCriteria.authIndices.map(normalizeScopeValue));
+  const accountApiKeyHashes = new Set(accountCriteria.apiKeyHashes.map(normalizeScopeValue));
+  const hasAccountSourceHashFilter = accountCriteria.sourceHashes.length > 0;
   const provider = normalizeScopeValue(scopeFilters.provider);
   const model = normalizeScopeValue(scopeFilters.model);
   const channel = normalizeScopeValue(scopeFilters.channel);
@@ -91,15 +99,24 @@ export const buildScopeFilteredRows = (
 
   return rows.filter((row) => {
     if (isActiveScopeFilterValue(scopeFilters.account)) {
-      const rowAccountValues = [
-        row.account,
-        row.accountMasked,
-        row.authLabel,
-        row.source,
-        row.sourceMasked,
-        row.authIndex,
-      ].map(normalizeScopeValue);
-      if (!rowAccountValues.includes(account)) return false;
+      if (accountAuthIndices.size > 0) {
+        if (!accountAuthIndices.has(normalizeScopeValue(row.authIndex))) return false;
+      } else if (accountApiKeyHashes.size > 0) {
+        if (!accountApiKeyHashes.has(normalizeScopeValue(row.apiKeyHash))) return false;
+      } else if (hasAccountSourceHashFilter) {
+        // source_hash is only available in analytics payloads, so avoid dropping rows after
+        // the backend has already applied the exact source_hash filter.
+      } else {
+        const rowAccountValues = [
+          row.account,
+          row.accountMasked,
+          row.authLabel,
+          row.source,
+          row.sourceMasked,
+          row.authIndex,
+        ].map(normalizeScopeValue);
+        if (!rowAccountValues.includes(account)) return false;
+      }
     }
 
     if (
@@ -218,6 +235,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       accountMasked: string;
       authLabels: Set<string>;
       authIndices: Set<string>;
+      apiKeyHashes: Set<string>;
       channels: Set<string>;
       modelMap: Map<
         string,
@@ -261,6 +279,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       accountMasked: row.accountMasked,
       authLabels: new Set<string>(),
       authIndices: new Set<string>(),
+      apiKeyHashes: new Set<string>(),
       channels: new Set<string>(),
       modelMap: new Map(),
       rows: [] as MonitoringEventRow[],
@@ -282,6 +301,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     existing.rows.push(row);
     existing.authLabels.add(row.authLabel);
     existing.authIndices.add(row.authIndex);
+    existing.apiKeyHashes.add(row.apiKeyHash);
     existing.channels.add(row.channel);
     existing.totalCalls += 1;
     existing.successCalls += row.failed ? 0 : 1;
@@ -334,13 +354,21 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
   return Array.from(grouped.values())
     .map((item) => {
       const channels = Array.from(item.channels).sort();
+      const authIndices = Array.from(item.authIndices).sort();
+      const apiKeyHashes = Array.from(item.apiKeyHashes).sort();
       return {
         id: item.id,
         account: item.account,
+        filterValue:
+          buildMonitoringAccountFilterValue({
+            account: item.account,
+            authIndices,
+            apiKeyHashes,
+          }) || item.account,
         displayAccount: resolveAccountDisplayName(item.account, channels),
         accountMasked: item.accountMasked,
         authLabels: Array.from(item.authLabels).sort(),
-        authIndices: Array.from(item.authIndices).sort(),
+        authIndices,
         channels,
         totalCalls: item.totalCalls,
         successCalls: item.successCalls,

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -231,6 +231,7 @@ export type MonitoringAccountModelSpendRow = {
 export type MonitoringAccountRow = {
   id: string;
   account: string;
+  filterValue?: string;
   displayAccount: string;
   accountMasked: string;
   authLabels: string[];
@@ -278,6 +279,14 @@ export type MonitoringApiKeyRow = {
   averageLatencyMs: number | null;
   lastSeenAt: number;
   models: MonitoringApiKeyModelSpendRow[];
+};
+
+export type MonitoringFilterOptions = {
+  accountRows: MonitoringAccountRow[];
+  apiKeyRows: MonitoringApiKeyRow[];
+  providers: string[];
+  models: string[];
+  channels: string[];
 };
 
 export type MonitoringRealtimeRow = {
@@ -357,6 +366,9 @@ export interface UseMonitoringDataReturn {
   failureSourceRows: MonitoringFailureSourceRow[];
   taskBuckets: MonitoringTaskBucketRow[];
   recentFailures: MonitoringFailureRow[];
+  accountRows: MonitoringAccountRow[];
+  apiKeyRows: MonitoringApiKeyRow[];
+  filterOptions: MonitoringFilterOptions;
   filteredRows: MonitoringEventRow[];
   eventsHasMore: boolean;
   eventsLoadingMore: boolean;

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -469,6 +469,7 @@ export interface DashboardSummaryParams {
 
 export interface MonitoringAnalyticsFilters {
   models?: string[];
+  providers?: string[];
   accounts?: string[];
   auth_indices?: string[];
   api_key_hashes?: string[];
@@ -491,6 +492,9 @@ export interface MonitoringAnalyticsInclude {
   channel_share?: boolean;
   model_stats?: boolean;
   failure_sources?: boolean;
+  account_stats?: boolean;
+  api_key_stats?: boolean;
+  filter_options?: boolean;
   task_buckets?: boolean;
   recent_failures?: number;
   events_page?: MonitoringAnalyticsEventsPageRequest;
@@ -596,6 +600,78 @@ export interface MonitoringAnalyticsFailureSourceRow {
   average_latency_ms: number | null;
 }
 
+export interface MonitoringAnalyticsAccountModelStatRow {
+  model: string;
+  calls: number;
+  success_calls: number;
+  failure_calls: number;
+  success_rate: number;
+  input_tokens: number;
+  output_tokens: number;
+  cached_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+  cost: number;
+  last_seen_ms: number;
+}
+
+export interface MonitoringAnalyticsAccountStatRow {
+  id: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
+  auth_indices?: string[];
+  sources?: string[];
+  source_hashes?: string[];
+  calls: number;
+  success_calls: number;
+  failure_calls: number;
+  success_rate: number;
+  input_tokens: number;
+  output_tokens: number;
+  cached_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+  cost: number;
+  average_latency_ms: number | null;
+  last_seen_ms: number;
+  models?: MonitoringAnalyticsAccountModelStatRow[];
+}
+
+export interface MonitoringAnalyticsApiKeyStatRow {
+  id: string;
+  api_key_hash: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
+  auth_indices?: string[];
+  sources?: string[];
+  source_hashes?: string[];
+  calls: number;
+  success_calls: number;
+  failure_calls: number;
+  success_rate: number;
+  input_tokens: number;
+  output_tokens: number;
+  cached_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_tokens: number;
+  cost: number;
+  average_latency_ms: number | null;
+  last_seen_ms: number;
+  models?: MonitoringAnalyticsAccountModelStatRow[];
+}
+
+export interface MonitoringAnalyticsFilterOptions {
+  account_stats?: MonitoringAnalyticsAccountStatRow[];
+  api_key_stats?: MonitoringAnalyticsApiKeyStatRow[];
+  channel_share?: MonitoringAnalyticsChannelShareRow[];
+  model_stats?: MonitoringAnalyticsModelStat[];
+}
+
 export interface MonitoringAnalyticsTaskBucketRow {
   bucket_key: string;
   total: number;
@@ -682,6 +758,9 @@ export interface MonitoringAnalyticsResponse {
   model_stats?: MonitoringAnalyticsModelStat[];
   channel_share?: MonitoringAnalyticsChannelShareRow[];
   failure_sources?: MonitoringAnalyticsFailureSourceRow[];
+  account_stats?: MonitoringAnalyticsAccountStatRow[];
+  api_key_stats?: MonitoringAnalyticsApiKeyStatRow[];
+  filter_options?: MonitoringAnalyticsFilterOptions;
   task_buckets?: MonitoringAnalyticsTaskBucketRow[];
   recent_failures?: MonitoringAnalyticsRecentFailure[];
   events?: MonitoringAnalyticsEventsResponse;


### PR DESCRIPTION
## Summary
- Build monitoring account, API key, provider, model, and channel options from aggregate filter options instead of the current event page.
- Preserve exact account focus tokens so scoped account views keep matching auth indices, API key hashes, and source hashes.
- Add API typings and adapter coverage for account/API key aggregate rows while keeping fallback behavior for older servers.

## Issues
Refs #70
Refs #42

## Testing
- npm --workspace apps/web run test -- hooks/useMonitoringData.test.ts model/analyticsAdapters.test.ts model/monitoringCenterPageModel.test.ts
- npm --workspace apps/web run type-check