### PR TITLE
fix(monitoring): calculate realtime TPS from total latency

### DIFF
--- a/apps/web/src/features/monitoring/model/eventRows.test.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.test.ts
@@ -34,19 +34,31 @@ const buildRows = (overrides: Partial<UsageDetailWithEndpoint> = {}) =>
   );
 
 describe('buildEventRows', () => {
-  it('calculates output tokens per second after TTFT when available', () => {
+  it('calculates output tokens per second from total latency', () => {
     const [row] = buildRows();
 
     expect(row.latencyMs).toBe(1500);
     expect(row.ttftMs).toBe(500);
-    expect(row.tokensPerSecond).toBe(20);
+    expect(row.tokensPerSecond).toBeCloseTo(20 / 1.5);
   });
 
-  it('falls back to total latency when TTFT is missing or not smaller than total latency', () => {
+  it('does not let TTFT change output tokens per second', () => {
     const [withoutTTFT] = buildRows({ ttft_ms: undefined });
+    const [smallTTFT] = buildRows({ ttft_ms: 100 });
     const [invalidTTFT] = buildRows({ ttft_ms: 2000 });
 
     expect(withoutTTFT.tokensPerSecond).toBeCloseTo(20 / 1.5);
+    expect(smallTTFT.tokensPerSecond).toBeCloseTo(20 / 1.5);
     expect(invalidTTFT.tokensPerSecond).toBeCloseTo(20 / 1.5);
+  });
+
+  it('does not calculate tokens per second without output tokens or total latency', () => {
+    const [noOutput] = buildRows({ tokens: { output_tokens: 0 } });
+    const [noLatency] = buildRows({ latency_ms: undefined });
+    const [zeroLatency] = buildRows({ latency_ms: 0 });
+
+    expect(noOutput.tokensPerSecond).toBeNull();
+    expect(noLatency.tokensPerSecond).toBeNull();
+    expect(zeroLatency.tokensPerSecond).toBeNull();
   });
 });

--- a/apps/web/src/features/monitoring/model/eventRows.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.ts
@@ -20,15 +20,11 @@ const toDurationMs = (value: unknown): number | null => {
 
 const calculateOutputTokensPerSecond = (
   outputTokens: number,
-  latencyMs: number | null,
-  ttftMs: number | null
+  latencyMs: number | null
 ): number | null => {
   if (outputTokens <= 0 || latencyMs === null || latencyMs <= 0) return null;
 
-  const outputDurationMs = ttftMs !== null && latencyMs > ttftMs ? latencyMs - ttftMs : latencyMs;
-  if (outputDurationMs <= 0) return null;
-
-  return outputTokens / (outputDurationMs / 1000);
+  return outputTokens / (latencyMs / 1000);
 };
 
 export const buildEventRows = (
@@ -108,7 +104,7 @@ export const buildEventRows = (
       );
       const latencyMs = toDurationMs(detail.latency_ms);
       const ttftMs = toDurationMs(detail.ttft_ms);
-      const tokensPerSecond = calculateOutputTokensPerSecond(outputTokens, latencyMs, ttftMs);
+      const tokensPerSecond = calculateOutputTokensPerSecond(outputTokens, latencyMs);
       const totalCost = calculateCost(detail, modelPrices);
       const statsIncluded = detail.failed === true || inputTokens > 0 || outputTokens > 0;
       const dayKey = buildLocalDayKey(timestampMs);


### PR DESCRIPTION
## Summary
- Change realtime request monitoring TPS to divide output tokens by the full request latency.
- Stop subtracting TTFT from the TPS denominator so the value matches the requested throughput definition.
- Keep rows without output tokens or usable latency from displaying misleading TPS values.

## Issues
Refs #60

## Testing
- npm --workspace apps/web run test -- model/eventRows.test.ts