### PR TITLE
feat(monitoring): paginate codex inspection results

### DIFF
--- a/apps/web/src/features/monitoring/CodexInspectionPage.module.scss
+++ b/apps/web/src/features/monitoring/CodexInspectionPage.module.scss
@@ -739,6 +739,60 @@
   overflow-x: auto;
 }
 
+.resultPaginationBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--inspect-line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--inspect-surface-muted) 62%, var(--inspect-surface));
+}
+
+.resultPaginationInfo {
+  min-width: 0;
+  color: var(--inspect-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.resultPaginationControls {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.resultPageSizeField {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  color: var(--inspect-muted);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.resultPageSizeSelect {
+  width: 118px;
+  flex: 0 0 auto;
+}
+
+.resultPageSizeSelectTrigger {
+  min-width: 96px;
+  height: 32px !important;
+  padding: 0 2px 0 10px !important;
+  border-radius: 10px !important;
+  font-size: 12px;
+  font-weight: 700;
+}
+
 .table {
   width: 100%;
   min-width: 920px;
@@ -2023,6 +2077,16 @@
   .settingsAutoCards {
     grid-template-columns: 1fr;
   }
+
+  .resultPaginationBar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .resultPaginationControls {
+    justify-content: flex-start;
+    width: 100%;
+  }
 }
 
 @container codex-inspection-page (max-width: 640px) {
@@ -2061,6 +2125,17 @@
 
   .logRow {
     grid-template-columns: 1fr;
+  }
+
+  .resultPaginationControls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .resultPageSizeField,
+  .resultPageSizeSelect,
+  .resultPageSizeSelectTrigger {
+    width: 100%;
   }
 
   .settingsField,

--- a/apps/web/src/features/monitoring/CodexInspectionPage.tsx
+++ b/apps/web/src/features/monitoring/CodexInspectionPage.tsx
@@ -33,6 +33,8 @@ import { CodexInspectionStatusPanel } from '@/features/monitoring/components/Cod
 import { InspectionConfigDrawer } from '@/features/monitoring/components/InspectionConfigDrawer';
 import { InspectionConfigFields } from '@/features/monitoring/components/InspectionConfigFields';
 import {
+  CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS,
+  buildCodexInspectionPaginationState,
   countActions,
   createCompletedProgressSnapshot,
   createIdleProgressSnapshot,
@@ -105,6 +107,10 @@ export function CodexInspectionPage() {
   const [executing, setExecuting] = useState(false);
   const [actionFilter, setActionFilter] = useState<ActionFilter>(
     () => initialLastRun?.actionFilter ?? 'all'
+  );
+  const [resultPage, setResultPage] = useState(1);
+  const [resultPageSize, setResultPageSize] = useState<number>(
+    CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS[0]
   );
   const logCounterRef = useRef(initialLastRun?.logs.length ?? 0);
   const sessionRef = useRef<CodexInspectionSession | null>(null);
@@ -493,6 +499,25 @@ export function CodexInspectionPage() {
     [suggestedResults, actionFilter]
   );
 
+  const resultPagination = useMemo(
+    () => buildCodexInspectionPaginationState(filteredResults, resultPage, resultPageSize),
+    [filteredResults, resultPage, resultPageSize]
+  );
+
+  useEffect(() => {
+    setResultPage(1);
+  }, [actionFilter, result?.startedAt, result?.finishedAt]);
+
+  useEffect(() => {
+    if (resultPage === resultPagination.currentPage) return;
+    setResultPage(resultPagination.currentPage);
+  }, [resultPage, resultPagination.currentPage]);
+
+  const handleResultPageSizeChange = useCallback((pageSize: number) => {
+    setResultPageSize(pageSize);
+    setResultPage(1);
+  }, []);
+
   const handleExecutePlanned = useCallback(() => {
     if (!result) return;
 
@@ -844,15 +869,20 @@ export function CodexInspectionPage() {
 
       <CodexInspectionResultsPanel
         result={result}
-        filteredResults={filteredResults}
+        filteredResults={resultPagination.pageItems}
         suggestedResults={suggestedResults}
         pendingActionCount={pendingActionCount}
         filterCounts={filterCounts}
         actionFilter={actionFilter}
+        pagination={resultPagination}
+        pageSize={resultPageSize}
+        pageSizeOptions={CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS}
         executing={executing}
         isInspectionInFlight={isInspectionInFlight}
         t={t}
         onActionFilterChange={setActionFilter}
+        onPageChange={setResultPage}
+        onPageSizeChange={handleResultPageSizeChange}
         onExecutePlanned={handleExecutePlanned}
         onExecuteSingle={handleExecuteSingle}
         filterLabel={filterLabel}

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
@@ -19,7 +19,10 @@ import { Panel } from '@/features/monitoring/components/CodexInspectionPanels';
 import { InspectionConfigDrawer } from '@/features/monitoring/components/InspectionConfigDrawer';
 import { InspectionConfigFields } from '@/features/monitoring/components/InspectionConfigFields';
 import {
+  CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS,
+  buildCodexInspectionPaginationState,
   buildConfigOverviewItems,
+  type CodexInspectionPaginationState,
   type CodexInspectionSummaryAccent,
   formatActionLabel,
   formatPercent,
@@ -112,6 +115,15 @@ type ServerCodexInspectionResultFilter =
   | 'reauth'
   | 'http_401'
   | 'keep';
+
+const filterServerCodexInspectionResults = (
+  results: CodexInspectionResult[],
+  filter: ServerCodexInspectionResultFilter
+) => {
+  if (filter === 'all') return results;
+  if (filter === 'http_401') return results.filter((item) => item.statusCode === 401);
+  return results.filter((item) => item.action === filter);
+};
 
 const COMMON_TIME_ZONES: ReadonlyArray<string> = [
   'UTC',
@@ -535,6 +547,10 @@ export function ServerCodexInspectionPage() {
   const [error, setError] = useState('');
   const [logsCollapsed, setLogsCollapsed] = useState(false);
   const [resultFilter, setResultFilter] = useState<ServerCodexInspectionResultFilter>('all');
+  const [resultPage, setResultPage] = useState(1);
+  const [resultPageSize, setResultPageSize] = useState<number>(
+    CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS[0]
+  );
   const [logLevelFilter, setLogLevelFilter] = useState<'all' | 'info' | 'success' | 'warning' | 'error'>('all');
   const [executingResultIds, setExecutingResultIds] = useState<Set<number>>(() => new Set());
   const [executingAllActions, setExecutingAllActions] = useState(false);
@@ -643,6 +659,30 @@ export function ServerCodexInspectionPage() {
       activeRun.enableCount +
       (activeRun.reauthCount ?? 0)
     : 0;
+
+  const resultRows = useMemo(() => detail?.results ?? [], [detail?.results]);
+  const filteredResultRows = useMemo(
+    () => filterServerCodexInspectionResults(resultRows, resultFilter),
+    [resultRows, resultFilter]
+  );
+  const resultPagination = useMemo(
+    () => buildCodexInspectionPaginationState(filteredResultRows, resultPage, resultPageSize),
+    [filteredResultRows, resultPage, resultPageSize]
+  );
+
+  useEffect(() => {
+    setResultPage(1);
+  }, [resultFilter, detail?.run.id]);
+
+  useEffect(() => {
+    if (resultPage === resultPagination.currentPage) return;
+    setResultPage(resultPagination.currentPage);
+  }, [resultPage, resultPagination.currentPage]);
+
+  const handleResultPageSizeChange = useCallback((pageSize: number) => {
+    setResultPageSize(pageSize);
+    setResultPage(1);
+  }, []);
 
   const scheduleOptions = useMemo(
     () => [
@@ -1326,7 +1366,11 @@ export function ServerCodexInspectionPage() {
     </Panel>
   );
 
-  const renderResultsPanel = (results: CodexInspectionResult[]) => {
+  const renderResultsPanel = (
+    results: CodexInspectionResult[],
+    filtered: CodexInspectionResult[],
+    pagination: CodexInspectionPaginationState<CodexInspectionResult>
+  ) => {
     const canonicalExecutableIds = getCanonicalServerCodexInspectionActionIds(results);
     const mixedActionIds = getMixedServerCodexInspectionActionIds(results);
     const executableResults = results.filter((item) => canonicalExecutableIds.has(item.id));
@@ -1362,12 +1406,6 @@ export function ServerCodexInspectionPage() {
       { value: 'http_401', label: t('monitoring.codex_inspection_filter_401') },
       { value: 'keep', label: t('monitoring.codex_inspection_action_keep') },
     ];
-    const filtered =
-      resultFilter === 'all'
-        ? results
-        : resultFilter === 'http_401'
-          ? results.filter((item) => item.statusCode === 401)
-          : results.filter((item) => item.action === resultFilter);
     return (
       <Panel
         title={t('monitoring.codex_inspection_results_title')}
@@ -1412,117 +1450,172 @@ export function ServerCodexInspectionPage() {
         }
       >
         {filtered.length > 0 ? (
-          <div className={styles.tableWrap}>
-            <table className={styles.table}>
-              <colgroup>
-                <col className={styles.accountColumn} />
-                <col className={styles.stateColumn} />
-                <col className={styles.httpColumn} />
-                <col className={styles.usageColumn} />
-                <col className={styles.actionColumn} />
-                <col className={styles.operationColumn} />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th>{t('monitoring.account_label')}</th>
-                  <th>{formatResultStateHeader(resultsRun, t)}</th>
-                  <th>{t('monitoring.codex_inspection_http_status')}</th>
-                  <th>{t('monitoring.codex_inspection_used_percent')}</th>
-                  <th>{t('monitoring.codex_inspection_next_action')}</th>
-                  <th>{t('monitoring.server_codex_inspection_results_state_detail')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map((item) => {
-                  const actionStatus = normalizeServerCodexInspectionActionStatus(item);
-                  return (
-                  <tr key={item.id || item.accountKey}>
-                    <td>
-                      <div className={styles.primaryCell}>
-                        <span className={styles.primaryAccount}>{item.displayAccount}</span>
-                        <small className={styles.primaryFile}>
-                          {item.fileName}
-                          {item.authIndex ? (
-                            <span className={styles.primaryIndex}>{` · #${item.authIndex}`}</span>
-                          ) : null}
-                        </small>
-                        {item.actionReason ? (
-                          <small className={styles.primaryReason}>{item.actionReason}</small>
-                        ) : null}
-                      </div>
-                    </td>
-                    <td>
-                      <span
-                        className={`${styles.stateChip} ${
-                          item.disabled ? styles.stateDisabled : styles.stateEnabled
-                        }`}
-                      >
-                        {item.disabled
-                          ? t('monitoring.codex_inspection_state_disabled')
-                          : t('monitoring.codex_inspection_state_enabled')}
-                      </span>
-                    </td>
-                    <td className={styles.monoCell}>{item.statusCode ?? '--'}</td>
-                    <td className={styles.monoCell}>{formatPercent(item.usedPercent ?? null)}</td>
-                    <td>
-                      <span className={`${styles.actionBadge} ${actionToneClass[item.action] ?? styles.actionKeep}`}>
-                        {resolveActionLabel(item.action, t)}
-                      </span>
-                    </td>
-                    <td>
-                      <div className={styles.serverResultOperation}>
-                        {(() => {
-                          const statusLabel = formatServerActionStatusLabel(item, t);
-                          const detailText =
-                            item.actionError || item.error || item.status || item.state || '--';
-                          return (
-                            <span
-                              className={
-                                actionStatus === 'failed' || item.actionError || item.error
-                                  ? styles.primaryError
-                                  : styles.primaryReason
-                              }
-                            >
-                              {statusLabel ? `${statusLabel} · ${detailText}` : detailText}
-                            </span>
-                          );
-                        })()}
-                        {canonicalExecutableIds.has(item.id) ? (
-                          <Button
-                            size="xs"
-                            variant={item.action === 'delete' ? 'danger' : 'secondary'}
-                            loading={executingResultIds.has(item.id)}
-                            disabled={!canExecuteActions || executingResultIds.size > 0}
-                            className={styles.serverResultActionButton}
-                            onClick={() => handleExecuteServerActions([item], 'single')}
-                          >
-                            {(() => {
-                              const ActionIcon = getServerActionIcon(item.action);
-                              return <ActionIcon size={13} />;
-                            })()}
-                            {resolveActionLabel(item.action, t)}
-                          </Button>
-                        ) : actionStatus === 'needs_review' || mixedActionIds.has(item.id) ? (
-                          <span className={styles.primaryReason}>
-                            {t('monitoring.server_codex_inspection_action_needs_review_hint')}
-                          </span>
-                        ) : isActionableServerCodexInspectionResult(item) ? (
-                          <span className={styles.primaryReason}>
-                            {t('monitoring.server_codex_inspection_file_level_action_hint')}
-                          </span>
-                        ) : item.action === 'reauth' ? (
-                          <span className={styles.primaryReason}>
-                            {t('monitoring.codex_inspection_manual_required')}
-                          </span>
-                        ) : null}
-                      </div>
-                    </td>
+          <>
+            <div className={styles.tableWrap}>
+              <table className={styles.table}>
+                <colgroup>
+                  <col className={styles.accountColumn} />
+                  <col className={styles.stateColumn} />
+                  <col className={styles.httpColumn} />
+                  <col className={styles.usageColumn} />
+                  <col className={styles.actionColumn} />
+                  <col className={styles.operationColumn} />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th>{t('monitoring.account_label')}</th>
+                    <th>{formatResultStateHeader(resultsRun, t)}</th>
+                    <th>{t('monitoring.codex_inspection_http_status')}</th>
+                    <th>{t('monitoring.codex_inspection_used_percent')}</th>
+                    <th>{t('monitoring.codex_inspection_next_action')}</th>
+                    <th>{t('monitoring.server_codex_inspection_results_state_detail')}</th>
                   </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {pagination.pageItems.map((item) => {
+                    const actionStatus = normalizeServerCodexInspectionActionStatus(item);
+                    return (
+                    <tr key={item.id || item.accountKey}>
+                      <td>
+                        <div className={styles.primaryCell}>
+                          <span className={styles.primaryAccount}>{item.displayAccount}</span>
+                          <small className={styles.primaryFile}>
+                            {item.fileName}
+                            {item.authIndex ? (
+                              <span className={styles.primaryIndex}>{` · #${item.authIndex}`}</span>
+                            ) : null}
+                          </small>
+                          {item.actionReason ? (
+                            <small className={styles.primaryReason}>{item.actionReason}</small>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td>
+                        <span
+                          className={`${styles.stateChip} ${
+                            item.disabled ? styles.stateDisabled : styles.stateEnabled
+                          }`}
+                        >
+                          {item.disabled
+                            ? t('monitoring.codex_inspection_state_disabled')
+                            : t('monitoring.codex_inspection_state_enabled')}
+                        </span>
+                      </td>
+                      <td className={styles.monoCell}>{item.statusCode ?? '--'}</td>
+                      <td className={styles.monoCell}>{formatPercent(item.usedPercent ?? null)}</td>
+                      <td>
+                        <span className={`${styles.actionBadge} ${actionToneClass[item.action] ?? styles.actionKeep}`}>
+                          {resolveActionLabel(item.action, t)}
+                        </span>
+                      </td>
+                      <td>
+                        <div className={styles.serverResultOperation}>
+                          {(() => {
+                            const statusLabel = formatServerActionStatusLabel(item, t);
+                            const detailText =
+                              item.actionError || item.error || item.status || item.state || '--';
+                            return (
+                              <span
+                                className={
+                                  actionStatus === 'failed' || item.actionError || item.error
+                                    ? styles.primaryError
+                                    : styles.primaryReason
+                                }
+                              >
+                                {statusLabel ? `${statusLabel} · ${detailText}` : detailText}
+                              </span>
+                            );
+                          })()}
+                          {canonicalExecutableIds.has(item.id) ? (
+                            <Button
+                              size="xs"
+                              variant={item.action === 'delete' ? 'danger' : 'secondary'}
+                              loading={executingResultIds.has(item.id)}
+                              disabled={!canExecuteActions || executingResultIds.size > 0}
+                              className={styles.serverResultActionButton}
+                              onClick={() => handleExecuteServerActions([item], 'single')}
+                            >
+                              {(() => {
+                                const ActionIcon = getServerActionIcon(item.action);
+                                return <ActionIcon size={13} />;
+                              })()}
+                              {resolveActionLabel(item.action, t)}
+                            </Button>
+                          ) : actionStatus === 'needs_review' || mixedActionIds.has(item.id) ? (
+                            <span className={styles.primaryReason}>
+                              {t('monitoring.server_codex_inspection_action_needs_review_hint')}
+                            </span>
+                          ) : isActionableServerCodexInspectionResult(item) ? (
+                            <span className={styles.primaryReason}>
+                              {t('monitoring.server_codex_inspection_file_level_action_hint')}
+                            </span>
+                          ) : item.action === 'reauth' ? (
+                            <span className={styles.primaryReason}>
+                              {t('monitoring.codex_inspection_manual_required')}
+                            </span>
+                          ) : null}
+                        </div>
+                      </td>
+                    </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            {pagination.totalPages > 1 ? (
+              <div className={styles.resultPaginationBar}>
+                <div className={styles.resultPaginationInfo}>
+                  {t('monitoring.pagination_info', {
+                    current: pagination.currentPage,
+                    total: pagination.totalPages,
+                    start: pagination.startItem,
+                    end: pagination.endItem,
+                    count: pagination.count,
+                  })}
+                </div>
+                <div className={styles.resultPaginationControls}>
+                  <div className={styles.resultPageSizeField}>
+                    <span>{t('monitoring.page_size_label')}</span>
+                    <Select
+                      className={styles.resultPageSizeSelect}
+                      triggerClassName={styles.resultPageSizeSelectTrigger}
+                      value={String(resultPageSize)}
+                      options={CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS.map((size) => ({
+                        value: String(size),
+                        label: t('monitoring.page_size_option', { count: size }),
+                      }))}
+                      onChange={(value) => {
+                        const parsed = Number.parseInt(value, 10);
+                        handleResultPageSizeChange(
+                          Number.isFinite(parsed) && parsed > 0 ? parsed : resultPageSize
+                        );
+                      }}
+                      ariaLabel={t('monitoring.page_size_label')}
+                      fullWidth={false}
+                    />
+                  </div>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setResultPage(Math.max(1, pagination.currentPage - 1))}
+                    disabled={pagination.currentPage <= 1}
+                  >
+                    {t('monitoring.pagination_prev')}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() =>
+                      setResultPage(Math.min(pagination.totalPages, pagination.currentPage + 1))
+                    }
+                    disabled={pagination.currentPage >= pagination.totalPages}
+                  >
+                    {t('monitoring.pagination_next')}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
         ) : results.length === 0 ? (
           <div className={styles.emptyAction}>
             <span>{t('monitoring.codex_inspection_empty')}</span>
@@ -1685,7 +1778,7 @@ export function ServerCodexInspectionPage() {
         {renderRunsPanel()}
         <div className={styles.serverDetailPanels}>
           {detail?.run.error ? <div className={styles.serverError} role="alert">{detail.run.error}</div> : null}
-          {renderResultsPanel(detail?.results ?? [])}
+          {renderResultsPanel(resultRows, filteredResultRows, resultPagination)}
           {renderLogsPanel(detail?.logs ?? [])}
         </div>
       </div>

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -16,6 +16,7 @@ import {
   type CodexInspectionRunResult,
 } from './codexInspection';
 import {
+  buildCodexInspectionPaginationState,
   buildConfigOverviewItems,
   countActions,
   filterByAction,
@@ -323,6 +324,29 @@ describe('Codex inspection action presentation', () => {
     });
     expect(filterByAction(items, 'reauth').map((item) => item.action)).toEqual(['reauth']);
     expect(filterByAction(items, 'http_401').map((item) => item.statusCode)).toEqual([401, 401]);
+  });
+
+  it('paginates inspection results and clamps out-of-range pages', () => {
+    const items = Array.from({ length: 45 }, (_, index) =>
+      createResultItem('disable', {
+        key: `item-${index + 1}`,
+        fileName: `item-${index + 1}.json`,
+      })
+    );
+
+    const secondPage = buildCodexInspectionPaginationState(items, 2, 20);
+    expect(secondPage.currentPage).toBe(2);
+    expect(secondPage.totalPages).toBe(3);
+    expect(secondPage.startItem).toBe(21);
+    expect(secondPage.endItem).toBe(40);
+    expect(secondPage.pageItems).toHaveLength(20);
+    expect(secondPage.pageItems[0].fileName).toBe('item-21.json');
+
+    const clamped = buildCodexInspectionPaginationState(items, 99, 20);
+    expect(clamped.currentPage).toBe(3);
+    expect(clamped.startItem).toBe(41);
+    expect(clamped.endItem).toBe(45);
+    expect(clamped.pageItems).toHaveLength(5);
   });
 });
 

--- a/apps/web/src/features/monitoring/components/CodexInspectionResultsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionResultsPanel.tsx
@@ -1,5 +1,6 @@
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
+import { Select } from '@/components/ui/Select';
 import {
   type CodexInspectionAction,
   type CodexInspectionResultItem,
@@ -8,6 +9,7 @@ import {
 } from '@/features/monitoring/codexInspection';
 import {
   ACTION_FILTERS,
+  type CodexInspectionPaginationState,
   formatActionLabel,
   formatCurrentStateLabel,
   formatPercent,
@@ -23,10 +25,15 @@ type CodexInspectionResultsPanelProps = {
   pendingActionCount: number;
   filterCounts: Record<ActionFilter, number>;
   actionFilter: ActionFilter;
+  pagination: CodexInspectionPaginationState<CodexInspectionResultItem>;
+  pageSize: number;
+  pageSizeOptions: readonly number[];
   executing: boolean;
   isInspectionInFlight: boolean;
   t: TFunction;
   onActionFilterChange: (filter: ActionFilter) => void;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
   onExecutePlanned: () => void;
   onExecuteSingle: (item: CodexInspectionResultItem) => void;
   filterLabel: (filter: ActionFilter) => string;
@@ -47,10 +54,15 @@ export function CodexInspectionResultsPanel({
   pendingActionCount,
   filterCounts,
   actionFilter,
+  pagination,
+  pageSize,
+  pageSizeOptions,
   executing,
   isInspectionInFlight,
   t,
   onActionFilterChange,
+  onPageChange,
+  onPageSizeChange,
   onExecutePlanned,
   onExecuteSingle,
   filterLabel,
@@ -188,6 +200,57 @@ export function CodexInspectionResultsPanel({
               </tbody>
             </table>
           </div>
+          {pagination.totalPages > 1 ? (
+            <div className={styles.resultPaginationBar}>
+              <div className={styles.resultPaginationInfo}>
+                {t('monitoring.pagination_info', {
+                  current: pagination.currentPage,
+                  total: pagination.totalPages,
+                  start: pagination.startItem,
+                  end: pagination.endItem,
+                  count: pagination.count,
+                })}
+              </div>
+              <div className={styles.resultPaginationControls}>
+                <div className={styles.resultPageSizeField}>
+                  <span>{t('monitoring.page_size_label')}</span>
+                  <Select
+                    className={styles.resultPageSizeSelect}
+                    triggerClassName={styles.resultPageSizeSelectTrigger}
+                    value={String(pageSize)}
+                    options={pageSizeOptions.map((size) => ({
+                      value: String(size),
+                      label: t('monitoring.page_size_option', { count: size }),
+                    }))}
+                    onChange={(value) => {
+                      const parsed = Number.parseInt(value, 10);
+                      onPageSizeChange(Number.isFinite(parsed) && parsed > 0 ? parsed : pageSize);
+                    }}
+                    ariaLabel={t('monitoring.page_size_label')}
+                    fullWidth={false}
+                  />
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => onPageChange(Math.max(1, pagination.currentPage - 1))}
+                  disabled={pagination.currentPage <= 1}
+                >
+                  {t('monitoring.pagination_prev')}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() =>
+                    onPageChange(Math.min(pagination.totalPages, pagination.currentPage + 1))
+                  }
+                  disabled={pagination.currentPage >= pagination.totalPages}
+                >
+                  {t('monitoring.pagination_next')}
+                </Button>
+              </div>
+            </div>
+          ) : null}
         </>
       ) : (
         <div className={styles.emptyBlock}>{t('monitoring.codex_inspection_empty')}</div>

--- a/apps/web/src/features/monitoring/model/codexInspectionPresentation.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionPresentation.ts
@@ -60,6 +60,15 @@ export type SummaryCard = {
   accent?: CodexInspectionSummaryAccent;
 };
 
+export type CodexInspectionPaginationState<T> = {
+  currentPage: number;
+  totalPages: number;
+  pageItems: T[];
+  startItem: number;
+  endItem: number;
+  count: number;
+};
+
 export type InspectionSettingsDraft = {
   targetType: string;
   workers: string;
@@ -85,6 +94,8 @@ export const ACTION_FILTERS: ActionFilter[] = [
   'reauth',
   'http_401',
 ];
+
+export const CODEX_INSPECTION_RESULT_PAGE_SIZE_OPTIONS = [20, 50, 100] as const;
 
 export const formatTimestamp = (value: number, locale: string) =>
   new Date(value).toLocaleString(locale);
@@ -289,6 +300,27 @@ export const filterByAction = (items: CodexInspectionResultItem[], filter: Actio
   if (filter === 'all') return items;
   if (filter === 'http_401') return items.filter((item) => item.statusCode === 401);
   return items.filter((item) => item.action === filter);
+};
+
+export const buildCodexInspectionPaginationState = <T>(
+  items: readonly T[],
+  page: number,
+  pageSize: number
+): CodexInspectionPaginationState<T> => {
+  const safePageSize = Math.max(1, pageSize);
+  const totalPages = Math.max(1, Math.ceil(items.length / safePageSize));
+  const currentPage = Math.min(Math.max(1, Number.isFinite(page) ? page : 1), totalPages);
+  const startIndex = (currentPage - 1) * safePageSize;
+  const endIndex = Math.min(startIndex + safePageSize, items.length);
+
+  return {
+    currentPage,
+    totalPages,
+    pageItems: items.slice(startIndex, endIndex),
+    startItem: items.length > 0 ? startIndex + 1 : 0,
+    endItem: endIndex,
+    count: items.length,
+  };
 };
 
 export const isCodexInspectionAutoExecutionEnabled = (


### PR DESCRIPTION
## Summary
Add frontend pagination for Codex inspection result tables in both local and server inspection modes.

## Changes
- Add shared presentation pagination state for Codex inspection results.
- Paginate local inspection results after filtering and reset page state when filters or runs change.
- Paginate server inspection results after filtering while preserving bulk actions across the full executable result set.
- Show pagination controls only when results exceed one page to avoid extra UI noise for small inspections.

## Testing
- npm run type-check
- npm run lint
- npm run test
- npm run build
- git diff --check

## Related
Closes #72