### PR TITLE
feat(manager-server): add offline admin key reset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ go run ./cmd/cpa-manager-plus
 - **CPA panel mode is missing monitoring/pricing/imports**: this is expected. These are Full Docker / Manager Server-hosted panel features.
 - **Data disappears after container rebuild**: mount `/data` to a Docker volume or host directory.
 - **Old data is missing after migrating from CPA-Manager**: verify that the Plus container is mounting the old `/data` volume, not a newly created empty `cpa-manager-plus-data` volume.
-- **Admin key is lost**: setting `CPA_MANAGER_ADMIN_KEY` does not overwrite an existing `settings.admin_credential_v1`. Follow the offline recovery steps in the migration guide after backing up `/data`.
+- **Admin key is lost**: setting `CPA_MANAGER_ADMIN_KEY` does not overwrite an existing `settings.admin_credential_v1`. Stop Manager Server, back up `/data`, and follow [Reset the Manager Server Admin Key](docs/reset-admin-key.md).
 - **Detailed FAQ**: see [FAQ and Troubleshooting](https://github.com/seakee/CPA-Manager-Plus/wiki/CPA-Manager-Plus-FAQ-and-Troubleshooting) or the [Chinese FAQ](https://github.com/seakee/CPA-Manager-Plus/wiki/CPA%E2%80%90Manager-%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E4%B8%8E%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88).
 
 ## References
@@ -442,6 +442,7 @@ go run ./cmd/cpa-manager-plus
 - CLIProxyAPI: https://github.com/router-for-me/CLIProxyAPI
 - Redis usage queue documentation: https://help.router-for.me/management/redis-usage-queue.html
 - Migration from CPA-Manager: [docs/migration-from-cpa-manager.md](docs/migration-from-cpa-manager.md)
+- Reset the Manager Server admin key: [docs/reset-admin-key.md](docs/reset-admin-key.md)
 - Release checklist: [docs/release-checklist.md](docs/release-checklist.md)
 
 ## Acknowledgements

--- a/README_CN.md
+++ b/README_CN.md
@@ -434,7 +434,7 @@ go run ./cmd/cpa-manager-plus
 - **CPA 控制面板方案没有监控/价格/导入导出**：这是预期行为，这些是完整 Docker / Manager Server 托管面板功能。
 - **容器重建后数据丢失**：确认 `/data` 已挂载到 Docker volume 或宿主机目录。
 - **从 CPA-Manager 迁移后看不到旧数据**：确认 Plus 容器挂载的是旧 `/data` volume，而不是新建的 `cpa-manager-plus-data` 空 volume。
-- **管理员密钥丢失**：已有 `settings.admin_credential_v1` 时，单独设置 `CPA_MANAGER_ADMIN_KEY` 不会覆盖旧凭证。按迁移指南的离线恢复步骤处理，并先备份 `/data`。
+- **管理员密钥丢失**：已有 `settings.admin_credential_v1` 时，单独设置 `CPA_MANAGER_ADMIN_KEY` 不会覆盖旧凭证。请先停止 Manager Server、备份 `/data`，再按 [重置 Manager Server 管理员密钥](docs/reset-admin-key.zh-CN.md) 处理。
 - **完整 FAQ**：查看 [CPA Manager Plus 常见问题与解决方案](https://github.com/seakee/CPA-Manager-Plus/wiki/CPA%E2%80%90Manager-%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E4%B8%8E%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88) 或 [English FAQ and Troubleshooting](https://github.com/seakee/CPA-Manager-Plus/wiki/CPA-Manager-Plus-FAQ-and-Troubleshooting)。
 
 ## 参考
@@ -442,6 +442,7 @@ go run ./cmd/cpa-manager-plus
 - CLIProxyAPI: https://github.com/router-for-me/CLIProxyAPI
 - Redis 用量队列文档: https://help.router-for.me/management/redis-usage-queue.html
 - CPA-Manager 到 CPA Manager Plus 迁移指南: [docs/migration-from-cpa-manager.zh-CN.md](docs/migration-from-cpa-manager.zh-CN.md)
+- 重置 Manager Server 管理员密钥: [docs/reset-admin-key.zh-CN.md](docs/reset-admin-key.zh-CN.md)
 - 发布前检查清单: [docs/release-checklist.zh-CN.md](docs/release-checklist.zh-CN.md)
 
 ## 致谢

--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -11,6 +11,7 @@ import (
 	_ "time/tzdata"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/command/adminreset"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/httpapi"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
@@ -21,6 +22,20 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "reset-admin-key", "reset-admin-password":
+			if err := adminreset.Run(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				log.Printf("reset admin key: %v", err)
+				os.Exit(1)
+			}
+			return
+		}
+	}
+	runServer()
+}
+
+func runServer() {
 	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("load config: %v", err)

--- a/apps/manager-server/internal/command/adminreset/command.go
+++ b/apps/manager-server/internal/command/adminreset/command.go
@@ -1,0 +1,164 @@
+package adminreset
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
+	adminauthsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/adminauth"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	_ "modernc.org/sqlite"
+)
+
+func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	opts, err := parseArgs(args, stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	adminKey, err := resolveAdminKey(opts)
+	if err != nil {
+		return err
+	}
+	dbPath, err := resolveDBPath(opts.DBPath)
+	if err != nil {
+		return err
+	}
+	if err := ensureManagerDB(ctx, dbPath); err != nil {
+		return err
+	}
+
+	st, err := store.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("open sqlite %s: %w", dbPath, err)
+	}
+	defer st.Close()
+
+	result, err := adminauthsvc.ResetAdminKey(ctx, st, adminKey)
+	if err != nil {
+		return fmt.Errorf("reset admin key: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(stdout, "CPA Manager Plus admin key reset.")
+	if result.Generated {
+		_, _ = fmt.Fprintf(stdout, "New admin key: %s\n", result.AdminKey)
+		_, _ = fmt.Fprintln(stdout, "Save this value now. It will not be shown again.")
+	} else {
+		_, _ = fmt.Fprintln(stdout, "Use the provided admin key to log in after restarting Manager Server.")
+	}
+	return nil
+}
+
+type options struct {
+	AdminKey     string
+	AdminKeyFile string
+	DBPath       string
+}
+
+func parseArgs(args []string, stderr io.Writer) (options, error) {
+	var opts options
+	fs := flag.NewFlagSet("reset-admin-key", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&opts.AdminKey, "admin-key", "", "new admin key; omitted to generate a random key")
+	fs.StringVar(&opts.AdminKeyFile, "admin-key-file", "", "file containing the new admin key")
+	fs.StringVar(&opts.DBPath, "db-path", "", "SQLite database path; defaults to Manager Server config")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "Usage: cpa-manager-plus reset-admin-key [--db-path PATH] [--admin-key VALUE | --admin-key-file PATH]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	if fs.NArg() > 0 {
+		return options{}, fmt.Errorf("unexpected argument %q", fs.Arg(0))
+	}
+	if strings.TrimSpace(opts.AdminKey) != "" && strings.TrimSpace(opts.AdminKeyFile) != "" {
+		return options{}, errors.New("--admin-key and --admin-key-file cannot be used together")
+	}
+	return opts, nil
+}
+
+func resolveAdminKey(opts options) (string, error) {
+	if strings.TrimSpace(opts.AdminKeyFile) == "" {
+		return strings.TrimSpace(opts.AdminKey), nil
+	}
+	data, err := os.ReadFile(opts.AdminKeyFile)
+	if err != nil {
+		return "", fmt.Errorf("read admin key file %s: %w", opts.AdminKeyFile, err)
+	}
+	adminKey := strings.TrimSpace(string(data))
+	if adminKey == "" {
+		return "", errors.New("admin key file is empty")
+	}
+	return adminKey, nil
+}
+
+func resolveDBPath(override string) (string, error) {
+	if strings.TrimSpace(override) != "" {
+		return strings.TrimSpace(override), nil
+	}
+	cfg, err := config.LoadWithoutCreatingDefault()
+	if err != nil {
+		return "", fmt.Errorf("load config: %w", err)
+	}
+	if strings.TrimSpace(cfg.DBPath) == "" {
+		return "", errors.New("SQLite database path is empty; pass --db-path")
+	}
+	return cfg.DBPath, nil
+}
+
+func ensureManagerDB(ctx context.Context, dbPath string) error {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("SQLite database not found at %s; pass --db-path or run the command from the configured Manager Server environment", dbPath)
+		}
+		return fmt.Errorf("stat sqlite %s: %w", dbPath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("SQLite database path is a directory: %s", dbPath)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("SQLite database at %s is empty; verify --db-path points to the Manager Server data file", dbPath)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("open sqlite %s for validation: %w", dbPath, err)
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(
+		ctx,
+		`select name from sqlite_schema where type = 'table' and name in ('settings', 'usage_events')`,
+	)
+	if err != nil {
+		return fmt.Errorf("validate sqlite %s: %w", dbPath, err)
+	}
+	defer rows.Close()
+
+	found := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("validate sqlite %s: %w", dbPath, err)
+		}
+		found[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("validate sqlite %s: %w", dbPath, err)
+	}
+	if !found["settings"] || !found["usage_events"] {
+		return fmt.Errorf("SQLite database at %s does not look like a CPA Manager Plus Manager Server database", dbPath)
+	}
+	return nil
+}

--- a/apps/manager-server/internal/command/adminreset/command_test.go
+++ b/apps/manager-server/internal/command/adminreset/command_test.go
@@ -1,0 +1,163 @@
+package adminreset
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+)
+
+func TestRunGeneratesAdminKey(t *testing.T) {
+	dbPath := newCommandTestDB(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if err := Run(context.Background(), []string{"--db-path", dbPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("run reset command: %v stderr=%s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	const marker = "New admin key: "
+	index := strings.Index(output, marker)
+	if index < 0 {
+		t.Fatalf("output does not contain generated key: %s", output)
+	}
+	adminKey := strings.TrimSpace(strings.Split(output[index+len(marker):], "\n")[0])
+	if !strings.HasPrefix(adminKey, "cmp_admin_") {
+		t.Fatalf("generated key = %q", adminKey)
+	}
+	requireAdminKeyVerifies(t, dbPath, adminKey)
+}
+
+func TestRunUsesProvidedAdminKeyWithoutEchoingIt(t *testing.T) {
+	dbPath := newCommandTestDB(t)
+	const adminKey = "cmp_admin_from_cli"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if err := Run(context.Background(), []string{"--db-path", dbPath, "--admin-key", adminKey}, &stdout, &stderr); err != nil {
+		t.Fatalf("run reset command: %v stderr=%s", err, stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), adminKey) {
+		t.Fatalf("stdout leaked provided admin key: %s", stdout.String())
+	}
+	requireAdminKeyVerifies(t, dbPath, adminKey)
+}
+
+func TestRunRejectsMissingDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "missing.sqlite")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run(context.Background(), []string{"--db-path", dbPath}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "SQLite database not found") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestRunRejectsEmptyDBFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	if err := os.WriteFile(dbPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty db file: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run(context.Background(), []string{"--db-path", dbPath}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestRunRejectsUnrelatedSQLiteDBWithoutMigratingIt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open unrelated sqlite: %v", err)
+	}
+	if _, err := db.Exec(`create table unrelated(id integer primary key)`); err != nil {
+		t.Fatalf("create unrelated table: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close unrelated sqlite: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err = Run(context.Background(), []string{"--db-path", dbPath}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "does not look like a CPA Manager Plus") {
+		t.Fatalf("err = %v", err)
+	}
+	requireNoManagerTables(t, dbPath)
+}
+
+func TestRunRejectsConflictingAdminKeyInputs(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run(context.Background(), []string{"--admin-key", "one", "--admin-key-file", "two"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func newCommandTestDB(t testing.TB) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	credential, err := security.NewAdminCredential("cmp_admin_old", "test")
+	if err != nil {
+		t.Fatalf("create credential: %v", err)
+	}
+	if err := st.SaveAdminCredential(context.Background(), credential); err != nil {
+		t.Fatalf("save credential: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	return dbPath
+}
+
+func requireNoManagerTables(t testing.TB, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRow(`select count(*) from sqlite_schema where type = 'table' and name in ('settings', 'usage_events')`).Scan(&count); err != nil {
+		t.Fatalf("count manager tables: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("manager table count = %d, want 0", count)
+	}
+}
+
+func requireAdminKeyVerifies(t testing.TB, dbPath string, adminKey string) {
+	t.Helper()
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	credential, ok, err := st.LoadAdminCredential(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("load credential ok=%v err=%v", ok, err)
+	}
+	if !security.VerifyAdminKey(credential, adminKey) {
+		t.Fatalf("admin key %q does not verify", adminKey)
+	}
+}

--- a/apps/manager-server/internal/config/config.go
+++ b/apps/manager-server/internal/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	TLSSkipVerify  bool
 }
 
+type LoadOptions struct {
+	CreateDefaultConfig bool
+}
+
 type fileConfig struct {
 	HTTPAddr          string   `json:"httpAddr,omitempty"`
 	DataDir           string   `json:"dataDir,omitempty"`
@@ -59,7 +63,15 @@ type fileConfig struct {
 }
 
 func Load() (Config, error) {
-	cfgFile, cfgDir, err := loadFileConfig()
+	return LoadWithOptions(LoadOptions{CreateDefaultConfig: true})
+}
+
+func LoadWithoutCreatingDefault() (Config, error) {
+	return LoadWithOptions(LoadOptions{})
+}
+
+func LoadWithOptions(options LoadOptions) (Config, error) {
+	cfgFile, cfgDir, err := loadFileConfig(options)
 	if err != nil {
 		return Config{}, err
 	}
@@ -117,8 +129,15 @@ func Load() (Config, error) {
 	}, nil
 }
 
-func loadFileConfig() (fileConfig, string, error) {
+func loadFileConfig(options LoadOptions) (fileConfig, string, error) {
 	if configPath := strings.TrimSpace(os.Getenv(configEnvKey)); configPath != "" {
+		if !options.CreateDefaultConfig {
+			cfg, cfgDir, ok, err := readFileConfig(configPath)
+			if err != nil || ok {
+				return cfg, cfgDir, err
+			}
+			return fileConfig{}, filepath.Dir(configPath), nil
+		}
 		return readOrCreateFileConfig(configPath)
 	}
 
@@ -132,6 +151,9 @@ func loadFileConfig() (fileConfig, string, error) {
 	}
 	if hasEnv("USAGE_DATA_DIR") || hasEnv("USAGE_DB_PATH") {
 		return fileConfig{}, "", nil
+	}
+	if !options.CreateDefaultConfig {
+		return fileConfig{}, filepath.Dir(configPath), nil
 	}
 	return createDefaultFileConfig(configPath)
 }

--- a/apps/manager-server/internal/config/config_test.go
+++ b/apps/manager-server/internal/config/config_test.go
@@ -34,6 +34,24 @@ func TestLoadCreatesDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestLoadWithoutCreatingDefaultDoesNotCreateConfig(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	t.Setenv(configEnvKey, configPath)
+
+	cfg, err := LoadWithoutCreatingDefault()
+	if err != nil {
+		t.Fatalf("LoadWithoutCreatingDefault() error = %v", err)
+	}
+	if want := filepath.Join(dir, "data", "usage.sqlite"); cfg.DBPath != want {
+		t.Fatalf("DBPath = %q, want %q", cfg.DBPath, want)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("config file exists or stat failed: %v", err)
+	}
+}
+
 func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
 	clearConfigEnv(t)
 	dir := t.TempDir()

--- a/apps/manager-server/internal/security/security_test.go
+++ b/apps/manager-server/internal/security/security_test.go
@@ -25,6 +25,19 @@ func TestAdminCredentialVerifiesOnlyAdminKey(t *testing.T) {
 	}
 }
 
+func TestGenerateAdminKeyUsesExpectedPrefixAndEntropyLength(t *testing.T) {
+	adminKey, err := GenerateAdminKey()
+	if err != nil {
+		t.Fatalf("generate admin key: %v", err)
+	}
+	if !strings.HasPrefix(adminKey, "cmp_admin_") {
+		t.Fatalf("admin key = %q", adminKey)
+	}
+	if got, want := len(strings.TrimPrefix(adminKey, "cmp_admin_")), 43; got != want {
+		t.Fatalf("encoded random length = %d, want %d", got, want)
+	}
+}
+
 func TestProtectorEncryptsAndDecryptsString(t *testing.T) {
 	protector, err := NewProtector([]byte("0123456789abcdef0123456789abcdef"))
 	if err != nil {

--- a/apps/manager-server/internal/service/adminauth/reset.go
+++ b/apps/manager-server/internal/service/adminauth/reset.go
@@ -1,0 +1,45 @@
+package adminauth
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+)
+
+type ResetAdminKeyResult struct {
+	AdminKey  string
+	Generated bool
+}
+
+func ResetAdminKey(ctx context.Context, st *store.Store, adminKey string) (ResetAdminKeyResult, error) {
+	adminKey = strings.TrimSpace(adminKey)
+	generated := false
+	source := "cli"
+	if adminKey == "" {
+		value, err := security.GenerateAdminKey()
+		if err != nil {
+			return ResetAdminKeyResult{}, err
+		}
+		adminKey = value
+		generated = true
+		source = "cli-generated"
+	}
+
+	credential, err := security.NewAdminCredential(adminKey, source)
+	if err != nil {
+		return ResetAdminKeyResult{}, err
+	}
+	if existing, ok, err := st.LoadAdminCredential(ctx); err != nil {
+		return ResetAdminKeyResult{}, err
+	} else if ok && existing.CreatedAtMS > 0 {
+		credential.CreatedAtMS = existing.CreatedAtMS
+	}
+	credential.RotatedAtMS = time.Now().UnixMilli()
+	if err := st.SaveAdminCredential(ctx, credential); err != nil {
+		return ResetAdminKeyResult{}, err
+	}
+	return ResetAdminKeyResult{AdminKey: adminKey, Generated: generated}, nil
+}

--- a/apps/manager-server/internal/service/adminauth/reset_test.go
+++ b/apps/manager-server/internal/service/adminauth/reset_test.go
@@ -1,0 +1,83 @@
+package adminauth
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+)
+
+func TestResetAdminKeyGeneratesNewKey(t *testing.T) {
+	st := newResetTestStore(t)
+	oldCredential, err := security.NewAdminCredential("cmp_admin_old", "test")
+	if err != nil {
+		t.Fatalf("create old credential: %v", err)
+	}
+	if err := st.SaveAdminCredential(context.Background(), oldCredential); err != nil {
+		t.Fatalf("save old credential: %v", err)
+	}
+
+	result, err := ResetAdminKey(context.Background(), st, "")
+	if err != nil {
+		t.Fatalf("reset admin key: %v", err)
+	}
+	if !result.Generated || !strings.HasPrefix(result.AdminKey, "cmp_admin_") {
+		t.Fatalf("result = %#v", result)
+	}
+
+	credential, ok, err := st.LoadAdminCredential(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("load credential ok=%v err=%v", ok, err)
+	}
+	if !security.VerifyAdminKey(credential, result.AdminKey) {
+		t.Fatal("generated key does not verify")
+	}
+	if security.VerifyAdminKey(credential, "cmp_admin_old") {
+		t.Fatal("old key still verifies")
+	}
+	if credential.Source != "cli-generated" || credential.RotatedAtMS <= 0 {
+		t.Fatalf("credential metadata = %#v", credential)
+	}
+	if credential.CreatedAtMS != oldCredential.CreatedAtMS {
+		t.Fatalf("CreatedAtMS = %d, want %d", credential.CreatedAtMS, oldCredential.CreatedAtMS)
+	}
+}
+
+func TestResetAdminKeyUsesProvidedKey(t *testing.T) {
+	st := newResetTestStore(t)
+	const newKey = "cmp_admin_new_key"
+
+	result, err := ResetAdminKey(context.Background(), st, newKey)
+	if err != nil {
+		t.Fatalf("reset admin key: %v", err)
+	}
+	if result.Generated || result.AdminKey != newKey {
+		t.Fatalf("result = %#v", result)
+	}
+
+	credential, ok, err := st.LoadAdminCredential(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("load credential ok=%v err=%v", ok, err)
+	}
+	if !security.VerifyAdminKey(credential, newKey) {
+		t.Fatal("provided key does not verify")
+	}
+	if credential.Source != "cli" || credential.RotatedAtMS <= 0 {
+		t.Fatalf("credential metadata = %#v", credential)
+	}
+}
+
+func newResetTestStore(t testing.TB) *store.Store {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = st.Close()
+	})
+	return st
+}

--- a/bin/release/package-native.sh
+++ b/bin/release/package-native.sh
@@ -50,6 +50,7 @@ for target in "${targets[@]}"; do
 
   cp "${repo_root}/README.md" "${package_dir}/README.md"
   cp "${repo_root}/README_CN.md" "${package_dir}/README_CN.md"
+  cp -R "${repo_root}/docs" "${package_dir}/docs"
   cp "${repo_root}/LICENSE" "${package_dir}/LICENSE"
 
   if [ "${goos}" = "windows" ]; then

--- a/docs/migration-from-cpa-manager.md
+++ b/docs/migration-from-cpa-manager.md
@@ -131,25 +131,7 @@ Backups must include both SQLite files and `data.key`. Do not upload `data.key` 
 
 ## Lost Admin Key Recovery
 
-The current version has no online admin-key reset endpoint. Once `settings.admin_credential_v1` exists, setting `CPA_MANAGER_ADMIN_KEY` again does not overwrite it.
-
-Offline recovery:
-
-1. Stop Manager Server.
-2. Back up the full `/data`.
-3. Delete the admin credential row:
-
-```bash
-sqlite3 /path/to/usage.sqlite "delete from settings where key = 'admin_credential_v1';"
-```
-
-4. Start with a new admin key:
-
-```bash
-CPA_MANAGER_ADMIN_KEY='replace-with-a-long-random-admin-key' ./cpa-manager-plus
-```
-
-For Docker, use a temporary sqlite container or a host sqlite tool against the mounted directory. Do not delete `manager_config_v1`, `setup`, or `data.key`.
+Admin-key reset instructions are maintained separately. Stop Manager Server, back up `/data`, and follow [Reset the Manager Server Admin Key](reset-admin-key.md).
 
 ## Rollback
 

--- a/docs/migration-from-cpa-manager.zh-CN.md
+++ b/docs/migration-from-cpa-manager.zh-CN.md
@@ -131,25 +131,7 @@ Plus 会把 CPA Management Key 加密存储到 SQLite。默认数据密钥位于
 
 ## 管理员密钥丢失处理
 
-当前版本没有在线重置管理员密钥接口。已有 `settings.admin_credential_v1` 时，重新设置 `CPA_MANAGER_ADMIN_KEY` 不会覆盖旧凭证。
-
-离线恢复步骤：
-
-1. 停止 Manager Server。
-2. 备份整个 `/data`。
-3. 删除 SQLite 中的管理员凭证记录：
-
-```bash
-sqlite3 /path/to/usage.sqlite "delete from settings where key = 'admin_credential_v1';"
-```
-
-4. 使用新的管理员密钥启动：
-
-```bash
-CPA_MANAGER_ADMIN_KEY='replace-with-a-long-random-admin-key' ./cpa-manager-plus
-```
-
-Docker 场景可以用临时 sqlite 容器或宿主机 sqlite 工具操作挂载目录。不要删除 `manager_config_v1`、`setup` 或 `data.key`。
+管理员密钥重置指引已单独维护。请先停止 Manager Server、备份 `/data`，再按 [重置 Manager Server 管理员密钥](reset-admin-key.zh-CN.md) 处理。
 
 ## 回滚
 

--- a/docs/reset-admin-key.md
+++ b/docs/reset-admin-key.md
@@ -1,0 +1,141 @@
+# Reset the Manager Server Admin Key
+
+This guide resets the CPA Manager Plus Manager Server admin key used by the full Docker / native Manager Server-hosted panel. It does not reset the CPA Management Key, and it does not recover a lost `data.key`.
+
+The reset command edits the local SQLite database. Stop Manager Server first so SQLite is not being written while the credential changes.
+
+## What the Command Does
+
+`cpa-manager-plus reset-admin-key` replaces `settings.admin_credential_v1` in the Manager Server SQLite database with a new salted HMAC credential.
+
+- If no key is provided, it generates a long random `cmp_admin_...` key using the same generator as first startup.
+- If a key is provided, the command stores only its digest and does not print the key back.
+- The command does not start the HTTP server, collector, or background workers.
+- The command does not need the CPA Management Key or `data.key`.
+
+The alias `reset-admin-password` is also accepted for users who think of the admin key as a password.
+
+## Before You Start
+
+1. Stop Manager Server.
+2. Back up the full data directory, including `usage.sqlite`, `usage.sqlite-wal`, and `usage.sqlite-shm` when those files exist.
+3. Make sure you are pointing at the real Manager Server database:
+   - Docker default: `/data/usage.sqlite`
+   - Native default: `data/usage.sqlite` next to the binary
+   - Custom deployments: the value of `USAGE_DB_PATH`
+
+## Docker Compose
+
+From the directory that contains your compose file:
+
+```bash
+docker compose -f docker-compose.manager.yml stop cpa-manager-plus
+docker compose -f docker-compose.manager.yml run --rm cpa-manager-plus reset-admin-key
+docker compose -f docker-compose.manager.yml up -d cpa-manager-plus
+```
+
+The command prints a generated key once:
+
+```text
+CPA Manager Plus admin key reset.
+New admin key: cmp_admin_...
+Save this value now. It will not be shown again.
+```
+
+Use that key on the Manager Server login page after restart.
+
+## Docker Named Volume
+
+If you run the container manually with the default named volume:
+
+```bash
+docker stop cpa-manager-plus
+docker run --rm \
+  -v cpa-manager-plus-data:/data \
+  seakee/cpa-manager-plus:latest \
+  reset-admin-key
+docker start cpa-manager-plus
+```
+
+If you use the GitHub Container Registry image, replace `seakee/cpa-manager-plus:latest` with `ghcr.io/seakee/cpa-manager-plus:latest`.
+
+## Docker Host Directory Mount
+
+If your container maps a host directory to `/data`, mount the same directory in the reset container:
+
+```bash
+docker stop cpa-manager-plus
+cp -a /srv/cpa-manager-plus-data /srv/cpa-manager-plus-data.backup
+docker run --rm \
+  -v /srv/cpa-manager-plus-data:/data \
+  seakee/cpa-manager-plus:latest \
+  reset-admin-key
+docker start cpa-manager-plus
+```
+
+## Provide a Specific Admin Key
+
+Prefer `--admin-key-file` so the key is not stored in shell history:
+
+```bash
+printf '%s\n' 'replace-with-a-long-random-admin-key' > /srv/new-cpamp-admin-key.txt
+docker stop cpa-manager-plus
+docker run --rm \
+  -v cpa-manager-plus-data:/data \
+  -v /srv/new-cpamp-admin-key.txt:/run/secrets/new_admin_key:ro \
+  seakee/cpa-manager-plus:latest \
+  reset-admin-key --admin-key-file /run/secrets/new_admin_key
+docker start cpa-manager-plus
+```
+
+`--admin-key` is available for controlled environments, but it may be recorded by shell history or process auditing:
+
+```bash
+cpa-manager-plus reset-admin-key --admin-key 'replace-with-a-long-random-admin-key'
+```
+
+## Native Packages
+
+Stop the native process first. Then run the command from the extracted package directory:
+
+macOS / Linux:
+
+```bash
+./cpa-manager-plus reset-admin-key
+```
+
+Windows PowerShell:
+
+```powershell
+.\cpa-manager-plus.exe reset-admin-key
+```
+
+If your SQLite database is not in the default package data directory, pass it explicitly:
+
+macOS / Linux:
+
+```bash
+./cpa-manager-plus reset-admin-key --db-path /path/to/usage.sqlite
+```
+
+Windows PowerShell:
+
+```powershell
+.\cpa-manager-plus.exe reset-admin-key --db-path C:\path\to\usage.sqlite
+```
+
+Then restart the native process and log in with the new admin key.
+
+## Troubleshooting
+
+- **`SQLite database not found`**: you are not running the command in the same configured environment as Manager Server. Pass `--db-path`, or mount the correct Docker volume/host directory.
+- **`is empty` / `does not look like a CPA Manager Plus Manager Server database`**: the path points to the wrong file or to a newly created empty file. Find the real `usage.sqlite` from the Manager Server data directory.
+- **`database is locked`**: Manager Server or another process is still using SQLite. Stop it and rerun the command.
+- **Login still fails**: confirm the panel is using the same Manager Server whose database was reset. For Docker, verify the volume name or host mount path.
+- **Generated key was not saved**: rerun the command while Manager Server is stopped. A new random key will be generated.
+
+## Security Notes
+
+- Treat the generated `cmp_admin_...` value as a secret.
+- Rotate any stored deployment secret if the old admin key may have leaked.
+- This reset only changes Manager Server authentication. CPA credentials and encrypted CPA Manager Plus configuration are unchanged.

--- a/docs/reset-admin-key.zh-CN.md
+++ b/docs/reset-admin-key.zh-CN.md
@@ -1,0 +1,141 @@
+# 重置 Manager Server 管理员密钥
+
+本文用于重置 CPA Manager Plus 完整 Docker / 原生 Manager Server 托管面板使用的管理员密钥。它不会重置 CPA Management Key，也不能恢复丢失的 `data.key`。
+
+重置命令会直接修改本地 SQLite 数据库。执行前请先停止 Manager Server，避免服务运行中继续写入 SQLite。
+
+## 命令作用
+
+`cpa-manager-plus reset-admin-key` 会替换 Manager Server SQLite 中的 `settings.admin_credential_v1`，写入新的盐和 HMAC 摘要。
+
+- 不指定密钥时，会复用首次启动初始化方案，生成一个长随机 `cmp_admin_...` 管理员密钥。
+- 指定密钥时，只保存摘要，命令不会把指定密钥回显到输出。
+- 命令不会启动 HTTP 服务、采集器或后台任务。
+- 命令不需要 CPA Management Key，也不需要 `data.key`。
+
+也可以使用别名 `reset-admin-password`，方便把管理员密钥理解为登录密码的用户。
+
+## 执行前检查
+
+1. 停止 Manager Server。
+2. 备份完整数据目录；如果存在 `usage.sqlite-wal`、`usage.sqlite-shm`，也要一起备份。
+3. 确认命令指向真实的 Manager Server 数据库：
+   - Docker 默认：`/data/usage.sqlite`
+   - 原生包默认：二进制旁边的 `data/usage.sqlite`
+   - 自定义部署：`USAGE_DB_PATH` 的值
+
+## Docker Compose
+
+在 compose 文件所在目录执行：
+
+```bash
+docker compose -f docker-compose.manager.yml stop cpa-manager-plus
+docker compose -f docker-compose.manager.yml run --rm cpa-manager-plus reset-admin-key
+docker compose -f docker-compose.manager.yml up -d cpa-manager-plus
+```
+
+命令会输出一次新生成的密钥：
+
+```text
+CPA Manager Plus admin key reset.
+New admin key: cmp_admin_...
+Save this value now. It will not be shown again.
+```
+
+重启后在 Manager Server 登录页使用这个新密钥登录。
+
+## Docker Named Volume
+
+如果你手动运行容器并使用默认命名卷：
+
+```bash
+docker stop cpa-manager-plus
+docker run --rm \
+  -v cpa-manager-plus-data:/data \
+  seakee/cpa-manager-plus:latest \
+  reset-admin-key
+docker start cpa-manager-plus
+```
+
+如果使用 GitHub Container Registry 镜像，请把 `seakee/cpa-manager-plus:latest` 替换为 `ghcr.io/seakee/cpa-manager-plus:latest`。
+
+## Docker 宿主机目录挂载
+
+如果容器把宿主机目录映射到 `/data`，重置容器也要挂载同一个目录：
+
+```bash
+docker stop cpa-manager-plus
+cp -a /srv/cpa-manager-plus-data /srv/cpa-manager-plus-data.backup
+docker run --rm \
+  -v /srv/cpa-manager-plus-data:/data \
+  seakee/cpa-manager-plus:latest \
+  reset-admin-key
+docker start cpa-manager-plus
+```
+
+## 指定管理员密钥
+
+推荐使用 `--admin-key-file`，避免密钥进入 shell history：
+
+```bash
+printf '%s\n' 'replace-with-a-long-random-admin-key' > /srv/new-cpamp-admin-key.txt
+docker stop cpa-manager-plus
+docker run --rm \
+  -v cpa-manager-plus-data:/data \
+  -v /srv/new-cpamp-admin-key.txt:/run/secrets/new_admin_key:ro \
+  seakee/cpa-manager-plus:latest \
+  reset-admin-key --admin-key-file /run/secrets/new_admin_key
+docker start cpa-manager-plus
+```
+
+`--admin-key` 也可用于受控环境，但可能被 shell history 或进程审计记录：
+
+```bash
+cpa-manager-plus reset-admin-key --admin-key 'replace-with-a-long-random-admin-key'
+```
+
+## 原生包
+
+先停止原生进程，再进入解压后的程序目录执行：
+
+macOS / Linux：
+
+```bash
+./cpa-manager-plus reset-admin-key
+```
+
+Windows PowerShell：
+
+```powershell
+.\cpa-manager-plus.exe reset-admin-key
+```
+
+如果 SQLite 数据库不在默认数据目录，显式指定路径：
+
+macOS / Linux：
+
+```bash
+./cpa-manager-plus reset-admin-key --db-path /path/to/usage.sqlite
+```
+
+Windows PowerShell：
+
+```powershell
+.\cpa-manager-plus.exe reset-admin-key --db-path C:\path\to\usage.sqlite
+```
+
+然后重新启动原生进程，并使用新的管理员密钥登录。
+
+## 排障
+
+- **`SQLite database not found`**：当前命令没有运行在 Manager Server 的真实配置环境中。请传入 `--db-path`，或挂载正确的 Docker volume / 宿主机目录。
+- **`is empty` / `does not look like a CPA Manager Plus Manager Server database`**：路径指向了错误文件或新建的空文件。请从 Manager Server 数据目录中找到真实的 `usage.sqlite`。
+- **`database is locked`**：Manager Server 或其他进程仍在使用 SQLite。停止相关进程后重试。
+- **重置后仍无法登录**：确认面板访问的是同一个 Manager Server。Docker 场景请检查 volume 名称或宿主机挂载路径。
+- **生成的新密钥没有保存**：在 Manager Server 停止状态下重新执行命令，会生成另一个随机密钥。
+
+## 安全提示
+
+- 把生成的 `cmp_admin_...` 当作密钥保存。
+- 如果旧管理员密钥可能泄露，请同步轮换部署系统中保存的旧密钥。
+- 该命令只修改 Manager Server 登录凭证，不会修改 CPA 凭证或已加密保存的 CPA Manager Plus 配置。


### PR DESCRIPTION
## Summary
Add an offline Manager Server admin key reset command for Docker and native package deployments.

## Changes
- Add `reset-admin-key` / `reset-admin-password` CLI handling.
- Reuse existing admin credential hashing and random key generation.
- Validate existing CPAMP SQLite schema before writing to avoid wrong-target resets.
- Add standalone English and Chinese reset guides.
- Include `docs/` in native release packages.

## Testing
- `go test ./internal/command/adminreset ./internal/service/adminauth ./internal/config`
- `go test ./...`
- `git diff --check`