### PR TITLE
fix: support cost multipliers for Priority/Fast service tiers

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/aggregate.go
+++ b/apps/manager-server/internal/repository/usageevent/aggregate.go
@@ -25,6 +25,7 @@ type Aggregate struct {
 type ModelStat struct {
 	Model               string
 	BillingModel        string
+	ServiceTier         string
 	Calls               int64
 	SuccessCalls        int64
 	InputTokens         int64
@@ -109,6 +110,7 @@ const topModelsSQL = `with top_models as (
 select
 	e.model,
 	coalesce(nullif(e.resolved_model, ''), e.model) as billing_model,
+	coalesce(e.service_tier, '') as service_tier,
 	count(*) as calls,
 	sum(case when e.failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(e.input_tokens), 0),
@@ -121,7 +123,7 @@ select
 from usage_events e
 join top_models t on t.model = e.model
 where e.timestamp_ms >= ? and e.timestamp_ms < ?
-group by e.model, billing_model
+group by e.model, billing_model, coalesce(e.service_tier, '')
 order by max(t.model_calls) desc, e.model, calls desc`
 
 // TopModelsBetween returns the most active models ordered by call count.
@@ -141,6 +143,7 @@ func (r *repository) TopModelsBetween(ctx context.Context, fromMs, toMs int64, l
 		if err := rows.Scan(
 			&stat.Model,
 			&stat.BillingModel,
+			&stat.ServiceTier,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,
@@ -161,6 +164,7 @@ func (r *repository) TopModelsBetween(ctx context.Context, fromMs, toMs int64, l
 const modelStatsSQL = `select
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
 	count(*) as calls,
 	sum(case when failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(input_tokens), 0),
@@ -172,7 +176,7 @@ const modelStatsSQL = `select
 	coalesce(sum(total_tokens), 0)
 from usage_events
 where timestamp_ms >= ? and timestamp_ms < ?
-group by model, billing_model
+group by model, billing_model, coalesce(service_tier, '')
 order by calls desc`
 
 // ModelStatsBetween returns per-model totals for all models in a window.
@@ -189,6 +193,7 @@ func (r *repository) ModelStatsBetween(ctx context.Context, fromMs, toMs int64) 
 		if err := rows.Scan(
 			&stat.Model,
 			&stat.BillingModel,
+			&stat.ServiceTier,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -50,6 +50,7 @@ type ChannelModelStat struct {
 	AuthProviderSnapshot string
 	Model                string
 	BillingModel         string
+	ServiceTier          string
 	Calls                int64
 	SuccessCalls         int64
 	FailureCalls         int64
@@ -60,6 +61,7 @@ type ChannelModelStat struct {
 	CacheCreationTokens  int64
 	TotalTokens          int64
 	AvgLatencyMS         sql.NullFloat64
+	LatencySamples       int64
 }
 
 type FailureSourceStat struct {
@@ -84,6 +86,7 @@ type AccountModelStat struct {
 	SourceHash           string
 	Model                string
 	BillingModel         string
+	ServiceTier          string
 	Calls                int64
 	SuccessCalls         int64
 	FailureCalls         int64
@@ -108,6 +111,7 @@ type APIKeyModelStat struct {
 	SourceHash           string
 	Model                string
 	BillingModel         string
+	ServiceTier          string
 	Calls                int64
 	SuccessCalls         int64
 	FailureCalls         int64
@@ -229,6 +233,7 @@ func (r *repository) ModelStatsWithFilter(ctx context.Context, filter AnalyticsF
 	query := `select
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
 	count(*) as calls,
 	sum(case when failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(input_tokens), 0),
@@ -239,7 +244,7 @@ func (r *repository) ModelStatsWithFilter(ctx context.Context, filter AnalyticsF
 	coalesce(sum(cache_creation_tokens), 0),
 	coalesce(sum(total_tokens), 0)
 from usage_events ` + where + `
-group by model, billing_model
+group by model, billing_model, coalesce(service_tier, '')
 order by calls desc`
 	if limit > 0 {
 		query = `with filtered as (
@@ -255,6 +260,7 @@ top_models as (
 select
 	f.model,
 	coalesce(nullif(f.resolved_model, ''), f.model) as billing_model,
+	coalesce(f.service_tier, '') as service_tier,
 	count(*) as calls,
 	sum(case when f.failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(f.input_tokens), 0),
@@ -266,7 +272,7 @@ select
 	coalesce(sum(f.total_tokens), 0)
 from filtered f
 join top_models t on t.model = f.model
-group by f.model, billing_model
+group by f.model, billing_model, coalesce(f.service_tier, '')
 order by max(t.model_calls) desc, f.model, calls desc`
 		args = append(args, limit)
 	}
@@ -282,6 +288,7 @@ order by max(t.model_calls) desc, f.model, calls desc`
 		if err := rows.Scan(
 			&stat.Model,
 			&stat.BillingModel,
+			&stat.ServiceTier,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,
@@ -366,6 +373,7 @@ func (r *repository) ChannelModelStatsWithFilter(ctx context.Context, filter Ana
 	coalesce(nullif(max(auth_provider_snapshot), ''), max(provider), ''),
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
 	count(*),
 	sum(case when failed = 0 then 1 else 0 end),
 	sum(case when failed = 1 then 1 else 0 end),
@@ -375,9 +383,10 @@ func (r *repository) ChannelModelStatsWithFilter(ctx context.Context, filter Ana
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
 	coalesce(sum(total_tokens), 0),
-	avg(nullif(latency_ms, 0))
+	avg(nullif(latency_ms, 0)),
+	count(nullif(latency_ms, 0))
 from usage_events `+where+`
-group by auth_index, model, billing_model
+group by auth_index, model, billing_model, coalesce(service_tier, '')
 order by count(*) desc`, args...)
 	if err != nil {
 		return nil, err
@@ -395,6 +404,7 @@ order by count(*) desc`, args...)
 			&stat.AuthProviderSnapshot,
 			&stat.Model,
 			&stat.BillingModel,
+			&stat.ServiceTier,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.FailureCalls,
@@ -405,6 +415,7 @@ order by count(*) desc`, args...)
 			&stat.CacheCreationTokens,
 			&stat.TotalTokens,
 			&stat.AvgLatencyMS,
+			&stat.LatencySamples,
 		); err != nil {
 			return nil, err
 		}
@@ -468,6 +479,7 @@ func (r *repository) AccountModelStatsWithFilter(ctx context.Context, filter Ana
 	coalesce(source_hash, ''),
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
 	count(*),
 	sum(case when failed = 0 then 1 else 0 end),
 	sum(case when failed = 1 then 1 else 0 end),
@@ -481,7 +493,7 @@ func (r *repository) AccountModelStatsWithFilter(ctx context.Context, filter Ana
 	avg(nullif(latency_ms, 0)),
 	count(nullif(latency_ms, 0))
 from usage_events `+where+`
-group by account_snapshot, auth_label_snapshot, coalesce(nullif(auth_provider_snapshot, ''), provider, ''), auth_index, source_hash, model, billing_model
+group by account_snapshot, auth_label_snapshot, coalesce(nullif(auth_provider_snapshot, ''), provider, ''), auth_index, source_hash, model, billing_model, coalesce(service_tier, '')
 order by max(timestamp_ms) desc, count(*) desc`, args...)
 	if err != nil {
 		return nil, err
@@ -500,6 +512,7 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 			&stat.SourceHash,
 			&stat.Model,
 			&stat.BillingModel,
+			&stat.ServiceTier,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.FailureCalls,
@@ -532,6 +545,7 @@ func (r *repository) APIKeyModelStatsWithFilter(ctx context.Context, filter Anal
 	coalesce(source_hash, ''),
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
 	count(*),
 	sum(case when failed = 0 then 1 else 0 end),
 	sum(case when failed = 1 then 1 else 0 end),
@@ -545,7 +559,7 @@ func (r *repository) APIKeyModelStatsWithFilter(ctx context.Context, filter Anal
 	avg(nullif(latency_ms, 0)),
 	count(nullif(latency_ms, 0))
 from usage_events `+where+`
-group by api_key_hash, account_snapshot, auth_label_snapshot, coalesce(nullif(auth_provider_snapshot, ''), provider, ''), auth_index, source_hash, model, billing_model
+group by api_key_hash, account_snapshot, auth_label_snapshot, coalesce(nullif(auth_provider_snapshot, ''), provider, ''), auth_index, source_hash, model, billing_model, coalesce(service_tier, '')
 order by max(timestamp_ms) desc, count(*) desc`, args...)
 	if err != nil {
 		return nil, err
@@ -565,6 +579,7 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 			&stat.SourceHash,
 			&stat.Model,
 			&stat.BillingModel,
+			&stat.ServiceTier,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.FailureCalls,

--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -518,9 +518,9 @@ func buildChannelHealth(stats []store.ChannelModelStat, prices map[string]store.
 		entry.row.Failures += stat.FailureCalls
 		entry.row.Tokens += stat.TotalTokens
 		entry.row.Cost += costForChannelStat(stat, prices)
-		if stat.AvgLatencyMS.Valid {
-			entry.latencySum += stat.AvgLatencyMS.Float64
-			entry.latencyN++
+		if stat.AvgLatencyMS.Valid && stat.LatencySamples > 0 {
+			entry.latencySum += stat.AvgLatencyMS.Float64 * float64(stat.LatencySamples)
+			entry.latencyN += stat.LatencySamples
 		}
 	}
 
@@ -666,7 +666,7 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 	if model == "" {
 		model = stat.Model
 	}
-	return pricing.CostForModel(model, pricing.ModelTokens{
+	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -680,7 +680,7 @@ func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.Mod
 	if model == "" {
 		model = stat.Model
 	}
-	return pricing.CostForModel(model, pricing.ModelTokens{
+	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,

--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -196,6 +196,59 @@ func TestSummaryUsesResolvedModelPricing(t *testing.T) {
 	}
 }
 
+func TestSummaryPricesPriorityAndDefaultServiceTiersSeparately(t *testing.T) {
+	db := newDashboardTestStore(t)
+	ctx := context.Background()
+	todayStart := int64(1_778_010_000_000)
+	nowMS := todayStart + 60*60*1000
+
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"gpt-5.4": {Prompt: 2.5},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	latency100 := int64(100)
+	latency200 := int64(200)
+	latency1000 := int64(1000)
+	standard := dashboardEvent("dashboard-tier-default", todayStart+1_000, "gpt-5.4", false, 1_000_000, 0, 0, 0, 0, 1_000_000, &latency100)
+	standard.ServiceTier = "default"
+	standardSecond := dashboardEvent("dashboard-tier-default-second", todayStart+1_500, "gpt-5.4", false, 0, 0, 0, 0, 0, 0, &latency200)
+	standardSecond.ServiceTier = "default"
+	priority := dashboardEvent("dashboard-tier-priority", todayStart+2_000, "gpt-5.4", false, 1_000_000, 0, 0, 0, 0, 1_000_000, &latency1000)
+	priority.ServiceTier = "priority"
+	if _, err := db.InsertEvents(ctx, []usage.Event{standard, standardSecond, priority}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Summary(ctx, SummaryParams{
+		TodayStartMS:   todayStart,
+		NowMS:          nowMS,
+		TopModels:      5,
+		RecentFailures: 1,
+	})
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+
+	if math.Abs(resp.Today.TotalCost-7.5) > 0.000001 {
+		t.Fatalf("today cost = %v, want 7.5", resp.Today.TotalCost)
+	}
+	if len(resp.TopModelsToday) != 1 || resp.TopModelsToday[0].Calls != 3 ||
+		math.Abs(resp.TopModelsToday[0].Cost-7.5) > 0.000001 {
+		t.Fatalf("top models = %#v", resp.TopModelsToday)
+	}
+	if len(resp.ModelCostRank) != 1 || math.Abs(resp.ModelCostRank[0].Cost-7.5) > 0.000001 {
+		t.Fatalf("model cost rank = %#v", resp.ModelCostRank)
+	}
+	if len(resp.ChannelHealth) != 1 || math.Abs(resp.ChannelHealth[0].Cost-7.5) > 0.000001 {
+		t.Fatalf("channel health = %#v", resp.ChannelHealth)
+	}
+	if resp.ChannelHealth[0].AverageLatencyMS == nil ||
+		math.Abs(*resp.ChannelHealth[0].AverageLatencyMS-(1300.0/3.0)) > 0.000001 {
+		t.Fatalf("channel health latency = %#v, want weighted 433.333333", resp.ChannelHealth[0].AverageLatencyMS)
+	}
+}
+
 func newDashboardTestStore(t *testing.T) *store.Store {
 	t.Helper()
 	db, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -710,9 +710,9 @@ func buildChannelShare(stats []store.ChannelModelStat, prices map[string]store.M
 		entry.row.Failure += stat.FailureCalls
 		entry.row.Tokens += stat.TotalTokens
 		entry.row.Cost += costForChannelStat(stat, prices)
-		if stat.AvgLatencyMS.Valid {
-			entry.latencySum += stat.AvgLatencyMS.Float64
-			entry.latencyN++
+		if stat.AvgLatencyMS.Valid && stat.LatencySamples > 0 {
+			entry.latencySum += stat.AvgLatencyMS.Float64 * float64(stat.LatencySamples)
+			entry.latencyN += stat.LatencySamples
 		}
 	}
 	result := make([]ChannelShareRow, 0, len(grouped))
@@ -1202,7 +1202,7 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 	if model == "" {
 		model = stat.Model
 	}
-	return pricing.CostForModel(model, pricing.ModelTokens{
+	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -1216,7 +1216,7 @@ func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.Mod
 	if model == "" {
 		model = stat.Model
 	}
-	return pricing.CostForModel(model, pricing.ModelTokens{
+	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -1230,7 +1230,7 @@ func costForAccountModelStat(stat store.AccountModelStat, prices map[string]stor
 	if model == "" {
 		model = stat.Model
 	}
-	return pricing.CostForModel(model, pricing.ModelTokens{
+	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -1244,7 +1244,7 @@ func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.
 	if model == "" {
 		model = stat.Model
 	}
-	return pricing.CostForModel(model, pricing.ModelTokens{
+	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -293,6 +293,93 @@ func TestAnalyticsUsesResolvedModelPricingInAggregates(t *testing.T) {
 	}
 }
 
+func TestAnalyticsPricesPriorityAndDefaultServiceTiersSeparately(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_010_000_000)
+	toMS := fromMS + 60*60*1000
+
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"gpt-5.4": {Prompt: 2.5},
+	}); err != nil {
+		t.Fatalf("save model prices: %v", err)
+	}
+
+	latency100 := int64(100)
+	latency200 := int64(200)
+	latency1000 := int64(1000)
+	standard := monitoringEvent("tier-default", fromMS+1_000, "gpt-5.4", "auth-1", "source-a", false, 1_000_000, 0, 0, 0, 1_000_000, &latency100)
+	standard.ServiceTier = "default"
+	standard.AccountSnapshot = "team@example.com"
+	standard.AuthLabelSnapshot = "Team"
+	standard.APIKeyHash = "client-key"
+	standardSecond := monitoringEvent("tier-default-second", fromMS+1_500, "gpt-5.4", "auth-1", "source-a", false, 0, 0, 0, 0, 0, &latency200)
+	standardSecond.ServiceTier = "default"
+	standardSecond.AccountSnapshot = "team@example.com"
+	standardSecond.AuthLabelSnapshot = "Team"
+	standardSecond.APIKeyHash = "client-key"
+	priority := monitoringEvent("tier-priority", fromMS+2_000, "gpt-5.4", "auth-1", "source-a", false, 1_000_000, 0, 0, 0, 1_000_000, &latency1000)
+	priority.ServiceTier = "priority"
+	priority.AccountSnapshot = "team@example.com"
+	priority.AuthLabelSnapshot = "Team"
+	priority.APIKeyHash = "client-key"
+	if _, err := db.InsertEvents(ctx, []usage.Event{standard, standardSecond, priority}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Include: Include{
+			Summary:      true,
+			ModelShare:   true,
+			ModelStats:   true,
+			ChannelShare: true,
+			AccountStats: true,
+			APIKeyStats:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+
+	assertCost := func(name string, got float64) {
+		t.Helper()
+		if math.Abs(got-7.5) > 0.000001 {
+			t.Fatalf("%s cost = %v, want 7.5", name, got)
+		}
+	}
+	if resp.Summary == nil {
+		t.Fatal("summary is nil")
+	}
+	assertCost("summary", resp.Summary.TotalCost)
+	if len(resp.ModelStats) != 1 || resp.ModelStats[0].Calls != 3 {
+		t.Fatalf("model stats = %#v", resp.ModelStats)
+	}
+	assertCost("model stats", resp.ModelStats[0].Cost)
+	if len(resp.ModelShare) != 1 {
+		t.Fatalf("model share = %#v", resp.ModelShare)
+	}
+	assertCost("model share", resp.ModelShare[0].Cost)
+	if len(resp.ChannelShare) != 1 {
+		t.Fatalf("channel share = %#v", resp.ChannelShare)
+	}
+	assertCost("channel share", resp.ChannelShare[0].Cost)
+	if resp.ChannelShare[0].AvgLatencyMS == nil || math.Abs(*resp.ChannelShare[0].AvgLatencyMS-(1300.0/3.0)) > 0.000001 {
+		t.Fatalf("channel latency = %#v, want weighted 433.333333", resp.ChannelShare[0].AvgLatencyMS)
+	}
+	if len(resp.AccountStats) != 1 || len(resp.AccountStats[0].Models) != 1 {
+		t.Fatalf("account stats = %#v", resp.AccountStats)
+	}
+	assertCost("account stats", resp.AccountStats[0].Cost)
+	assertCost("account model stats", resp.AccountStats[0].Models[0].Cost)
+	if len(resp.APIKeyStats) != 1 || len(resp.APIKeyStats[0].Models) != 1 {
+		t.Fatalf("api key stats = %#v", resp.APIKeyStats)
+	}
+	assertCost("api key stats", resp.APIKeyStats[0].Cost)
+	assertCost("api key model stats", resp.APIKeyStats[0].Models[0].Cost)
+}
+
 func TestAnalyticsAppliesFilters(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/pricing/cost.go
+++ b/apps/manager-server/internal/service/pricing/cost.go
@@ -1,7 +1,11 @@
 // Package pricing converts token aggregates into monetary cost given a model price book.
 package pricing
 
-import "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+import (
+	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+)
 
 // PerMillion divides by one million to convert token-priced units (per 1M tokens).
 const PerMillion = 1_000_000.0
@@ -51,6 +55,37 @@ func CostForModel(modelName string, tokens ModelTokens, prices map[string]model.
 		float64(cachedTokens)*price.Cache/PerMillion
 }
 
+// ServiceTierMultiplier returns the OpenAI Priority processing multiplier for
+// the actual usage service tier. This compatibility layer keeps today's tier
+// multiplier rules centralized; a future price model should store explicit
+// per-tier prices such as standard, priority, flex, and batch.
+func ServiceTierMultiplier(modelName string, serviceTier string) float64 {
+	tier := strings.ToLower(strings.TrimSpace(serviceTier))
+	if tier != "priority" && tier != "fast" {
+		return 1
+	}
+
+	modelName = strings.ToLower(strings.TrimSpace(modelName))
+	switch {
+	case isModelFamily(modelName, "gpt-5.5"):
+		return 2.5
+	case isModelFamily(modelName, "gpt-5.4-mini"):
+		return 2
+	case isModelFamily(modelName, "gpt-5.4"):
+		return 2
+	case isModelFamily(modelName, "gpt-5.3-codex"):
+		return 2
+	default:
+		return 1
+	}
+}
+
+// CostForModelWithServiceTier computes standard token cost first, then applies
+// the multiplier for the actual service_tier recorded by usage.
+func CostForModelWithServiceTier(modelName string, serviceTier string, tokens ModelTokens, prices map[string]model.ModelPrice) float64 {
+	return CostForModel(modelName, tokens, prices) * ServiceTierMultiplier(modelName, serviceTier)
+}
+
 // SumCost folds CostForModel over a slice of (model, tokens) tuples.
 type Item struct {
 	Model  string
@@ -78,4 +113,8 @@ func fallbackPrice(value float64, fallback float64) float64 {
 		return value
 	}
 	return fallback
+}
+
+func isModelFamily(modelName string, family string) bool {
+	return modelName == family || strings.HasPrefix(modelName, family+"-")
 }

--- a/apps/manager-server/internal/service/pricing/cost_test.go
+++ b/apps/manager-server/internal/service/pricing/cost_test.go
@@ -72,3 +72,64 @@ func TestCostForModelPricesResidualCompatCachedWithFineGrainedCache(t *testing.T
 		t.Fatalf("cost = %v, want 2.3", cost)
 	}
 }
+
+func TestServiceTierMultiplier(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		serviceTier string
+		want        float64
+	}{
+		{name: "gpt-5.4 default", model: "gpt-5.4", serviceTier: "default", want: 1},
+		{name: "gpt-5.4 priority", model: "gpt-5.4", serviceTier: "priority", want: 2},
+		{name: "gpt-5.4 fast", model: "gpt-5.4", serviceTier: "fast", want: 2},
+		{name: "gpt-5.4 mini priority", model: "gpt-5.4-mini", serviceTier: "priority", want: 2},
+		{name: "gpt-5.5 priority", model: "gpt-5.5", serviceTier: "priority", want: 2.5},
+		{name: "gpt-5.3 codex priority", model: "gpt-5.3-codex", serviceTier: "priority", want: 2},
+		{name: "unknown tier", model: "gpt-5.4", serviceTier: "accelerated", want: 1},
+		{name: "unknown priority model", model: "gpt-unknown", serviceTier: "priority", want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ServiceTierMultiplier(tt.model, tt.serviceTier)
+			if got != tt.want {
+				t.Fatalf("ServiceTierMultiplier(%q, %q) = %v, want %v", tt.model, tt.serviceTier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCostForModelWithServiceTier(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.4": {Prompt: 2.5, Completion: 5, Cache: 1},
+	}
+
+	tokens := ModelTokens{InputTokens: 1_000_000}
+	if cost := CostForModelWithServiceTier("gpt-5.4", "default", tokens, prices); math.Abs(cost-2.5) > 0.000001 {
+		t.Fatalf("default cost = %v, want 2.5", cost)
+	}
+	if cost := CostForModelWithServiceTier("gpt-5.4", "priority", tokens, prices); math.Abs(cost-5) > 0.000001 {
+		t.Fatalf("priority cost = %v, want 5", cost)
+	}
+	if cost := CostForModelWithServiceTier("missing-model", "priority", tokens, prices); cost != 0 {
+		t.Fatalf("missing model cost = %v, want 0", cost)
+	}
+}
+
+func TestCostForModelWithServiceTierPreservesCacheBuckets(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.4": {Prompt: 2, Completion: 4, Cache: 1, CacheRead: 0.5, CacheCreation: 3},
+	}
+
+	cost := CostForModelWithServiceTier("gpt-5.4", "priority", ModelTokens{
+		InputTokens:         1_000_000,
+		CachedTokens:        100_000,
+		CacheReadTokens:     200_000,
+		CacheCreationTokens: 100_000,
+	}, prices)
+
+	if math.Abs(cost-4.6) > 0.000001 {
+		t.Fatalf("priority cache cost = %v, want 4.6", cost)
+	}
+}

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -7,6 +7,7 @@ import {
   collectUsageDetailsWithEndpoint,
   compatibleCachedTokens,
   extractTotalTokens,
+  getServiceTierMultiplier,
   normalizeUsageSourceId,
 } from './usage';
 import { maskSensitiveText } from './format';
@@ -313,6 +314,20 @@ describe('calculateCost model price preference', () => {
     expect(cost).toBeCloseTo(50);
   });
 
+  it('applies the tier multiplier to the requested price fallback', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 1_000_000, output_tokens: 0 },
+        __modelName: 'gpt-5.4',
+        __resolvedModel: 'unknown-upstream',
+        service_tier: 'priority',
+      },
+      prices
+    );
+
+    expect(cost).toBeCloseTo(100);
+  });
+
   it('charges cached input tokens only at the cache price', () => {
     const cost = calculateCost(
       {
@@ -353,5 +368,89 @@ describe('calculateCost model price preference', () => {
     );
 
     expect(cost).toBeCloseTo(2.3);
+  });
+
+  it('applies gpt-5.4 priority service tier multiplier', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 1_000_000 },
+        __modelName: 'gpt-5.4',
+        service_tier: 'priority',
+      },
+      {
+        'gpt-5.4': { prompt: 2.5, completion: 5, cache: 1 },
+      }
+    );
+
+    expect(cost).toBeCloseTo(5);
+  });
+
+  it('applies gpt-5.5 priority service tier multiplier', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 1_000_000 },
+        __modelName: 'gpt-5.5',
+        serviceTier: 'priority',
+      },
+      {
+        'gpt-5.5': { prompt: 2, completion: 4, cache: 1 },
+      }
+    );
+
+    expect(cost).toBeCloseTo(5);
+  });
+
+  it('keeps default and missing service tier at standard cost', () => {
+    const modelPrices = {
+      'gpt-5.4': { prompt: 2.5, completion: 5, cache: 1 },
+    };
+
+    expect(
+      calculateCost(
+        {
+          tokens: { input_tokens: 1_000_000 },
+          __modelName: 'gpt-5.4',
+          service_tier: 'default',
+        },
+        modelPrices
+      )
+    ).toBeCloseTo(2.5);
+    expect(
+      calculateCost(
+        {
+          tokens: { input_tokens: 1_000_000 },
+          __modelName: 'gpt-5.4',
+        },
+        modelPrices
+      )
+    ).toBeCloseTo(2.5);
+  });
+
+  it('does not guess priority multiplier for unknown models', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 1_000_000 },
+        __modelName: 'unknown-model',
+        service_tier: 'priority',
+      },
+      {
+        'unknown-model': { prompt: 2.5, completion: 5, cache: 1 },
+      }
+    );
+
+    expect(cost).toBeCloseTo(2.5);
+  });
+});
+
+describe('getServiceTierMultiplier', () => {
+  it('matches backend priority tier rules', () => {
+    expect(getServiceTierMultiplier('gpt-5.4', 'default')).toBe(1);
+    expect(getServiceTierMultiplier('gpt-5.4', 'priority')).toBe(2);
+    expect(getServiceTierMultiplier('gpt-5.4', 'fast')).toBe(2);
+    expect(getServiceTierMultiplier('gpt-5.4-mini', 'priority')).toBe(2);
+    expect(getServiceTierMultiplier('gpt-5.5', 'priority')).toBe(2.5);
+    expect(getServiceTierMultiplier('gpt-5.3-codex', 'priority')).toBe(2);
+    expect(getServiceTierMultiplier('gpt-5.4', 'unknown')).toBe(1);
+    expect(getServiceTierMultiplier('unknown-model', 'priority')).toBe(1);
   });
 });

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -124,6 +124,28 @@ const readDetailString = (value: unknown): string | undefined => {
   return text || undefined;
 };
 
+const isModelFamily = (modelName: string, family: string): boolean =>
+  modelName === family || modelName.startsWith(`${family}-`);
+
+export function getServiceTierMultiplier(modelName: string, serviceTier?: string): number {
+  const tier = String(serviceTier ?? '')
+    .trim()
+    .toLowerCase();
+  if (tier !== 'priority' && tier !== 'fast') return 1;
+
+  const normalizedModel = String(modelName ?? '')
+    .trim()
+    .toLowerCase();
+  // OpenAI Priority pricing currently publishes tier multipliers for these
+  // model families. Keep this as a compatibility layer until model prices can
+  // be represented per tier, such as standard, priority, flex, and batch.
+  if (isModelFamily(normalizedModel, 'gpt-5.5')) return 2.5;
+  if (isModelFamily(normalizedModel, 'gpt-5.4-mini')) return 2;
+  if (isModelFamily(normalizedModel, 'gpt-5.4')) return 2;
+  if (isModelFamily(normalizedModel, 'gpt-5.3-codex')) return 2;
+  return 1;
+}
+
 export const compatibleCachedTokens = (
   cachedTokens: unknown,
   cacheTokens: unknown,
@@ -556,12 +578,18 @@ export function extractTotalTokens(detail: unknown): number {
 }
 
 export function calculateCost(
-  detail: Pick<UsageDetail, 'tokens' | '__modelName' | '__resolvedModel'>,
+  detail: Pick<
+    UsageDetail,
+    'tokens' | '__modelName' | '__resolvedModel' | 'service_tier' | 'serviceTier'
+  >,
   modelPrices: Record<string, ModelPrice>
 ): number {
   const resolvedModel = detail.__resolvedModel || '';
   const requestedModel = detail.__modelName || '';
-  const price = modelPrices[resolvedModel] || modelPrices[requestedModel];
+  const resolvedPrice = resolvedModel ? modelPrices[resolvedModel] : undefined;
+  const requestedPrice = requestedModel ? modelPrices[requestedModel] : undefined;
+  const price = resolvedPrice || requestedPrice;
+  const pricedModel = resolvedPrice ? resolvedModel : requestedPrice ? requestedModel : '';
   if (!price) return 0;
 
   const inputTokens = Math.max(toFiniteNumber(detail.tokens.input_tokens), 0);
@@ -574,24 +602,28 @@ export function calculateCost(
   const cacheCreationTokens = Math.max(toFiniteNumber(detail.tokens.cache_creation_tokens), 0);
   const promptPrice = Number(price.prompt) || 0;
   const completionPrice = Number(price.completion) || 0;
+  let standardCost = 0;
   if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
     const cacheReadPrice = Number(price.cacheRead) || Number(price.cache) || 0;
     const cacheCreationPrice = Number(price.cacheCreation) || promptPrice;
     const promptTokens = Math.max(inputTokens - cachedTokens, 0);
-    const total =
+    standardCost =
       (promptTokens / TOKENS_PER_PRICE_UNIT) * promptPrice +
       (completionTokens / TOKENS_PER_PRICE_UNIT) * completionPrice +
       (cachedTokens / TOKENS_PER_PRICE_UNIT) * (Number(price.cache) || 0) +
       (cacheReadTokens / TOKENS_PER_PRICE_UNIT) * cacheReadPrice +
       (cacheCreationTokens / TOKENS_PER_PRICE_UNIT) * cacheCreationPrice;
-    return Number.isFinite(total) && total > 0 ? total : 0;
+  } else {
+    const promptTokens = Math.max(inputTokens - cachedTokens, 0);
+    const promptCost = (promptTokens / TOKENS_PER_PRICE_UNIT) * promptPrice;
+    const completionCost = (completionTokens / TOKENS_PER_PRICE_UNIT) * completionPrice;
+    const cachedCost = (cachedTokens / TOKENS_PER_PRICE_UNIT) * (Number(price.cache) || 0);
+    standardCost = promptCost + cachedCost + completionCost;
   }
 
-  const promptTokens = Math.max(inputTokens - cachedTokens, 0);
-  const promptCost = (promptTokens / TOKENS_PER_PRICE_UNIT) * promptPrice;
-  const completionCost = (completionTokens / TOKENS_PER_PRICE_UNIT) * completionPrice;
-  const cachedCost = (cachedTokens / TOKENS_PER_PRICE_UNIT) * (Number(price.cache) || 0);
-  const total = promptCost + cachedCost + completionCost;
+  const serviceTier = detail.service_tier ?? detail.serviceTier;
+  const multiplier = getServiceTierMultiplier(pricedModel, serviceTier);
+  const total = standardCost * multiplier;
   return Number.isFinite(total) && total > 0 ? total : 0;
 }
 


### PR DESCRIPTION
# English Version

## PR Title

fix: support cost multipliers for Priority/Fast service tiers

## PR Description

### Background

Fixes issue #97: CPAMP did not apply OpenAI Priority processing / fast-mode cost multipliers when estimating usage cost. As a result, cost estimates could be lower than expected when fast / priority mode was used.

CPA usage records already include the `service_tier` field, and CPAMP already parses and displays it. This PR updates both backend aggregated cost calculation and frontend fallback cost calculation to use the actual recorded `service_tier`.

### Changes

* Added tier-aware cost calculation:

  * Kept the existing `CostForModel` behavior unchanged.
  * Added `CostForModelWithServiceTier`.
  * Added a centralized `ServiceTierMultiplier` helper.
* Added current Priority/Fast multipliers:

  * `gpt-5.5`: 2.5x
  * `gpt-5.4`: 2x
  * `gpt-5.4-mini`: 2x
  * `gpt-5.3-codex`: 2x
* Kept empty tier, `default`, unknown tiers, and unknown models at 1x.
* Added `service_tier` as a grouping dimension in backend usage analytics, preventing default and priority requests for the same model from being merged before cost calculation.
* Updated Dashboard and Monitoring cost calculation to use the actual `service_tier`.
* Updated frontend `calculateCost` to read `service_tier` / `serviceTier`, keeping local fallback cost calculation consistent with the backend.
* Added backend and frontend tests covering priority, fast, default, unknown models, cache buckets, and mixed-tier aggregation.

### Why grouping by service_tier is necessary

The same billing model can have both default and priority requests. If tokens are merged first and then a single multiplier is applied, the final cost can be incorrect.

This PR preserves `service_tier` during aggregation, calculates cost per tier, and then merges the results for display. Therefore:

* default requests are charged at standard cost;
* priority / fast requests use the configured multiplier;
* mixed-tier usage for the same model is aggregated correctly.

### Test Coverage

Added or updated tests for:

* `gpt-5.4` default: 1x
* `gpt-5.4` priority: 2x
* `gpt-5.4` fast: 2x
* `gpt-5.4-mini` priority: 2x
* `gpt-5.5` priority: 2.5x
* `gpt-5.3-codex` priority: 2x
* unknown tier: 1x
* unknown model + priority: 1x
* missing model price still returns 0
* cacheRead / cacheCreation buckets keep their existing pricing behavior under priority
* mixed default + priority usage for the same model is calculated per tier before being summed
* Monitoring, Dashboard, and frontend fallback cost calculation remain consistent

### Related
Closes #97