### PR TITLE
Sort OpenAI-compatible providers by priority descending

### DIFF
--- a/apps/web/src/components/providers/OpenAISection/OpenAISection.tsx
+++ b/apps/web/src/components/providers/OpenAISection/OpenAISection.tsx
@@ -23,16 +23,18 @@ import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
 import { ProviderStatusBar } from '../ProviderStatusBar';
 import { usePageTransitionLayer } from '@/components/common/PageTransitionLayer';
 import {
-  getOpenAIProviderRecentWindowStats,
   getOpenAIProviderRecentStatusData,
   getOpenAIProviderTotalStats,
   getOpenAIProviderKey,
   getProviderTotalStats,
   type ProviderRecentUsageMap,
 } from '../utils';
-
-type SortOption = 'name' | 'priority' | 'recent-success';
-type SortDirection = 'asc' | 'desc';
+import {
+  sortOpenAIProviders,
+  type IndexedOpenAIProvider,
+  type OpenAIProviderSortDirection as SortDirection,
+  type OpenAIProviderSortOption as SortOption,
+} from './sort';
 
 interface FloatingToolbarStyle {
   left: number;
@@ -54,11 +56,6 @@ interface OpenAISectionProps {
   onEdit: (index: number) => void;
   onDelete: (index: number) => void;
   onToggle: (index: number, enabled: boolean) => void;
-}
-
-interface IndexedOpenAIProvider {
-  config: OpenAIProviderConfig;
-  originalIndex: number;
 }
 
 const getApiKeyEntryRenderKey = (
@@ -87,7 +84,7 @@ export function OpenAISection({
   const actionsDisabled = disableControls || loading || isSwitching;
   const toggleDisabled = disableControls || loading || isSwitching;
   const [sortOption, setSortOption] = useState<SortOption>('priority');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set());
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [dropdownLayout, setDropdownLayout] = useState({ openAbove: false, maxHeight: 300 });
@@ -270,59 +267,12 @@ export function OpenAISection({
   );
 
   const sortedConfigs = useMemo<IndexedOpenAIProvider[]>(() => {
-    const indexed = configs.map((config, originalIndex) => ({ config, originalIndex }));
-    const filtered = indexed.filter(({ config }) => {
-      if (selectedModels.size === 0) return true;
-      return config.models?.some((model) => selectedModels.has(model.name));
+    return sortOpenAIProviders(configs, {
+      sortOption,
+      sortDirection,
+      usageByProvider,
+      selectedModels,
     });
-
-    const sorted = [...filtered];
-    const direction = sortDirection === 'desc' ? -1 : 1;
-    const providerStats =
-      sortOption === 'recent-success'
-        ? new Map(
-            sorted.map(({ config }) => [
-              config,
-              getOpenAIProviderRecentWindowStats(config, usageByProvider),
-            ])
-          )
-        : null;
-
-    switch (sortOption) {
-      case 'name':
-        sorted.sort((a, b) => direction * a.config.name.localeCompare(b.config.name));
-        break;
-      case 'priority':
-        sorted.sort((a, b) => {
-          const priorityA = a.config.priority ?? Number.MAX_SAFE_INTEGER;
-          const priorityB = b.config.priority ?? Number.MAX_SAFE_INTEGER;
-          const priorityDiff = priorityA - priorityB;
-
-          if (priorityDiff !== 0) {
-            return direction * priorityDiff;
-          }
-
-          return direction * a.config.name.localeCompare(b.config.name);
-        });
-        break;
-      case 'recent-success':
-        sorted.sort((a, b) => {
-          const successDiff =
-            (providerStats?.get(a.config)?.success ?? 0) -
-            (providerStats?.get(b.config)?.success ?? 0);
-
-          if (successDiff !== 0) {
-            return direction * successDiff;
-          }
-
-          return direction * a.config.name.localeCompare(b.config.name);
-        });
-        break;
-      default:
-        break;
-    }
-
-    return sorted;
   }, [configs, sortOption, sortDirection, usageByProvider, selectedModels]);
 
   const toggleModelSelection = (modelName: string) => {

--- a/apps/web/src/components/providers/OpenAISection/sort.test.ts
+++ b/apps/web/src/components/providers/OpenAISection/sort.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { OpenAIProviderConfig } from '@/types';
+import { sortOpenAIProvidersByPriority } from './sort';
+
+describe('sortOpenAIProvidersByPriority', () => {
+  const providers: OpenAIProviderConfig[] = [
+    {
+      name: 'unset',
+      baseUrl: 'https://unset.example.com/v1',
+      apiKeyEntries: [],
+    },
+    {
+      name: 'middle',
+      baseUrl: 'https://middle.example.com/v1',
+      apiKeyEntries: [],
+      priority: 3,
+    },
+    {
+      name: 'highest',
+      baseUrl: 'https://highest.example.com/v1',
+      apiKeyEntries: [],
+      priority: 10,
+    },
+    {
+      name: 'lowest',
+      baseUrl: 'https://lowest.example.com/v1',
+      apiKeyEntries: [],
+      priority: -1,
+    },
+  ];
+
+  it('sorts priorities high to low by default and treats missing priority as 0', () => {
+    expect(sortOpenAIProvidersByPriority(providers).map((item) => item.originalIndex)).toEqual([
+      2, 1, 0, 3,
+    ]);
+  });
+
+  it('sorts priorities low to high when requested and treats missing priority as 0', () => {
+    expect(
+      sortOpenAIProvidersByPriority(providers, 'asc').map((item) => item.originalIndex)
+    ).toEqual([3, 0, 1, 2]);
+  });
+
+  it('uses the existing name fallback when effective priorities are equal', () => {
+    const tiedProviders: OpenAIProviderConfig[] = [
+      {
+        name: 'alpha',
+        baseUrl: 'https://alpha.example.com/v1',
+        apiKeyEntries: [],
+        priority: 5,
+      },
+      {
+        name: 'zulu',
+        baseUrl: 'https://zulu.example.com/v1',
+        apiKeyEntries: [],
+        priority: 5,
+      },
+    ];
+
+    expect(sortOpenAIProvidersByPriority(tiedProviders).map((item) => item.config.name)).toEqual([
+      'zulu',
+      'alpha',
+    ]);
+  });
+});

--- a/apps/web/src/components/providers/OpenAISection/sort.ts
+++ b/apps/web/src/components/providers/OpenAISection/sort.ts
@@ -1,0 +1,100 @@
+import type { OpenAIProviderConfig } from '@/types';
+import {
+  getOpenAIProviderRecentWindowStats,
+  type ProviderRecentUsageMap,
+} from '../utils';
+
+export type OpenAIProviderSortDirection = 'asc' | 'desc';
+export type OpenAIProviderSortOption = 'priority' | 'name' | 'recent-success';
+
+export interface IndexedOpenAIProvider {
+  config: OpenAIProviderConfig;
+  originalIndex: number;
+}
+
+interface SortOpenAIProvidersOptions {
+  sortOption?: OpenAIProviderSortOption;
+  sortDirection?: OpenAIProviderSortDirection;
+  usageByProvider?: ProviderRecentUsageMap;
+  selectedModels?: ReadonlySet<string>;
+}
+
+const getPriority = (config: OpenAIProviderConfig) => {
+  const priority = config.priority;
+  return typeof priority === 'number' && Number.isFinite(priority) ? priority : 0;
+};
+
+const applyDirection = (value: number, direction: OpenAIProviderSortDirection) =>
+  direction === 'desc' ? -value : value;
+
+const compareByName = (
+  left: OpenAIProviderConfig,
+  right: OpenAIProviderConfig,
+  direction: OpenAIProviderSortDirection
+) => applyDirection(left.name.localeCompare(right.name), direction);
+
+const matchesSelectedModels = (
+  config: OpenAIProviderConfig,
+  selectedModels: ReadonlySet<string>
+) => {
+  if (selectedModels.size === 0) return true;
+  return config.models?.some((model) => selectedModels.has(model.name)) ?? false;
+};
+
+export const sortOpenAIProviders = (
+  providers: OpenAIProviderConfig[],
+  {
+    sortOption = 'priority',
+    sortDirection = 'desc',
+    usageByProvider = new Map(),
+    selectedModels = new Set<string>(),
+  }: SortOpenAIProvidersOptions = {}
+): IndexedOpenAIProvider[] => {
+  const sorted = providers
+    .map((config, originalIndex) => ({ config, originalIndex }))
+    .filter(({ config }) => matchesSelectedModels(config, selectedModels));
+  const providerStats =
+    sortOption === 'recent-success'
+      ? new Map(
+          sorted.map(({ config, originalIndex }) => [
+            originalIndex,
+            getOpenAIProviderRecentWindowStats(config, usageByProvider),
+          ])
+        )
+      : null;
+
+  return sorted.sort((left, right) => {
+    switch (sortOption) {
+      case 'name': {
+        const diff = compareByName(left.config, right.config, sortDirection);
+        if (diff !== 0) return diff;
+        break;
+      }
+      case 'recent-success': {
+        const leftSuccess = providerStats?.get(left.originalIndex)?.success ?? 0;
+        const rightSuccess = providerStats?.get(right.originalIndex)?.success ?? 0;
+        const diff = leftSuccess - rightSuccess;
+        if (diff !== 0) return applyDirection(diff, sortDirection);
+        const nameDiff = compareByName(left.config, right.config, sortDirection);
+        if (nameDiff !== 0) return nameDiff;
+        break;
+      }
+      case 'priority':
+      default: {
+        const diff = getPriority(left.config) - getPriority(right.config);
+        if (diff !== 0) return applyDirection(diff, sortDirection);
+        const nameDiff = compareByName(left.config, right.config, sortDirection);
+        if (nameDiff !== 0) return nameDiff;
+        break;
+      }
+    }
+
+    return left.originalIndex - right.originalIndex;
+  });
+};
+
+export const sortOpenAIProvidersByPriority = (
+  providers: OpenAIProviderConfig[],
+  direction: OpenAIProviderSortDirection = 'desc'
+): IndexedOpenAIProvider[] =>
+  sortOpenAIProviders(providers, { sortOption: 'priority', sortDirection: direction });


### PR DESCRIPTION
## Summary
- default the OpenAI-compatible provider list to priority descending
- treat missing or non-finite priority as `0` so unfilled priority does not sort first
- keep the existing OpenAI name fallback for equal effective priority/recent-success ties

## Scope
- OpenAI-compatible provider menu sorting only
- no CodexSection changes
- no backend/API changes
- no broader UI refactor

Fixes #102

## Verification
- `npm --workspace apps/web run test -- src/components/providers/OpenAISection src/components/providers/CodexSection/sort.test.ts`
- `npm --workspace apps/web run type-check`
- `npm --workspace apps/web run lint -- --max-warnings=0`
- `npm --workspace apps/web run build`
- `git diff --check`
