### PR TITLE
fix(monitoring): report total event counts while paging

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -149,6 +149,7 @@ type TaskBucket struct {
 }
 
 type EventPageItem struct {
+	ID                    int64
 	EventHash             string
 	TimestampMS           int64
 	Timestamp             string
@@ -185,6 +186,7 @@ type EventPageItem struct {
 type EventsPage struct {
 	Items        []EventPageItem
 	NextBeforeMS int64
+	NextBeforeID int64
 	HasMore      bool
 }
 
@@ -719,17 +721,40 @@ limit ?`, args...)
 	return failures, rows.Err()
 }
 
-func (r *repository) EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, limit int) (EventsPage, error) {
+func (r *repository) EventsCountWithFilter(ctx context.Context, filter AnalyticsFilter) (int64, error) {
+	where, args := analyticsWhere(filter)
+	var total int64
+	if err := r.db.QueryRowContext(ctx, `select count(*) from usage_events `+where, args...).Scan(&total); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func (r *repository) EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, beforeID int64, limit int) (EventsPage, error) {
 	if limit <= 0 {
 		return EventsPage{}, nil
 	}
 	queryLimit := limit + 1
-	if beforeMS > 0 && beforeMS < filter.ToMS {
-		filter.ToMS = beforeMS
-	}
 	where, args := analyticsWhere(filter)
+	// Keyset pagination cursor. The non-unique timestamp index implicitly
+	// carries the rowid (id is "integer primary key"), so ordering by
+	// (timestamp_ms desc, id desc) stays index-backed. Using the compound
+	// (timestamp_ms, id) cursor instead of only timestamp_ms guarantees that
+	// many rows sharing one timestamp_ms are never skipped across pages.
+	// beforeID <= 0 falls back to the legacy timestamp-only cursor for old
+	// clients that do not send before_id yet.
+	if beforeMS > 0 {
+		if beforeID > 0 {
+			where += " and (timestamp_ms < ? or (timestamp_ms = ? and id < ?))"
+			args = append(args, beforeMS, beforeMS, beforeID)
+		} else {
+			where += " and timestamp_ms < ?"
+			args = append(args, beforeMS)
+		}
+	}
 	args = append(args, queryLimit)
 	rows, err := r.db.QueryContext(ctx, `select
+	id,
 	event_hash,
 	timestamp_ms,
 	timestamp,
@@ -774,6 +799,7 @@ limit ?`, args...)
 		var item EventPageItem
 		var failed int
 		if err := rows.Scan(
+			&item.ID,
 			&item.EventHash,
 			&item.TimestampMS,
 			&item.Timestamp,
@@ -820,10 +846,13 @@ limit ?`, args...)
 		items = items[:limit]
 	}
 	nextBeforeMS := int64(0)
+	nextBeforeID := int64(0)
 	if hasMore && len(items) > 0 {
-		nextBeforeMS = items[len(items)-1].TimestampMS
+		last := items[len(items)-1]
+		nextBeforeMS = last.TimestampMS
+		nextBeforeID = last.ID
 	}
-	return EventsPage{Items: items, NextBeforeMS: nextBeforeMS, HasMore: hasMore}, nil
+	return EventsPage{Items: items, NextBeforeMS: nextBeforeMS, NextBeforeID: nextBeforeID, HasMore: hasMore}, nil
 }
 
 func (r *repository) ActiveDaysWithFilter(ctx context.Context, filter AnalyticsFilter) (int64, error) {

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -30,7 +30,8 @@ type Repository interface {
 	APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error)
 	TaskBucketsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]TaskBucket, error)
 	RecentFailuresWithFilter(ctx context.Context, filter AnalyticsFilter, limit int) ([]RecentFailure, error)
-	EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, limit int) (EventsPage, error)
+	EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, beforeID int64, limit int) (EventsPage, error)
+	EventsCountWithFilter(ctx context.Context, filter AnalyticsFilter) (int64, error)
 	ActiveDaysWithFilter(ctx context.Context, filter AnalyticsFilter) (int64, error)
 	ZeroTokenModelsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]string, error)
 }

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -67,6 +67,7 @@ type Include struct {
 type EventsPage struct {
 	Limit    int    `json:"limit"`
 	BeforeMS *int64 `json:"before_ms"`
+	BeforeID *int64 `json:"before_id"`
 }
 
 type Response struct {
@@ -290,7 +291,9 @@ type RecentFailure struct {
 type EventsResponse struct {
 	Items        []EventRow `json:"items"`
 	NextBeforeMS int64      `json:"next_before_ms"`
+	NextBeforeID int64      `json:"next_before_id"`
 	HasMore      bool       `json:"has_more"`
+	TotalCount   int64      `json:"total_count"`
 }
 
 type EventRow struct {
@@ -346,6 +349,12 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		Granularity:   granularity,
 	}
 
+	// summaryTotalCalls caches the count(*) computed for the summary so the
+	// events page can reuse it as total_count without a second table scan
+	// (summary and events use the exact same filter).
+	var summaryTotalCalls int64
+	summaryComputed := false
+
 	var modelStats []store.ModelStat
 	needsModelStats := req.Include.Summary || req.Include.ModelShare || req.Include.ModelStats
 	if needsModelStats {
@@ -384,6 +393,8 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 			return Response{}, err
 		}
 		response.Summary = buildSummary(agg, rollingAgg, activeDays, modelStats, taskBuckets, prices, zeroTokenModels)
+		summaryTotalCalls = agg.TotalCalls
+		summaryComputed = true
 	}
 	if req.Include.Timeline {
 		points, err := s.store.TimelineWithFilter(ctx, filter, granularity)
@@ -462,11 +473,27 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		if req.Include.EventsPage.BeforeMS != nil {
 			beforeMS = *req.Include.EventsPage.BeforeMS
 		}
-		page, err := s.store.EventsPageWithFilter(ctx, filter, beforeMS, limit)
+		beforeID := int64(0)
+		if req.Include.EventsPage.BeforeID != nil {
+			beforeID = *req.Include.EventsPage.BeforeID
+		}
+		page, err := s.store.EventsPageWithFilter(ctx, filter, beforeMS, beforeID, limit)
 		if err != nil {
 			return Response{}, err
 		}
-		response.Events = buildEvents(page)
+		// total_count is the real number of events matching the current filter
+		// (time range + scope filters + search), independent of the pagination
+		// cursor. Reuse the summary aggregate count when it was already computed
+		// for this same filter to avoid a second scan; otherwise run a
+		// lightweight count(*).
+		total := summaryTotalCalls
+		if !summaryComputed {
+			total, err = s.store.EventsCountWithFilter(ctx, filter)
+			if err != nil {
+				return Response{}, err
+			}
+		}
+		response.Events = buildEvents(page, total)
 	}
 
 	return response, nil
@@ -1150,7 +1177,7 @@ func buildRecentFailures(failures []store.RecentFailure) []RecentFailure {
 	return result
 }
 
-func buildEvents(page store.EventsPage) *EventsResponse {
+func buildEvents(page store.EventsPage, totalCount int64) *EventsResponse {
 	items := make([]EventRow, 0, len(page.Items))
 	for _, item := range page.Items {
 		items = append(items, EventRow{
@@ -1186,7 +1213,7 @@ func buildEvents(page store.EventsPage) *EventsResponse {
 			FailSummary:           item.FailSummary,
 		})
 	}
-	return &EventsResponse{Items: items, NextBeforeMS: page.NextBeforeMS, HasMore: page.HasMore}
+	return &EventsResponse{Items: items, NextBeforeMS: page.NextBeforeMS, NextBeforeID: page.NextBeforeID, HasMore: page.HasMore, TotalCount: totalCount}
 }
 
 func sumCost(stats []store.ModelStat, prices map[string]store.ModelPrice) float64 {

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"path/filepath"
 	"testing"
@@ -698,6 +699,175 @@ func TestAnalyticsFilterOptionsIgnoreActiveScopeFilters(t *testing.T) {
 	}
 	if len(resp.FilterOptions.ChannelShare) != 2 {
 		t.Fatalf("channel/provider filter options should ignore active account/model filters: %#v", resp.FilterOptions.ChannelShare)
+	}
+}
+
+func TestAnalyticsEventsPageReportsTotalCountWhilePaging(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_400_000_000)
+	toMS := fromMS + 60*60*1000
+
+	const total = 25
+	events := make([]usage.Event, 0, total)
+	for i := range total {
+		events = append(events, monitoringEvent(
+			fmt.Sprintf("total-%02d", i),
+			fromMS+int64(i+1)*1_000,
+			"gpt-a", "auth-1", "source-a", false, 1, 1, 0, 0, 2, nil,
+		))
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	// First page with summary enabled: total_count must reflect the full match
+	// count, not the page size.
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS:  fromMS,
+		ToMS:    toMS,
+		Include: Include{Summary: true, EventsPage: &EventsPage{Limit: 10}},
+	})
+	if err != nil {
+		t.Fatalf("analytics page 1: %v", err)
+	}
+	if resp.Events == nil || len(resp.Events.Items) != 10 || !resp.Events.HasMore {
+		t.Fatalf("page 1 = %#v", resp.Events)
+	}
+	if resp.Events.TotalCount != total {
+		t.Fatalf("page 1 total_count = %d, want %d", resp.Events.TotalCount, total)
+	}
+	if resp.Events.NextBeforeMS == 0 || resp.Events.NextBeforeID == 0 {
+		t.Fatalf("page 1 cursor = ms %d id %d", resp.Events.NextBeforeMS, resp.Events.NextBeforeID)
+	}
+
+	// Second page without summary exercises the standalone count(*) branch and
+	// must still report the full total, not the remaining count.
+	beforeMS := resp.Events.NextBeforeMS
+	beforeID := resp.Events.NextBeforeID
+	resp2, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Include: Include{
+			EventsPage: &EventsPage{Limit: 10, BeforeMS: &beforeMS, BeforeID: &beforeID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics page 2: %v", err)
+	}
+	if resp2.Events == nil || len(resp2.Events.Items) != 10 || !resp2.Events.HasMore {
+		t.Fatalf("page 2 = %#v", resp2.Events)
+	}
+	if resp2.Events.TotalCount != total {
+		t.Fatalf("page 2 total_count = %d, want %d", resp2.Events.TotalCount, total)
+	}
+	if resp2.Events.Items[0].EventHash == resp.Events.Items[len(resp.Events.Items)-1].EventHash {
+		t.Fatalf("page 2 overlaps page 1 boundary item")
+	}
+}
+
+func TestAnalyticsEventsPageTotalCountRespectsFilters(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_500_000_000)
+	toMS := fromMS + 60*60*1000
+
+	events := make([]usage.Event, 0, 11)
+	for i := range 8 {
+		events = append(events, monitoringEvent(fmt.Sprintf("ok-%d", i), fromMS+int64(i+1)*1_000, "gpt-a", "auth-1", "source-a", false, 1, 1, 0, 0, 2, nil))
+	}
+	for i := range 3 {
+		events = append(events, monitoringEvent(fmt.Sprintf("fail-%d", i), fromMS+int64(100+i)*1_000, "gpt-b", "auth-2", "source-b", true, 1, 1, 0, 0, 2, nil))
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	all, err := New(db).Analytics(ctx, Request{FromMS: fromMS, ToMS: toMS, Include: Include{EventsPage: &EventsPage{Limit: 50}}})
+	if err != nil {
+		t.Fatalf("analytics all: %v", err)
+	}
+	if all.Events == nil || all.Events.TotalCount != 11 {
+		t.Fatalf("all total_count = %#v", all.Events)
+	}
+
+	failed, err := New(db).Analytics(ctx, Request{FromMS: fromMS, ToMS: toMS, Filters: Filters{FailedOnly: true}, Include: Include{EventsPage: &EventsPage{Limit: 50}}})
+	if err != nil {
+		t.Fatalf("analytics failed only: %v", err)
+	}
+	if failed.Events == nil || failed.Events.TotalCount != 3 || len(failed.Events.Items) != 3 {
+		t.Fatalf("failed total_count = %#v", failed.Events)
+	}
+
+	byModel, err := New(db).Analytics(ctx, Request{FromMS: fromMS, ToMS: toMS, Filters: Filters{Models: []string{"gpt-a"}}, Include: Include{EventsPage: &EventsPage{Limit: 50}}})
+	if err != nil {
+		t.Fatalf("analytics model filter: %v", err)
+	}
+	if byModel.Events == nil || byModel.Events.TotalCount != 8 {
+		t.Fatalf("model total_count = %#v", byModel.Events)
+	}
+}
+
+func TestAnalyticsEventsPageStableCursorAvoidsSkippingSameTimestamp(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_600_000_000)
+	toMS := fromMS + 60*60*1000
+
+	// Every event shares one timestamp_ms so the page boundary lands inside a
+	// single millisecond. A timestamp-only cursor would skip the remaining
+	// rows; the compound (timestamp_ms, id) cursor must page through all of
+	// them without dropping or duplicating any.
+	const total = 12
+	sharedTS := fromMS + 5_000
+	events := make([]usage.Event, 0, total)
+	for i := range total {
+		events = append(events, monitoringEvent(fmt.Sprintf("same-ts-%02d", i), sharedTS, "gpt-a", "auth-1", "source-a", false, 1, 1, 0, 0, 2, nil))
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	svc := New(db)
+	seen := make(map[string]bool, total)
+	var beforeMS, beforeID int64
+	pages := 0
+	for {
+		page := &EventsPage{Limit: 5}
+		if beforeMS > 0 {
+			ms := beforeMS
+			id := beforeID
+			page.BeforeMS = &ms
+			page.BeforeID = &id
+		}
+		resp, err := svc.Analytics(ctx, Request{FromMS: fromMS, ToMS: toMS, Include: Include{EventsPage: page}})
+		if err != nil {
+			t.Fatalf("analytics page %d: %v", pages, err)
+		}
+		if resp.Events == nil {
+			t.Fatalf("analytics page %d returned no events", pages)
+		}
+		if resp.Events.TotalCount != total {
+			t.Fatalf("page %d total_count = %d, want %d", pages, resp.Events.TotalCount, total)
+		}
+		for _, item := range resp.Events.Items {
+			if seen[item.EventHash] {
+				t.Fatalf("duplicate event %s across pages", item.EventHash)
+			}
+			seen[item.EventHash] = true
+		}
+		pages++
+		if !resp.Events.HasMore {
+			break
+		}
+		beforeMS = resp.Events.NextBeforeMS
+		beforeID = resp.Events.NextBeforeID
+		if pages > total+2 {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+	if len(seen) != total {
+		t.Fatalf("collected %d unique events, want %d (same-timestamp rows were skipped)", len(seen), total)
 	}
 }
 

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -285,8 +285,12 @@ func (s *Store) RecentFailuresWithFilter(ctx context.Context, filter AnalyticsFi
 	return s.UsageEvents.RecentFailuresWithFilter(ctx, filter, limit)
 }
 
-func (s *Store) EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, limit int) (EventsPage, error) {
-	return s.UsageEvents.EventsPageWithFilter(ctx, filter, beforeMS, limit)
+func (s *Store) EventsPageWithFilter(ctx context.Context, filter AnalyticsFilter, beforeMS int64, beforeID int64, limit int) (EventsPage, error) {
+	return s.UsageEvents.EventsPageWithFilter(ctx, filter, beforeMS, beforeID, limit)
+}
+
+func (s *Store) EventsCountWithFilter(ctx context.Context, filter AnalyticsFilter) (int64, error) {
+	return s.UsageEvents.EventsCountWithFilter(ctx, filter)
 }
 
 func (s *Store) ActiveDaysWithFilter(ctx context.Context, filter AnalyticsFilter) (int64, error) {

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -2012,3 +2012,17 @@
     grid-template-columns: 1fr;
   }
 }
+
+.loadMoreEventsBar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px 0 4px;
+}
+
+.loadMoreEventsSummary {
+  color: var(--color-text-muted, #6b7280);
+  font-size: 13px;
+}

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -301,6 +301,8 @@ export function MonitoringCenterPage() {
     filteredRows,
     eventsHasMore,
     eventsLoadingMore,
+    eventsTotalCount,
+    eventsLoadedCount,
     lastRefreshedAt: monitoringLastRefreshedAt,
     isTransitioningScope: monitoringScopeTransitioning,
     hasPresentationSnapshot: hasMonitoringPresentationSnapshot,
@@ -1313,6 +1315,8 @@ export function MonitoringCenterPage() {
               failedOnlyActive={failedOnlyActive}
               eventsHasMore={eventsHasMore}
               eventsLoadingMore={eventsLoadingMore}
+              eventsTotalCount={eventsTotalCount}
+              eventsLoadedCount={eventsLoadedCount}
               overallLoading={overallLoading}
               hasPrices={hasPrices}
               locale={i18n.language}

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MonitoringEventRow } from '@/features/monitoring/hooks/useMonitoringData';
 import { RealtimeEventsPanel } from './RealtimeEventsPanel';
 
-const t = ((key: string) => {
+const t = ((key: string, options?: Record<string, unknown>) => {
   const messages: Record<string, string> = {
     'common.loading': 'Loading',
     'common.copy': 'Copy',
@@ -24,6 +24,8 @@ const t = ((key: string) => {
     'monitoring.load_more_events': 'Load more',
     'monitoring.log_rows': 'Rows',
     'monitoring.no_more_events': 'No more events',
+    'monitoring.events_loaded_summary': 'Loaded {{loaded}} of {{total}} events',
+    'monitoring.events_all_loaded': 'All {{total}} events loaded',
     'monitoring.reasoning_effort': 'Effort',
     'monitoring.reasoning_effort_short': 'Effort',
     'monitoring.recent_failures': 'Failures',
@@ -39,7 +41,13 @@ const t = ((key: string) => {
     'monitoring.this_call_usage': 'Usage',
     'monitoring.ttft_short': 'TTFT',
   };
-  return messages[key] ?? key;
+  let message = messages[key] ?? key;
+  if (options) {
+    message = message.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+      String((options as Record<string, unknown>)[name] ?? '')
+    );
+  }
+  return message;
 }) as unknown as TFunction;
 
 const noop = vi.fn();
@@ -49,6 +57,13 @@ type PanelRow = MonitoringEventRow & {
   successRate: number;
   streamKey: string;
   recentPattern: boolean[];
+};
+
+type PanelOverrides = {
+  eventsHasMore?: boolean;
+  eventsLoadingMore?: boolean;
+  eventsTotalCount?: number;
+  eventsLoadedCount?: number;
 };
 
 const baseRow = (overrides: Partial<PanelRow> = {}): PanelRow => ({
@@ -101,7 +116,7 @@ const baseRow = (overrides: Partial<PanelRow> = {}): PanelRow => ({
   ...overrides,
 });
 
-const renderPanel = (row: PanelRow) =>
+const renderPanel = (row: PanelRow, overrides: PanelOverrides = {}) =>
   renderToStaticMarkup(
     <RealtimeEventsPanel
       embedded
@@ -116,8 +131,10 @@ const renderPanel = (row: PanelRow) =>
       pageSize={10}
       scopedFailureCount={row.failed ? 1 : 0}
       failedOnlyActive={false}
-      eventsHasMore={false}
-      eventsLoadingMore={false}
+      eventsHasMore={overrides.eventsHasMore ?? false}
+      eventsLoadingMore={overrides.eventsLoadingMore ?? false}
+      eventsTotalCount={overrides.eventsTotalCount ?? 1}
+      eventsLoadedCount={overrides.eventsLoadedCount ?? 1}
       overallLoading={false}
       hasPrices={false}
       locale="en-US"
@@ -262,5 +279,39 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('C 4');
     expect(markup).not.toContain('Read 4');
     expect(markup).not.toContain('Create 1');
+  });
+
+  it('shows the loaded vs total summary with a load-more action when more pages exist', () => {
+    const markup = renderPanel(baseRow(), {
+      eventsHasMore: true,
+      eventsLoadedCount: 500,
+      eventsTotalCount: 8000,
+    });
+
+    expect(markup).toContain('Loaded 500 of 8000 events');
+    expect(markup).toContain('Load more');
+    expect(markup).not.toContain('Loaded 8000 of 8000');
+  });
+
+  it('shows the all-loaded summary without a load-more action once fully loaded', () => {
+    const markup = renderPanel(baseRow(), {
+      eventsHasMore: false,
+      eventsLoadedCount: 8000,
+      eventsTotalCount: 8000,
+    });
+
+    expect(markup).toContain('All 8000 events loaded');
+    expect(markup).not.toContain('Load more');
+  });
+
+  it('falls back to the loaded count when the backend omits a larger total', () => {
+    const markup = renderPanel(baseRow(), {
+      eventsHasMore: true,
+      eventsLoadedCount: 500,
+      eventsTotalCount: 500,
+    });
+
+    expect(markup).toContain('Loaded 500 of 500 events');
+    expect(markup).toContain('Load more');
   });
 });

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -40,6 +40,8 @@ type RealtimeEventsPanelProps = {
   failedOnlyActive: boolean;
   eventsHasMore: boolean;
   eventsLoadingMore: boolean;
+  eventsTotalCount: number;
+  eventsLoadedCount: number;
   overallLoading: boolean;
   hasPrices: boolean;
   locale: string;
@@ -231,6 +233,8 @@ export function RealtimeEventsPanel({
   failedOnlyActive,
   eventsHasMore,
   eventsLoadingMore,
+  eventsTotalCount,
+  eventsLoadedCount,
   overallLoading,
   hasPrices,
   locale,
@@ -491,6 +495,14 @@ export function RealtimeEventsPanel({
       />
       {rows.length > 0 ? (
         <div className={styles.loadMoreEventsBar}>
+          <span className={styles.loadMoreEventsSummary}>
+            {eventsHasMore
+              ? t('monitoring.events_loaded_summary', {
+                  loaded: eventsLoadedCount,
+                  total: eventsTotalCount,
+                })
+              : t('monitoring.events_all_loaded', { total: eventsTotalCount })}
+          </span>
           {eventsHasMore ? (
             <Button
               variant="secondary"
@@ -500,9 +512,7 @@ export function RealtimeEventsPanel({
             >
               {eventsLoadingMore ? t('common.loading') : t('monitoring.load_more_events')}
             </Button>
-          ) : (
-            <span>{t('monitoring.no_more_events')}</span>
-          )}
+          ) : null}
         </div>
       ) : null}
     </>

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -95,6 +95,8 @@ const createPresentationSnapshot = (id: string): MonitoringPresentationSnapshot 
     filteredRows: [row],
     eventsHasMore: id.includes('more'),
     eventsLoadingMore: false,
+    eventsTotalCount: 1,
+    eventsLoadedCount: 1,
     lastRefreshedAt: new Date(1_768_759_000_000),
   };
 };

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -101,6 +101,7 @@ const EMPTY_MONITORING_ANALYTICS_EVENT_ROWS: MonitoringAnalyticsEventRow[] = [];
 interface MonitoringEventsPageState {
   scopeKey: string;
   beforeMs: number | null;
+  beforeId: number | null;
   items: MonitoringAnalyticsEventRow[];
   hasMore: boolean;
   loadingMore: boolean;
@@ -125,6 +126,8 @@ export type MonitoringPresentationSnapshot = Pick<
   | 'filteredRows'
   | 'eventsHasMore'
   | 'eventsLoadingMore'
+  | 'eventsTotalCount'
+  | 'eventsLoadedCount'
   | 'lastRefreshedAt'
 >;
 
@@ -142,6 +145,7 @@ interface MonitoringPresentationSnapshotStore {
 const createEventsPageState = (scopeKey = ''): MonitoringEventsPageState => ({
   scopeKey,
   beforeMs: null,
+  beforeId: null,
   items: [],
   hasMore: false,
   loadingMore: false,
@@ -311,9 +315,9 @@ export function useMonitoringData({
       setError(payload.error);
       setLoading(false);
       setEventsPageState((previous) =>
-        previous.beforeMs === null && !previous.loadingMore
+        previous.beforeMs === null && previous.beforeId === null && !previous.loadingMore
           ? previous
-          : { ...previous, beforeMs: null, loadingMore: false }
+          : { ...previous, beforeMs: null, beforeId: null, loadingMore: false }
       );
       setAnalyticsNowMs(Date.now());
     },
@@ -425,6 +429,7 @@ export function useMonitoringData({
       ? eventsPageState
       : createEventsPageState(eventsScopeKey);
   const eventsBeforeMs = activeEventsPageState.beforeMs;
+  const eventsBeforeId = activeEventsPageState.beforeId;
   const eventItems = activeEventsPageState.items;
   const eventsHasMore = activeEventsPageState.hasMore;
   const eventsLoadingMore = activeEventsPageState.loadingMore;
@@ -450,7 +455,11 @@ export function useMonitoringData({
       filter_options: true,
       task_buckets: true,
       recent_failures: 8,
-      events_page: { limit: MONITORING_EVENTS_PAGE_LIMIT, before_ms: eventsBeforeMs },
+      events_page: {
+        limit: MONITORING_EVENTS_PAGE_LIMIT,
+        before_ms: eventsBeforeMs,
+        before_id: eventsBeforeId,
+      },
       granularity: analyticsGranularity,
     },
     throttleMs: 1_000,
@@ -475,11 +484,15 @@ export function useMonitoringData({
     ]
   );
   const displayEventsHasMore = currentAnalyticsData?.events?.has_more ?? eventsHasMore;
+  const eventsLoadedCount = displayEventItems.length;
+  const displayEventsTotalCount =
+    currentAnalyticsData?.events?.total_count ?? eventsLoadedCount;
 
   useEffect(() => {
     const page = currentAnalyticsData?.events;
     if (!page) return;
     const requestBeforeMs = eventsBeforeMs;
+    const requestBeforeId = eventsBeforeId;
     const pageKey = buildEventsPageKey(
       eventsScopeKey,
       requestBeforeMs,
@@ -496,6 +509,7 @@ export function useMonitoringData({
         return {
           scopeKey: eventsScopeKey,
           beforeMs: requestBeforeMs,
+          beforeId: requestBeforeId,
           items: mergeMonitoringEventsPageItems(base.items, page.items, requestBeforeMs),
           hasMore: page.has_more,
           loadingMore: false,
@@ -506,7 +520,7 @@ export function useMonitoringData({
     return () => {
       cancelled = true;
     };
-  }, [currentAnalyticsData?.events, eventsScopeKey, eventsBeforeMs]);
+  }, [currentAnalyticsData?.events, eventsScopeKey, eventsBeforeMs, eventsBeforeId]);
 
   useEffect(() => {
     if (analytics.error) {
@@ -527,14 +541,16 @@ export function useMonitoringData({
     if (analytics.loading || eventsLoadingMore || !eventsHasMore) return;
     const nextBeforeMs = currentAnalyticsData?.events?.next_before_ms;
     if (!nextBeforeMs) return;
+    const nextBeforeId = currentAnalyticsData?.events?.next_before_id ?? null;
     setEventsPageState((previous) => {
       const base =
         previous.scopeKey === eventsScopeKey ? previous : createEventsPageState(eventsScopeKey);
       if (base.loadingMore) return base;
-      return { ...base, beforeMs: nextBeforeMs, loadingMore: true };
+      return { ...base, beforeMs: nextBeforeMs, beforeId: nextBeforeId, loadingMore: true };
     });
   }, [
     currentAnalyticsData?.events?.next_before_ms,
+    currentAnalyticsData?.events?.next_before_id,
     analytics.loading,
     eventsScopeKey,
     eventsHasMore,
@@ -761,6 +777,8 @@ export function useMonitoringData({
       filteredRows,
       eventsHasMore: displayEventsHasMore,
       eventsLoadingMore,
+      eventsTotalCount: displayEventsTotalCount,
+      eventsLoadedCount,
       lastRefreshedAt: analytics.lastRefreshedAt,
     }),
     [
@@ -769,6 +787,8 @@ export function useMonitoringData({
       apiKeyRows,
       channelRows,
       displayEventsHasMore,
+      displayEventsTotalCount,
+      eventsLoadedCount,
       eventsLoadingMore,
       failureSourceRows,
       filterOptions,
@@ -879,6 +899,8 @@ export function useMonitoringData({
     filteredRows: presentationSnapshot.filteredRows,
     eventsHasMore: presentationSnapshot.eventsHasMore,
     eventsLoadingMore: presentationSnapshot.eventsLoadingMore,
+    eventsTotalCount: presentationSnapshot.eventsTotalCount,
+    eventsLoadedCount: presentationSnapshot.eventsLoadedCount,
     lastRefreshedAt: presentationSnapshot.lastRefreshedAt,
     isTransitioningScope: analytics.dataStale,
     hasPresentationSnapshot: presentationResolution.hasPresentationSnapshot,

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -374,6 +374,8 @@ export interface UseMonitoringDataReturn {
   filteredRows: MonitoringEventRow[];
   eventsHasMore: boolean;
   eventsLoadingMore: boolean;
+  eventsTotalCount: number;
+  eventsLoadedCount: number;
   lastRefreshedAt: Date | null;
   isTransitioningScope: boolean;
   hasPresentationSnapshot: boolean;

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1891,7 +1891,9 @@
     "page_size_label": "Per page",
     "page_size_option": "{{count}} / page",
     "load_more_events": "Load more events",
-    "no_more_events": "No more events"
+    "no_more_events": "No more events",
+    "events_loaded_summary": "Loaded {{loaded}} of {{total}} events",
+    "events_all_loaded": "All {{total}} events loaded"
   },
   "logs": {
     "title": "Logs Viewer",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -1887,7 +1887,9 @@
     "page_size_label": "На странице",
     "page_size_option": "{{count}} / стр.",
     "load_more_events": "Загрузить ещё события",
-    "no_more_events": "Больше событий нет"
+    "no_more_events": "Больше событий нет",
+    "events_loaded_summary": "Загружено {{loaded}} из {{total}} событий",
+    "events_all_loaded": "Все {{total}} событий загружены"
   },
   "logs": {
     "title": "Просмотр журналов",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -1891,7 +1891,9 @@
     "page_size_label": "每页",
     "page_size_option": "{{count}} 条/页",
     "load_more_events": "加载更多事件",
-    "no_more_events": "没有更多事件"
+    "no_more_events": "没有更多事件",
+    "events_loaded_summary": "已加载 {{loaded}} / 共 {{total}} 条",
+    "events_all_loaded": "已加载全部 {{total}} 条"
   },
   "logs": {
     "title": "日志查看",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -1916,7 +1916,9 @@
     "page_size_label": "每頁",
     "page_size_option": "{{count}} 行/頁",
     "load_more_events": "載入更多事件",
-    "no_more_events": "沒有更多事件"
+    "no_more_events": "沒有更多事件",
+    "events_loaded_summary": "已載入 {{loaded}} / 共 {{total}} 筆",
+    "events_all_loaded": "已載入全部 {{total}} 筆"
   },
   "logs": {
     "title": "記錄檢視",

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -482,6 +482,7 @@ export interface MonitoringAnalyticsFilters {
 export interface MonitoringAnalyticsEventsPageRequest {
   limit?: number;
   before_ms?: number | null;
+  before_id?: number | null;
 }
 
 export interface MonitoringAnalyticsInclude {
@@ -747,7 +748,9 @@ export interface MonitoringAnalyticsEventRow {
 export interface MonitoringAnalyticsEventsResponse {
   items: MonitoringAnalyticsEventRow[];
   next_before_ms: number;
+  next_before_id?: number;
   has_more: boolean;
+  total_count?: number;
 }
 
 export interface MonitoringAnalyticsResponse {


### PR DESCRIPTION
## Summary
Fix monitoring event pagination so the UI reports the full filtered event count while loading pages.

## Cause
The events page only exposed page-level pagination state, and timestamp-only cursors could skip rows when many events shared the same timestamp.

## Solution
- Add backend `total_count` and compound `timestamp_ms`/`id` cursor support.
- Reuse summary totals when available, otherwise count filtered events directly.
- Pass the new cursor/total fields through the web data layer.
- Show loaded-vs-total progress in the realtime events panel.

## Testing
- Backend focused tests and frontend type-check passed in the reviewed changes.

Fixes #101