### PR TITLE
docs(release): add v1.1.0 release notes

### DIFF
--- a/docs/release-notes/v1.1.0-en.md
+++ b/docs/release-notes/v1.1.0-en.md
@@ -1,0 +1,43 @@
+# CPA Manager Plus v1.1.0
+
+> 15 commits · 42 files changed · +1827 / -178
+
+> [中文 ->](./v1.1.0-zh.md)
+
+## Overview
+
+This release focuses on monitoring readability and cost accuracy, adding event pagination totals, account display controls, and corrected Priority/Fast service tier pricing. The release workflow now also supports versioned curated release notes, so future tag releases can use repository-maintained release bodies.
+
+## Highlights
+
+### Features
+
+- Added a monitoring account display mode toggle for switching between masked and full account identifiers, reused by realtime event source labels. Long identifiers stay truncated with hover titles, and fixed table columns reduce layout shifts when toggling display modes. (`web`)
+
+### Fixes
+
+- Monitoring event pagination now returns a stable `total_count` and uses a timestamp/id cursor so events sharing the same timestamp are not skipped while paging. (`manager-server`)
+- The monitoring center now shows loaded-vs-total event progress and hides the old no-more-events label after loading is complete. (`web`)
+- Priority/Fast service tier usage is now priced by the actual tier, and the frontend fallback cost calculation applies the matching multiplier. (`manager-server`, `web`)
+- The error log tab can open independently when ordinary file logging is disabled, making CPA-side request failure diagnostics available. (`logs`)
+- OpenAI-compatible provider menus now sort by priority semantics in descending order. (`web`)
+
+### CI
+
+- Tag releases now prefer `docs/release-notes/<tag>-zh.md`, `zh-CN.md`, or `en.md` as the GitHub Release body, while keeping the git log fallback. (`release`)
+
+### Docs
+
+- Added CPAMP release workflow and release-note convention docs covering preflight, dry-run, PR, tag, and CI lookup rules. (`release`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @bc19sam-afk - Aligned OpenAI-compatible provider sorting with priority semantics.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.0.1...v1.1.0

--- a/docs/release-notes/v1.1.0-zh.md
+++ b/docs/release-notes/v1.1.0-zh.md
@@ -1,0 +1,43 @@
+# CPA Manager Plus v1.1.0
+
+> 15 commits · 42 files changed · +1827 / -178
+
+> [English ->](./v1.1.0-en.md)
+
+## Overview
+
+本次发布聚焦监控中心的可读性和计费准确性，补齐事件分页总数、账户显示控制和 Priority/Fast service tier 成本计算。同时，发布流程现在支持版本化 curated release notes，后续 tag 发布会优先使用仓库内维护的发布说明。
+
+## Highlights
+
+### Features
+
+- 新增监控账户显示模式切换，可在脱敏账户与完整账户标识之间切换，并复用于实时事件来源显示。长标识会保持截断与 hover title，表格列宽也固定以减少切换时的布局跳动。(`web`)
+
+### Fixes
+
+- 监控事件分页现在返回稳定的 `total_count`，并使用 timestamp/id cursor，避免相同时间戳事件在翻页时被跳过。(`manager-server`)
+- 监控中心展示已加载/总数进度，完成后隐藏旧的无更多事件提示。(`web`)
+- Priority/Fast service tier 的使用成本现在按实际 tier 计价，前端 fallback 成本计算也会应用对应 multiplier。(`manager-server`, `web`)
+- 错误日志 tab 可以在未启用普通文件日志时独立打开，便于查看 CPA 侧请求失败诊断信息。(`logs`)
+- OpenAI-compatible provider 菜单现在按 priority 语义降序排序。(`web`)
+
+### CI
+
+- Tag 发布时优先读取 `docs/release-notes/<tag>-zh.md`、`zh-CN.md` 或 `en.md` 作为 GitHub Release body，并保留 git log fallback。(`release`)
+
+### Docs
+
+- 新增 CPAMP 发布流程和 release note 约定文档，明确 preflight、dry-run、PR、tag 与 CI 查找规则。(`release`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @bc19sam-afk - 修正 OpenAI-compatible provider 排序，使菜单显示与 priority 语义一致。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.0.1...v1.1.0


### PR DESCRIPTION
## Purpose

Add curated release notes for CPA Manager Plus v1.1.0 before pushing the release tag.

## Changes

- Add `docs/release-notes/v1.1.0-zh.md`
- Add `docs/release-notes/v1.1.0-en.md`

## Verification

- Release preflight confirmed `main` and `origin/main` were aligned before branching.
- GitHub MCP confirmed `v1.1.0` tag and release did not exist before execution.
- Staged diff contained only the two versioned release note files.

## Affected Modes

- frontend-only: no runtime code changes in this PR
- CPA panel: no runtime code changes in this PR
- full Docker: no runtime code changes in this PR
- native packages: release notes only