### PR TITLE
fix(monitoring): prevent history navigation render loop

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -53,6 +53,7 @@ import { MonitoringDataPanel } from '@/features/monitoring/components/Monitoring
 import { MonitoringActionBar } from '@/features/monitoring/components/MonitoringActionBar';
 import { MonitoringCustomRangeModal } from '@/features/monitoring/components/MonitoringCustomRangeModal';
 import { MonitoringFiltersPanel } from '@/features/monitoring/components/MonitoringFiltersPanel';
+import { usePageTransitionLayer } from '@/components/common/PageTransitionLayer';
 import { IconInbox } from '@/components/ui/icons';
 import {
   MonitoringStatusHeader,
@@ -128,6 +129,8 @@ export function MonitoringCenterPage() {
   const showNotification = useNotificationStore((state) => state.showNotification);
   const showConfirmation = useNotificationStore((state) => state.showConfirmation);
   const requestMonitoringAvailability = useRequestMonitoringAvailability();
+  const pageTransitionLayer = usePageTransitionLayer();
+  const isCurrentLayer = pageTransitionLayer ? pageTransitionLayer.status === 'current' : true;
   const initialAccountOverviewUiState = useRef(readAccountOverviewUiState());
   const initialMonitoringCenterUiState = useRef(readMonitoringCenterUiState());
   const [timeRange, setTimeRange] = useState<MonitoringTimeRange>(
@@ -341,12 +344,14 @@ export function MonitoringCenterPage() {
     setCurrentAccountPage(1);
   }, [setCurrentAccountPage]);
 
-  useHeaderRefresh(refreshAll);
+  useHeaderRefresh(refreshAll, isCurrentLayer);
   useInterval(
     () => {
       void refreshAll().catch(() => {});
     },
-    connectionStatus === 'connected' && Number(autoRefreshMs) > 0 ? Number(autoRefreshMs) : null
+    isCurrentLayer && connectionStatus === 'connected' && Number(autoRefreshMs) > 0
+      ? Number(autoRefreshMs)
+      : null
   );
 
   const monitoringUnavailable =

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.renderLoop.test.tsx
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.renderLoop.test.tsx
@@ -1,0 +1,82 @@
+import { Profiler } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ApiKeyAlias } from '@/services/api/usageService';
+import type { ModelPrice } from '@/utils/usage';
+
+vi.mock('../services/monitoringMetaService', () => ({
+  loadMonitoringMetaPayload: vi.fn(async () => ({
+    authFiles: [],
+    channels: [],
+    error: '',
+  })),
+}));
+
+vi.mock('./useMonitoringAnalytics', () => ({
+  useMonitoringAnalytics: () => ({
+    enabled: true,
+    loading: false,
+    error: '',
+    data: null,
+    dataStale: false,
+    lastRefreshedAt: null,
+    serviceBase: 'http://manager.local',
+    unavailableReason: '',
+    refresh: vi.fn(),
+  }),
+}));
+
+import { useMonitoringData } from './useMonitoringData';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const EMPTY_MODEL_PRICES: Record<string, ModelPrice> = {};
+const EMPTY_API_KEY_ALIASES: ApiKeyAlias[] = [];
+const ALL_SCOPE_FILTERS = {
+  account: 'all',
+  provider: 'all',
+  model: 'all',
+  channel: 'all',
+  apiKeyHash: 'all',
+  status: 'all',
+} as const;
+
+describe('useMonitoringData render stability', () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    renderer?.unmount();
+    renderer = null;
+  });
+
+  it('settles while analytics events are still waiting for the first page', async () => {
+    let renderCount = 0;
+
+    function Harness() {
+      useMonitoringData({
+        config: null,
+        modelPrices: EMPTY_MODEL_PRICES,
+        apiKeyAliases: EMPTY_API_KEY_ALIASES,
+        timeRange: 'today',
+        customTimeRange: null,
+        searchQuery: '',
+        searchApiKeyHash: '',
+        scopeFilters: ALL_SCOPE_FILTERS,
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(
+        <Profiler id="monitoring-data" onRender={() => {
+          renderCount += 1;
+        }}>
+          <Harness />
+        </Profiler>
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(renderCount).toBeLessThan(10);
+  });
+});

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -424,10 +424,13 @@ export function useMonitoringData({
     ]
   );
 
-  const activeEventsPageState =
-    eventsPageState.scopeKey === eventsScopeKey
-      ? eventsPageState
-      : createEventsPageState(eventsScopeKey);
+  const activeEventsPageState = useMemo(
+    () =>
+      eventsPageState.scopeKey === eventsScopeKey
+        ? eventsPageState
+        : createEventsPageState(eventsScopeKey),
+    [eventsPageState, eventsScopeKey]
+  );
   const eventsBeforeMs = activeEventsPageState.beforeMs;
   const eventsBeforeId = activeEventsPageState.beforeId;
   const eventItems = activeEventsPageState.items;


### PR DESCRIPTION
## Summary
Fixes `#/monitoring` freezing when entering the page through browser history navigation. The monitoring events pagination fallback now keeps a stable reference while the first analytics page is still loading, preventing repeated snapshot state writes from spinning the render loop. Monitoring page refresh handlers are also limited to the current page transition layer so hidden stacked/exiting monitoring pages do not keep refreshing in the background.

## Scope
- `useMonitoringData`: memoized the fallback `activeEventsPageState` used before the first analytics events page is available, keeping the page-state reference stable across renders.
- `MonitoringCenterPage`: gated `useHeaderRefresh` and monitoring auto-refresh with `usePageTransitionLayer().isCurrentLayer`, so non-current transition layers stop triggering refresh work.
- `useMonitoringData.renderLoop.test`: added a regression test that verifies the analytics-first-page waiting state does not cause excessive re-renders.

## Tests
- `npm --workspace apps/web run test -- src/features/monitoring/hooks/useMonitoringData.renderLoop.test.tsx src/features/monitoring/hooks/useMonitoringData.test.ts src/features/monitoring/MonitoringCenterPage.test.tsx src/features/monitoring/components/RealtimeEventsPanel.test.tsx src/features/monitoring/components/MonitoringDataPanel.test.tsx`
- `npm --workspace apps/web run type-check`
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run build`
- Verified locally with a local panel proxy against the remote test environment: `dashboard ->
monitoring -> back -> forward` stayed responsive without Chromium high CPU.

Fixes #92