### PR TITLE
feat(monitoring): improve summary card number display

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -1548,9 +1548,12 @@
   }
 
   .summaryHero,
-  .summarySub,
-  .summaryGrid {
+  .summarySub {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .summaryGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .accountOverviewCardGrid {
@@ -1703,8 +1706,8 @@
   .summaryCard,
   .summaryCardPrimary,
   .summaryCardSecondary {
-    height: 128px;
-    min-height: 128px;
+    height: auto;
+    min-height: 112px;
     border-radius: var(--app-radius-md);
   }
 
@@ -1810,11 +1813,11 @@
   }
 
   .summaryValue {
-    font-size: 26px;
+    font-size: 22px;
   }
 
   .summaryCardSecondary .summaryValue {
-    font-size: 26px;
+    font-size: 22px;
   }
 
   .priceActionsBar {

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
@@ -2,6 +2,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import type { TFunction } from 'i18next';
 import { AccountExpandedDetails, AccountOverviewCard } from './MonitoringCenterPage';
+import { MonitoringSummarySection } from '@/features/monitoring/components/MonitoringSummarySection';
+import {
+  buildPrimarySummaryCards,
+  buildSecondarySummaryCards,
+} from '@/features/monitoring/model/monitoringCenterPageModel';
+import type { MonitoringSummary } from '@/features/monitoring/hooks/useMonitoringData';
 import { buildEmptyMonitoringStatusData } from '@/features/monitoring/accountOverviewState';
 import { buildRealtimeSourceDisplay } from '@/features/monitoring/realtimeSourceDisplay';
 
@@ -33,6 +39,7 @@ const t = ((key: string, options?: Record<string, unknown>) => {
     'monitoring.account_overview_collapse_models': 'Collapse',
     'monitoring.account_overview_no_models': 'No model details',
     'monitoring.total_calls': 'Total calls',
+    'monitoring.call_success_rate': 'Success rate',
     'monitoring.calls': 'Calls',
     'stats.success': 'Success',
     'stats.failure': 'Failure',
@@ -49,6 +56,13 @@ const t = ((key: string, options?: Record<string, unknown>) => {
     'monitoring.cache_read_tokens_short': 'Read',
     'monitoring.cache_creation_tokens_short': 'Create',
     'monitoring.estimated_cost': 'Estimated Cost',
+    'monitoring.estimated_cost_hint': 'Configured model prices',
+    'monitoring.estimated_cost_missing': 'No configured model prices',
+    'monitoring.accounts_suffix': 'accounts',
+    'monitoring.groups_suffix': 'groups',
+    'monitoring.reasoning_tokens': 'Reasoning',
+    'monitoring.of_token_mix': 'Share',
+    'monitoring.of_input_tokens': 'Input share',
     'usage_stats.model_price_model': 'Model',
     'monitoring.last_sync': 'Last sync',
     'monitoring.account_quota_title': 'Account Quota',
@@ -70,6 +84,115 @@ const t = ((key: string, options?: Record<string, unknown>) => {
   });
   return value;
 }) as TFunction;
+
+describe('MonitoringCenterPage summary cards', () => {
+  it('renders all request monitoring summary metrics in one ordered grid with large values intact', () => {
+    const summary: MonitoringSummary = {
+      totalCalls: 25_500,
+      successCalls: 23_600,
+      failureCalls: 1_900,
+      successRate: 0.999,
+      inputTokens: 2_783_500_000,
+      outputTokens: 11_700_000,
+      reasoningTokens: 5_000_000,
+      cachedTokens: 2_595_300_000,
+      cacheReadTokens: 444_400_000,
+      cacheCreationTokens: 555_500_000,
+      totalTokens: 2_795_200_000,
+      totalCost: 9_999_999.99,
+      averageLatencyMs: 999,
+      rpm30m: 0,
+      tpm30m: 0,
+      avgDailyRequests: 0,
+      avgDailyTokens: 0,
+      approxTasks: 0,
+      approxTaskFailures: 0,
+      approxTaskSuccessRate: 0,
+      zeroTokenCalls: 0,
+      zeroTokenModels: [],
+    };
+    const primaryCards = buildPrimarySummaryCards({
+      summary,
+      accountCount: 999,
+      failedGroupCount: 88,
+      hasPrices: true,
+      locale: 'en',
+      t,
+    });
+    const secondaryCards = buildSecondarySummaryCards(summary, 'en', t);
+
+    const html = renderToStaticMarkup(
+      <MonitoringSummarySection primaryCards={primaryCards} secondaryCards={secondaryCards} />
+    );
+    const labels = [
+      'Total calls',
+      'Success rate',
+      'Failure calls',
+      'Estimated Cost',
+      'Total Tokens',
+      'Input Tokens',
+      'Output Tokens',
+      'Cached Tokens',
+    ];
+    let previousIndex = -1;
+
+    labels.forEach((label) => {
+      const index = html.indexOf(label);
+      expect(index).toBeGreaterThan(previousIndex);
+      previousIndex = index;
+    });
+
+    expect(html).toContain('_summaryGrid');
+    expect(html.match(/<strong/g)).toHaveLength(8);
+    expect(html).toContain('25.5K');
+    expect(html).toContain('1.9K');
+    expect(html).toContain('2.8B');
+    expect(html).toContain('2.6B');
+    expect(html).toContain('role="tooltip"');
+    expect(html).toContain('2,795,200,000');
+    expect(html).toContain('2,783,500,000');
+    expect(html).toContain('2,595,300,000');
+    expect(html).toContain('$9,999,999.99');
+    expect(html).toContain('Reasoning 5.0M');
+    expect(html).toContain('Share 99.6%');
+    expect(html).toContain('Share 0.4%');
+    expect(html).toContain('Input share 93.2% · Create 555.5M · Read 444.4M');
+  });
+
+  it('hides cache creation and read meta when both cached sub-metrics are zero', () => {
+    const secondaryCards = buildSecondarySummaryCards(
+      {
+        totalCalls: 1,
+        successCalls: 1,
+        failureCalls: 0,
+        successRate: 1,
+        inputTokens: 1_000,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedTokens: 932,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalTokens: 1_000,
+        totalCost: 0,
+        averageLatencyMs: null,
+        rpm30m: 0,
+        tpm30m: 0,
+        avgDailyRequests: 0,
+        avgDailyTokens: 0,
+        approxTasks: 0,
+        approxTaskFailures: 0,
+        approxTaskSuccessRate: 0,
+        zeroTokenCalls: 0,
+        zeroTokenModels: [],
+      },
+      'en',
+      t
+    );
+    const cachedCard = secondaryCards.find((card) => card.label === 'Cached Tokens');
+
+    expect(cachedCard?.meta).toBe('Input share 93.2%');
+  });
+});
 
 describe('MonitoringCenterPage account card', () => {
   it('prefers readable channel names in realtime source cells', () => {

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -629,8 +629,8 @@ export function MonitoringCenterPage() {
   );
 
   const secondarySummaryCards = useMemo(
-    () => buildSecondarySummaryCards(scopedSummary, t),
-    [scopedSummary, t]
+    () => buildSecondarySummaryCards(scopedSummary, i18n.language, t),
+    [i18n.language, scopedSummary, t]
   );
 
   const dataTabs = useMemo<MonitoringTab<MonitoringDataTab>[]>(() => {

--- a/apps/web/src/features/monitoring/components/MonitoringShared.tsx
+++ b/apps/web/src/features/monitoring/components/MonitoringShared.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, type ComponentType, type KeyboardEvent, type ReactNode } from 'react';
+import {
+  useEffect,
+  useId,
+  useState,
+  type ComponentType,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
@@ -39,6 +46,7 @@ export type SummaryCardAccent =
 export type SummaryCardProps = {
   label: string;
   value: string;
+  valueTitle?: string;
   meta: string;
   tone?: MonitoringStatusTone;
   variant?: 'primary' | 'secondary';
@@ -92,6 +100,7 @@ const summaryAccentClassMap: Record<SummaryCardAccent, string> = {
 export function SummaryCard({
   label,
   value,
+  valueTitle,
   meta,
   tone,
   variant = 'primary',
@@ -99,6 +108,9 @@ export function SummaryCard({
   accent = 'blue',
 }: SummaryCardProps) {
   const Icon = icon ? summaryIconMap[icon] : null;
+  const tooltipId = useId();
+  const tooltipValue = valueTitle ?? value;
+  const hasValueTooltip = tooltipValue !== value;
   const cardClassName = [
     'card',
     styles.summaryCard,
@@ -121,9 +133,21 @@ export function SummaryCard({
         </span>
       </div>
       <div className={styles.summaryCardBody}>
-        <strong className={`${styles.summaryValue} ${tone ? styles[`tone${tone}`] : ''}`}>
-          {value}
-        </strong>
+        <span className={styles.summaryValueWrap}>
+          <strong
+            className={`${styles.summaryValue} ${tone ? styles[`tone${tone}`] : ''}`}
+            tabIndex={hasValueTooltip ? 0 : undefined}
+            aria-describedby={hasValueTooltip ? tooltipId : undefined}
+          >
+            {value}
+          </strong>
+          {hasValueTooltip ? (
+            <span id={tooltipId} className={styles.summaryValueTooltip} role="tooltip">
+              <span className={styles.summaryValueTooltipLabel}>{label}</span>
+              <span className={styles.summaryValueTooltipValue}>{tooltipValue}</span>
+            </span>
+          ) : null}
+        </span>
         <span className={styles.summaryMeta} title={meta}>
           {meta}
         </span>

--- a/apps/web/src/features/monitoring/components/MonitoringSummarySection.tsx
+++ b/apps/web/src/features/monitoring/components/MonitoringSummarySection.tsx
@@ -10,15 +10,12 @@ export function MonitoringSummarySection({
   primaryCards,
   secondaryCards,
 }: MonitoringSummarySectionProps) {
+  const cards = [...primaryCards, ...secondaryCards];
+
   return (
     <section className={styles.summarySection}>
-      <div className={styles.summaryHero}>
-        {primaryCards.map((card) => (
-          <SummaryCard key={card.label} {...card} />
-        ))}
-      </div>
-      <div className={styles.summarySub}>
-        {secondaryCards.map((card) => (
+      <div className={styles.summaryGrid}>
+        {cards.map((card) => (
           <SummaryCard key={card.label} {...card} />
         ))}
       </div>

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -109,6 +109,19 @@ export const getTodayStartInputValue = () => {
 
 export const getCurrentInputValue = () => formatDateTimeLocalValue(new Date());
 
+const formatFullNumber = (value: number, locale?: string) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '0';
+
+  try {
+    return new Intl.NumberFormat(locale || undefined, {
+      maximumFractionDigits: 0,
+    }).format(num);
+  } catch {
+    return String(Math.round(num));
+  }
+};
+
 export const parseDateTimeLocalValue = (value: string) => {
   if (!value) return null;
   const timestamp = new Date(value).getTime();
@@ -378,6 +391,7 @@ export const buildPrimarySummaryCards = ({
   {
     label: t('monitoring.total_calls'),
     value: formatCompactNumber(summary.totalCalls),
+    valueTitle: formatFullNumber(summary.totalCalls, locale),
     meta: `${accountCount} ${t('monitoring.accounts_suffix')}`,
     icon: 'calls',
     accent: 'blue',
@@ -393,6 +407,7 @@ export const buildPrimarySummaryCards = ({
   {
     label: t('monitoring.failure_calls'),
     value: formatCompactNumber(summary.failureCalls),
+    valueTitle: formatFullNumber(summary.failureCalls, locale),
     meta: `${failedGroupCount} ${t('monitoring.groups_suffix')}`,
     tone: summary.failureCalls > 0 ? 'bad' : 'good',
     icon: 'failure',
@@ -401,6 +416,7 @@ export const buildPrimarySummaryCards = ({
   {
     label: t('monitoring.estimated_cost'),
     value: hasPrices ? formatUsd(summary.totalCost) : '--',
+    valueTitle: hasPrices ? formatUsd(summary.totalCost) : undefined,
     meta: hasPrices ? t('monitoring.estimated_cost_hint') : t('monitoring.estimated_cost_missing'),
     tone: hasPrices ? undefined : 'warn',
     icon: 'cost',
@@ -410,45 +426,59 @@ export const buildPrimarySummaryCards = ({
 
 export const buildSecondarySummaryCards = (
   summary: MonitoringSummary,
+  locale: string,
   t: TFunction
-): SummaryCardProps[] => [
-  {
-    label: t('monitoring.total_tokens'),
-    value: formatCompactNumber(summary.totalTokens),
-    meta: `${t('monitoring.reasoning_tokens')} ${formatCompactNumber(summary.reasoningTokens)}`,
-    variant: 'secondary',
-    icon: 'tokens',
-    accent: 'indigo',
-  },
-  {
-    label: t('monitoring.input_tokens'),
-    value: formatCompactNumber(summary.inputTokens),
-    meta: `${t('monitoring.of_token_mix')} ${formatPercent(summary.totalTokens > 0 ? summary.inputTokens / summary.totalTokens : 0)}`,
-    variant: 'secondary',
-    icon: 'input',
-    accent: 'cyan',
-  },
-  {
-    label: t('monitoring.output_tokens'),
-    value: formatCompactNumber(summary.outputTokens),
-    meta: `${t('monitoring.of_token_mix')} ${formatPercent(summary.totalTokens > 0 ? summary.outputTokens / summary.totalTokens : 0)}`,
-    variant: 'secondary',
-    icon: 'output',
-    accent: 'violet',
-  },
-  {
-    label: t('monitoring.cached_tokens'),
-    value: formatCompactNumber(summary.cachedTokens),
-    meta: [
-      `${t('monitoring.of_input_tokens')} ${formatPercent(summary.inputTokens > 0 ? summary.cachedTokens / summary.inputTokens : 0)}`,
+): SummaryCardProps[] => {
+  const cachedTokenMetaParts = [
+    `${t('monitoring.of_input_tokens')} ${formatPercent(summary.inputTokens > 0 ? summary.cachedTokens / summary.inputTokens : 0)}`,
+  ];
+
+  if (summary.cacheCreationTokens > 0 || summary.cacheReadTokens > 0) {
+    cachedTokenMetaParts.push(
       `${t('monitoring.cache_creation_tokens_short')} ${formatCompactNumber(summary.cacheCreationTokens)}`,
-      `${t('monitoring.cache_read_tokens_short')} ${formatCompactNumber(summary.cacheReadTokens)}`,
-    ].join(' · '),
-    variant: 'secondary',
-    icon: 'cache',
-    accent: 'teal',
-  },
-];
+      `${t('monitoring.cache_read_tokens_short')} ${formatCompactNumber(summary.cacheReadTokens)}`
+    );
+  }
+
+  return [
+    {
+      label: t('monitoring.total_tokens'),
+      value: formatCompactNumber(summary.totalTokens),
+      valueTitle: formatFullNumber(summary.totalTokens, locale),
+      meta: `${t('monitoring.reasoning_tokens')} ${formatCompactNumber(summary.reasoningTokens)}`,
+      variant: 'secondary',
+      icon: 'tokens',
+      accent: 'indigo',
+    },
+    {
+      label: t('monitoring.input_tokens'),
+      value: formatCompactNumber(summary.inputTokens),
+      valueTitle: formatFullNumber(summary.inputTokens, locale),
+      meta: `${t('monitoring.of_token_mix')} ${formatPercent(summary.totalTokens > 0 ? summary.inputTokens / summary.totalTokens : 0)}`,
+      variant: 'secondary',
+      icon: 'input',
+      accent: 'cyan',
+    },
+    {
+      label: t('monitoring.output_tokens'),
+      value: formatCompactNumber(summary.outputTokens),
+      valueTitle: formatFullNumber(summary.outputTokens, locale),
+      meta: `${t('monitoring.of_token_mix')} ${formatPercent(summary.totalTokens > 0 ? summary.outputTokens / summary.totalTokens : 0)}`,
+      variant: 'secondary',
+      icon: 'output',
+      accent: 'violet',
+    },
+    {
+      label: t('monitoring.cached_tokens'),
+      value: formatCompactNumber(summary.cachedTokens),
+      valueTitle: formatFullNumber(summary.cachedTokens, locale),
+      meta: cachedTokenMetaParts.join(' · '),
+      variant: 'secondary',
+      icon: 'cache',
+      accent: 'teal',
+    },
+  ];
+};
 
 export const isUsageImportFile = (file: File) => {
   const normalizedName = file.name.toLowerCase();

--- a/apps/web/src/features/monitoring/styles/_monitoring-summary-table.scss
+++ b/apps/web/src/features/monitoring/styles/_monitoring-summary-table.scss
@@ -3,7 +3,7 @@
 @mixin styles {
   .summarySection {
     display: grid;
-    gap: 14px;
+    gap: 12px;
     min-width: 0;
   }
 
@@ -11,8 +11,13 @@
   .summarySub,
   .summaryGrid {
     display: grid;
-    grid-auto-rows: 1fr;
-    gap: 12px;
+    grid-auto-rows: minmax(112px, auto);
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .summaryGrid {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
   }
 
   .summaryHero {
@@ -35,13 +40,14 @@
     --summary-accent: var(--monitor-accent);
 
     isolation: isolate;
+    overflow: visible;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     min-width: 0;
-    height: 136px;
-    min-height: 136px;
-    padding: 16px;
+    height: auto;
+    min-height: 112px;
+    padding: 12px;
     border-radius: var(--app-radius-md);
     background: var(--glass-bg);
     backdrop-filter: var(--glass-backdrop-filter);
@@ -54,14 +60,19 @@
 
   .summaryCardPrimary,
   .summaryCardSecondary {
-    height: 136px;
-    min-height: 136px;
-    padding: 16px;
+    height: auto;
+    min-height: 112px;
+    padding: 12px;
     box-shadow: var(--shadow);
   }
 
   .summaryCard:hover {
+    z-index: 5;
     transform: translateY(-1px);
+  }
+
+  .summaryCard:focus-within {
+    z-index: 5;
   }
 
   .summaryCard:hover {
@@ -74,7 +85,7 @@
     z-index: 1;
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
     min-width: 0;
   }
 
@@ -82,12 +93,17 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
-    flex: 0 0 32px;
+    width: 28px;
+    height: 28px;
+    flex: 0 0 28px;
     border-radius: 8px;
     background: color-mix(in srgb, var(--summary-accent) 12%, transparent);
     color: var(--summary-accent);
+  }
+
+  .summaryIcon svg {
+    width: 16px;
+    height: 16px;
   }
 
   .summaryCardBody {
@@ -119,41 +135,120 @@
   .summaryValue {
     min-width: 0;
     max-width: 100%;
-    overflow: hidden;
     color: var(--monitor-ink);
-    font-size: 28px;
+    font-size: 24px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
-    line-height: 1;
+    line-height: 1.05;
     letter-spacing: 0;
-    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .summaryValueWrap {
+    position: relative;
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .summaryValueWrap .summaryValue {
+    cursor: default;
+    outline: 0;
+  }
+
+  .summaryValueWrap .summaryValue[tabindex='0'] {
+    cursor: help;
+  }
+
+  .summaryValueWrap .summaryValue[tabindex='0']:focus-visible {
+    border-radius: 6px;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--summary-accent) 28%, transparent);
+  }
+
+  .summaryValueTooltip {
+    position: absolute;
+    left: 0;
+    bottom: calc(100% + 8px);
+    z-index: 4;
+    display: grid;
+    gap: 3px;
+    width: max-content;
+    min-width: min(160px, 100%);
+    max-width: min(280px, calc(100vw - 32px));
+    padding: 8px 10px;
+    border: 1px solid color-mix(in srgb, var(--monitor-accent) 78%, var(--monitor-line));
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--monitor-accent) 92%, var(--monitor-accent-strong));
+    color: var(--primary-contrast, #fff);
+    box-shadow: 0 14px 30px color-mix(in srgb, var(--monitor-accent) 28%, transparent);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(4px);
+    transition:
+      opacity 0.14s ease,
+      transform 0.14s ease;
+  }
+
+  .summaryValueTooltip::after {
+    content: '';
+    position: absolute;
+    left: 16px;
+    bottom: -5px;
+    width: 9px;
+    height: 9px;
+    border-right: 1px solid color-mix(in srgb, var(--monitor-accent) 78%, var(--monitor-line));
+    border-bottom: 1px solid color-mix(in srgb, var(--monitor-accent) 78%, var(--monitor-line));
+    background: inherit;
+    transform: rotate(45deg);
+  }
+
+  .summaryValueWrap:hover .summaryValueTooltip,
+  .summaryValueWrap:focus-within .summaryValueTooltip {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .summaryValueTooltipLabel {
+    color: color-mix(in srgb, var(--primary-contrast, #fff) 72%, transparent);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1.2;
     white-space: nowrap;
   }
 
+  .summaryValueTooltipValue {
+    color: var(--primary-contrast, #fff);
+    font-size: 13px;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+
   .summaryCardSecondary .summaryValue {
-    font-size: 28px;
+    font-size: 24px;
   }
 
   .summaryMeta {
-    margin-top: 6px;
+    margin-top: 5px;
     color: var(--monitor-muted);
-    display: -webkit-box;
-    overflow: hidden;
-    font-size: 12px;
+    display: block;
+    font-size: 11px;
     font-weight: 500;
-    line-height: 1.45;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
   }
 
   .summaryCardChart {
     position: absolute;
-    right: 0;
-    bottom: -5px;
+    right: 8px;
+    bottom: 8px;
     z-index: 0;
-    width: 46%;
-    min-width: 96px;
-    height: 34px;
+    width: calc(46% - 8px);
+    min-width: 72px;
+    height: 28px;
     color: var(--summary-accent);
     opacity: 0.5;
     pointer-events: none;

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -7,10 +7,23 @@ import {
   collectUsageDetailsWithEndpoint,
   compatibleCachedTokens,
   extractTotalTokens,
+  formatCompactNumber,
   getServiceTierMultiplier,
   normalizeUsageSourceId,
 } from './usage';
 import { maskSensitiveText } from './format';
+
+describe('formatCompactNumber', () => {
+  it('keeps large values compact as data grows beyond millions', () => {
+    expect(formatCompactNumber(999)).toBe('999');
+    expect(formatCompactNumber(1_200)).toBe('1.2K');
+    expect(formatCompactNumber(999_950)).toBe('1.0M');
+    expect(formatCompactNumber(2_795_200_000)).toBe('2.8B');
+    expect(formatCompactNumber(1_200_000_000_000)).toBe('1.2T');
+    expect(formatCompactNumber(-2_500_000_000_000_000)).toBe('-2.5P');
+    expect(formatCompactNumber(Number.POSITIVE_INFINITY)).toBe('0');
+  });
+});
 
 describe('usage source candidates', () => {
   it('includes the masked source emitted by CPA for raw upstream keys', () => {

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -695,8 +695,24 @@ export function formatCompactNumber(value: number): string {
 
   const abs = Math.abs(num);
   if (abs === 0) return '0';
-  if (abs >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
-  if (abs >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+  const units = [
+    { threshold: 1_000_000_000_000_000, suffix: 'P' },
+    { threshold: 1_000_000_000_000, suffix: 'T' },
+    { threshold: 1_000_000_000, suffix: 'B' },
+    { threshold: 1_000_000, suffix: 'M' },
+    { threshold: 1_000, suffix: 'K' },
+  ];
+  const unit = units.find((item) => abs >= item.threshold);
+
+  if (unit) {
+    const formatted = (num / unit.threshold).toFixed(1);
+    const nextUnit = units[units.indexOf(unit) - 1];
+    if (nextUnit && Math.abs(Number(formatted)) >= 1000) {
+      return `${(num / nextUnit.threshold).toFixed(1)}${nextUnit.suffix}`;
+    }
+    return `${formatted}${unit.suffix}`;
+  }
+
   return abs >= 1 ? num.toFixed(0) : num.toFixed(2);
 }
 


### PR DESCRIPTION
## Summary
Improve monitoring summary cards with clearer compact numbers and full-value tooltips.

## Changes
- Add accessible full-value tooltips for compact summary card metrics
- Combine primary and secondary monitoring summary cards into a unified grid
- Extend compact number formatting to support B/T/P suffixes
- Hide cache creation/read token meta when both values are zero
- Add/update monitoring and usage formatting tests

## Testing
- [x] npm run test

## Related
Closes #65