### PR TITLE
docs(release): add v1.1.1 release notes

### DIFF
--- a/docs/release-notes/v1.1.1-en.md
+++ b/docs/release-notes/v1.1.1-en.md
@@ -1,0 +1,32 @@
+# CPA Manager Plus v1.1.1
+
+> 5 commits · 11 files changed · +486 / -95
+
+> [中文 ->](./v1.1.1-zh.md)
+
+## Overview
+
+This patch release continues polishing the monitoring summary experience, improves large-number and request metric display, and fixes a data refresh loop that could be triggered by history navigation. The changes are concentrated in the frontend monitoring page and usage formatting, so upgrade risk is low.
+
+## Highlights
+
+### Features
+
+- Monitoring request summary cards now show clearer metric content and supporting tooltips, with matching summary table styling to make request volume, latency, and token usage easier to scan. (`monitoring`)
+- Compact usage number formatting now supports larger usage ranges, reducing truncation or inconsistent display for high token counts, request totals, and cost-related values. (`web`)
+
+### Fixes
+
+- Fixed a monitoring history navigation path where the data hook could repeatedly refresh and cause a render loop. (`monitoring`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @kcocoa - Fixed the monitoring history navigation render loop and improved monitoring page stability.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.1.0...v1.1.1

--- a/docs/release-notes/v1.1.1-zh.md
+++ b/docs/release-notes/v1.1.1-zh.md
@@ -1,0 +1,32 @@
+# CPA Manager Plus v1.1.1
+
+> 5 commits · 11 files changed · +486 / -95
+
+> [English ->](./v1.1.1-en.md)
+
+## Overview
+
+本次补丁发布继续打磨监控中心摘要体验，优化长数字与请求指标的展示，并修复历史导航可能触发的数据刷新循环。整体变更集中在前端监控页面和使用量格式化，升级风险较低。
+
+## Highlights
+
+### Features
+
+- 监控请求摘要卡片现在展示更清晰的指标内容和辅助提示，表格摘要样式也同步调整，便于快速判断请求规模、耗时和 token 使用情况。(`monitoring`)
+- compact usage 数字格式支持更大的用量范围，减少大额 token、请求数和费用相关数字在界面中的截断或不一致显示。(`web`)
+
+### Fixes
+
+- 修复监控历史导航时数据 hook 可能反复触发刷新并造成 render loop 的问题。(`monitoring`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @kcocoa - 修复监控历史导航中的 render loop 问题，提升监控页面稳定性。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.1.0...v1.1.1


### PR DESCRIPTION
## Purpose

Add curated release notes for `v1.1.1` so the tag release workflow uses repository-maintained release body content.

## Files

- `docs/release-notes/v1.1.1-zh.md`
- `docs/release-notes/v1.1.1-en.md`

## Verification

- Release notes are docs-only.
- The release workflow checks `docs/release-notes/{tag}-zh.md` first, then `zh-CN`, then `en`.

## Affected modes

- frontend-only: no runtime change
- CPA panel: no runtime change
- full Docker: no runtime change
- native packages: release body only