### PR TITLE
fix(monitoring): handle Anthropic cache usage tokens

### DIFF
--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -379,13 +379,37 @@ func readTokenFields(record map[string]any) (int64, int64, int64, int64, int64, 
 	if cache == 0 {
 		cache = readInt(record, "cache_tokens", "cacheTokens")
 	}
-	cacheRead := readIntFrom(tokens, "cache_read_tokens", "cacheReadTokens")
+	cacheRead := readFirstIntFrom(tokens,
+		"cache_read_tokens",
+		"cacheReadTokens",
+		"cache_read_input_tokens",
+		"cacheReadInputTokens",
+	)
 	if cacheRead == 0 {
-		cacheRead = readInt(record, "cache_read_tokens", "cacheReadTokens")
+		cacheRead = readFirstIntFrom(record,
+			"cache_read_tokens",
+			"cacheReadTokens",
+			"cache_read_input_tokens",
+			"cacheReadInputTokens",
+		)
 	}
-	cacheCreation := readIntFrom(tokens, "cache_creation_tokens", "cacheCreationTokens")
+	cacheCreation := readFirstIntFrom(tokens,
+		"cache_creation_tokens",
+		"cacheCreationTokens",
+		"cache_creation_input_tokens",
+		"cacheCreationInputTokens",
+		"cache_write_input_tokens",
+		"cacheWriteInputTokens",
+	)
 	if cacheCreation == 0 {
-		cacheCreation = readInt(record, "cache_creation_tokens", "cacheCreationTokens")
+		cacheCreation = readFirstIntFrom(record,
+			"cache_creation_tokens",
+			"cacheCreationTokens",
+			"cache_creation_input_tokens",
+			"cacheCreationInputTokens",
+			"cache_write_input_tokens",
+			"cacheWriteInputTokens",
+		)
 	}
 	total := readIntFrom(tokens, "total_tokens", "totalTokens", "total")
 	if total == 0 {
@@ -454,6 +478,16 @@ func readString(record map[string]any, keys ...string) string {
 
 func readInt(record map[string]any, keys ...string) int64 {
 	return readIntFrom(record, keys...)
+}
+
+func readFirstIntFrom(record map[string]any, keys ...string) int64 {
+	for _, key := range keys {
+		value := readIntFrom(record, key)
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 func readIntFrom(record map[string]any, keys ...string) int64 {

--- a/apps/manager-server/internal/usage/import_test.go
+++ b/apps/manager-server/internal/usage/import_test.go
@@ -285,6 +285,58 @@ func TestNormalizeRawReadsCPA7118UsageFields(t *testing.T) {
 	}
 }
 
+func TestNormalizeRawReadsAnthropicCacheUsageFields(t *testing.T) {
+	payload := `{
+	  "timestamp": "2026-04-25T00:00:00Z",
+	  "provider": "anthropic",
+	  "model": "claude-sonnet-4-5",
+	  "endpoint": "POST /v1/messages",
+	  "usage": {
+	    "input_tokens": 100,
+	    "output_tokens": 20,
+	    "cached_tokens": 34,
+	    "cache_creation_input_tokens": 11,
+	    "cache_read_input_tokens": 23
+	  }
+	}`
+	event, err := NormalizeRaw([]byte(payload))
+	if err != nil {
+		t.Fatalf("normalize anthropic payload: %v", err)
+	}
+	if event.InputTokens != 100 || event.OutputTokens != 20 ||
+		event.CachedTokens != 34 || event.CacheReadTokens != 23 ||
+		event.CacheCreationTokens != 11 || event.TotalTokens != 154 {
+		t.Fatalf("event tokens = %#v", event)
+	}
+
+	legacyPayload := BuildPayload([]Event{event})
+	detail := legacyPayload.APIs["POST /v1/messages"].Models["claude-sonnet-4-5"].Details[0]
+	if detail.Tokens.CachedTokens != 0 || detail.Tokens.CacheReadTokens != 23 ||
+		detail.Tokens.CacheCreationTokens != 11 || detail.Tokens.TotalTokens != 154 {
+		t.Fatalf("detail tokens = %#v", detail.Tokens)
+	}
+}
+
+func TestNormalizeRawReadsAnthropicCacheUsageFieldsAtTopLevel(t *testing.T) {
+	payload := `{
+	  "timestamp": "2026-04-25T00:00:00Z",
+	  "provider": "anthropic",
+	  "model": "claude-opus-4-1",
+	  "endpoint": "POST /v1/messages",
+	  "input_tokens": 10,
+	  "output_tokens": 5,
+	  "cacheReadInputTokens": 7,
+	  "cacheCreationInputTokens": 3
+	}`
+	event, err := NormalizeRaw([]byte(payload))
+	if err != nil {
+		t.Fatalf("normalize anthropic top-level payload: %v", err)
+	}
+	if event.CacheReadTokens != 7 || event.CacheCreationTokens != 3 || event.TotalTokens != 25 {
+		t.Fatalf("event tokens = %#v", event)
+	}
+}
+
 func TestCompatibleCachedTokensDoesNotDoubleCountFineGrainedCache(t *testing.T) {
 	if got := CompatibleCachedTokens(5, 0, 4, 1); got != 0 {
 		t.Fatalf("fully mirrored cached tokens = %d, want 0", got)

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
@@ -149,16 +149,16 @@ describe('MonitoringCenterPage summary cards', () => {
     expect(html).toContain('25.5K');
     expect(html).toContain('1.9K');
     expect(html).toContain('2.8B');
-    expect(html).toContain('2.6B');
+    expect(html).toContain('3.6B');
     expect(html).toContain('role="tooltip"');
     expect(html).toContain('2,795,200,000');
     expect(html).toContain('2,783,500,000');
-    expect(html).toContain('2,595,300,000');
+    expect(html).toContain('3,595,200,000');
     expect(html).toContain('$9,999,999.99');
     expect(html).toContain('Reasoning 5.0M');
     expect(html).toContain('Share 99.6%');
     expect(html).toContain('Share 0.4%');
-    expect(html).toContain('Input share 93.2% · Create 555.5M · Read 444.4M');
+    expect(html).toContain('Share 56.2% · Cached Tokens 2.6B · Create 555.5M · Read 444.4M');
   });
 
   it('hides cache creation and read meta when both cached sub-metrics are zero', () => {

--- a/apps/web/src/features/monitoring/accountOverviewCardMetrics.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewCardMetrics.test.ts
@@ -18,6 +18,8 @@ describe('accountOverviewCardMetrics', () => {
       'input-tokens',
       'output-tokens',
       'cached-tokens',
+      'cache-creation-tokens',
+      'cache-read-tokens',
     ]);
   });
 });

--- a/apps/web/src/features/monitoring/accountOverviewState.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.test.ts
@@ -218,6 +218,8 @@ describe('accountOverviewState', () => {
       'input-tokens',
       'output-tokens',
       'cached-tokens',
+      'cache-creation-tokens',
+      'cache-read-tokens',
     ]);
   });
 

--- a/apps/web/src/features/monitoring/accountOverviewState.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.ts
@@ -39,6 +39,8 @@ export const ACCOUNT_OVERVIEW_CARD_METRIC_KEYS = [
   'input-tokens',
   'output-tokens',
   'cached-tokens',
+  'cache-creation-tokens',
+  'cache-read-tokens',
 ] as const;
 const DEFAULT_ACCOUNT_OVERVIEW_CARD_PAGINATION = {
   page: 1,

--- a/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
@@ -317,24 +317,40 @@ export function AccountTokenMetricGrid({
   const getTokenMetricIcon = (key: string) => {
     if (key === 'input-tokens') return <IconInbox size={13} />;
     if (key === 'output-tokens') return <IconTrendingUp size={13} />;
-    if (key === 'cached-tokens') return <IconTimer size={13} />;
+    if (key === 'cached-tokens' || key === 'cache-creation-tokens' || key === 'cache-read-tokens') {
+      return <IconTimer size={13} />;
+    }
     return <IconChartLine size={13} />;
   };
   const getTokenMetricToneClassName = (key: string) => {
     if (key === 'input-tokens') return styles.accountMetricIconInput;
     if (key === 'output-tokens') return styles.accountMetricIconOutput;
-    if (key === 'cached-tokens') return styles.accountMetricIconCached;
+    if (key === 'cached-tokens' || key === 'cache-creation-tokens' || key === 'cache-read-tokens') {
+      return styles.accountMetricIconCached;
+    }
     return styles.accountMetricIconTotal;
   };
 
   if (variant === 'table') {
     const tokenStructureMetrics = metrics.filter((metric) =>
-      ['input-tokens', 'output-tokens', 'cached-tokens'].includes(metric.key)
+      [
+        'input-tokens',
+        'output-tokens',
+        'cached-tokens',
+        'cache-creation-tokens',
+        'cache-read-tokens',
+      ].includes(metric.key)
     );
     const getTokenStructureRowToneClassName = (key: string) => {
       if (key === 'input-tokens') return styles.tokenStructureRowInput;
       if (key === 'output-tokens') return styles.tokenStructureRowOutput;
-      if (key === 'cached-tokens') return styles.tokenStructureRowCached;
+      if (
+        key === 'cached-tokens' ||
+        key === 'cache-creation-tokens' ||
+        key === 'cache-read-tokens'
+      ) {
+        return styles.tokenStructureRowCached;
+      }
       return '';
     };
 
@@ -457,7 +473,11 @@ function AccountHealthStatusPanel({
     },
     {
       key: 'success-rate',
-      label: shortLabel(t, 'monitoring.column_success_rate_short', 'monitoring.column_success_rate'),
+      label: shortLabel(
+        t,
+        'monitoring.column_success_rate_short',
+        'monitoring.column_success_rate'
+      ),
       fullLabel: t('monitoring.column_success_rate'),
       value: formatPercent(row.successRate),
       className: getSuccessRateClassName(row.successRate),

--- a/apps/web/src/features/monitoring/components/ApiKeySummaryPanel.tsx
+++ b/apps/web/src/features/monitoring/components/ApiKeySummaryPanel.tsx
@@ -132,6 +132,22 @@ const buildApiKeySummaryMetrics = (
     value: formatCompactNumber(row.cachedTokens),
   },
   {
+    key: 'cache-creation-tokens',
+    label: shortLabel(
+      t,
+      'monitoring.cache_creation_tokens_short',
+      'monitoring.cache_creation_tokens'
+    ),
+    fullLabel: t('monitoring.cache_creation_tokens'),
+    value: formatCompactNumber(row.cacheCreationTokens),
+  },
+  {
+    key: 'cache-read-tokens',
+    label: shortLabel(t, 'monitoring.cache_read_tokens_short', 'monitoring.cache_read_tokens'),
+    fullLabel: t('monitoring.cache_read_tokens'),
+    value: formatCompactNumber(row.cacheReadTokens),
+  },
+  {
     key: 'estimated-cost',
     label: shortLabel(t, 'monitoring.estimated_cost_short', 'monitoring.estimated_cost'),
     fullLabel: t('monitoring.estimated_cost'),

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -202,9 +202,7 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('Elapsed');
     expect(markup).toContain('1.5 s');
     expect(markup).toContain('20');
-    expect(markup).toContain('I 10 · O 20 · C 5');
-    expect(markup).not.toContain('Read 4');
-    expect(markup).not.toContain('Create 1');
+    expect(markup).toContain('I 10 · O 20 · C 5 · Create 1 · Read 4');
     expect(markup).toContain('role="tooltip"');
     expect(markup).toContain('aria-describedby=');
     expect(markup).toContain('aria-label="HTTP 429 · rate limit exceeded"');
@@ -267,7 +265,9 @@ describe('RealtimeEventsPanel', () => {
     const fullMarkup = renderPanel(row, { accountDisplayMode: 'full' });
 
     expect(maskedMarkup).toContain('>ver***@example.com</span>');
-    expect(maskedMarkup).toContain('title="ver***@example.com · Provider: openai · very-long-user@example.com');
+    expect(maskedMarkup).toContain(
+      'title="ver***@example.com · Provider: openai · very-long-user@example.com'
+    );
     expect(fullMarkup).toContain('>very-long-user@example.com</span>');
     expect(fullMarkup).toContain('title="very-long-user@example.com · Provider: openai');
   });
@@ -315,8 +315,12 @@ describe('RealtimeEventsPanel', () => {
   it('colors normal millisecond and second metrics green for both ttft and elapsed time', () => {
     const markup = renderPanel(baseRow({ latencyMs: 470, ttftMs: 120 }));
 
-    expect(markup).toMatch(/class="[^"]*realtimeMetricText[^"]*realtimeMetricLeft[^"]*goodText[^"]*">120 ms/);
-    expect(markup).toMatch(/class="[^"]*realtimeMetricText[^"]*realtimeMetricRight[^"]*goodText[^"]*">470 ms/);
+    expect(markup).toMatch(
+      /class="[^"]*realtimeMetricText[^"]*realtimeMetricLeft[^"]*goodText[^"]*">120 ms/
+    );
+    expect(markup).toMatch(
+      /class="[^"]*realtimeMetricText[^"]*realtimeMetricRight[^"]*goodText[^"]*">470 ms/
+    );
   });
 
   it('renders residual cached tokens even when they equal cache read tokens', () => {
@@ -329,8 +333,8 @@ describe('RealtimeEventsPanel', () => {
     );
 
     expect(markup).toContain('C 4');
-    expect(markup).not.toContain('Read 4');
-    expect(markup).not.toContain('Create 1');
+    expect(markup).toContain('Read 4');
+    expect(markup).toContain('Create 1');
   });
 
   it('shows the loaded vs total summary with a load-more action when more pages exist', () => {

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -86,7 +86,7 @@ const shortLabel = (
 ) => {
   const fallback = t(fallbackKey, fallbackDefault ? { defaultValue: fallbackDefault } : undefined);
   const label = t(shortKey, { defaultValue: fallback });
-  return label === shortKey ? fallbackDefault ?? fallback : label;
+  return label === shortKey ? (fallbackDefault ?? fallback) : label;
 };
 
 const formatShortHash = (value: string | null | undefined) => {
@@ -215,6 +215,25 @@ const buildFailureDetails = (row: MonitoringEventRow, t: TFunction) => {
     label: buildFailureMetaText(row, t),
     copyText: [statusText, summary].filter(Boolean).join('\n'),
   };
+};
+
+const buildRealtimeTokenSummary = (row: MonitoringEventRow, t: TFunction) => {
+  const parts = [
+    `I ${formatCompactNumber(row.inputTokens)}`,
+    `O ${formatCompactNumber(row.outputTokens)}`,
+    `C ${formatCompactNumber(row.cachedTokens)}`,
+  ];
+  if (row.cacheCreationTokens > 0) {
+    parts.push(
+      `${shortLabel(t, 'monitoring.cache_creation_tokens_short', 'monitoring.cache_creation_tokens', 'Create')} ${formatCompactNumber(row.cacheCreationTokens)}`
+    );
+  }
+  if (row.cacheReadTokens > 0) {
+    parts.push(
+      `${shortLabel(t, 'monitoring.cache_read_tokens_short', 'monitoring.cache_read_tokens', 'Read')} ${formatCompactNumber(row.cacheReadTokens)}`
+    );
+  }
+  return parts.join(' · ');
 };
 
 export function RealtimeEventsPanelActions({
@@ -398,9 +417,7 @@ export function RealtimeEventsPanel({
               <th className={styles.realtimeTpsColumn}>{t('monitoring.column_output_tps')}</th>
               <th className={styles.realtimeLatencyColumn}>
                 <span className={styles.realtimeLatencyHeader}>
-                  <span className={styles.realtimeMetricLeft}>
-                    {t('monitoring.ttft_short')}
-                  </span>
+                  <span className={styles.realtimeMetricLeft}>{t('monitoring.ttft_short')}</span>
                   <span className={styles.realtimeMetricSeparator}>｜</span>
                   <span className={styles.realtimeMetricRight}>
                     {t('monitoring.elapsed_short')}
@@ -585,7 +602,7 @@ export function RealtimeEventsPanel({
                   <td>
                     <div className={styles.primaryCell}>
                       <span>{formatCompactNumber(row.totalTokens)}</span>
-                      <small>{`I ${formatCompactNumber(row.inputTokens)} · O ${formatCompactNumber(row.outputTokens)} · C ${formatCompactNumber(row.cachedTokens)}`}</small>
+                      <small>{buildRealtimeTokenSummary(row, t)}</small>
                     </div>
                   </td>
                   <td>{hasPrices ? formatUsd(row.totalCost) : '--'}</td>

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -146,6 +146,22 @@ export const buildAccountSummaryMetrics = (
     value: formatCompactNumber(row.cachedTokens),
   },
   {
+    key: 'cache-creation-tokens',
+    label: shortLabel(
+      t,
+      'monitoring.cache_creation_tokens_short',
+      'monitoring.cache_creation_tokens'
+    ),
+    fullLabel: t('monitoring.cache_creation_tokens'),
+    value: formatCompactNumber(row.cacheCreationTokens),
+  },
+  {
+    key: 'cache-read-tokens',
+    label: shortLabel(t, 'monitoring.cache_read_tokens_short', 'monitoring.cache_read_tokens'),
+    fullLabel: t('monitoring.cache_read_tokens'),
+    value: formatCompactNumber(row.cacheReadTokens),
+  },
+  {
     key: 'estimated-cost',
     label: shortLabel(t, 'monitoring.estimated_cost_short', 'monitoring.estimated_cost'),
     fullLabel: t('monitoring.estimated_cost'),

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -177,7 +177,11 @@ export const buildProviderOptionsFromValues = (
     [
       {
         value: 'all',
-        label: shortLabel(t, 'monitoring.filter_all_providers_short', 'monitoring.filter_all_providers'),
+        label: shortLabel(
+          t,
+          'monitoring.filter_all_providers_short',
+          'monitoring.filter_all_providers'
+        ),
       },
       ...buildSortedValueOptions(providers),
     ],
@@ -194,7 +198,11 @@ export const buildAccountOptions = (
     [
       {
         value: 'all',
-        label: shortLabel(t, 'monitoring.filter_all_accounts_short', 'monitoring.filter_all_accounts'),
+        label: shortLabel(
+          t,
+          'monitoring.filter_all_accounts_short',
+          'monitoring.filter_all_accounts'
+        ),
       },
       ...Array.from(
         new Map(
@@ -257,7 +265,11 @@ export const buildChannelOptionsFromValues = (
     [
       {
         value: 'all',
-        label: shortLabel(t, 'monitoring.filter_all_channels_short', 'monitoring.filter_all_channels'),
+        label: shortLabel(
+          t,
+          'monitoring.filter_all_channels_short',
+          'monitoring.filter_all_channels'
+        ),
       },
       ...buildSortedValueOptions(channels),
     ],
@@ -273,7 +285,11 @@ const buildApiKeyOptionsFromMap = (
     [
       {
         value: 'all',
-        label: shortLabel(t, 'monitoring.filter_all_api_keys_short', 'monitoring.filter_all_api_keys'),
+        label: shortLabel(
+          t,
+          'monitoring.filter_all_api_keys_short',
+          'monitoring.filter_all_api_keys'
+        ),
       },
       ...Array.from(optionMap.entries())
         .sort((left, right) => left[1].localeCompare(right[1]))
@@ -318,11 +334,19 @@ export const buildStatusOptions = (t: TFunction): MonitoringOption[] => [
   },
   {
     value: 'success',
-    label: shortLabel(t, 'monitoring.filter_status_success_short', 'monitoring.filter_status_success'),
+    label: shortLabel(
+      t,
+      'monitoring.filter_status_success_short',
+      'monitoring.filter_status_success'
+    ),
   },
   {
     value: 'failed',
-    label: shortLabel(t, 'monitoring.filter_status_failed_short', 'monitoring.filter_status_failed'),
+    label: shortLabel(
+      t,
+      'monitoring.filter_status_failed_short',
+      'monitoring.filter_status_failed'
+    ),
   },
 ];
 
@@ -536,15 +560,33 @@ export const buildSecondarySummaryCards = (
   locale: string,
   t: TFunction
 ): SummaryCardProps[] => {
+  const totalCacheTokens =
+    summary.cachedTokens + summary.cacheCreationTokens + summary.cacheReadTokens;
+  const hasFineGrainedCache = summary.cacheCreationTokens > 0 || summary.cacheReadTokens > 0;
+  const tokenMixTotal =
+    summary.inputTokens + summary.outputTokens + summary.reasoningTokens + totalCacheTokens;
   const cachedTokenMetaParts = [
-    `${t('monitoring.of_input_tokens')} ${formatPercent(summary.inputTokens > 0 ? summary.cachedTokens / summary.inputTokens : 0)}`,
+    hasFineGrainedCache
+      ? `${t('monitoring.of_token_mix')} ${formatPercent(tokenMixTotal > 0 ? totalCacheTokens / tokenMixTotal : 0)}`
+      : `${t('monitoring.of_input_tokens')} ${formatPercent(summary.inputTokens > 0 ? totalCacheTokens / summary.inputTokens : 0)}`,
   ];
 
-  if (summary.cacheCreationTokens > 0 || summary.cacheReadTokens > 0) {
-    cachedTokenMetaParts.push(
-      `${t('monitoring.cache_creation_tokens_short')} ${formatCompactNumber(summary.cacheCreationTokens)}`,
-      `${t('monitoring.cache_read_tokens_short')} ${formatCompactNumber(summary.cacheReadTokens)}`
-    );
+  if (hasFineGrainedCache) {
+    if (summary.cachedTokens > 0) {
+      cachedTokenMetaParts.push(
+        `${shortLabel(t, 'monitoring.cached_tokens_short', 'monitoring.cached_tokens')} ${formatCompactNumber(summary.cachedTokens)}`
+      );
+    }
+    if (summary.cacheCreationTokens > 0) {
+      cachedTokenMetaParts.push(
+        `${t('monitoring.cache_creation_tokens_short')} ${formatCompactNumber(summary.cacheCreationTokens)}`
+      );
+    }
+    if (summary.cacheReadTokens > 0) {
+      cachedTokenMetaParts.push(
+        `${t('monitoring.cache_read_tokens_short')} ${formatCompactNumber(summary.cacheReadTokens)}`
+      );
+    }
   }
 
   return [
@@ -581,8 +623,8 @@ export const buildSecondarySummaryCards = (
     {
       label: shortLabel(t, 'monitoring.cached_tokens_short', 'monitoring.cached_tokens'),
       fullLabel: t('monitoring.cached_tokens'),
-      value: formatCompactNumber(summary.cachedTokens),
-      valueTitle: formatFullNumber(summary.cachedTokens, locale),
+      value: formatCompactNumber(totalCacheTokens),
+      valueTitle: formatFullNumber(totalCacheTokens, locale),
       meta: cachedTokenMetaParts.join(' · '),
       variant: 'secondary',
       icon: 'cache',

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -247,6 +247,41 @@ describe('usage detail collection', () => {
     expect(detail.tokens.cached_tokens).toBe(0);
     expect(detail.tokens.cache_read_tokens).toBe(500);
   });
+
+  it('normalizes Anthropic cache input token fields', () => {
+    const usageData = {
+      apis: {
+        'POST /v1/messages': {
+          models: {
+            'claude-sonnet': {
+              details: [
+                {
+                  timestamp: '2026-05-19T10:00:00Z',
+                  source: 'alice@example.com',
+                  auth_index: 'auth-1',
+                  tokens: {
+                    input_tokens: 100,
+                    output_tokens: 20,
+                    cached_tokens: 34,
+                    cache_creation_input_tokens: 11,
+                    cache_read_input_tokens: 23,
+                  },
+                  failed: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const detail = collectUsageDetailsWithEndpoint(usageData)[0];
+
+    expect(detail.tokens.cached_tokens).toBe(0);
+    expect(detail.tokens.cache_creation_tokens).toBe(11);
+    expect(detail.tokens.cache_read_tokens).toBe(23);
+    expect(detail.tokens.total_tokens).toBe(154);
+  });
 });
 
 describe('usage token helpers', () => {
@@ -269,6 +304,20 @@ describe('usage token helpers', () => {
         },
       })
     ).toBe(43);
+  });
+
+  it('uses Anthropic cache input fields when total tokens are missing', () => {
+    expect(
+      extractTotalTokens({
+        tokens: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cached_tokens: 34,
+          cache_read_input_tokens: 23,
+          cache_creation_input_tokens: 11,
+        },
+      })
+    ).toBe(154);
   });
 });
 

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -25,7 +25,13 @@ export interface UsageTokens {
   cached_tokens?: number;
   cache_tokens?: number;
   cache_read_tokens?: number;
+  cache_read_input_tokens?: number;
+  cacheReadInputTokens?: number;
   cache_creation_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cacheCreationInputTokens?: number;
+  cache_write_input_tokens?: number;
+  cacheWriteInputTokens?: number;
   total_tokens?: number;
 }
 
@@ -96,6 +102,20 @@ const BACKEND_MASKED_SOURCE_REGEX = /^m:(\*{4}|[^\s/\\]{4}\.\.\.[^\s/\\]{4})$/;
 const keyFingerprintCache = new Map<string, string>();
 const usageDetailsCache = new WeakMap<object, UsageDetail[]>();
 const usageDetailsWithEndpointCache = new WeakMap<object, UsageDetailWithEndpoint[]>();
+const CACHE_READ_TOKEN_KEYS = [
+  'cache_read_tokens',
+  'cacheReadTokens',
+  'cache_read_input_tokens',
+  'cacheReadInputTokens',
+] as const;
+const CACHE_CREATION_TOKEN_KEYS = [
+  'cache_creation_tokens',
+  'cacheCreationTokens',
+  'cache_creation_input_tokens',
+  'cacheCreationInputTokens',
+  'cache_write_input_tokens',
+  'cacheWriteInputTokens',
+] as const;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -103,6 +123,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const toFiniteNumber = (value: unknown): number => {
   const numberValue = typeof value === 'number' ? value : Number(value);
   return Number.isFinite(numberValue) ? numberValue : 0;
+};
+
+const readFirstTokenNumber = (record: Record<string, unknown>, keys: readonly string[]): number => {
+  for (const key of keys) {
+    const value = toFiniteNumber(record[key]);
+    if (value !== 0) return value;
+  }
+  return 0;
 };
 
 const toPositiveNumber = (value: unknown): number | undefined => {
@@ -317,10 +345,8 @@ export function extractTTFTMs(detail: unknown): number | null {
 
 const readTokens = (detail: Record<string, unknown>): UsageTokens => {
   const tokensRaw = isRecord(detail.tokens) ? detail.tokens : {};
-  const cacheReadTokens = toFiniteNumber(tokensRaw.cache_read_tokens ?? tokensRaw.cacheReadTokens);
-  const cacheCreationTokens = toFiniteNumber(
-    tokensRaw.cache_creation_tokens ?? tokensRaw.cacheCreationTokens
-  );
+  const cacheReadTokens = readFirstTokenNumber(tokensRaw, CACHE_READ_TOKEN_KEYS);
+  const cacheCreationTokens = readFirstTokenNumber(tokensRaw, CACHE_CREATION_TOKEN_KEYS);
   const cachedTokens = compatibleCachedTokens(
     tokensRaw.cached_tokens ?? tokensRaw.cachedTokens,
     tokensRaw.cache_tokens ?? tokensRaw.cacheTokens,
@@ -546,6 +572,8 @@ export function collectUsageDetailsWithEndpoint(usageData: unknown): UsageDetail
 export function extractTotalTokens(detail: unknown): number {
   const record = isRecord(detail) ? detail : null;
   const tokens = record && isRecord(record.tokens) ? record.tokens : {};
+  const cacheReadTokens = Math.max(readFirstTokenNumber(tokens, CACHE_READ_TOKEN_KEYS), 0);
+  const cacheCreationTokens = Math.max(readFirstTokenNumber(tokens, CACHE_CREATION_TOKEN_KEYS), 0);
   const explicitTotal = toFiniteNumber(tokens.total_tokens ?? tokens.totalTokens);
   if (explicitTotal > 0) return explicitTotal;
 
@@ -555,16 +583,8 @@ export function extractTotalTokens(detail: unknown): number {
   const cachedTokens = compatibleCachedTokens(
     tokens.cached_tokens ?? tokens.cachedTokens,
     tokens.cache_tokens ?? tokens.cacheTokens,
-    tokens.cache_read_tokens ?? tokens.cacheReadTokens,
-    tokens.cache_creation_tokens ?? tokens.cacheCreationTokens
-  );
-  const cacheReadTokens = Math.max(
-    toFiniteNumber(tokens.cache_read_tokens ?? tokens.cacheReadTokens),
-    0
-  );
-  const cacheCreationTokens = Math.max(
-    toFiniteNumber(tokens.cache_creation_tokens ?? tokens.cacheCreationTokens),
-    0
+    cacheReadTokens,
+    cacheCreationTokens
   );
 
   return (


### PR DESCRIPTION
## Summary
Fix Anthropic protocol cache usage tracking and monitoring display.

## Cause
Anthropic responses use cache_read_input_tokens and cache_creation_input_tokens, while the manager only recognized normalized cache_read_tokens and cache_creation_tokens. The UI also emphasized residual cached tokens, which can be 0 when cache read/create are tracked separately.

## Solution
- Parse Anthropic cache input token aliases in backend usage normalization.
- Normalize the same aliases in frontend legacy usage parsing.
- Show cache create/read metrics in monitoring summary, realtime rows, account cards, and API key summaries.

## Testing
- npm run test
- npm run type-check
- npm run lint
- go test ./...