### PR TITLE
fix(monitoring): search full account snapshots

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -28,6 +28,27 @@ type AnalyticsFilter struct {
 	ExcludeZeroTokens bool
 }
 
+var analyticsSearchTextColumns = []string{
+	"model",
+	"resolved_model",
+	"endpoint",
+	"method",
+	"path",
+	"source",
+	"source_hash",
+	"api_key_hash",
+	"auth_index",
+	"account_snapshot",
+	"auth_label_snapshot",
+	"auth_file_snapshot",
+	"auth_provider_snapshot",
+	"auth_project_id_snapshot",
+	"reasoning_effort",
+	"service_tier",
+	"executor_type",
+	"fail_summary",
+}
+
 type TimelinePoint struct {
 	BucketMS int64
 	Calls    int64
@@ -898,13 +919,16 @@ func analyticsWhere(filter AnalyticsFilter) (string, []any) {
 	hash := strings.TrimSpace(strings.ToLower(filter.SearchAPIKeyHash))
 	if query != "" {
 		like := "%" + query + "%"
-		if hash != "" {
-			conditions = append(conditions, `(lower(coalesce(model, '')) like ? or lower(coalesce(resolved_model, '')) like ? or lower(coalesce(endpoint, '')) like ? or lower(coalesce(source, '')) like ? or lower(coalesce(source_hash, '')) like ? or lower(coalesce(api_key_hash, '')) like ? or lower(coalesce(auth_project_id_snapshot, '')) like ? or lower(coalesce(reasoning_effort, '')) like ? or lower(coalesce(service_tier, '')) like ? or lower(coalesce(executor_type, '')) like ? or lower(coalesce(fail_summary, '')) like ? or lower(coalesce(api_key_hash, '')) = ?)`)
-			args = append(args, like, like, like, like, like, like, like, like, like, like, like, hash)
-		} else {
-			conditions = append(conditions, `(lower(coalesce(model, '')) like ? or lower(coalesce(resolved_model, '')) like ? or lower(coalesce(endpoint, '')) like ? or lower(coalesce(source, '')) like ? or lower(coalesce(source_hash, '')) like ? or lower(coalesce(api_key_hash, '')) like ? or lower(coalesce(auth_project_id_snapshot, '')) like ? or lower(coalesce(reasoning_effort, '')) like ? or lower(coalesce(service_tier, '')) like ? or lower(coalesce(executor_type, '')) like ? or lower(coalesce(fail_summary, '')) like ?)`)
-			args = append(args, like, like, like, like, like, like, like, like, like, like, like)
+		searchConditions := make([]string, 0, len(analyticsSearchTextColumns)+1)
+		for _, column := range analyticsSearchTextColumns {
+			searchConditions = append(searchConditions, fmt.Sprintf("lower(coalesce(%s, '')) like ?", column))
+			args = append(args, like)
 		}
+		if hash != "" {
+			searchConditions = append(searchConditions, "lower(coalesce(api_key_hash, '')) = ?")
+			args = append(args, hash)
+		}
+		conditions = append(conditions, "("+strings.Join(searchConditions, " or ")+")")
 	} else if hash != "" {
 		conditions = append(conditions, "lower(coalesce(api_key_hash, '')) = ?")
 		args = append(args, hash)

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -518,6 +518,45 @@ func TestAnalyticsSearchMatchesResolvedModelAndProjectID(t *testing.T) {
 	}
 }
 
+func TestAnalyticsSearchMatchesAccountSnapshotsWhenSourceIsMasked(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_060_000_000)
+	toMS := fromMS + 60*60*1000
+
+	alice := monitoringEvent("search-account-alice", fromMS+1_000, "gpt-a", "auth-a", "source-a", false, 1, 1, 0, 0, 2, nil)
+	alice.Source = "ali***@example.com"
+	alice.AccountSnapshot = "alice.smith@example.com"
+	alice.AuthLabelSnapshot = "Alice Work Account"
+	alice.AuthFileSnapshot = "alice.json"
+	bob := monitoringEvent("search-account-bob", fromMS+2_000, "gpt-b", "auth-b", "source-b", false, 1, 1, 0, 0, 2, nil)
+	bob.Source = "ali***@example.com"
+	bob.AccountSnapshot = "alina.team@example.com"
+	bob.AuthLabelSnapshot = "Alina Work Account"
+	bob.AuthFileSnapshot = "alina.json"
+	if _, err := db.InsertEvents(ctx, []usage.Event{alice, bob}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	for _, query := range []string{"ALICE.SMITH@example.com", "Alice Work Account", "alice.json"} {
+		resp, err := New(db).Analytics(ctx, Request{
+			FromMS:      fromMS,
+			ToMS:        toMS,
+			SearchQuery: query,
+			Include:     Include{Summary: true, EventsPage: &EventsPage{Limit: 10}},
+		})
+		if err != nil {
+			t.Fatalf("analytics search %q: %v", query, err)
+		}
+		if resp.Summary == nil || resp.Summary.TotalCalls != 1 {
+			t.Fatalf("search %q summary = %#v", query, resp.Summary)
+		}
+		if resp.Events == nil || len(resp.Events.Items) != 1 || resp.Events.Items[0].EventHash != "search-account-alice" {
+			t.Fatalf("search %q events = %#v", query, resp.Events)
+		}
+	}
+}
+
 func TestAnalyticsReportsZeroTokenModels(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
Fix monitoring analytics search so full account identifiers shown in the UI are searchable.

## Cause
The backend search_query filter searched masked source and other metadata, but omitted account snapshot fields used for full account display.

## Solution
- Build analytics search predicates from a shared column list
- Include account snapshot/auth metadata fields
- Add regression coverage for masked source plus full account search

## Testing
- go test ./internal/service/monitoring ./internal/repository/usageevent
- npm run manager-server:test

## Related
Fixes #117