### PR TITLE
docs(release): add v1.2.0 release notes

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: release
+description: CPAMP-specific release workflow. Use when the user asks to run or plan the CPA Manager Plus release flow, create versioned release notes, open or merge the release PR, or push the release tag.
+---
+
+# CPAMP Release
+
+This is a repo-local Codex skill for CPA Manager Plus only. Do not generalize
+it to other projects or install it globally. Follow `docs/release.md`,
+`.github/workflows/release.yml`, and the shared approval semantics in
+`/Users/seakee/.codex/prompt-policy.md`.
+
+GitHub remote operations must use the GitHub MCP tools (`mcp__github__*`) when
+available. Do not use `gh` for PRs, branch reads/writes, release checks, or
+other GitHub API work while MCP can cover the operation.
+
+## Hard Rules
+
+1. Explicit confirmation is required before any state-changing operation.
+2. Before confirmation, run read-only checks only: inspect auth, refs, status,
+   tags, commits, and render previews. Do not switch branches, pull, write
+   files, commit, push, merge, or tag.
+3. `--dry-run` is non-mutating: preview notes and the execution plan only.
+4. Release notes must be committed to `main` through a release PR before the
+   tag is pushed.
+5. `docs/release-notes/` is reserved for versioned note files:
+   `docs/release-notes/<tag>-<lang>.md`.
+6. No AI markers in commits, PRs, release notes, or tags.
+7. Do not mutate `.gitignore` or tracked collaboration files unless the user
+   explicitly approves that exact scope.
+8. If the current GitHub MCP toolset cannot perform a required remote mutation
+   such as creating a tag/ref or deleting a remote branch, stop and ask for an
+   explicit fallback decision. Do not silently use `gh` or `git push`.
+
+## Read First
+
+- `docs/release.md`
+- `.github/workflows/release.yml`
+- Current branch/status and current tags
+
+## Pre-Confirmation Workflow
+
+1. Read-only preflight:
+
+```bash
+current_branch="$(git branch --show-current)"
+git status --porcelain
+git rev-parse --verify main
+git rev-parse --verify origin/main
+git rev-list --left-right --count main...origin/main
+last_tag="$(git tag --list 'v*' --sort=-v:refname | head -1)"
+```
+
+Also use GitHub MCP for remote source-of-truth checks:
+
+- `mcp__github__list_branches` for `main` and the planned release branch.
+- `mcp__github__list_tags` or `mcp__github__get_tag` for the previous and
+  planned tags.
+- `mcp__github__get_file_contents` when remote file contents are needed.
+
+Abort or ask for direction if the tree is dirty, MCP access is missing, refs
+are missing, local `main` differs from remote `main`, or the planned remote
+branch/tag already exists.
+
+2. Resolve version:
+   - Validate an explicit version as `v<major>.<minor>.<patch>` with optional
+     prerelease suffix.
+   - If omitted, infer from `${last_tag}..HEAD --no-merges`: breaking changes
+     -> major, `feat` -> minor, otherwise patch.
+   - Confirm the tag does not already exist.
+
+3. Collect release data from `${last_tag}..HEAD`:
+   - commit count
+   - shortstat
+   - non-merge commit subjects grouped by conventional type
+   - external contributors, excluding repo owner
+
+4. Draft release note content in memory, using `docs/release.md` as the
+   template. Render previews for requested languages. Do not write files yet.
+
+5. Present the plan:
+   - version/tag
+   - note files to be written
+   - branch `release/<version>`
+   - commit message
+   - PR base `main`
+   - merge method
+   - tag push step
+   - whether `main` needs update after confirmation
+
+Stop here for `--dry-run`.
+
+## Execute After Confirmation
+
+Only after explicit confirmation, use GitHub MCP for the remote release PR flow:
+
+1. `mcp__github__create_branch` to create `release/<version>` from `main`.
+2. `mcp__github__push_files` to commit the confirmed release note files to that
+   branch in one commit.
+3. `mcp__github__create_pull_request` to open the release PR against `main`.
+4. `mcp__github__pull_request_read` with `get_status` and/or `get_check_runs`
+   to inspect PR checks when requested.
+5. `mcp__github__merge_pull_request` to merge with the selected method.
+
+Do not use `gh pr create` or local `git push` for operations covered by MCP.
+If tag creation or remote branch deletion is required and no MCP tool for that
+operation is available, stop after the MCP-supported steps and report the exact
+remaining action instead of using a fallback automatically.
+
+Report the PR URL, release tag URL, and Actions run link.

--- a/docs/release-notes/v1.2.0-en.md
+++ b/docs/release-notes/v1.2.0-en.md
@@ -1,0 +1,34 @@
+# CPA Manager Plus v1.2.0
+
+> 10 commits · 34 files changed · +1307 / -527
+
+> [中文 ->](./v1.2.0-zh.md)
+
+## Overview
+
+This release improves monitoring readability in dense information surfaces and completes Anthropic cache read/create token collection and display. The sidebar, monitoring filters, metrics, tables, and cards now use more compact visible labels while preserving full titles and accessibility context; the Manager config form and monitoring account overview also fix state behavior that could mislead users.
+
+## Highlights
+
+### Features
+
+- Sidebar navigation now supports compact labels while preserving full labels in titles, reducing overflow risk for long English and Russian labels in narrow layouts. (`layout`)
+- Monitoring tabs, toolbar controls, status metadata, pagination controls, filters, sort options, and metric models now provide compact labels with long copy centralized in the model layer. (`monitoring`)
+- Monitoring account cards, overview tables, API key summaries, and realtime event tables now consume compact labels, making dense tables and cards easier to scan without changing layout rules. (`monitoring`)
+- English and Russian now include short labels for the sidebar, monitoring filters, tabs, metrics, and pagination, giving constrained UI areas localized compact copy. (`i18n`)
+
+### Fixes
+
+- Fixed backend parsing for Anthropic `cache_read_input_tokens` and `cache_creation_input_tokens` aliases, with coverage for nested usage payloads and top-level camelCase fields. (`manager-server`)
+- Frontend usage parsing, monitoring summaries, realtime rows, account cards, and API key summaries now display Anthropic cache read/create metrics instead of only showing `Cached=0`. (`web`)
+- Monitoring search now covers account snapshot, auth label, auth file, provider, and auth index metadata so full account identifiers are searchable. (`monitoring`)
+- Manager config dirty state is now computed from normalized form differences; an empty CPA Management Key rotation field keeps the saved key, with additional autofill guards. (`config`)
+- Monitoring account overview no longer exposes enable/disable controls or write actions; account status remains a read-only summary to avoid provider-wide side effects from aggregate rows. (`monitoring`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.1.1...v1.2.0

--- a/docs/release-notes/v1.2.0-zh.md
+++ b/docs/release-notes/v1.2.0-zh.md
@@ -1,0 +1,34 @@
+# CPA Manager Plus v1.2.0
+
+> 10 commits · 34 files changed · +1307 / -527
+
+> [English ->](./v1.2.0-en.md)
+
+## Overview
+
+本次发布提升监控中心在高密度信息场景下的可读性，并补齐 Anthropic cache read/create token 的采集和展示。侧边栏、监控筛选、指标、表格和卡片使用更紧凑的可见文案，同时保留完整标题与无障碍信息；配置表单和监控账号概览也修复了容易误导用户的状态问题。
+
+## Highlights
+
+### Features
+
+- 侧边栏导航支持 compact label，并把完整标签保留在 title 中，减少英文和俄文长标签在窄布局中的溢出风险。(`layout`)
+- 监控页的标签页、工具栏控件、状态信息、分页控件、筛选项、排序项和指标模型新增紧凑标签，长文案集中在模型层维护。(`monitoring`)
+- 监控账号卡片、概览表、API key 摘要和实时事件表开始消费 compact labels，密集表格和卡片在不改变布局规则的前提下更易扫描。(`monitoring`)
+- 英文和俄文新增侧边栏、监控筛选、标签页、指标和分页的短文案，为受限 UI 区域提供本地化 compact copy。(`i18n`)
+
+### Fixes
+
+- 修复 Anthropic cache_read_input_tokens 和 cache_creation_input_tokens 别名未被后端解析的问题，nested usage payload 和顶层 camelCase 字段均已覆盖。(`manager-server`)
+- 前端使用量解析和监控摘要、实时行、账号卡片、API key 摘要现在会展示 Anthropic cache read/create 指标，避免只看到 Cached=0。(`web`)
+- 监控搜索现在覆盖 account snapshot、auth label、auth file、provider 和 auth index 元数据，可搜索完整账号标识。(`monitoring`)
+- Manager 配置的 dirty state 改为基于标准化表单差异计算，空的 CPA Management Key 轮换字段会保留已保存 key，并增加 autofill 防护。(`config`)
+- 监控账号概览移除启用/禁用控件和写操作，账号状态保持为只读汇总，避免聚合账号行触发 provider-wide 副作用。(`monitoring`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.1.1...v1.2.0


### PR DESCRIPTION
## Purpose

Add curated release notes for `v1.2.0` so the tag-triggered release workflow can use them as the GitHub Release body.

Also update the repo-local release skill to require GitHub MCP for supported GitHub remote operations.

## Tests

- `git diff --check`
- Release preflight: remote `main` verified at `b3cfdd4`; `v1.2.0` tag and `release/v1.2.0` branch had no collision before branch creation.

## Affected Modes

- release workflow only