### PR TITLE
style(ui): improve dropdown menu boundaries

### DIFF
--- a/apps/web/src/components/ui/DropdownMenu.module.scss
+++ b/apps/web/src/components/ui/DropdownMenu.module.scss
@@ -53,13 +53,27 @@
   min-width: 168px;
   max-width: 280px;
   padding: 4px;
-  border: 1px solid var(--border-color, #e5e7eb);
+  border: 1px solid
+    color-mix(in srgb, var(--primary-color, #409eff) 22%, var(--border-primary, #d1d5db));
   border-radius: 12px;
   background: var(--bg-primary, #fff);
-  box-shadow: var(--shadow-lg, 0 16px 32px rgba(15, 23, 42, 0.12));
+  box-shadow:
+    0 16px 32px rgba(15, 23, 42, 0.14),
+    0 0 0 1px color-mix(in srgb, var(--primary-color, #409eff) 8%, transparent);
   color: var(--text-primary, #111827);
   font-size: 13px;
   line-height: 1.4;
+}
+
+:global([data-theme='dark']) .menu {
+  border-color: color-mix(
+    in srgb,
+    var(--primary-color, #409eff) 30%,
+    var(--border-primary, rgba(255, 255, 255, 0.12))
+  );
+  box-shadow:
+    0 16px 32px rgba(0, 0, 0, 0.42),
+    0 0 0 1px color-mix(in srgb, var(--primary-color, #409eff) 14%, transparent);
 }
 
 .item {

--- a/apps/web/src/components/ui/Select.module.scss
+++ b/apps/web/src/components/ui/Select.module.scss
@@ -76,10 +76,12 @@
 .dropdown {
   position: fixed;
   background: var(--glass-bg);
-  border: 1px solid var(--glass-border);
+  border: 1px solid color-mix(in srgb, var(--app-input-border-focus) 28%, var(--app-border-strong));
   border-radius: var(--app-radius-md);
   padding: 6px;
-  box-shadow: var(--glass-shadow);
+  box-shadow:
+    0 18px 36px rgba(15, 23, 42, 0.16),
+    0 0 0 1px color-mix(in srgb, var(--app-input-border-focus) 10%, transparent);
   backdrop-filter: blur(var(--app-blur));
   -webkit-backdrop-filter: blur(var(--app-blur));
   display: flex;
@@ -89,6 +91,13 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
+}
+
+:global([data-theme='dark']) .dropdown {
+  border-color: color-mix(in srgb, var(--app-input-border-focus) 34%, var(--app-border-strong));
+  box-shadow:
+    0 18px 36px rgba(0, 0, 0, 0.42),
+    0 0 0 1px color-mix(in srgb, var(--app-input-border-focus) 16%, transparent);
 }
 
 .option {


### PR DESCRIPTION
## Summary
Improve visual separation for opened dropdown menus across the UI.

## Changes
- Strengthen Select dropdown borders and shadows, including dark theme overrides.
- Align DropdownMenu panel elevation with Select for clearer menu boundaries.

## Testing
- [x] npm run build