### PR TITLE
docs(release): add v1.2.1 release notes

### DIFF
--- a/docs/release-notes/v1.2.1-en.md
+++ b/docs/release-notes/v1.2.1-en.md
@@ -1,0 +1,31 @@
+# CPA Manager Plus v1.2.1
+
+> 7 commits · 17 files changed · +1123 / -615
+
+> [中文 ->](./v1.2.1-zh.md)
+
+## Overview
+
+This release focuses on Auth Files import efficiency by adding a Sub2API auth JSON paste flow, allowing users to convert and save authentication files directly from pasted JSON content. It also improves dropdown menu boundary behavior and removes tracked local collaboration command files that should not continue shipping with the repository.
+
+## Highlights
+
+### Features
+
+- Auth Files now supports pasting Sub2API auth JSON, covering parsing, conversion, API saving, localized copy, and interaction tests. (`auth-files`)
+
+### UI Polish
+
+- Adjusted Dropdown Menu and Select boundary styling to reduce visual issues when menus sit near viewport edges or overflow. (`ui`)
+
+### Chore
+
+- Removed tracked Claude release command and local agent files so collaboration configuration no longer remains in release content. (`repo`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.2.0...v1.2.1

--- a/docs/release-notes/v1.2.1-zh.md
+++ b/docs/release-notes/v1.2.1-zh.md
@@ -1,0 +1,31 @@
+# CPA Manager Plus v1.2.1
+
+> 7 commits · 17 files changed · +1123 / -615
+
+> [English ->](./v1.2.1-en.md)
+
+## Overview
+
+本次发布聚焦 Auth Files 的导入效率，新增 Sub2API auth JSON 粘贴入口，让用户可以直接从 JSON 内容转换并保存认证文件；同时优化下拉菜单边界表现，并清理不应继续随仓库发布的本地协作命令文件。
+
+## Highlights
+
+### Features
+
+- Auth Files 支持粘贴 Sub2API auth JSON，覆盖解析、转换、API 保存、本地化文案和交互测试。(`auth-files`)
+
+### UI Polish
+
+- 调整 Dropdown Menu 和 Select 的边界样式，减少菜单贴边或溢出时的视觉问题。(`ui`)
+
+### Chore
+
+- 移除已跟踪的 Claude release command 和本地 agent 文件，避免协作配置继续进入发布内容。(`repo`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.2.0...v1.2.1


### PR DESCRIPTION
## Purpose

Add curated Chinese and English release notes for CPA Manager Plus v1.2.1.

## Notes

- Previous tag: v1.2.0
- Version: v1.2.1
- Files: docs/release-notes/v1.2.1-zh.md, docs/release-notes/v1.2.1-en.md

## Verification

- Release preflight checked local status, main/origin alignment, existing tags, and remote branches.
- No build required for release note files.