### PR TITLE
feat(ui): add reusable segmented tabs

### DIFF
--- a/apps/web/src/components/ui/SegmentedTabs.module.scss
+++ b/apps/web/src/components/ui/SegmentedTabs.module.scss
@@ -1,0 +1,85 @@
+@use '../../styles/mixins' as *;
+
+.root {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 4px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface-subtle) 78%, var(--bg-primary));
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.responsiveFullWidth {
+  @include mobile {
+    width: 100%;
+  }
+}
+
+.item {
+  @include button-reset;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-height: 34px;
+  min-width: 112px;
+  padding: 0 15px;
+  border-radius: 10px;
+  border: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--text-secondary) 84%, var(--text-primary));
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover:not(.disabled) {
+    color: var(--primary-active);
+    background: color-mix(in srgb, var(--primary-color) 6%, var(--bg-primary));
+  }
+}
+
+.equalWidth .item {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.active,
+.active:hover:not(.disabled) {
+  color: var(--primary-active);
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--primary-color));
+  box-shadow:
+    0 1px 3px rgba(15, 23, 42, 0.1),
+    inset 0 0 0 1px color-mix(in srgb, var(--primary-color) 16%, transparent);
+  font-weight: 800;
+}
+
+.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}

--- a/apps/web/src/components/ui/SegmentedTabs.test.tsx
+++ b/apps/web/src/components/ui/SegmentedTabs.test.tsx
@@ -1,0 +1,118 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { describe, expect, it } from 'vitest';
+import {
+  SegmentedTabs,
+  type SegmentedTabItem,
+  type SegmentedTabsLinkProps,
+} from './SegmentedTabs';
+
+const baseItems: ReadonlyArray<SegmentedTabItem<'visual' | 'source' | 'manager'>> = [
+  { id: 'visual', label: 'Visual' },
+  { id: 'source', label: 'Source' },
+  { id: 'manager', label: 'Manager', disabled: true },
+];
+
+function TestLink({ to, children, ...props }: SegmentedTabsLinkProps) {
+  return (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  );
+}
+
+describe('SegmentedTabs', () => {
+  it('renders one tab per item', () => {
+    const markup = renderToStaticMarkup(
+      <SegmentedTabs
+        items={baseItems}
+        activeTab="visual"
+        onChange={() => {}}
+        ariaLabel="Editor tabs"
+      />
+    );
+
+    expect(markup.match(/role="tab"/g) ?? []).toHaveLength(3);
+    expect(markup).toContain('role="tablist"');
+    expect(markup).toContain('aria-label="Editor tabs"');
+  });
+
+  it('marks the active tab with aria-selected and tabIndex', () => {
+    const markup = renderToStaticMarkup(
+      <SegmentedTabs
+        items={baseItems}
+        activeTab="source"
+        onChange={() => {}}
+        ariaLabel="Editor tabs"
+      />
+    );
+
+    expect(markup).toContain('id="segmented-tabs-source" aria-selected="true" tabindex="0"');
+    expect(markup).toContain('id="segmented-tabs-visual" aria-selected="false" tabindex="-1"');
+  });
+
+  it('calls onChange when clicking an enabled inactive tab', () => {
+    const changes: string[] = [];
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        <SegmentedTabs
+          items={baseItems}
+          activeTab="visual"
+          onChange={(tab) => changes.push(tab)}
+          ariaLabel="Editor tabs"
+        />
+      );
+    });
+
+    const tabs = renderer!.root.findAllByProps({ role: 'tab' });
+
+    act(() => {
+      tabs[1].props.onClick({ preventDefault: () => {} });
+    });
+
+    expect(changes).toEqual(['source']);
+  });
+
+  it('does not call onChange for disabled tabs', () => {
+    const changes: string[] = [];
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        <SegmentedTabs
+          items={baseItems}
+          activeTab="visual"
+          onChange={(tab) => changes.push(tab)}
+          ariaLabel="Editor tabs"
+        />
+      );
+    });
+
+    const tabs = renderer!.root.findAllByProps({ role: 'tab' });
+
+    act(() => {
+      tabs[2].props.onClick({ preventDefault: () => {} });
+    });
+
+    expect(changes).toEqual([]);
+  });
+
+  it('renders link tabs when a link component is provided', () => {
+    const markup = renderToStaticMarkup(
+      <SegmentedTabs
+        items={[
+          { id: 'local', label: 'Local', to: '/codex-inspection' },
+          { id: 'server', label: 'Server', to: '/codex-inspection/server' },
+        ]}
+        activeTab="server"
+        ariaLabel="Inspection mode"
+        linkComponent={TestLink}
+      />
+    );
+
+    expect(markup).toContain('href="/codex-inspection/server"');
+    expect(markup).toContain('aria-selected="true"');
+  });
+});

--- a/apps/web/src/components/ui/SegmentedTabs.tsx
+++ b/apps/web/src/components/ui/SegmentedTabs.tsx
@@ -1,0 +1,180 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type ComponentType,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+import styles from './SegmentedTabs.module.scss';
+
+export type SegmentedTabItem<Id extends string = string> = {
+  id: Id;
+  label: ReactNode;
+  disabled?: boolean;
+  title?: string;
+  to?: string;
+};
+
+export type SegmentedTabsLinkProps = {
+  to: string;
+  className: string;
+  role: 'tab';
+  id: string;
+  'aria-selected': boolean;
+  'aria-disabled'?: boolean;
+  tabIndex: number;
+  title?: string;
+  onClick: (event: MouseEvent<HTMLElement>) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+  children: ReactNode;
+  ref?: (node: HTMLElement | null) => void;
+};
+
+type SegmentedTabsProps<Id extends string> = {
+  items: ReadonlyArray<SegmentedTabItem<Id>>;
+  activeTab: Id;
+  ariaLabel: string;
+  onChange?: (tab: Id) => void;
+  idBase?: string;
+  className?: string;
+  fullWidth?: boolean;
+  equalWidth?: boolean;
+  responsiveFullWidth?: boolean;
+  disabled?: boolean;
+  linkComponent?: ComponentType<SegmentedTabsLinkProps>;
+};
+
+export function SegmentedTabs<Id extends string>({
+  items,
+  activeTab,
+  ariaLabel,
+  onChange,
+  idBase = 'segmented-tabs',
+  className = '',
+  fullWidth = false,
+  equalWidth = false,
+  responsiveFullWidth = true,
+  disabled = false,
+  linkComponent: LinkComponent,
+}: SegmentedTabsProps<Id>) {
+  const itemRefs = useRef<Map<Id, HTMLElement | null>>(new Map());
+  const enabledItems = useMemo(
+    () => items.filter((item) => !disabled && !item.disabled),
+    [disabled, items]
+  );
+
+  const focusItem = useCallback((itemId: Id) => {
+    itemRefs.current.get(itemId)?.focus();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>, currentId: Id) => {
+      if (enabledItems.length === 0) return;
+
+      const currentIndex = enabledItems.findIndex((item) => item.id === currentId);
+      if (currentIndex === -1) return;
+
+      let nextIndex = currentIndex;
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = (currentIndex + 1) % enabledItems.length;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex = (currentIndex - 1 + enabledItems.length) % enabledItems.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = enabledItems.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      const nextItem = enabledItems[nextIndex];
+      focusItem(nextItem.id);
+      if (!nextItem.to) {
+        onChange?.(nextItem.id);
+      }
+    },
+    [enabledItems, focusItem, onChange]
+  );
+
+  const rootClassName = [
+    styles.root,
+    fullWidth ? styles.fullWidth : '',
+    equalWidth ? styles.equalWidth : '',
+    responsiveFullWidth ? styles.responsiveFullWidth : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={rootClassName} role="tablist" aria-label={ariaLabel}>
+      {items.map((item) => {
+        const isActive = item.id === activeTab;
+        const isDisabled = disabled || Boolean(item.disabled);
+        const itemClassName = [
+          styles.item,
+          isActive ? styles.active : '',
+          isDisabled ? styles.disabled : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        const itemId = `${idBase}-${item.id}`;
+        const setItemRef = (node: HTMLElement | null) => {
+          itemRefs.current.set(item.id, node);
+        };
+        const handleClick = (event: MouseEvent<HTMLElement>) => {
+          if (isDisabled) {
+            event.preventDefault();
+            return;
+          }
+          if (!isActive) {
+            onChange?.(item.id);
+          }
+        };
+        const commonProps = {
+          className: itemClassName,
+          role: 'tab' as const,
+          id: itemId,
+          'aria-selected': isActive,
+          tabIndex: isActive && !isDisabled ? 0 : -1,
+          title: item.title,
+          onClick: handleClick,
+          onKeyDown: (event: KeyboardEvent<HTMLElement>) => handleKeyDown(event, item.id),
+          children: item.label,
+        };
+
+        if (item.to && !isDisabled && LinkComponent) {
+          return (
+            <LinkComponent
+              key={item.id}
+              {...commonProps}
+              ref={setItemRef}
+              to={item.to}
+            />
+          );
+        }
+
+        return (
+          <button
+            key={item.id}
+            {...commonProps}
+            ref={setItemRef}
+            type="button"
+            disabled={isDisabled}
+            aria-disabled={isDisabled || undefined}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/config/ConfigPage.module.scss
+++ b/apps/web/src/features/config/ConfigPage.module.scss
@@ -21,17 +21,19 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 12px;
   min-width: 0;
-  padding: 8px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--bg-primary) 72%, var(--surface-subtle));
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--bg-primary) 84%, var(--surface-subtle));
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.04),
+    inset 0 1px 0 color-mix(in srgb, var(--bg-primary) 92%, transparent);
 
   @include mobile {
     align-items: stretch;
-    padding: 7px;
+    padding: 8px;
   }
 }
 
@@ -63,107 +65,6 @@
   @include mobile {
     width: 100%;
   }
-}
-
-.tabBar {
-  display: inline-flex;
-  align-items: stretch;
-  gap: 0;
-  padding: 0;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--bg-primary) 94%, var(--surface-subtle));
-  border: 1px solid color-mix(in srgb, var(--border-color) 88%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--bg-primary) 72%, transparent);
-  width: fit-content;
-  max-width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
-  @include mobile {
-    width: 100%;
-  }
-}
-
-.tabItem {
-  @include button-reset;
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 32px;
-  padding: 0 16px;
-  border-radius: 0;
-  border: 0;
-  border-left: 1px solid color-mix(in srgb, var(--border-color) 72%, transparent);
-  background: transparent;
-  color: color-mix(in srgb, var(--text-secondary) 84%, var(--text-primary));
-  font-size: 13px;
-  font-weight: 700;
-  white-space: nowrap;
-  transition:
-    color 0.15s ease,
-    background-color 0.15s ease,
-    border-color 0.15s ease,
-    transform 0.15s ease;
-
-  &::after {
-    content: '';
-    position: absolute;
-    right: 12px;
-    bottom: 0;
-    left: 12px;
-    height: 2px;
-    border-radius: 999px 999px 0 0;
-    background: transparent;
-    transition: background-color 0.15s ease;
-  }
-
-  &:hover:not(:disabled) {
-    color: var(--primary-active);
-    background: color-mix(in srgb, var(--primary-color) 6%, var(--bg-primary));
-    border-left-color: color-mix(in srgb, var(--border-color) 72%, transparent);
-  }
-
-  &:first-child {
-    border-left: 0;
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-    transform: none;
-  }
-
-  @include mobile {
-    flex: 1;
-    text-align: center;
-  }
-}
-
-.tabActive {
-  color: var(--primary-active);
-  background: color-mix(in srgb, var(--primary-color) 11%, var(--bg-primary));
-  border-left-color: transparent;
-  box-shadow: none;
-  font-weight: 800;
-
-  &::after {
-    background: var(--primary-color);
-  }
-
-  &:hover:not(:disabled) {
-    color: var(--primary-active);
-    background: color-mix(in srgb, var(--primary-color) 11%, var(--bg-primary));
-  }
-}
-
-.tabActive + .tabItem {
-  border-left-color: transparent;
 }
 
 .workspaceShell {

--- a/apps/web/src/features/config/ConfigPage.tsx
+++ b/apps/web/src/features/config/ConfigPage.tsx
@@ -6,6 +6,7 @@ import { parse as parseYaml, parseDocument } from 'yaml';
 import { usePageTransitionLayer } from '@/components/common/PageTransitionLayer';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { SegmentedTabs, type SegmentedTabItem } from '@/components/ui/SegmentedTabs';
 import {
   IconCheck,
   IconChevronDown,
@@ -1178,39 +1179,41 @@ export function ConfigPage() {
     panelHostedByUsageService === true
       ? t('config_management.manager.runtime_embedded')
       : t('config_management.manager.runtime_external');
+  const configEditorTabs = useMemo<ReadonlyArray<SegmentedTabItem<ConfigEditorTab>>>(
+    () => [
+      {
+        id: 'visual',
+        label: t('config_management.tabs.visual'),
+        disabled: saving || loading,
+      },
+      {
+        id: 'source',
+        label: t('config_management.tabs.source'),
+        disabled: saving || loading,
+      },
+      ...(showManagerTab
+        ? [
+            {
+              id: 'manager' as const,
+              label: t('config_management.tabs.manager'),
+              disabled: managerSaving || managerLoading,
+            },
+          ]
+        : []),
+    ],
+    [loading, managerLoading, managerSaving, saving, showManagerTab, t]
+  );
 
   return (
     <div className={styles.container}>
       <div className={styles.workspaceShell}>
         <div className={styles.pageMeta}>
-          <div className={styles.tabBar}>
-            <button
-              type="button"
-              className={`${styles.tabItem} ${activeTab === 'visual' ? styles.tabActive : ''}`}
-              onClick={() => handleTabChange('visual')}
-              disabled={saving || loading}
-            >
-              {t('config_management.tabs.visual')}
-            </button>
-            <button
-              type="button"
-              className={`${styles.tabItem} ${activeTab === 'source' ? styles.tabActive : ''}`}
-              onClick={() => handleTabChange('source')}
-              disabled={saving || loading}
-            >
-              {t('config_management.tabs.source')}
-            </button>
-            {showManagerTab ? (
-              <button
-                type="button"
-                className={`${styles.tabItem} ${activeTab === 'manager' ? styles.tabActive : ''}`}
-                onClick={() => handleTabChange('manager')}
-                disabled={managerSaving || managerLoading}
-              >
-                {t('config_management.tabs.manager')}
-              </button>
-            ) : null}
-          </div>
+          <SegmentedTabs
+            items={configEditorTabs}
+            activeTab={activeTab}
+            onChange={handleTabChange}
+            ariaLabel={t('config_management.title')}
+          />
           <div className={`${styles.statusBadge} ${getStatusClass()}`}>{getStatusText()}</div>
         </div>
 

--- a/apps/web/src/features/monitoring/CodexInspectionPage.module.scss
+++ b/apps/web/src/features/monitoring/CodexInspectionPage.module.scss
@@ -45,50 +45,6 @@
   min-width: 0;
 }
 
-.modeSwitchTabs {
-  display: inline-flex;
-  align-items: stretch;
-  flex: 0 0 auto;
-  padding: 3px;
-  border: 1px solid color-mix(in srgb, var(--inspect-line) 86%, transparent);
-  border-radius: 12px;
-  background: var(--inspect-surface-muted);
-}
-
-.modeSwitchTab {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 34px;
-  min-width: 104px;
-  padding: 0 14px;
-  border-radius: 9px;
-  color: var(--inspect-muted);
-  font-size: 13px;
-  font-weight: 800;
-  line-height: 1.2;
-  letter-spacing: 0;
-  text-align: center;
-  text-decoration: none;
-  white-space: nowrap;
-  transition:
-    background-color 0.18s ease,
-    color 0.18s ease,
-    box-shadow 0.18s ease;
-}
-
-.modeSwitchTab:hover {
-  color: var(--inspect-ink);
-  background: color-mix(in srgb, var(--inspect-accent) 6%, var(--inspect-surface));
-}
-
-.modeSwitchTabActive,
-.modeSwitchTabActive:hover {
-  color: var(--inspect-accent-strong);
-  background: var(--inspect-surface);
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
-}
-
 .modeSwitchCopy {
   display: grid;
   gap: 4px;
@@ -2092,17 +2048,6 @@
 @container codex-inspection-page (max-width: 640px) {
   .modeSwitchPanel {
     border-radius: 16px;
-  }
-
-  .modeSwitchTabs {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
-  }
-
-  .modeSwitchTab {
-    min-width: 0;
-    padding: 0 10px;
   }
 
   .panel,

--- a/apps/web/src/features/monitoring/components/CodexInspectionModeTabs.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionModeTabs.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { SegmentedTabs, type SegmentedTabItem } from '@/components/ui/SegmentedTabs';
 import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 import styles from '../CodexInspectionPage.module.scss';
 
@@ -41,6 +42,13 @@ export function CodexInspectionModeTabs({ activeMode }: CodexInspectionModeTabsP
       availability.checking ||
       availability.serverCodexInspectionAvailable
   );
+  const modeTabs: ReadonlyArray<SegmentedTabItem<CodexInspectionMode>> = visibleModes.map(
+    (item) => ({
+      id: item.mode,
+      label: t(item.labelKey),
+      to: item.path,
+    })
+  );
 
   return (
     <section
@@ -48,26 +56,13 @@ export function CodexInspectionModeTabs({ activeMode }: CodexInspectionModeTabsP
       aria-label={t('monitoring.codex_inspection_mode_label')}
     >
       <div className={styles.modeSwitchMain}>
-        <div
-          className={styles.modeSwitchTabs}
-          role="tablist"
-          aria-label={t('monitoring.codex_inspection_mode_label')}
-        >
-          {visibleModes.map((item) => {
-            const active = activeMode === item.mode;
-            return (
-              <Link
-                key={item.mode}
-                to={item.path}
-                role="tab"
-                aria-selected={active}
-                className={`${styles.modeSwitchTab} ${active ? styles.modeSwitchTabActive : ''}`}
-              >
-                {t(item.labelKey)}
-              </Link>
-            );
-          })}
-        </div>
+        <SegmentedTabs
+          items={modeTabs}
+          activeTab={activeMode}
+          ariaLabel={t('monitoring.codex_inspection_mode_label')}
+          equalWidth
+          linkComponent={Link}
+        />
 
         <div className={styles.modeSwitchCopy}>
           <span className={styles.modeSwitchEyebrow}>


### PR DESCRIPTION
## Summary
Add a reusable segmented tabs UI component and use it for lightweight tab switching in the config panel and Codex inspection pages.

## Changes
- Add `SegmentedTabs` with button and link rendering modes, disabled state handling, keyboard navigation, and responsive styling.
- Replace config editor tabs with the shared component and remove the active underline styling.
- Replace Codex inspection mode tabs with the shared component while preserving route navigation.
- Add component tests for rendering, active state, disabled behavior, click handling, and link mode.

## Testing
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test`

## Affected Modes
- frontend-only