### PR TITLE
fix: avoid overlapping monitoring analytics refreshes

### DIFF
--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
@@ -178,6 +178,67 @@ describe('useMonitoringAnalytics', () => {
     });
   });
 
+  it('allows a root events page refresh to supersede in-flight pagination', async () => {
+    const requests = installDeferredAnalyticsMock();
+    const scopeKey = 'range:today';
+
+    await act(async () => {
+      renderer = create(
+        <Harness
+          dataScopeKey={scopeKey}
+          include={{
+            summary: true,
+            events_page: { limit: 500, before_ms: 12_345, before_id: 99 },
+          }}
+        />
+      );
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer?.update(
+        <Harness
+          dataScopeKey={scopeKey}
+          nowMs={15_000}
+          include={{
+            summary: true,
+            events_page: { limit: 500, before_ms: null, before_id: null },
+          }}
+        />
+      );
+      await flushPromises();
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+    expect(getAnalyticsMock.mock.calls[0]?.[2].include?.events_page).toEqual({
+      limit: 500,
+      before_ms: 12_345,
+      before_id: 99,
+    });
+    expect(getAnalyticsMock.mock.calls[1]?.[2].include?.events_page).toEqual({
+      limit: 500,
+      before_ms: null,
+      before_id: null,
+    });
+
+    await act(async () => {
+      requests[1]?.resolve(createResponse(2));
+      await flushPromises();
+    });
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.data?.generated_at_ms).toBe(2);
+
+    await act(async () => {
+      requests[0]?.resolve(createResponse(1));
+      await flushPromises();
+    });
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.data?.generated_at_ms).toBe(2);
+  });
+
   it('ignores stale responses that resolve after a newer scope', async () => {
     const requests = installDeferredAnalyticsMock();
 

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
@@ -1,7 +1,15 @@
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { monitoringAnalyticsApi } from '@/services/api/usageService';
-import { useMonitoringAnalytics } from './useMonitoringAnalytics';
+import {
+  monitoringAnalyticsApi,
+  type MonitoringAnalyticsFilters,
+  type MonitoringAnalyticsInclude,
+  type MonitoringAnalyticsResponse,
+} from '@/services/api/usageService';
+import {
+  useMonitoringAnalytics,
+  type UseMonitoringAnalyticsReturn,
+} from './useMonitoringAnalytics';
 
 vi.mock('@/hooks/useRequestMonitoringAvailability', () => ({
   useRequestMonitoringAvailability: () => ({
@@ -27,35 +35,87 @@ vi.mock('@/services/api/usageService', () => ({
 
 const getAnalyticsMock = vi.mocked(monitoringAnalyticsApi.getAnalytics);
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+interface HarnessProps {
+  dataScopeKey?: string;
+  fromMs?: number;
+  toMs?: number;
+  nowMs?: number;
+  searchQuery?: string;
+  filters?: MonitoringAnalyticsFilters;
+  include?: MonitoringAnalyticsInclude;
+}
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const createResponse = (generatedAtMS: number): MonitoringAnalyticsResponse => ({
+  generated_at_ms: generatedAtMS,
+  granularity: 'hour',
+});
+
+const installDeferredAnalyticsMock = () => {
+  const requests: Array<Deferred<MonitoringAnalyticsResponse>> = [];
+  getAnalyticsMock.mockImplementation(() => {
+    const request = createDeferred<MonitoringAnalyticsResponse>();
+    requests.push(request);
+    return request.promise;
+  });
+  return requests;
+};
+
 describe('useMonitoringAnalytics', () => {
   let renderer: ReactTestRenderer | null = null;
+  let latestResult: UseMonitoringAnalyticsReturn | null = null;
 
   afterEach(() => {
     renderer?.unmount();
     renderer = null;
+    latestResult = null;
     getAnalyticsMock.mockReset();
   });
 
-  it('does not supersede an in-flight refresh for the same data scope', async () => {
-    const resolvers: Array<(value: { generated_at_ms: number; granularity: string }) => void> = [];
-    getAnalyticsMock.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolvers.push(resolve);
-        })
-    );
+  function Harness({
+    dataScopeKey = 'today',
+    fromMs = 1,
+    toMs = 10_000,
+    nowMs = toMs,
+    searchQuery,
+    filters,
+    include = { summary: true },
+  }: HarnessProps) {
+    latestResult = useMonitoringAnalytics({
+      fromMs,
+      toMs,
+      nowMs,
+      dataScopeKey,
+      searchQuery,
+      filters,
+      include,
+      throttleMs: 0,
+    });
+    return null;
+  }
 
-    function Harness({ nowMs }: { nowMs: number }) {
-      useMonitoringAnalytics({
-        fromMs: 1,
-        toMs: nowMs,
-        nowMs,
-        dataScopeKey: 'today',
-        include: { summary: true },
-        throttleMs: 0,
-      });
-      return null;
-    }
+  it('does not supersede an in-flight refresh for the same data scope', async () => {
+    const requests = installDeferredAnalyticsMock();
 
     await act(async () => {
       renderer = create(<Harness nowMs={10_000} />);
@@ -65,21 +125,122 @@ describe('useMonitoringAnalytics', () => {
 
     await act(async () => {
       renderer?.update(<Harness nowMs={15_000} />);
-      await Promise.resolve();
+      await flushPromises();
     });
 
     expect(getAnalyticsMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      resolvers[0]?.({ generated_at_ms: 1, granularity: 'hour' });
-      await Promise.resolve();
+      requests[0]?.resolve(createResponse(1));
+      await flushPromises();
     });
 
     await act(async () => {
       renderer?.update(<Harness nowMs={20_000} />);
-      await Promise.resolve();
+      await flushPromises();
     });
 
     expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts a new request when the analytics scope changes', async () => {
+    installDeferredAnalyticsMock();
+
+    await act(async () => {
+      renderer = create(<Harness dataScopeKey="range:today" />);
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer?.update(
+        <Harness
+          dataScopeKey="search:error|range:7d|model:gpt-5"
+          fromMs={2}
+          toMs={20_000}
+          nowMs={20_000}
+          searchQuery=" error "
+          filters={{ models: ['gpt-5'] }}
+          include={{ summary: true, granularity: 'day' }}
+        />
+      );
+      await flushPromises();
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+    expect(getAnalyticsMock.mock.calls[1]?.[2]).toEqual({
+      from_ms: 2,
+      to_ms: 20_000,
+      now_ms: 20_000,
+      search_query: 'error',
+      filters: { models: ['gpt-5'] },
+      include: { summary: true, granularity: 'day' },
+    });
+  });
+
+  it('ignores stale responses that resolve after a newer scope', async () => {
+    const requests = installDeferredAnalyticsMock();
+
+    await act(async () => {
+      renderer = create(<Harness dataScopeKey="range:today" />);
+    });
+
+    await act(async () => {
+      renderer?.update(<Harness dataScopeKey="range:7d" fromMs={2} toMs={20_000} />);
+      await flushPromises();
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      requests[1]?.resolve(createResponse(2));
+      await flushPromises();
+    });
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.data?.generated_at_ms).toBe(2);
+
+    await act(async () => {
+      requests[0]?.resolve(createResponse(1));
+      await flushPromises();
+    });
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.data?.generated_at_ms).toBe(2);
+  });
+
+  it('clears in-flight state after a failed request and allows retry', async () => {
+    const requests = installDeferredAnalyticsMock();
+
+    await act(async () => {
+      renderer = create(<Harness dataScopeKey="range:today" />);
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      requests[0]?.reject(new Error('network failed'));
+      await flushPromises();
+    });
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.error).toBe('network failed');
+
+    await act(async () => {
+      void latestResult?.refresh({ force: true });
+      await flushPromises();
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+    expect(latestResult?.loading).toBe(true);
+    expect(latestResult?.error).toBe('');
+
+    await act(async () => {
+      requests[1]?.resolve(createResponse(2));
+      await flushPromises();
+    });
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.data?.generated_at_ms).toBe(2);
   });
 });

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
@@ -1,0 +1,85 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { monitoringAnalyticsApi } from '@/services/api/usageService';
+import { useMonitoringAnalytics } from './useMonitoringAnalytics';
+
+vi.mock('@/hooks/useRequestMonitoringAvailability', () => ({
+  useRequestMonitoringAvailability: () => ({
+    checking: false,
+    available: true,
+    managerServiceAvailable: true,
+    modelPricesAvailable: true,
+    serviceBase: 'http://manager.local',
+    reason: '',
+  }),
+}));
+
+vi.mock('@/stores', () => ({
+  useAuthStore: (selector: (state: { managementKey: string }) => unknown) =>
+    selector({ managementKey: 'admin-key' }),
+}));
+
+vi.mock('@/services/api/usageService', () => ({
+  monitoringAnalyticsApi: {
+    getAnalytics: vi.fn(),
+  },
+}));
+
+const getAnalyticsMock = vi.mocked(monitoringAnalyticsApi.getAnalytics);
+
+describe('useMonitoringAnalytics', () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    renderer?.unmount();
+    renderer = null;
+    getAnalyticsMock.mockReset();
+  });
+
+  it('does not supersede an in-flight refresh for the same data scope', async () => {
+    const resolvers: Array<(value: { generated_at_ms: number; granularity: string }) => void> = [];
+    getAnalyticsMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    function Harness({ nowMs }: { nowMs: number }) {
+      useMonitoringAnalytics({
+        fromMs: 1,
+        toMs: nowMs,
+        nowMs,
+        dataScopeKey: 'today',
+        include: { summary: true },
+        throttleMs: 0,
+      });
+      return null;
+    }
+
+    await act(async () => {
+      renderer = create(<Harness nowMs={10_000} />);
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer?.update(<Harness nowMs={15_000} />);
+      await Promise.resolve();
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvers[0]?.({ generated_at_ms: 1, granularity: 'hour' });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      renderer?.update(<Harness nowMs={20_000} />);
+      await Promise.resolve();
+    });
+
+    expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -101,7 +102,7 @@ describe('useMonitoringAnalytics', () => {
     filters,
     include = { summary: true },
   }: HarnessProps) {
-    latestResult = useMonitoringAnalytics({
+    const result = useMonitoringAnalytics({
       fromMs,
       toMs,
       nowMs,
@@ -111,6 +112,9 @@ describe('useMonitoringAnalytics', () => {
       include,
       throttleMs: 0,
     });
+    useEffect(() => {
+      latestResult = result;
+    }, [result]);
     return null;
   }
 

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
@@ -51,6 +51,28 @@ const stableJson = (value: unknown) => JSON.stringify(value ?? {});
 
 const parseJson = <T>(value: string): T => JSON.parse(value) as T;
 
+const buildInFlightRequestIdentityKey = (
+  dataScopeKey: string | undefined,
+  request: MonitoringAnalyticsRequest,
+  requestKey: string
+) => {
+  if (!dataScopeKey) {
+    return requestKey;
+  }
+
+  const eventsPage = request.include?.events_page;
+  return stableJson({
+    dataScopeKey,
+    eventsPage: eventsPage
+      ? {
+          limit: eventsPage.limit ?? null,
+          before_ms: eventsPage.before_ms ?? null,
+          before_id: eventsPage.before_id ?? null,
+        }
+      : null,
+  });
+};
+
 export function useMonitoringAnalytics({
   fromMs,
   toMs,
@@ -73,7 +95,7 @@ export function useMonitoringAnalytics({
   const requestIdRef = useRef(0);
   const lastStartedAtRef = useRef(0);
   const lastRequestKeyRef = useRef('');
-  const inFlightScopeKeyRef = useRef('');
+  const inFlightRequestIdentityKeyRef = useRef('');
   const inFlightRequestIdRef = useRef(0);
 
   const filtersKey = useMemo(() => stableJson(filters), [filters]);
@@ -120,6 +142,10 @@ export function useMonitoringAnalytics({
   }, [eventsPageKey, filtersKey, fromMs, includeKey, nowMs, searchApiKeyHash, searchQuery, toMs]);
 
   const requestKey = useMemo(() => (request ? stableJson(request) : ''), [request]);
+  const inFlightRequestIdentityKey = useMemo(
+    () => (request ? buildInFlightRequestIdentityKey(dataScopeKey, request, requestKey) : ''),
+    [dataScopeKey, request, requestKey]
+  );
   const activeDataScopeKey = dataScopeKey || requestKey;
   const serviceBase = availability.serviceBase;
   const enabled = availability.available && Boolean(serviceBase) && Boolean(request);
@@ -128,7 +154,7 @@ export function useMonitoringAnalytics({
     async (options: MonitoringAnalyticsRefreshOptions = {}) => {
       if (!enabled || !request || !serviceBase) {
         requestIdRef.current += 1;
-        inFlightScopeKeyRef.current = '';
+        inFlightRequestIdentityKeyRef.current = '';
         inFlightRequestIdRef.current = 0;
         setData(null);
         setDataScopeStateKey('');
@@ -137,7 +163,7 @@ export function useMonitoringAnalytics({
         return;
       }
 
-      if (inFlightScopeKeyRef.current === activeDataScopeKey) {
+      if (inFlightRequestIdentityKeyRef.current === inFlightRequestIdentityKey) {
         return;
       }
 
@@ -155,7 +181,7 @@ export function useMonitoringAnalytics({
       requestIdRef.current = requestId;
       lastStartedAtRef.current = startedAt;
       lastRequestKeyRef.current = requestKey;
-      inFlightScopeKeyRef.current = activeDataScopeKey;
+      inFlightRequestIdentityKeyRef.current = inFlightRequestIdentityKey;
       inFlightRequestIdRef.current = requestId;
       setLoading(true);
       setError('');
@@ -175,7 +201,7 @@ export function useMonitoringAnalytics({
         setError(err instanceof Error ? err.message : String(err));
       } finally {
         if (inFlightRequestIdRef.current === requestId) {
-          inFlightScopeKeyRef.current = '';
+          inFlightRequestIdentityKeyRef.current = '';
           inFlightRequestIdRef.current = 0;
         }
         if (requestIdRef.current === requestId) {
@@ -183,7 +209,16 @@ export function useMonitoringAnalytics({
         }
       }
     },
-    [activeDataScopeKey, enabled, managementKey, request, requestKey, serviceBase, throttleMs]
+    [
+      activeDataScopeKey,
+      enabled,
+      inFlightRequestIdentityKey,
+      managementKey,
+      request,
+      requestKey,
+      serviceBase,
+      throttleMs,
+    ]
   );
 
   useEffect(() => {

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
@@ -73,6 +73,8 @@ export function useMonitoringAnalytics({
   const requestIdRef = useRef(0);
   const lastStartedAtRef = useRef(0);
   const lastRequestKeyRef = useRef('');
+  const inFlightScopeKeyRef = useRef('');
+  const inFlightRequestIdRef = useRef(0);
 
   const filtersKey = useMemo(() => stableJson(filters), [filters]);
   const includeKey = useMemo(() => stableJson(include), [include]);
@@ -126,10 +128,16 @@ export function useMonitoringAnalytics({
     async (options: MonitoringAnalyticsRefreshOptions = {}) => {
       if (!enabled || !request || !serviceBase) {
         requestIdRef.current += 1;
+        inFlightScopeKeyRef.current = '';
+        inFlightRequestIdRef.current = 0;
         setData(null);
         setDataScopeStateKey('');
         setLastRefreshedAt(null);
         setLoading(false);
+        return;
+      }
+
+      if (inFlightScopeKeyRef.current === activeDataScopeKey) {
         return;
       }
 
@@ -147,6 +155,8 @@ export function useMonitoringAnalytics({
       requestIdRef.current = requestId;
       lastStartedAtRef.current = startedAt;
       lastRequestKeyRef.current = requestKey;
+      inFlightScopeKeyRef.current = activeDataScopeKey;
+      inFlightRequestIdRef.current = requestId;
       setLoading(true);
       setError('');
 
@@ -164,6 +174,10 @@ export function useMonitoringAnalytics({
         if (requestIdRef.current !== requestId) return;
         setError(err instanceof Error ? err.message : String(err));
       } finally {
+        if (inFlightRequestIdRef.current === requestId) {
+          inFlightScopeKeyRef.current = '';
+          inFlightRequestIdRef.current = 0;
+        }
         if (requestIdRef.current === requestId) {
           setLoading(false);
         }


### PR DESCRIPTION
## Summary
- Prevent duplicate monitoring analytics refreshes for the same data scope while a request is already in flight.
- Keep scope changes such as range/filter changes able to start a new request.
- Add a regression test for overlapping same-scope refreshes.

## Verification
- npm --workspace apps/web run test -- src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx src/features/monitoring/hooks/useMonitoringData.renderLoop.test.tsx
- npm --workspace apps/web run type-check

Fixes #128