### PR TITLE
feat: auto disable quota-exhausted auth files

### DIFF
--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -76,9 +76,17 @@ func runServer() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	rateLimitAutoDisableWorker := worker.NewRateLimitAutoDisableWorker(db)
-	manager.SetUsageEventHandler(rateLimitAutoDisableWorker)
-	rateLimitAutoDisableWorker.Start(ctx)
+	if cfg.QuotaCooldownEnabled {
+		rateLimitAutoDisableWorker := worker.NewRateLimitAutoDisableWorker(db, collector.RuntimeConfig{
+			CPAUpstreamURL: cfg.CPAUpstreamURL,
+			ManagementKey:  cfg.ManagementKey,
+		})
+		manager.SetUsageEventHandler(rateLimitAutoDisableWorker)
+		rateLimitAutoDisableWorker.Start(ctx)
+		log.Printf("quota cooldown worker enabled")
+	} else {
+		log.Printf("quota cooldown worker disabled (set USAGE_QUOTA_COOLDOWN_ENABLED=1 to enable)")
+	}
 
 	collectorWorker.Start(ctx)
 

--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -76,6 +76,10 @@ func runServer() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	rateLimitAutoDisableWorker := worker.NewRateLimitAutoDisableWorker(db)
+	manager.SetUsageEventHandler(rateLimitAutoDisableWorker)
+	rateLimitAutoDisableWorker.Start(ctx)
+
 	collectorWorker.Start(ctx)
 
 	serverApp := httpapi.New(cfg, db, manager)

--- a/apps/manager-server/internal/collector/collector.go
+++ b/apps/manager-server/internal/collector/collector.go
@@ -41,14 +41,19 @@ type RuntimeConfig struct {
 	TLSSkipVerify  bool
 }
 
+type UsageEventHandler interface {
+	HandleUsageEvents(ctx context.Context, cfg RuntimeConfig, events []usage.Event)
+}
+
 type Manager struct {
-	base             config.Config
-	store            *store.Store
-	snapshotResolver *authSnapshotResolver
-	mu               sync.Mutex
-	cancel           context.CancelFunc
-	status           Status
-	runtimeCfg       RuntimeConfig
+	base              config.Config
+	store             *store.Store
+	snapshotResolver  *authSnapshotResolver
+	usageEventHandler UsageEventHandler
+	mu                sync.Mutex
+	cancel            context.CancelFunc
+	status            Status
+	runtimeCfg        RuntimeConfig
 }
 
 func NewManager(base config.Config, store *store.Store) *Manager {
@@ -98,6 +103,12 @@ func (m *Manager) Status() Status {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.status
+}
+
+func (m *Manager) SetUsageEventHandler(handler UsageEventHandler) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.usageEventHandler = handler
 }
 
 func (m *Manager) setStatus(update func(*Status)) {
@@ -405,6 +416,9 @@ func (m *Manager) processItems(ctx context.Context, cfg RuntimeConfig, items []s
 	if err != nil {
 		return err
 	}
+	if result.Inserted > 0 {
+		m.handleUsageEvents(ctx, cfg, events)
+	}
 	if result.Inserted > 0 || result.Skipped > 0 {
 		m.setStatus(func(status *Status) {
 			status.LastInsertedAt = time.Now().UnixMilli()
@@ -438,6 +452,16 @@ func classifyUsageControlPayload(payload string) usageControlPayload {
 		return usageControlSupportRefresh
 	}
 	return usageControlNone
+}
+
+func (m *Manager) handleUsageEvents(ctx context.Context, cfg RuntimeConfig, events []usage.Event) {
+	m.mu.Lock()
+	handler := m.usageEventHandler
+	m.mu.Unlock()
+	if handler == nil {
+		return
+	}
+	handler.HandleUsageEvents(ctx, cfg, events)
 }
 
 func (m *Manager) enrichAccountSnapshots(ctx context.Context, cfg RuntimeConfig, events []usage.Event) {

--- a/apps/manager-server/internal/collector/collector.go
+++ b/apps/manager-server/internal/collector/collector.go
@@ -45,6 +45,10 @@ type UsageEventHandler interface {
 	HandleUsageEvents(ctx context.Context, cfg RuntimeConfig, events []usage.Event)
 }
 
+type UsageRuntimeConfigHandler interface {
+	UpdateRuntimeConfig(ctx context.Context, cfg RuntimeConfig)
+}
+
 type Manager struct {
 	base              config.Config
 	store             *store.Store
@@ -77,6 +81,7 @@ func (m *Manager) Start(ctx context.Context, cfg RuntimeConfig) {
 		m.cancel = nil
 	}
 	m.runtimeCfg = cfg
+	handler := m.usageEventHandler
 	m.status.Collector = "starting"
 	m.status.Upstream = cfg.CPAUpstreamURL
 	m.status.Mode = collectorMode(valueOr(cfg.CollectorMode, m.base.CollectorMode))
@@ -86,6 +91,9 @@ func (m *Manager) Start(ctx context.Context, cfg RuntimeConfig) {
 
 	runCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
+	if runtimeHandler, ok := handler.(UsageRuntimeConfigHandler); ok {
+		go runtimeHandler.UpdateRuntimeConfig(runCtx, cfg)
+	}
 	go m.run(runCtx, cfg)
 }
 
@@ -107,8 +115,15 @@ func (m *Manager) Status() Status {
 
 func (m *Manager) SetUsageEventHandler(handler UsageEventHandler) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.usageEventHandler = handler
+	cfg := m.runtimeCfg
+	running := m.cancel != nil
+	m.mu.Unlock()
+	if running {
+		if runtimeHandler, ok := handler.(UsageRuntimeConfigHandler); ok {
+			runtimeHandler.UpdateRuntimeConfig(context.Background(), cfg)
+		}
+	}
 }
 
 func (m *Manager) setStatus(update func(*Status)) {
@@ -417,7 +432,7 @@ func (m *Manager) processItems(ctx context.Context, cfg RuntimeConfig, items []s
 		return err
 	}
 	if result.Inserted > 0 {
-		m.handleUsageEvents(ctx, cfg, events)
+		m.handleUsageEvents(ctx, cfg, insertedEvents(events, result.InsertedEventHashes))
 	}
 	if result.Inserted > 0 || result.Skipped > 0 {
 		m.setStatus(func(status *Status) {
@@ -452,6 +467,25 @@ func classifyUsageControlPayload(payload string) usageControlPayload {
 		return usageControlSupportRefresh
 	}
 	return usageControlNone
+}
+
+func insertedEvents(events []usage.Event, insertedHashes []string) []usage.Event {
+	if len(events) == 0 || len(insertedHashes) == 0 {
+		return nil
+	}
+	remaining := make(map[string]int, len(insertedHashes))
+	for _, hash := range insertedHashes {
+		remaining[hash]++
+	}
+	inserted := make([]usage.Event, 0, len(insertedHashes))
+	for _, event := range events {
+		if remaining[event.EventHash] <= 0 {
+			continue
+		}
+		inserted = append(inserted, event)
+		remaining[event.EventHash]--
+	}
+	return inserted
 }
 
 func (m *Manager) handleUsageEvents(ctx context.Context, cfg RuntimeConfig, events []usage.Event) {

--- a/apps/manager-server/internal/collector/collector_test.go
+++ b/apps/manager-server/internal/collector/collector_test.go
@@ -12,7 +12,16 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
+
+type recordingUsageHandler struct {
+	events []usage.Event
+}
+
+func (h *recordingUsageHandler) HandleUsageEvents(_ context.Context, _ RuntimeConfig, events []usage.Event) {
+	h.events = append(h.events, events...)
+}
 
 func TestManagerConsumesHTTPUsageQueue(t *testing.T) {
 	var calls int32
@@ -178,6 +187,62 @@ func TestManagerFallsBackToRESPWhenHTTPQueueUnsupported(t *testing.T) {
 		status := manager.Status()
 		return status.Transport == "resp" && strings.Contains(status.LastError, "unsupported RESP prefix")
 	})
+}
+
+func TestManagerOnlyPassesInsertedEventsToHandler(t *testing.T) {
+	db := newTestStore(t)
+	cfg := testConfig(t, "http")
+	manager := NewManager(cfg, db)
+	handler := &recordingUsageHandler{}
+	manager.SetUsageEventHandler(handler)
+
+	duplicateQuotaPayload := `{
+		"request_id":"duplicate-quota",
+		"timestamp":"2026-05-06T00:00:00Z",
+		"provider":"codex",
+		"model":"gpt-test",
+		"endpoint":"POST /v1/chat/completions",
+		"auth_file_snapshot":"codex-auth.json",
+		"auth_index":"auth-1",
+		"failed":true,
+		"fail_status_code":429,
+		"fail_body":"{\"error\":{\"type\":\"usage_limit_reached\",\"resets_in_seconds\":60}}"
+	}`
+	duplicateEvent, err := usage.NormalizeRaw([]byte(duplicateQuotaPayload))
+	if err != nil {
+		t.Fatalf("normalize duplicate payload: %v", err)
+	}
+	if _, err := db.InsertEvents(context.Background(), []usage.Event{duplicateEvent}); err != nil {
+		t.Fatalf("seed duplicate event: %v", err)
+	}
+
+	newNormalPayload := `{
+		"request_id":"new-normal",
+		"timestamp":"2026-05-06T00:00:01Z",
+		"provider":"codex",
+		"model":"gpt-test",
+		"endpoint":"POST /v1/chat/completions",
+		"input_tokens":1,
+		"output_tokens":2
+	}`
+	newEvent, err := usage.NormalizeRaw([]byte(newNormalPayload))
+	if err != nil {
+		t.Fatalf("normalize new payload: %v", err)
+	}
+
+	if err := manager.processItems(context.Background(), RuntimeConfig{}, []string{duplicateQuotaPayload, newNormalPayload}); err != nil {
+		t.Fatalf("process items: %v", err)
+	}
+
+	if len(handler.events) != 1 {
+		t.Fatalf("handler events = %#v, want only newly inserted normal event", handler.events)
+	}
+	if handler.events[0].EventHash != newEvent.EventHash {
+		t.Fatalf("handler event hash = %q, want %q", handler.events[0].EventHash, newEvent.EventHash)
+	}
+	if handler.events[0].EventHash == duplicateEvent.EventHash || handler.events[0].FailStatusCode == http.StatusTooManyRequests {
+		t.Fatalf("duplicate quota event was passed to handler: %#v", handler.events[0])
+	}
 }
 
 func TestManagerSkipsUsageControlPayloadsAndRefreshesSnapshots(t *testing.T) {

--- a/apps/manager-server/internal/config/config.go
+++ b/apps/manager-server/internal/config/config.go
@@ -19,23 +19,24 @@ const defaultAdminSecretFile = "/run/secrets/cpa_admin_key"
 const defaultDataKeySecretFile = "/run/secrets/cpa_data_key"
 
 type Config struct {
-	HTTPAddr       string
-	DataDir        string
-	DBPath         string
-	CPAUpstreamURL string
-	ManagementKey  string
-	AdminKey       string
-	DataKey        string
-	DataKeyPath    string
-	CollectorMode  string
-	Queue          string
-	PopSide        string
-	BatchSize      int
-	PollInterval   time.Duration
-	QueryLimit     int
-	PanelPath      string
-	CORSOrigins    []string
-	TLSSkipVerify  bool
+	HTTPAddr             string
+	DataDir              string
+	DBPath               string
+	CPAUpstreamURL       string
+	ManagementKey        string
+	AdminKey             string
+	DataKey              string
+	DataKeyPath          string
+	CollectorMode        string
+	Queue                string
+	PopSide              string
+	BatchSize            int
+	PollInterval         time.Duration
+	QueryLimit           int
+	PanelPath            string
+	CORSOrigins          []string
+	TLSSkipVerify        bool
+	QuotaCooldownEnabled bool
 }
 
 type LoadOptions struct {
@@ -43,23 +44,24 @@ type LoadOptions struct {
 }
 
 type fileConfig struct {
-	HTTPAddr          string   `json:"httpAddr,omitempty"`
-	DataDir           string   `json:"dataDir,omitempty"`
-	DBPath            string   `json:"dbPath,omitempty"`
-	CPAUpstreamURL    string   `json:"cpaUpstreamUrl,omitempty"`
-	ManagementKeyFile string   `json:"managementKeyFile,omitempty"`
-	AdminKeyFile      string   `json:"adminKeyFile,omitempty"`
-	DataKeyFile       string   `json:"dataKeyFile,omitempty"`
-	DataKeyPath       string   `json:"dataKeyPath,omitempty"`
-	CollectorMode     string   `json:"collectorMode,omitempty"`
-	Queue             string   `json:"queue,omitempty"`
-	PopSide           string   `json:"popSide,omitempty"`
-	BatchSize         int      `json:"batchSize,omitempty"`
-	PollIntervalMS    int      `json:"pollIntervalMs,omitempty"`
-	QueryLimit        int      `json:"queryLimit,omitempty"`
-	PanelPath         string   `json:"panelPath,omitempty"`
-	CORSOrigins       []string `json:"corsOrigins,omitempty"`
-	TLSSkipVerify     bool     `json:"tlsSkipVerify,omitempty"`
+	HTTPAddr             string   `json:"httpAddr,omitempty"`
+	DataDir              string   `json:"dataDir,omitempty"`
+	DBPath               string   `json:"dbPath,omitempty"`
+	CPAUpstreamURL       string   `json:"cpaUpstreamUrl,omitempty"`
+	ManagementKeyFile    string   `json:"managementKeyFile,omitempty"`
+	AdminKeyFile         string   `json:"adminKeyFile,omitempty"`
+	DataKeyFile          string   `json:"dataKeyFile,omitempty"`
+	DataKeyPath          string   `json:"dataKeyPath,omitempty"`
+	CollectorMode        string   `json:"collectorMode,omitempty"`
+	Queue                string   `json:"queue,omitempty"`
+	PopSide              string   `json:"popSide,omitempty"`
+	BatchSize            int      `json:"batchSize,omitempty"`
+	PollIntervalMS       int      `json:"pollIntervalMs,omitempty"`
+	QueryLimit           int      `json:"queryLimit,omitempty"`
+	PanelPath            string   `json:"panelPath,omitempty"`
+	CORSOrigins          []string `json:"corsOrigins,omitempty"`
+	TLSSkipVerify        bool     `json:"tlsSkipVerify,omitempty"`
+	QuotaCooldownEnabled bool     `json:"quotaCooldownEnabled,omitempty"`
 }
 
 func Load() (Config, error) {
@@ -109,23 +111,24 @@ func LoadWithOptions(options LoadOptions) (Config, error) {
 	}
 
 	return Config{
-		HTTPAddr:       env("HTTP_ADDR", stringFallback(cfgFile.HTTPAddr, "0.0.0.0:18317")),
-		DataDir:        dataDir,
-		DBPath:         env("USAGE_DB_PATH", dbPathFallback),
-		CPAUpstreamURL: env("CPA_UPSTREAM_URL", cfgFile.CPAUpstreamURL),
-		ManagementKey:  readSecret("CPA_MANAGEMENT_KEY", "CPA_MANAGEMENT_KEY_FILE", managementKeyFile),
-		AdminKey:       readSecret("CPA_MANAGER_ADMIN_KEY", "CPA_MANAGER_ADMIN_KEY_FILE", adminKeyFile),
-		DataKey:        readSecret("CPA_MANAGER_DATA_KEY", "CPA_MANAGER_DATA_KEY_FILE", dataKeyFile),
-		DataKeyPath:    env("CPA_MANAGER_DATA_KEY_PATH", dataKeyPath),
-		CollectorMode:  normalizeCollectorMode(env("USAGE_COLLECTOR_MODE", stringFallback(cfgFile.CollectorMode, "auto"))),
-		Queue:          env("USAGE_RESP_QUEUE", stringFallback(cfgFile.Queue, "usage")),
-		PopSide:        env("USAGE_RESP_POP_SIDE", stringFallback(cfgFile.PopSide, "right")),
-		BatchSize:      envInt("USAGE_BATCH_SIZE", intFallback(cfgFile.BatchSize, 100)),
-		PollInterval:   time.Duration(envInt("USAGE_POLL_INTERVAL_MS", intFallback(cfgFile.PollIntervalMS, 500))) * time.Millisecond,
-		QueryLimit:     envInt("USAGE_QUERY_LIMIT", intFallback(cfgFile.QueryLimit, 50000)),
-		PanelPath:      env("PANEL_PATH", resolveConfigPath(cfgFile.PanelPath, cfgDir)),
-		CORSOrigins:    splitCSV(env("USAGE_CORS_ORIGINS", strings.Join(sliceFallback(cfgFile.CORSOrigins, []string{"*"}), ","))),
-		TLSSkipVerify:  envBool("USAGE_RESP_TLS_SKIP_VERIFY", cfgFile.TLSSkipVerify),
+		HTTPAddr:             env("HTTP_ADDR", stringFallback(cfgFile.HTTPAddr, "0.0.0.0:18317")),
+		DataDir:              dataDir,
+		DBPath:               env("USAGE_DB_PATH", dbPathFallback),
+		CPAUpstreamURL:       env("CPA_UPSTREAM_URL", cfgFile.CPAUpstreamURL),
+		ManagementKey:        readSecret("CPA_MANAGEMENT_KEY", "CPA_MANAGEMENT_KEY_FILE", managementKeyFile),
+		AdminKey:             readSecret("CPA_MANAGER_ADMIN_KEY", "CPA_MANAGER_ADMIN_KEY_FILE", adminKeyFile),
+		DataKey:              readSecret("CPA_MANAGER_DATA_KEY", "CPA_MANAGER_DATA_KEY_FILE", dataKeyFile),
+		DataKeyPath:          env("CPA_MANAGER_DATA_KEY_PATH", dataKeyPath),
+		CollectorMode:        normalizeCollectorMode(env("USAGE_COLLECTOR_MODE", stringFallback(cfgFile.CollectorMode, "auto"))),
+		Queue:                env("USAGE_RESP_QUEUE", stringFallback(cfgFile.Queue, "usage")),
+		PopSide:              env("USAGE_RESP_POP_SIDE", stringFallback(cfgFile.PopSide, "right")),
+		BatchSize:            envInt("USAGE_BATCH_SIZE", intFallback(cfgFile.BatchSize, 100)),
+		PollInterval:         time.Duration(envInt("USAGE_POLL_INTERVAL_MS", intFallback(cfgFile.PollIntervalMS, 500))) * time.Millisecond,
+		QueryLimit:           envInt("USAGE_QUERY_LIMIT", intFallback(cfgFile.QueryLimit, 50000)),
+		PanelPath:            env("PANEL_PATH", resolveConfigPath(cfgFile.PanelPath, cfgDir)),
+		CORSOrigins:          splitCSV(env("USAGE_CORS_ORIGINS", strings.Join(sliceFallback(cfgFile.CORSOrigins, []string{"*"}), ","))),
+		TLSSkipVerify:        envBool("USAGE_RESP_TLS_SKIP_VERIFY", cfgFile.TLSSkipVerify),
+		QuotaCooldownEnabled: envBool("USAGE_QUOTA_COOLDOWN_ENABLED", cfgFile.QuotaCooldownEnabled),
 	}, nil
 }
 

--- a/apps/manager-server/internal/config/config_test.go
+++ b/apps/manager-server/internal/config/config_test.go
@@ -73,7 +73,8 @@ func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
   "queryLimit": 900,
   "panelPath": "panel.html",
   "corsOrigins": ["http://panel.local"],
-  "tlsSkipVerify": true
+  "tlsSkipVerify": true,
+  "quotaCooldownEnabled": true
 }`), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -109,6 +110,9 @@ func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
 	}
 	if !cfg.TLSSkipVerify {
 		t.Fatal("TLSSkipVerify = false")
+	}
+	if !cfg.QuotaCooldownEnabled {
+		t.Fatal("QuotaCooldownEnabled = false")
 	}
 }
 
@@ -187,6 +191,7 @@ func clearConfigEnv(t *testing.T) {
 		"USAGE_QUERY_LIMIT",
 		"USAGE_CORS_ORIGINS",
 		"USAGE_RESP_TLS_SKIP_VERIFY",
+		"USAGE_QUOTA_COOLDOWN_ENABLED",
 		"PANEL_PATH",
 	} {
 		t.Setenv(key, "")

--- a/apps/manager-server/internal/model/quota_cooldown.go
+++ b/apps/manager-server/internal/model/quota_cooldown.go
@@ -1,0 +1,39 @@
+package model
+
+const (
+	QuotaCooldownOwnerUsage429 = "cpamp_usage_429"
+
+	QuotaCooldownStatusActive    = "active"
+	QuotaCooldownStatusRecovered = "recovered"
+	QuotaCooldownStatusSkipped   = "skipped"
+)
+
+type QuotaCooldown struct {
+	ID               int64
+	AuthFileName     string
+	AuthIndex        string
+	AccountSnapshot  string
+	Provider         string
+	RecoverAtMS      int64
+	Owner            string
+	EventHash        string
+	PreDisabledState bool
+	Status           string
+	DisabledAtMS     int64
+	RecoveredAtMS    int64
+	LastError        string
+	CreatedAtMS      int64
+	UpdatedAtMS      int64
+}
+
+type QuotaCooldownUpsert struct {
+	AuthFileName     string
+	AuthIndex        string
+	AccountSnapshot  string
+	Provider         string
+	RecoverAtMS      int64
+	Owner            string
+	EventHash        string
+	PreDisabledState bool
+	DisabledAtMS     int64
+}

--- a/apps/manager-server/internal/model/usage_event.go
+++ b/apps/manager-server/internal/model/usage_event.go
@@ -5,6 +5,7 @@ import "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 type UsageEvent = usage.Event
 
 type InsertResult struct {
-	Inserted int `json:"inserted"`
-	Skipped  int `json:"skipped"`
+	Inserted            int      `json:"inserted"`
+	Skipped             int      `json:"skipped"`
+	InsertedEventHashes []string `json:"-"`
 }

--- a/apps/manager-server/internal/repository/quotacooldown/repository.go
+++ b/apps/manager-server/internal/repository/quotacooldown/repository.go
@@ -1,0 +1,263 @@
+package quotacooldown
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+)
+
+type Repository interface {
+	UpsertActive(ctx context.Context, cooldown model.QuotaCooldownUpsert) (model.QuotaCooldown, error)
+	ListDue(ctx context.Context, nowMS int64, limit int) ([]model.QuotaCooldown, error)
+	ListActive(ctx context.Context) ([]model.QuotaCooldown, error)
+	MarkRecovered(ctx context.Context, id int64, recoveredAtMS int64) error
+	MarkSkipped(ctx context.Context, id int64, reason string) error
+	RecordFailure(ctx context.Context, id int64, reason string) error
+}
+
+type repository struct {
+	db *sql.DB
+}
+
+func New(db *sql.DB) Repository {
+	return &repository{db: db}
+}
+
+func (r *repository) UpsertActive(ctx context.Context, cooldown model.QuotaCooldownUpsert) (model.QuotaCooldown, error) {
+	cooldown.AuthFileName = strings.TrimSpace(cooldown.AuthFileName)
+	cooldown.Owner = strings.TrimSpace(cooldown.Owner)
+	if cooldown.AuthFileName == "" {
+		return model.QuotaCooldown{}, errors.New("quota cooldown auth file name is required")
+	}
+	if cooldown.Owner == "" {
+		return model.QuotaCooldown{}, errors.New("quota cooldown owner is required")
+	}
+	if cooldown.RecoverAtMS <= 0 {
+		return model.QuotaCooldown{}, errors.New("quota cooldown recover_at_ms is required")
+	}
+	now := time.Now().UnixMilli()
+	if cooldown.DisabledAtMS <= 0 {
+		cooldown.DisabledAtMS = now
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return model.QuotaCooldown{}, err
+	}
+	defer tx.Rollback()
+
+	var id int64
+	err = tx.QueryRowContext(ctx, `select id from quota_cooldowns where auth_file_name = ? and owner = ? and status = ? limit 1`, cooldown.AuthFileName, cooldown.Owner, model.QuotaCooldownStatusActive).Scan(&id)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return model.QuotaCooldown{}, err
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		res, execErr := tx.ExecContext(ctx, `insert into quota_cooldowns (
+			auth_file_name, auth_index, account_snapshot, provider, recover_at_ms,
+			owner, event_hash, pre_disabled_state, status, disabled_at_ms,
+			created_at_ms, updated_at_ms
+		) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			cooldown.AuthFileName,
+			nullString(cooldown.AuthIndex),
+			nullString(cooldown.AccountSnapshot),
+			nullString(cooldown.Provider),
+			cooldown.RecoverAtMS,
+			cooldown.Owner,
+			nullString(cooldown.EventHash),
+			boolInt(cooldown.PreDisabledState),
+			model.QuotaCooldownStatusActive,
+			cooldown.DisabledAtMS,
+			now,
+			now,
+		)
+		if execErr != nil {
+			return model.QuotaCooldown{}, execErr
+		}
+		id, err = res.LastInsertId()
+		if err != nil {
+			return model.QuotaCooldown{}, err
+		}
+	} else {
+		_, err = tx.ExecContext(ctx, `update quota_cooldowns set
+			auth_index = ?,
+			account_snapshot = ?,
+			provider = ?,
+			recover_at_ms = max(recover_at_ms, ?),
+			event_hash = ?,
+			pre_disabled_state = ?,
+			disabled_at_ms = ?,
+			last_error = null,
+			updated_at_ms = ?
+		where id = ?`,
+			nullString(cooldown.AuthIndex),
+			nullString(cooldown.AccountSnapshot),
+			nullString(cooldown.Provider),
+			cooldown.RecoverAtMS,
+			nullString(cooldown.EventHash),
+			boolInt(cooldown.PreDisabledState),
+			cooldown.DisabledAtMS,
+			now,
+			id,
+		)
+		if err != nil {
+			return model.QuotaCooldown{}, err
+		}
+	}
+	item, ok, err := getByID(ctx, tx, id)
+	if err != nil {
+		return model.QuotaCooldown{}, err
+	}
+	if !ok {
+		return model.QuotaCooldown{}, sql.ErrNoRows
+	}
+	if err := tx.Commit(); err != nil {
+		return model.QuotaCooldown{}, err
+	}
+	return item, nil
+}
+
+func (r *repository) ListDue(ctx context.Context, nowMS int64, limit int) ([]model.QuotaCooldown, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := r.db.QueryContext(ctx, selectQuotaCooldowns+` where status = ? and recover_at_ms <= ? order by recover_at_ms asc, id asc limit ?`, model.QuotaCooldownStatusActive, nowMS, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanList(rows)
+}
+
+func (r *repository) ListActive(ctx context.Context) ([]model.QuotaCooldown, error) {
+	rows, err := r.db.QueryContext(ctx, selectQuotaCooldowns+` where status = ? order by recover_at_ms asc, id asc`, model.QuotaCooldownStatusActive)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanList(rows)
+}
+
+func (r *repository) MarkRecovered(ctx context.Context, id int64, recoveredAtMS int64) error {
+	if recoveredAtMS <= 0 {
+		recoveredAtMS = time.Now().UnixMilli()
+	}
+	_, err := r.db.ExecContext(ctx, `update quota_cooldowns set status = ?, recovered_at_ms = ?, last_error = null, updated_at_ms = ? where id = ?`, model.QuotaCooldownStatusRecovered, recoveredAtMS, recoveredAtMS, id)
+	return err
+}
+
+func (r *repository) MarkSkipped(ctx context.Context, id int64, reason string) error {
+	now := time.Now().UnixMilli()
+	_, err := r.db.ExecContext(ctx, `update quota_cooldowns set status = ?, last_error = ?, updated_at_ms = ? where id = ?`, model.QuotaCooldownStatusSkipped, nullString(reason), now, id)
+	return err
+}
+
+func (r *repository) RecordFailure(ctx context.Context, id int64, reason string) error {
+	now := time.Now().UnixMilli()
+	_, err := r.db.ExecContext(ctx, `update quota_cooldowns set last_error = ?, updated_at_ms = ? where id = ? and status = ?`, nullString(reason), now, id, model.QuotaCooldownStatusActive)
+	return err
+}
+
+const selectQuotaCooldowns = `select
+	id, auth_file_name, auth_index, account_snapshot, provider, recover_at_ms,
+	owner, event_hash, pre_disabled_state, status, disabled_at_ms,
+	recovered_at_ms, last_error, created_at_ms, updated_at_ms
+from quota_cooldowns`
+
+func getByID(ctx context.Context, q queryer, id int64) (model.QuotaCooldown, bool, error) {
+	row := q.QueryRowContext(ctx, selectQuotaCooldowns+` where id = ?`, id)
+	item, err := scanRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return model.QuotaCooldown{}, false, nil
+	}
+	if err != nil {
+		return model.QuotaCooldown{}, false, err
+	}
+	return item, true, nil
+}
+
+type queryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func scanList(rows *sql.Rows) ([]model.QuotaCooldown, error) {
+	items := make([]model.QuotaCooldown, 0)
+	for rows.Next() {
+		item, err := scanScanner(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func scanRow(row *sql.Row) (model.QuotaCooldown, error) {
+	return scanScanner(row)
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanScanner(row scanner) (model.QuotaCooldown, error) {
+	var item model.QuotaCooldown
+	var authIndex sql.NullString
+	var accountSnapshot sql.NullString
+	var provider sql.NullString
+	var eventHash sql.NullString
+	var recoveredAtMS sql.NullInt64
+	var lastError sql.NullString
+	var preDisabled int
+	err := row.Scan(
+		&item.ID,
+		&item.AuthFileName,
+		&authIndex,
+		&accountSnapshot,
+		&provider,
+		&item.RecoverAtMS,
+		&item.Owner,
+		&eventHash,
+		&preDisabled,
+		&item.Status,
+		&item.DisabledAtMS,
+		&recoveredAtMS,
+		&lastError,
+		&item.CreatedAtMS,
+		&item.UpdatedAtMS,
+	)
+	if err != nil {
+		return model.QuotaCooldown{}, err
+	}
+	item.AuthIndex = authIndex.String
+	item.AccountSnapshot = accountSnapshot.String
+	item.Provider = provider.String
+	item.EventHash = eventHash.String
+	item.PreDisabledState = preDisabled != 0
+	if recoveredAtMS.Valid {
+		item.RecoveredAtMS = recoveredAtMS.Int64
+	}
+	item.LastError = lastError.String
+	return item, nil
+}
+
+func nullString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -150,6 +150,25 @@ func Migrate(db *sql.DB) error {
 			foreign key(run_id) references codex_inspection_runs(id) on delete cascade
 		)`,
 		`create index if not exists idx_codex_inspection_logs_run on codex_inspection_logs(run_id, created_at_ms)`,
+		`create table if not exists quota_cooldowns (
+			id integer primary key autoincrement,
+			auth_file_name text not null,
+			auth_index text,
+			account_snapshot text,
+			provider text,
+			recover_at_ms integer not null,
+			owner text not null,
+			event_hash text,
+			pre_disabled_state integer not null default 0,
+			status text not null,
+			disabled_at_ms integer not null,
+			recovered_at_ms integer,
+			last_error text,
+			created_at_ms integer not null,
+			updated_at_ms integer not null
+		)`,
+		`create index if not exists idx_quota_cooldowns_due on quota_cooldowns(status, recover_at_ms)`,
+		`create unique index if not exists idx_quota_cooldowns_active_owner on quota_cooldowns(auth_file_name, owner) where status = 'active'`,
 	}
 	for _, statement := range statements {
 		if _, err := db.Exec(statement); err != nil {

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -131,6 +131,7 @@ func (r *repository) InsertBatch(ctx context.Context, events []model.UsageEvent)
 		affected, _ := res.RowsAffected()
 		if affected > 0 {
 			result.Inserted++
+			result.InsertedEventHashes = append(result.InsertedEventHashes, event.EventHash)
 		} else {
 			result.Skipped++
 		}

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/codexinspection"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/deadletter"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/modelprice"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/quotacooldown"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/setting"
 	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageevent"
@@ -32,6 +33,8 @@ type InsertResult = model.InsertResult
 type ModelPrice = model.ModelPrice
 type ModelPriceSyncResult = model.ModelPriceSyncResult
 type APIKeyAlias = model.APIKeyAlias
+type QuotaCooldown = model.QuotaCooldown
+type QuotaCooldownUpsert = model.QuotaCooldownUpsert
 
 var DefaultCodexInspectionConfig = model.DefaultCodexInspectionConfig
 var NormalizeCodexInspectionConfig = model.NormalizeCodexInspectionConfig
@@ -60,6 +63,7 @@ type Store struct {
 	ModelPrices      modelprice.Repository
 	APIKeyAliases    apikeyalias.Repository
 	CodexInspections codexinspection.Repository
+	QuotaCooldowns   quotacooldown.Repository
 }
 
 func Open(path string, protector ...*security.Protector) (*Store, error) {
@@ -79,6 +83,7 @@ func New(db *sql.DB, protector ...*security.Protector) *Store {
 		ModelPrices:      modelprice.New(db),
 		APIKeyAliases:    apikeyalias.New(db),
 		CodexInspections: codexinspection.New(db),
+		QuotaCooldowns:   quotacooldown.New(db),
 	}
 }
 
@@ -191,6 +196,26 @@ func (s *Store) ListCodexInspectionLogs(ctx context.Context, runID int64) ([]Cod
 
 func (s *Store) InsertEvents(ctx context.Context, events []usage.Event) (InsertResult, error) {
 	return s.UsageEvents.InsertBatch(ctx, events)
+}
+
+func (s *Store) UpsertQuotaCooldown(ctx context.Context, cooldown QuotaCooldownUpsert) (QuotaCooldown, error) {
+	return s.QuotaCooldowns.UpsertActive(ctx, cooldown)
+}
+
+func (s *Store) ListDueQuotaCooldowns(ctx context.Context, nowMS int64, limit int) ([]QuotaCooldown, error) {
+	return s.QuotaCooldowns.ListDue(ctx, nowMS, limit)
+}
+
+func (s *Store) MarkQuotaCooldownRecovered(ctx context.Context, id int64, recoveredAtMS int64) error {
+	return s.QuotaCooldowns.MarkRecovered(ctx, id, recoveredAtMS)
+}
+
+func (s *Store) MarkQuotaCooldownSkipped(ctx context.Context, id int64, reason string) error {
+	return s.QuotaCooldowns.MarkSkipped(ctx, id, reason)
+}
+
+func (s *Store) RecordQuotaCooldownFailure(ctx context.Context, id int64, reason string) error {
+	return s.QuotaCooldowns.RecordFailure(ctx, id, reason)
 }
 
 func (s *Store) AddDeadLetter(ctx context.Context, payload string, parseErr error) error {

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -445,7 +445,25 @@ func readFailFields(record map[string]any) (int64, string) {
 	if body == "" {
 		body = readString(record, "fail_body", "failBody")
 	}
+	if headers, ok := compactJSON(first(record, "response_headers", "responseHeaders", "headers")); ok && headers != "{}" && headers != "[]" {
+		if body == "" {
+			body = headers
+		} else {
+			body = body + "\n" + headers
+		}
+	}
 	return statusCode, body
+}
+
+func compactJSON(value any) (string, bool) {
+	if value == nil {
+		return "", false
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
 }
 
 func readOptionalInt(record map[string]any, keys ...string) *int64 {

--- a/apps/manager-server/internal/usage/import_test.go
+++ b/apps/manager-server/internal/usage/import_test.go
@@ -252,10 +252,12 @@ func TestNormalizeRawReadsCPA7118UsageFields(t *testing.T) {
 		event.TotalTokens != 33 {
 		t.Fatalf("event tokens = %#v", event)
 	}
-	if !event.Failed || event.FailStatusCode != 429 || event.FailBody != "rate limit exceeded" {
+	if !event.Failed || event.FailStatusCode != 429 ||
+		!strings.Contains(event.FailBody, "rate limit exceeded") ||
+		!strings.Contains(event.FailBody, "Retry-After") {
 		t.Fatalf("event failure = %#v", event)
 	}
-	if event.FailSummary != "rate limit exceeded" {
+	if !strings.Contains(event.FailSummary, "rate limit exceeded") || !strings.Contains(event.FailSummary, "Retry-After") {
 		t.Fatalf("fail summary = %q", event.FailSummary)
 	}
 	if event.LatencyMS == nil || *event.LatencyMS != 1500 {
@@ -279,7 +281,8 @@ func TestNormalizeRawReadsCPA7118UsageFields(t *testing.T) {
 		detail.ExecutorType != "codex" || detail.Tokens.CacheReadTokens != 4 ||
 		detail.Tokens.CacheCreationTokens != 1 || detail.FailStatusCode != 429 ||
 		detail.Tokens.CachedTokens != 0 || detail.Tokens.CacheTokens != 0 ||
-		detail.FailSummary != "rate limit exceeded" || detail.TTFTMS == nil ||
+		!strings.Contains(detail.FailSummary, "rate limit exceeded") ||
+		!strings.Contains(detail.FailSummary, "Retry-After") || detail.TTFTMS == nil ||
 		*detail.TTFTMS != 450 {
 		t.Fatalf("detail = %#v", detail)
 	}

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
@@ -25,20 +25,22 @@ const (
 	quotaAutoDisableQueueSize     = 256
 	quotaAutoDisableDefaultTick   = 15 * time.Second
 	quotaAutoDisableActionTimeout = 15 * time.Second
+	quotaCooldownDueLimit         = 100
 )
 
 // RateLimitAutoDisableWorker reacts to request-monitoring events in near real time.
-// When CPA reports a quota-exhausted response with a reset time, the worker disables
-// the corresponding auth file immediately and re-enables that same file when the
-// reported reset time arrives.
+// It only handles Codex 429 usage_limit_reached responses that include an explicit
+// reset time. Disables are persisted with CPAMP ownership, so recovery never relies
+// solely on in-memory timers and never re-enables pre-existing/manual disables.
 type RateLimitAutoDisableWorker struct {
 	store  *store.Store
 	client *http.Client
 
 	jobs chan quotaAutoDisableCandidate
 
-	mu                  sync.Mutex
-	scheduledEnables    map[string]scheduledQuotaEnable
+	mu                  sync.RWMutex
+	baseURL             string
+	managementKey       string
 	enableCheckInterval time.Duration
 }
 
@@ -46,6 +48,7 @@ type quotaAutoDisableCandidate struct {
 	BaseURL        string
 	ManagementKey  string
 	FileName       string
+	AuthIndex      string
 	DisplayAccount string
 	Provider       string
 	ResetAt        time.Time
@@ -53,27 +56,19 @@ type quotaAutoDisableCandidate struct {
 	Reason         string
 }
 
-type scheduledQuotaEnable struct {
-	BaseURL           string
-	ManagementKey     string
-	FileName          string
-	DisplayAccount    string
-	Provider          string
-	DisabledAt        time.Time
-	ResetAt           time.Time
-	NextEnableAttempt time.Time
-	LastEventHash     string
-	Reason            string
-}
+type authFile map[string]any
 
-func NewRateLimitAutoDisableWorker(st *store.Store) *RateLimitAutoDisableWorker {
-	return &RateLimitAutoDisableWorker{
+func NewRateLimitAutoDisableWorker(st *store.Store, initial ...collectorpkg.RuntimeConfig) *RateLimitAutoDisableWorker {
+	w := &RateLimitAutoDisableWorker{
 		store:               st,
 		client:              &http.Client{Timeout: quotaAutoDisableActionTimeout},
 		jobs:                make(chan quotaAutoDisableCandidate, quotaAutoDisableQueueSize),
-		scheduledEnables:    make(map[string]scheduledQuotaEnable),
 		enableCheckInterval: quotaAutoDisableDefaultTick,
 	}
+	if len(initial) > 0 {
+		w.setRuntimeConfig(initial[0].CPAUpstreamURL, initial[0].ManagementKey)
+	}
+	return w
 }
 
 func (w *RateLimitAutoDisableWorker) Start(ctx context.Context) {
@@ -92,6 +87,7 @@ func (w *RateLimitAutoDisableWorker) HandleUsageEvents(ctx context.Context, cfg 
 	if baseURL == "" || managementKey == "" {
 		return
 	}
+	w.setRuntimeConfig(baseURL, managementKey)
 	now := time.Now()
 	for _, event := range events {
 		candidate, ok := quotaAutoDisableCandidateFromEvent(event, baseURL, managementKey, now)
@@ -116,6 +112,7 @@ func (w *RateLimitAutoDisableWorker) run(ctx context.Context) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	w.enableDue(ctx, time.Now())
 	for {
 		select {
 		case <-ctx.Done():
@@ -128,7 +125,24 @@ func (w *RateLimitAutoDisableWorker) run(ctx context.Context) {
 	}
 }
 
+func (w *RateLimitAutoDisableWorker) setRuntimeConfig(baseURL string, managementKey string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.baseURL = strings.TrimSpace(baseURL)
+	w.managementKey = strings.TrimSpace(managementKey)
+}
+
+func (w *RateLimitAutoDisableWorker) runtimeConfig() (string, string) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.baseURL, w.managementKey
+}
+
 func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candidate quotaAutoDisableCandidate) {
+	if w == nil || w.store == nil || w.store.QuotaCooldowns == nil {
+		log.Printf("[quota-auto-disable] store unavailable, skip auth file %q", candidate.FileName)
+		return
+	}
 	if candidate.FileName == "" || candidate.BaseURL == "" || candidate.ManagementKey == "" {
 		return
 	}
@@ -138,275 +152,276 @@ func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candid
 		return
 	}
 
-	w.mu.Lock()
-	existing, alreadyScheduled := w.scheduledEnables[candidate.FileName]
-	if alreadyScheduled {
-		if candidate.ResetAt.After(existing.ResetAt) {
-			existing.ResetAt = candidate.ResetAt
-			existing.NextEnableAttempt = candidate.ResetAt
-			existing.LastEventHash = candidate.EventHash
-			existing.Reason = candidate.Reason
-			w.scheduledEnables[candidate.FileName] = existing
-			log.Printf("[quota-auto-disable] extended auth file %q auto-enable time to %s", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
-		}
-		w.mu.Unlock()
+	current, ok, err := w.currentAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, candidate.AuthIndex)
+	if err != nil {
+		log.Printf("[quota-auto-disable] failed to verify auth file %q before disable: %v", candidate.FileName, err)
 		return
 	}
-	w.mu.Unlock()
+	if !ok {
+		log.Printf("[quota-auto-disable] auth file %q authIndex=%q not found/currently mismatched, skip auto disable", candidate.FileName, candidate.AuthIndex)
+		return
+	}
+	preDisabled := authFileDisabled(current)
+	if preDisabled {
+		if w.extendExistingCooldown(ctx, candidate, current) {
+			return
+		}
+		log.Printf("[quota-auto-disable] auth file %q was already disabled without CPAMP ownership; skip auto disable/recovery", candidate.FileName)
+		return
+	}
 
-	log.Printf("[quota-auto-disable] quota exhausted for auth file %q account=%q provider=%q resetAt=%s, disabling", candidate.FileName, candidate.DisplayAccount, candidate.Provider, candidate.ResetAt.Format(time.RFC3339))
+	log.Printf("[quota-auto-disable] Codex usage limit reached for auth file %q account=%q provider=%q resetAt=%s, disabling", candidate.FileName, candidate.DisplayAccount, candidate.Provider, candidate.ResetAt.Format(time.RFC3339))
 	if err := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, true); err != nil {
 		log.Printf("[quota-auto-disable] failed to disable auth file %q: %v", candidate.FileName, err)
 		return
 	}
 
-	w.mu.Lock()
-	if existing, ok := w.scheduledEnables[candidate.FileName]; ok && existing.ResetAt.After(candidate.ResetAt) {
-		w.mu.Unlock()
+	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
+		AuthFileName:     candidate.FileName,
+		AuthIndex:        firstNonEmpty(candidate.AuthIndex, authFileAuthIndex(current)),
+		AccountSnapshot:  candidate.DisplayAccount,
+		Provider:         strings.ToLower(strings.TrimSpace(candidate.Provider)),
+		RecoverAtMS:      candidate.ResetAt.UnixMilli(),
+		Owner:            model.QuotaCooldownOwnerUsage429,
+		EventHash:        candidate.EventHash,
+		PreDisabledState: preDisabled,
+		DisabledAtMS:     now.UnixMilli(),
+	})
+	if err != nil {
+		log.Printf("[quota-auto-disable] disabled auth file %q but failed to persist cooldown ownership: %v", candidate.FileName, err)
+		if rollbackErr := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, false); rollbackErr != nil {
+			log.Printf("[quota-auto-disable] failed to roll back auth file %q after cooldown persistence error: %v", candidate.FileName, rollbackErr)
+		}
 		return
 	}
-	w.scheduledEnables[candidate.FileName] = scheduledQuotaEnable{
-		BaseURL:           candidate.BaseURL,
-		ManagementKey:     candidate.ManagementKey,
-		FileName:          candidate.FileName,
-		DisplayAccount:    candidate.DisplayAccount,
-		Provider:          candidate.Provider,
-		DisabledAt:        now,
-		ResetAt:           candidate.ResetAt,
-		NextEnableAttempt: candidate.ResetAt,
-		LastEventHash:     candidate.EventHash,
-		Reason:            candidate.Reason,
+	log.Printf("[quota-auto-disable] disabled auth file %q; persisted CPAMP-owned auto-enable at %s", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
+}
+
+func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context, candidate quotaAutoDisableCandidate, current authFile) bool {
+	active, err := w.store.QuotaCooldowns.ListActive(ctx)
+	if err != nil {
+		log.Printf("[quota-auto-disable] failed to check active cooldowns for auth file %q: %v", candidate.FileName, err)
+		return false
 	}
-	w.mu.Unlock()
-	log.Printf("[quota-auto-disable] disabled auth file %q; scheduled auto-enable at %s", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
+	var existing store.QuotaCooldown
+	for _, item := range active {
+		if item.AuthFileName == candidate.FileName && item.Owner == model.QuotaCooldownOwnerUsage429 {
+			existing = item
+			break
+		}
+	}
+	if existing.ID == 0 {
+		return false
+	}
+	currentIndex := authFileAuthIndex(current)
+	if existing.AuthIndex != "" && currentIndex != existing.AuthIndex {
+		log.Printf("[quota-auto-disable] active cooldown auth index mismatch for auth file %q: stored=%q current=%q", candidate.FileName, existing.AuthIndex, currentIndex)
+		return false
+	}
+	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
+		AuthFileName:     candidate.FileName,
+		AuthIndex:        firstNonEmpty(candidate.AuthIndex, existing.AuthIndex, authFileAuthIndex(current)),
+		AccountSnapshot:  firstNonEmpty(candidate.DisplayAccount, existing.AccountSnapshot),
+		Provider:         strings.ToLower(strings.TrimSpace(firstNonEmpty(candidate.Provider, existing.Provider))),
+		RecoverAtMS:      candidate.ResetAt.UnixMilli(),
+		Owner:            model.QuotaCooldownOwnerUsage429,
+		EventHash:        candidate.EventHash,
+		PreDisabledState: false,
+		DisabledAtMS:     existing.DisabledAtMS,
+	})
+	if err != nil {
+		log.Printf("[quota-auto-disable] failed to extend active cooldown for auth file %q: %v", candidate.FileName, err)
+		return false
+	}
+	log.Printf("[quota-auto-disable] extended CPAMP-owned auth file %q auto-enable time to %s", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
+	return true
 }
 
 func (w *RateLimitAutoDisableWorker) enableDue(ctx context.Context, now time.Time) {
-	w.mu.Lock()
-	due := make([]scheduledQuotaEnable, 0)
-	for _, item := range w.scheduledEnables {
-		if !item.NextEnableAttempt.After(now) {
-			due = append(due, item)
-		}
+	if w == nil || w.store == nil || w.store.QuotaCooldowns == nil {
+		return
 	}
-	w.mu.Unlock()
-
+	baseURL, managementKey := w.runtimeConfig()
+	if baseURL == "" || managementKey == "" {
+		return
+	}
+	due, err := w.store.ListDueQuotaCooldowns(ctx, now.UnixMilli(), quotaCooldownDueLimit)
+	if err != nil {
+		log.Printf("[quota-auto-disable] failed to list due quota cooldowns: %v", err)
+		return
+	}
 	for _, item := range due {
-		w.mu.Lock()
-		current, ok := w.scheduledEnables[item.FileName]
-		if !ok || !current.ResetAt.Equal(item.ResetAt) || current.NextEnableAttempt.After(now) {
-			w.mu.Unlock()
-			continue
-		}
-		w.mu.Unlock()
-
-		log.Printf("[quota-auto-disable] reset time reached for auth file %q account=%q, enabling", item.FileName, item.DisplayAccount)
-		if err := w.patchAuthFile(ctx, item.BaseURL, item.ManagementKey, item.FileName, false); err != nil {
-			log.Printf("[quota-auto-disable] failed to enable auth file %q: %v", item.FileName, err)
-			w.mu.Lock()
-			current, ok := w.scheduledEnables[item.FileName]
-			if ok && current.ResetAt.Equal(item.ResetAt) {
-				current.NextEnableAttempt = time.Now().Add(30 * time.Second)
-				w.scheduledEnables[item.FileName] = current
-			}
-			w.mu.Unlock()
-			continue
-		}
-		w.mu.Lock()
-		current, ok = w.scheduledEnables[item.FileName]
-		if ok && current.ResetAt.Equal(item.ResetAt) {
-			delete(w.scheduledEnables, item.FileName)
-		}
-		w.mu.Unlock()
-		log.Printf("[quota-auto-disable] enabled auth file %q after quota reset", item.FileName)
+		w.recoverCooldown(ctx, baseURL, managementKey, item, now)
 	}
 }
 
+func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseURL string, managementKey string, item store.QuotaCooldown, now time.Time) {
+	if item.Owner != model.QuotaCooldownOwnerUsage429 {
+		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, "unknown owner")
+		return
+	}
+	if item.PreDisabledState {
+		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, "pre-disabled before CPAMP action")
+		return
+	}
+	current, ok, err := w.currentAuthFile(ctx, baseURL, managementKey, item.AuthFileName, item.AuthIndex)
+	if err != nil {
+		_ = w.store.RecordQuotaCooldownFailure(ctx, item.ID, err.Error())
+		log.Printf("[quota-auto-disable] failed to verify auth file %q before recovery: %v", item.AuthFileName, err)
+		return
+	}
+	if !ok {
+		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, "auth file missing or auth index mismatch")
+		log.Printf("[quota-auto-disable] auth file %q authIndex=%q missing/mismatched, skip auto-enable", item.AuthFileName, item.AuthIndex)
+		return
+	}
+	if !authFileDisabled(current) {
+		_ = w.store.MarkQuotaCooldownRecovered(ctx, item.ID, now.UnixMilli())
+		log.Printf("[quota-auto-disable] auth file %q already enabled; marked cooldown recovered", item.AuthFileName)
+		return
+	}
+
+	log.Printf("[quota-auto-disable] reset time reached for auth file %q account=%q, enabling", item.AuthFileName, item.AccountSnapshot)
+	if err := w.patchAuthFile(ctx, baseURL, managementKey, item.AuthFileName, false); err != nil {
+		_ = w.store.RecordQuotaCooldownFailure(ctx, item.ID, err.Error())
+		log.Printf("[quota-auto-disable] failed to enable auth file %q: %v", item.AuthFileName, err)
+		return
+	}
+	if err := w.store.MarkQuotaCooldownRecovered(ctx, item.ID, now.UnixMilli()); err != nil {
+		log.Printf("[quota-auto-disable] enabled auth file %q but failed to mark cooldown recovered: %v", item.AuthFileName, err)
+		return
+	}
+	log.Printf("[quota-auto-disable] enabled auth file %q after Codex usage-limit reset", item.AuthFileName)
+}
+
 func quotaAutoDisableCandidateFromEvent(event usage.Event, baseURL string, managementKey string, now time.Time) (quotaAutoDisableCandidate, bool) {
-	if !isQuotaExhaustedEvent(event) {
+	resetAt, ok := codexUsageLimitResetTimeFromEvent(event, now)
+	if !ok {
 		return quotaAutoDisableCandidate{}, false
 	}
 	fileName := strings.TrimSpace(event.AuthFileSnapshot)
 	if fileName == "" {
-		log.Printf("[quota-auto-disable] quota event %q has no auth file snapshot, skip auto disable", event.EventHash)
-		return quotaAutoDisableCandidate{}, false
-	}
-	resetAt, ok := quotaResetTimeFromEvent(event, now)
-	if !ok {
-		log.Printf("[quota-auto-disable] quota event for auth file %q has no parseable reset time, skip auto disable", fileName)
+		log.Printf("[quota-auto-disable] Codex usage-limit event %q has no auth file snapshot, skip auto disable", event.EventHash)
 		return quotaAutoDisableCandidate{}, false
 	}
 	return quotaAutoDisableCandidate{
 		BaseURL:        baseURL,
 		ManagementKey:  managementKey,
 		FileName:       fileName,
+		AuthIndex:      strings.TrimSpace(event.AuthIndex),
 		DisplayAccount: firstNonEmpty(event.AccountSnapshot, event.AuthLabelSnapshot, event.Source, fileName),
-		Provider:       event.Provider,
+		Provider:       "codex",
 		ResetAt:        resetAt,
 		EventHash:      event.EventHash,
 		Reason:         event.FailSummary,
 	}, true
 }
 
-func isQuotaExhaustedEvent(event usage.Event) bool {
-	if !event.Failed {
-		return false
-	}
-	statusCode := event.FailStatusCode
-	body := strings.ToLower(strings.Join([]string{event.FailSummary, event.FailBody, event.RawJSON}, "\n"))
-	if strings.Contains(body, "quota_exhausted") ||
-		strings.Contains(body, "quota exhausted") ||
-		strings.Contains(body, "quota exceeded") ||
-		strings.Contains(body, "limit reached") ||
-		strings.Contains(body, "payment_required") ||
-		strings.Contains(body, "rate_limit_exceeded") ||
-		strings.Contains(body, "rate limit exceeded") ||
-		strings.Contains(body, "rate limit reached") ||
-		strings.Contains(body, "usage limit") {
-		return true
-	}
-	return statusCode == http.StatusPaymentRequired && strings.Contains(body, "quota")
-}
-
-func quotaResetTimeFromEvent(event usage.Event, now time.Time) (time.Time, bool) {
-	candidates := []string{event.FailBody, event.FailSummary, event.RawJSON}
-	for _, candidate := range candidates {
-		if resetAt, ok := resetTimeFromText(candidate, now); ok {
-			return resetAt, true
-		}
-	}
-	return time.Time{}, false
-}
-
-func resetTimeFromText(text string, now time.Time) (time.Time, bool) {
-	text = strings.TrimSpace(text)
-	if text == "" {
+func codexUsageLimitResetTimeFromEvent(event usage.Event, now time.Time) (time.Time, bool) {
+	if !event.Failed || event.FailStatusCode != http.StatusTooManyRequests {
 		return time.Time{}, false
 	}
-	var decoded any
-	if err := json.Unmarshal([]byte(text), &decoded); err == nil {
-		if resetAt, ok := resetTimeFromJSON(decoded, now, ""); ok {
+	provider := strings.ToLower(strings.TrimSpace(firstNonEmpty(event.Provider, event.AuthProviderSnapshot)))
+	if provider != "codex" {
+		return time.Time{}, false
+	}
+	for _, text := range []string{event.FailBody, event.RawJSON, event.FailSummary} {
+		text = strings.TrimSpace(text)
+		if text == "" {
+			continue
+		}
+		var decoded any
+		decoder := json.NewDecoder(strings.NewReader(text))
+		decoder.UseNumber()
+		if err := decoder.Decode(&decoded); err != nil {
+			continue
+		}
+		if resetAt, ok := usageLimitResetFromJSON(decoded, now); ok {
 			return resetAt, true
 		}
-	}
-	if resetAt, ok := resetTimeFromPlainText(text, now); ok {
-		return resetAt, true
 	}
 	return time.Time{}, false
 }
 
-func resetTimeFromJSON(value any, now time.Time, keyHint string) (time.Time, bool) {
+func usageLimitResetFromJSON(value any, now time.Time) (time.Time, bool) {
 	switch typed := value.(type) {
 	case map[string]any:
-		preferred := []string{
-			"reset_at", "resetAt", "reset_time", "resetTime", "resets_at", "resetsAt",
-			"rate_limit_reset_at", "rateLimitResetAt", "retry-after", "Retry-After", "retry_after", "retryAfter",
-			"x-ratelimit-reset", "X-RateLimit-Reset", "x_rate_limit_reset", "xRateLimitReset",
-		}
-		for _, key := range preferred {
-			if raw, ok := typed[key]; ok {
-				if resetAt, ok := parseResetValue(raw, now, key); ok {
-					return resetAt, true
-				}
-			}
-		}
-		for key, child := range typed {
-			if resetAt, ok := resetTimeFromJSON(child, now, key); ok {
+		if isUsageLimitMap(typed) {
+			if resetAt, ok := explicitCodexResetTime(typed, now); ok {
 				return resetAt, true
 			}
 		}
-	case []any:
-		if isResetKey(keyHint) || isRetryAfterKey(keyHint) {
-			for _, item := range typed {
-				if resetAt, ok := parseResetValue(item, now, keyHint); ok {
+		if rawError, ok := typed["error"]; ok {
+			if errorMap, ok := rawError.(map[string]any); ok && isUsageLimitMap(errorMap) {
+				if resetAt, ok := explicitCodexResetTime(errorMap, now); ok {
+					return resetAt, true
+				}
+				if resetAt, ok := explicitCodexResetTime(typed, now); ok {
 					return resetAt, true
 				}
 			}
 		}
 		for _, child := range typed {
-			if resetAt, ok := resetTimeFromJSON(child, now, keyHint); ok {
+			if resetAt, ok := usageLimitResetFromJSON(child, now); ok {
 				return resetAt, true
 			}
 		}
-	default:
-		if isResetKey(keyHint) || isRetryAfterKey(keyHint) {
-			return parseResetValue(typed, now, keyHint)
+	case []any:
+		for _, child := range typed {
+			if resetAt, ok := usageLimitResetFromJSON(child, now); ok {
+				return resetAt, true
+			}
 		}
 	}
 	return time.Time{}, false
 }
 
-func parseResetValue(value any, now time.Time, keyHint string) (time.Time, bool) {
+func isUsageLimitMap(value map[string]any) bool {
+	return strings.EqualFold(strings.TrimSpace(fmt.Sprint(value["type"])), "usage_limit_reached")
+}
+
+func explicitCodexResetTime(value map[string]any, now time.Time) (time.Time, bool) {
+	for _, key := range []string{"resets_at", "resetsAt"} {
+		if raw, ok := value[key]; ok {
+			return parseResetValue(raw, now, false)
+		}
+	}
+	for _, key := range []string{"resets_in_seconds", "resetsInSeconds"} {
+		if raw, ok := value[key]; ok {
+			return parseResetValue(raw, now, true)
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseResetValue(value any, now time.Time, relative bool) (time.Time, bool) {
 	if value == nil {
 		return time.Time{}, false
 	}
-	if isRetryAfterKey(keyHint) {
-		return parseRetryAfterValue(value, now)
-	}
 	switch typed := value.(type) {
 	case json.Number:
-		return parseResetNumberString(typed.String(), now, false)
+		return parseResetNumberString(typed.String(), now, relative)
 	case float64:
-		return resetTimeFromNumber(typed, now, false)
+		return resetTimeFromNumber(typed, now, relative)
 	case int:
-		return resetTimeFromNumber(float64(typed), now, false)
+		return resetTimeFromNumber(float64(typed), now, relative)
 	case int64:
-		return resetTimeFromNumber(float64(typed), now, false)
+		return resetTimeFromNumber(float64(typed), now, relative)
 	case string:
-		return parseResetNumberString(strings.TrimSpace(typed), now, false)
+		return parseResetNumberString(strings.TrimSpace(typed), now, relative)
 	default:
-		return parseResetNumberString(strings.TrimSpace(fmt.Sprint(typed)), now, false)
+		return parseResetNumberString(strings.TrimSpace(fmt.Sprint(typed)), now, relative)
 	}
-}
-
-func parseRetryAfterValue(value any, now time.Time) (time.Time, bool) {
-	switch typed := value.(type) {
-	case []any:
-		for _, item := range typed {
-			if resetAt, ok := parseRetryAfterValue(item, now); ok {
-				return resetAt, true
-			}
-		}
-		return time.Time{}, false
-	case string:
-		text := strings.TrimSpace(typed)
-		if text == "" {
-			return time.Time{}, false
-		}
-		if seconds, err := strconv.ParseFloat(text, 64); err == nil && seconds > 0 {
-			return now.Add(time.Duration(seconds * float64(time.Second))), true
-		}
-		if parsed, err := http.ParseTime(text); err == nil {
-			return parsed, true
-		}
-		return time.Time{}, false
-	case json.Number:
-		seconds, err := strconv.ParseFloat(typed.String(), 64)
-		if err == nil && seconds > 0 {
-			return now.Add(time.Duration(seconds * float64(time.Second))), true
-		}
-	case float64:
-		if typed > 0 {
-			return now.Add(time.Duration(typed * float64(time.Second))), true
-		}
-	case int:
-		if typed > 0 {
-			return now.Add(time.Duration(typed) * time.Second), true
-		}
-	case int64:
-		if typed > 0 {
-			return now.Add(time.Duration(typed) * time.Second), true
-		}
-	}
-	return time.Time{}, false
 }
 
 func parseResetNumberString(text string, now time.Time, relative bool) (time.Time, bool) {
 	if text == "" || strings.EqualFold(text, "null") {
 		return time.Time{}, false
 	}
-	if parsed, ok := parseCommonTime(text); ok {
-		return parsed, true
+	if !relative {
+		if parsed, ok := parseCommonTime(text); ok {
+			return parsed, true
+		}
 	}
 	value, err := strconv.ParseFloat(text, 64)
 	if err != nil || value <= 0 {
@@ -426,13 +441,9 @@ func resetTimeFromNumber(value float64, now time.Time, relative bool) (time.Time
 	if value > 1_000_000_000_000 {
 		return time.UnixMilli(int64(value)), true
 	}
-	// Unix seconds, e.g. Codex rate_limit.reset_at.
+	// Unix seconds.
 	if value > 1_000_000_000 {
 		return time.Unix(int64(value), 0), true
-	}
-	// Some providers return seconds-until-reset in a reset field.
-	if value < 366*24*60*60 {
-		return now.Add(time.Duration(value * float64(time.Second))), true
 	}
 	return time.Time{}, false
 }
@@ -455,52 +466,140 @@ func parseCommonTime(text string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-var plainResetPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)(retry-after|retry_after)\D{0,20}(\d+(?:\.\d+)?)`),
-	regexp.MustCompile(`(?i)(reset(?:s)?(?:[_ -]?at|[_ -]?time)?)\D{0,40}(\d{10,13}|\d+(?:\.\d+)?)`),
-}
-
-func resetTimeFromPlainText(text string, now time.Time) (time.Time, bool) {
-	for _, pattern := range plainResetPatterns {
-		match := pattern.FindStringSubmatch(text)
-		if len(match) < 3 {
+func (w *RateLimitAutoDisableWorker) currentAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, authIndex string) (authFile, bool, error) {
+	files, err := w.fetchAuthFiles(ctx, baseURL, managementKey)
+	if err != nil {
+		return nil, false, err
+	}
+	fileName = strings.TrimSpace(fileName)
+	authIndex = strings.TrimSpace(authIndex)
+	for _, file := range files {
+		if authFileName(file) != fileName {
 			continue
 		}
-		keyHint := match[1]
-		if isRetryAfterKey(keyHint) {
-			return parseRetryAfterValue(match[2], now)
+		if authIndex != "" && authFileAuthIndex(file) != authIndex {
+			continue
 		}
-		if resetAt, ok := parseResetNumberString(match[2], now, false); ok {
-			return resetAt, true
+		return file, true, nil
+	}
+	return nil, false, nil
+}
+
+func (w *RateLimitAutoDisableWorker) fetchAuthFiles(ctx context.Context, baseURL string, managementKey string) ([]authFile, error) {
+	base := cpa.NormalizeBaseURL(baseURL)
+	paths := []string{
+		base + "/auth-files",
+		base + "/v0/management/auth-files",
+	}
+	client := w.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	var endpointErrors []string
+	for _, endpoint := range paths {
+		reqCtx, cancel := context.WithTimeout(ctx, quotaAutoDisableActionTimeout)
+		req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
+		if reqErr != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, reqErr))
+			continue
+		}
+		req.Header.Set("Authorization", "Bearer "+managementKey)
+		res, doErr := client.Do(req)
+		cancel()
+		if doErr != nil {
+			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, doErr))
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+		_ = res.Body.Close()
+		if res.StatusCode < 200 || res.StatusCode >= 300 {
+			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: HTTP %d %s", endpoint, res.StatusCode, strings.TrimSpace(string(body))))
+			continue
+		}
+		files, err := parseAuthFiles(body)
+		if err != nil {
+			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, err))
+			continue
+		}
+		return files, nil
+	}
+	if len(endpointErrors) == 0 {
+		return nil, errors.New("no auth-file endpoint attempted")
+	}
+	return nil, fmt.Errorf("all auth-file endpoints failed: %s", strings.Join(endpointErrors, "; "))
+}
+
+func parseAuthFiles(body []byte) ([]authFile, error) {
+	var decoded any
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	files := authFilesFromJSON(decoded)
+	if files == nil {
+		return []authFile{}, nil
+	}
+	return files, nil
+}
+
+func authFilesFromJSON(value any) []authFile {
+	switch typed := value.(type) {
+	case []any:
+		files := make([]authFile, 0, len(typed))
+		for _, item := range typed {
+			if m, ok := item.(map[string]any); ok {
+				files = append(files, authFile(m))
+			}
+		}
+		return files
+	case map[string]any:
+		for _, key := range []string{"auth_files", "authFiles", "files", "items", "data"} {
+			if child, ok := typed[key]; ok {
+				if files := authFilesFromJSON(child); files != nil {
+					return files
+				}
+			}
 		}
 	}
-	return time.Time{}, false
+	return nil
 }
 
-func isResetKey(key string) bool {
-	normalized := normalizeKey(key)
-	return normalized == "resetat" ||
-		normalized == "resettime" ||
-		normalized == "resetsat" ||
-		normalized == "ratelimitresetat" ||
-		normalized == "ratelimitreset" ||
-		normalized == "xratelimitreset"
+func authFileName(file authFile) string {
+	return firstNonEmpty(stringField(file, "name"), stringField(file, "file_name"), stringField(file, "fileName"), stringField(file, "id"))
 }
 
-func isRetryAfterKey(key string) bool {
-	normalized := normalizeKey(key)
-	return normalized == "retryafter"
+func authFileAuthIndex(file authFile) string {
+	return firstNonEmpty(stringField(file, "auth_index"), stringField(file, "authIndex"), stringField(file, "auth-index"))
 }
 
-func normalizeKey(key string) string {
-	key = strings.ToLower(strings.TrimSpace(key))
-	var b strings.Builder
-	for _, r := range key {
-		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
-			b.WriteRune(r)
+func authFileDisabled(file authFile) bool {
+	if raw, ok := file["disabled"]; ok {
+		switch value := raw.(type) {
+		case bool:
+			return value
+		case json.Number:
+			parsed, _ := strconv.ParseFloat(value.String(), 64)
+			return parsed != 0
+		case float64:
+			return value != 0
+		case string:
+			return strings.EqualFold(strings.TrimSpace(value), "true") || strings.TrimSpace(value) == "1"
 		}
 	}
-	return b.String()
+	status := strings.ToLower(firstNonEmpty(stringField(file, "status"), stringField(file, "state")))
+	return status == "disabled" || status == "inactive"
+}
+
+func stringField(file authFile, key string) string {
+	if file == nil {
+		return ""
+	}
+	if value, ok := file[key]; ok && value != nil {
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+	return ""
 }
 
 func (w *RateLimitAutoDisableWorker) disableAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string) error {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -1,0 +1,576 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+const (
+	quotaAutoDisableQueueSize     = 256
+	quotaAutoDisableDefaultTick   = 15 * time.Second
+	quotaAutoDisableActionTimeout = 15 * time.Second
+)
+
+// RateLimitAutoDisableWorker reacts to request-monitoring events in near real time.
+// When CPA reports a quota-exhausted response with a reset time, the worker disables
+// the corresponding auth file immediately and re-enables that same file when the
+// reported reset time arrives.
+type RateLimitAutoDisableWorker struct {
+	store  *store.Store
+	client *http.Client
+
+	jobs chan quotaAutoDisableCandidate
+
+	mu                  sync.Mutex
+	scheduledEnables    map[string]scheduledQuotaEnable
+	enableCheckInterval time.Duration
+}
+
+type quotaAutoDisableCandidate struct {
+	BaseURL        string
+	ManagementKey  string
+	FileName       string
+	DisplayAccount string
+	Provider       string
+	ResetAt        time.Time
+	EventHash      string
+	Reason         string
+}
+
+type scheduledQuotaEnable struct {
+	BaseURL           string
+	ManagementKey     string
+	FileName          string
+	DisplayAccount    string
+	Provider          string
+	DisabledAt        time.Time
+	ResetAt           time.Time
+	NextEnableAttempt time.Time
+	LastEventHash     string
+	Reason            string
+}
+
+func NewRateLimitAutoDisableWorker(st *store.Store) *RateLimitAutoDisableWorker {
+	return &RateLimitAutoDisableWorker{
+		store:               st,
+		client:              &http.Client{Timeout: quotaAutoDisableActionTimeout},
+		jobs:                make(chan quotaAutoDisableCandidate, quotaAutoDisableQueueSize),
+		scheduledEnables:    make(map[string]scheduledQuotaEnable),
+		enableCheckInterval: quotaAutoDisableDefaultTick,
+	}
+}
+
+func (w *RateLimitAutoDisableWorker) Start(ctx context.Context) {
+	go w.run(ctx)
+}
+
+// HandleUsageEvents is called by the request-monitoring collector after raw CPA
+// usage events are normalized and enriched with auth-file snapshots. It does not
+// poll historical events; it only reacts to newly observed request failures.
+func (w *RateLimitAutoDisableWorker) HandleUsageEvents(ctx context.Context, cfg collectorpkg.RuntimeConfig, events []usage.Event) {
+	if w == nil || len(events) == 0 {
+		return
+	}
+	baseURL := strings.TrimSpace(cfg.CPAUpstreamURL)
+	managementKey := strings.TrimSpace(cfg.ManagementKey)
+	if baseURL == "" || managementKey == "" {
+		return
+	}
+	now := time.Now()
+	for _, event := range events {
+		candidate, ok := quotaAutoDisableCandidateFromEvent(event, baseURL, managementKey, now)
+		if !ok {
+			continue
+		}
+		select {
+		case w.jobs <- candidate:
+		case <-ctx.Done():
+			return
+		default:
+			log.Printf("[quota-auto-disable] job queue full, dropped auth file %q event=%q", candidate.FileName, candidate.EventHash)
+		}
+	}
+}
+
+func (w *RateLimitAutoDisableWorker) run(ctx context.Context) {
+	interval := w.enableCheckInterval
+	if interval <= 0 {
+		interval = quotaAutoDisableDefaultTick
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case candidate := <-w.jobs:
+			w.handleCandidate(ctx, candidate)
+		case <-ticker.C:
+			w.enableDue(ctx, time.Now())
+		}
+	}
+}
+
+func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candidate quotaAutoDisableCandidate) {
+	if candidate.FileName == "" || candidate.BaseURL == "" || candidate.ManagementKey == "" {
+		return
+	}
+	now := time.Now()
+	if !candidate.ResetAt.After(now) {
+		log.Printf("[quota-auto-disable] quota event for auth file %q has non-future reset time %s, skip auto disable", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
+		return
+	}
+
+	w.mu.Lock()
+	existing, alreadyScheduled := w.scheduledEnables[candidate.FileName]
+	if alreadyScheduled {
+		if candidate.ResetAt.After(existing.ResetAt) {
+			existing.ResetAt = candidate.ResetAt
+			existing.NextEnableAttempt = candidate.ResetAt
+			existing.LastEventHash = candidate.EventHash
+			existing.Reason = candidate.Reason
+			w.scheduledEnables[candidate.FileName] = existing
+			log.Printf("[quota-auto-disable] extended auth file %q auto-enable time to %s", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
+		}
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+
+	log.Printf("[quota-auto-disable] quota exhausted for auth file %q account=%q provider=%q resetAt=%s, disabling", candidate.FileName, candidate.DisplayAccount, candidate.Provider, candidate.ResetAt.Format(time.RFC3339))
+	if err := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, true); err != nil {
+		log.Printf("[quota-auto-disable] failed to disable auth file %q: %v", candidate.FileName, err)
+		return
+	}
+
+	w.mu.Lock()
+	if existing, ok := w.scheduledEnables[candidate.FileName]; ok && existing.ResetAt.After(candidate.ResetAt) {
+		w.mu.Unlock()
+		return
+	}
+	w.scheduledEnables[candidate.FileName] = scheduledQuotaEnable{
+		BaseURL:           candidate.BaseURL,
+		ManagementKey:     candidate.ManagementKey,
+		FileName:          candidate.FileName,
+		DisplayAccount:    candidate.DisplayAccount,
+		Provider:          candidate.Provider,
+		DisabledAt:        now,
+		ResetAt:           candidate.ResetAt,
+		NextEnableAttempt: candidate.ResetAt,
+		LastEventHash:     candidate.EventHash,
+		Reason:            candidate.Reason,
+	}
+	w.mu.Unlock()
+	log.Printf("[quota-auto-disable] disabled auth file %q; scheduled auto-enable at %s", candidate.FileName, candidate.ResetAt.Format(time.RFC3339))
+}
+
+func (w *RateLimitAutoDisableWorker) enableDue(ctx context.Context, now time.Time) {
+	w.mu.Lock()
+	due := make([]scheduledQuotaEnable, 0)
+	for _, item := range w.scheduledEnables {
+		if !item.NextEnableAttempt.After(now) {
+			due = append(due, item)
+		}
+	}
+	w.mu.Unlock()
+
+	for _, item := range due {
+		w.mu.Lock()
+		current, ok := w.scheduledEnables[item.FileName]
+		if !ok || !current.ResetAt.Equal(item.ResetAt) || current.NextEnableAttempt.After(now) {
+			w.mu.Unlock()
+			continue
+		}
+		w.mu.Unlock()
+
+		log.Printf("[quota-auto-disable] reset time reached for auth file %q account=%q, enabling", item.FileName, item.DisplayAccount)
+		if err := w.patchAuthFile(ctx, item.BaseURL, item.ManagementKey, item.FileName, false); err != nil {
+			log.Printf("[quota-auto-disable] failed to enable auth file %q: %v", item.FileName, err)
+			w.mu.Lock()
+			current, ok := w.scheduledEnables[item.FileName]
+			if ok && current.ResetAt.Equal(item.ResetAt) {
+				current.NextEnableAttempt = time.Now().Add(30 * time.Second)
+				w.scheduledEnables[item.FileName] = current
+			}
+			w.mu.Unlock()
+			continue
+		}
+		w.mu.Lock()
+		current, ok = w.scheduledEnables[item.FileName]
+		if ok && current.ResetAt.Equal(item.ResetAt) {
+			delete(w.scheduledEnables, item.FileName)
+		}
+		w.mu.Unlock()
+		log.Printf("[quota-auto-disable] enabled auth file %q after quota reset", item.FileName)
+	}
+}
+
+func quotaAutoDisableCandidateFromEvent(event usage.Event, baseURL string, managementKey string, now time.Time) (quotaAutoDisableCandidate, bool) {
+	if !isQuotaExhaustedEvent(event) {
+		return quotaAutoDisableCandidate{}, false
+	}
+	fileName := strings.TrimSpace(event.AuthFileSnapshot)
+	if fileName == "" {
+		log.Printf("[quota-auto-disable] quota event %q has no auth file snapshot, skip auto disable", event.EventHash)
+		return quotaAutoDisableCandidate{}, false
+	}
+	resetAt, ok := quotaResetTimeFromEvent(event, now)
+	if !ok {
+		log.Printf("[quota-auto-disable] quota event for auth file %q has no parseable reset time, skip auto disable", fileName)
+		return quotaAutoDisableCandidate{}, false
+	}
+	return quotaAutoDisableCandidate{
+		BaseURL:        baseURL,
+		ManagementKey:  managementKey,
+		FileName:       fileName,
+		DisplayAccount: firstNonEmpty(event.AccountSnapshot, event.AuthLabelSnapshot, event.Source, fileName),
+		Provider:       event.Provider,
+		ResetAt:        resetAt,
+		EventHash:      event.EventHash,
+		Reason:         event.FailSummary,
+	}, true
+}
+
+func isQuotaExhaustedEvent(event usage.Event) bool {
+	if !event.Failed {
+		return false
+	}
+	statusCode := event.FailStatusCode
+	body := strings.ToLower(strings.Join([]string{event.FailSummary, event.FailBody, event.RawJSON}, "\n"))
+	if strings.Contains(body, "quota_exhausted") ||
+		strings.Contains(body, "quota exhausted") ||
+		strings.Contains(body, "quota exceeded") ||
+		strings.Contains(body, "limit reached") ||
+		strings.Contains(body, "payment_required") ||
+		strings.Contains(body, "rate_limit_exceeded") ||
+		strings.Contains(body, "rate limit exceeded") ||
+		strings.Contains(body, "rate limit reached") ||
+		strings.Contains(body, "usage limit") {
+		return true
+	}
+	return statusCode == http.StatusPaymentRequired && strings.Contains(body, "quota")
+}
+
+func quotaResetTimeFromEvent(event usage.Event, now time.Time) (time.Time, bool) {
+	candidates := []string{event.FailBody, event.FailSummary, event.RawJSON}
+	for _, candidate := range candidates {
+		if resetAt, ok := resetTimeFromText(candidate, now); ok {
+			return resetAt, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func resetTimeFromText(text string, now time.Time) (time.Time, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return time.Time{}, false
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(text), &decoded); err == nil {
+		if resetAt, ok := resetTimeFromJSON(decoded, now, ""); ok {
+			return resetAt, true
+		}
+	}
+	if resetAt, ok := resetTimeFromPlainText(text, now); ok {
+		return resetAt, true
+	}
+	return time.Time{}, false
+}
+
+func resetTimeFromJSON(value any, now time.Time, keyHint string) (time.Time, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		preferred := []string{
+			"reset_at", "resetAt", "reset_time", "resetTime", "resets_at", "resetsAt",
+			"rate_limit_reset_at", "rateLimitResetAt", "retry-after", "Retry-After", "retry_after", "retryAfter",
+			"x-ratelimit-reset", "X-RateLimit-Reset", "x_rate_limit_reset", "xRateLimitReset",
+		}
+		for _, key := range preferred {
+			if raw, ok := typed[key]; ok {
+				if resetAt, ok := parseResetValue(raw, now, key); ok {
+					return resetAt, true
+				}
+			}
+		}
+		for key, child := range typed {
+			if resetAt, ok := resetTimeFromJSON(child, now, key); ok {
+				return resetAt, true
+			}
+		}
+	case []any:
+		if isResetKey(keyHint) || isRetryAfterKey(keyHint) {
+			for _, item := range typed {
+				if resetAt, ok := parseResetValue(item, now, keyHint); ok {
+					return resetAt, true
+				}
+			}
+		}
+		for _, child := range typed {
+			if resetAt, ok := resetTimeFromJSON(child, now, keyHint); ok {
+				return resetAt, true
+			}
+		}
+	default:
+		if isResetKey(keyHint) || isRetryAfterKey(keyHint) {
+			return parseResetValue(typed, now, keyHint)
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseResetValue(value any, now time.Time, keyHint string) (time.Time, bool) {
+	if value == nil {
+		return time.Time{}, false
+	}
+	if isRetryAfterKey(keyHint) {
+		return parseRetryAfterValue(value, now)
+	}
+	switch typed := value.(type) {
+	case json.Number:
+		return parseResetNumberString(typed.String(), now, false)
+	case float64:
+		return resetTimeFromNumber(typed, now, false)
+	case int:
+		return resetTimeFromNumber(float64(typed), now, false)
+	case int64:
+		return resetTimeFromNumber(float64(typed), now, false)
+	case string:
+		return parseResetNumberString(strings.TrimSpace(typed), now, false)
+	default:
+		return parseResetNumberString(strings.TrimSpace(fmt.Sprint(typed)), now, false)
+	}
+}
+
+func parseRetryAfterValue(value any, now time.Time) (time.Time, bool) {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if resetAt, ok := parseRetryAfterValue(item, now); ok {
+				return resetAt, true
+			}
+		}
+		return time.Time{}, false
+	case string:
+		text := strings.TrimSpace(typed)
+		if text == "" {
+			return time.Time{}, false
+		}
+		if seconds, err := strconv.ParseFloat(text, 64); err == nil && seconds > 0 {
+			return now.Add(time.Duration(seconds * float64(time.Second))), true
+		}
+		if parsed, err := http.ParseTime(text); err == nil {
+			return parsed, true
+		}
+		return time.Time{}, false
+	case json.Number:
+		seconds, err := strconv.ParseFloat(typed.String(), 64)
+		if err == nil && seconds > 0 {
+			return now.Add(time.Duration(seconds * float64(time.Second))), true
+		}
+	case float64:
+		if typed > 0 {
+			return now.Add(time.Duration(typed * float64(time.Second))), true
+		}
+	case int:
+		if typed > 0 {
+			return now.Add(time.Duration(typed) * time.Second), true
+		}
+	case int64:
+		if typed > 0 {
+			return now.Add(time.Duration(typed) * time.Second), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseResetNumberString(text string, now time.Time, relative bool) (time.Time, bool) {
+	if text == "" || strings.EqualFold(text, "null") {
+		return time.Time{}, false
+	}
+	if parsed, ok := parseCommonTime(text); ok {
+		return parsed, true
+	}
+	value, err := strconv.ParseFloat(text, 64)
+	if err != nil || value <= 0 {
+		return time.Time{}, false
+	}
+	return resetTimeFromNumber(value, now, relative)
+}
+
+func resetTimeFromNumber(value float64, now time.Time, relative bool) (time.Time, bool) {
+	if value <= 0 {
+		return time.Time{}, false
+	}
+	if relative {
+		return now.Add(time.Duration(value * float64(time.Second))), true
+	}
+	// Unix milliseconds, e.g. JavaScript timestamps.
+	if value > 1_000_000_000_000 {
+		return time.UnixMilli(int64(value)), true
+	}
+	// Unix seconds, e.g. Codex rate_limit.reset_at.
+	if value > 1_000_000_000 {
+		return time.Unix(int64(value), 0), true
+	}
+	// Some providers return seconds-until-reset in a reset field.
+	if value < 366*24*60*60 {
+		return now.Add(time.Duration(value * float64(time.Second))), true
+	}
+	return time.Time{}, false
+}
+
+func parseCommonTime(text string) (time.Time, bool) {
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		time.RFC1123,
+		time.RFC1123Z,
+		"2006-01-02T15:04:05.000Z07:00",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		if parsed, err := time.Parse(layout, text); err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+var plainResetPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(retry-after|retry_after)\D{0,20}(\d+(?:\.\d+)?)`),
+	regexp.MustCompile(`(?i)(reset(?:s)?(?:[_ -]?at|[_ -]?time)?)\D{0,40}(\d{10,13}|\d+(?:\.\d+)?)`),
+}
+
+func resetTimeFromPlainText(text string, now time.Time) (time.Time, bool) {
+	for _, pattern := range plainResetPatterns {
+		match := pattern.FindStringSubmatch(text)
+		if len(match) < 3 {
+			continue
+		}
+		keyHint := match[1]
+		if isRetryAfterKey(keyHint) {
+			return parseRetryAfterValue(match[2], now)
+		}
+		if resetAt, ok := parseResetNumberString(match[2], now, false); ok {
+			return resetAt, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func isResetKey(key string) bool {
+	normalized := normalizeKey(key)
+	return normalized == "resetat" ||
+		normalized == "resettime" ||
+		normalized == "resetsat" ||
+		normalized == "ratelimitresetat" ||
+		normalized == "ratelimitreset" ||
+		normalized == "xratelimitreset"
+}
+
+func isRetryAfterKey(key string) bool {
+	normalized := normalizeKey(key)
+	return normalized == "retryafter"
+}
+
+func normalizeKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	var b strings.Builder
+	for _, r := range key {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func (w *RateLimitAutoDisableWorker) disableAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string) error {
+	return w.patchAuthFile(ctx, baseURL, managementKey, fileName, true)
+}
+
+func (w *RateLimitAutoDisableWorker) enableAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string) error {
+	return w.patchAuthFile(ctx, baseURL, managementKey, fileName, false)
+}
+
+func (w *RateLimitAutoDisableWorker) patchAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {
+	payload := map[string]any{"name": fileName, "disabled": disabled}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	base := cpa.NormalizeBaseURL(baseURL)
+	paths := []string{
+		base + "/auth-files",
+		base + "/auth-files/status",
+		base + "/v0/management/auth-files",
+		base + "/v0/management/auth-files/status",
+	}
+
+	client := w.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	var endpointErrors []string
+	for _, endpoint := range paths {
+		reqCtx, cancel := context.WithTimeout(ctx, quotaAutoDisableActionTimeout)
+		req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodPatch, endpoint, bytes.NewReader(data))
+		if reqErr != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, reqErr))
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+managementKey)
+
+		res, doErr := client.Do(req)
+		cancel()
+		if doErr != nil {
+			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, doErr))
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		_ = res.Body.Close()
+
+		if res.StatusCode >= 200 && res.StatusCode < 300 {
+			return nil
+		}
+		endpointErrors = append(endpointErrors, fmt.Sprintf("%s: HTTP %d %s", endpoint, res.StatusCode, strings.TrimSpace(string(body))))
+	}
+	if len(endpointErrors) == 0 {
+		return errors.New("no auth-file status endpoint attempted")
+	}
+	return fmt.Errorf("all auth-file status endpoints failed: %s", strings.Join(endpointErrors, "; "))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// NormalizeBaseURL is exported for legacy tests.
+var NormalizeBaseURL = cpa.NormalizeBaseURL

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -75,11 +75,8 @@ func (w *RateLimitAutoDisableWorker) Start(ctx context.Context) {
 	go w.run(ctx)
 }
 
-// HandleUsageEvents is called by the request-monitoring collector after raw CPA
-// usage events are normalized and enriched with auth-file snapshots. It does not
-// poll historical events; it only reacts to newly observed request failures.
-func (w *RateLimitAutoDisableWorker) HandleUsageEvents(ctx context.Context, cfg collectorpkg.RuntimeConfig, events []usage.Event) {
-	if w == nil || len(events) == 0 {
+func (w *RateLimitAutoDisableWorker) UpdateRuntimeConfig(ctx context.Context, cfg collectorpkg.RuntimeConfig) {
+	if w == nil {
 		return
 	}
 	baseURL := strings.TrimSpace(cfg.CPAUpstreamURL)
@@ -88,6 +85,25 @@ func (w *RateLimitAutoDisableWorker) HandleUsageEvents(ctx context.Context, cfg 
 		return
 	}
 	w.setRuntimeConfig(baseURL, managementKey)
+	w.enableDue(ctx, time.Now())
+}
+
+// HandleUsageEvents is called by the request-monitoring collector after raw CPA
+// usage events are normalized and enriched with auth-file snapshots. It does not
+// poll historical events; it only reacts to newly observed request failures.
+func (w *RateLimitAutoDisableWorker) HandleUsageEvents(ctx context.Context, cfg collectorpkg.RuntimeConfig, events []usage.Event) {
+	if w == nil {
+		return
+	}
+	baseURL := strings.TrimSpace(cfg.CPAUpstreamURL)
+	managementKey := strings.TrimSpace(cfg.ManagementKey)
+	if baseURL == "" || managementKey == "" {
+		return
+	}
+	w.setRuntimeConfig(baseURL, managementKey)
+	if len(events) == 0 {
+		return
+	}
 	now := time.Now()
 	for _, event := range events {
 		candidate, ok := quotaAutoDisableCandidateFromEvent(event, baseURL, managementKey, now)

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -5,155 +5,182 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
 
-func TestQuotaAutoDisableCandidateRequiresQuotaResetAndFile(t *testing.T) {
+func TestQuotaAutoDisableCandidateRequiresStrictCodexUsageLimit(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	event := usage.Event{
+	base := usage.Event{
 		EventHash:        "evt-1",
 		Failed:           true,
 		FailStatusCode:   http.StatusTooManyRequests,
-		FailBody:         `{"error":{"code":"quota_exhausted","message":"quota exhausted","reset_at":1700000360}}`,
+		FailBody:         `{"error":{"type":"usage_limit_reached","resets_in_seconds":60}}`,
 		AuthFileSnapshot: "codex-auth.json",
+		AuthIndex:        "auth-1",
 		AccountSnapshot:  "user@example.com",
 		Provider:         "codex",
 	}
 
-	candidate, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now)
+	candidate, ok := quotaAutoDisableCandidateFromEvent(base, "http://cpa", "key", now)
 	if !ok {
 		t.Fatalf("candidate not detected")
 	}
-	if candidate.FileName != "codex-auth.json" || candidate.DisplayAccount != "user@example.com" {
+	if candidate.FileName != "codex-auth.json" || candidate.AuthIndex != "auth-1" || candidate.DisplayAccount != "user@example.com" {
 		t.Fatalf("candidate identity = %#v", candidate)
 	}
-	if got := candidate.ResetAt.Unix(); got != 1_700_000_360 {
+	if got := candidate.ResetAt.Unix(); got != 1_700_000_060 {
 		t.Fatalf("reset unix = %d", got)
 	}
 
-	event.AuthFileSnapshot = ""
-	if _, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now); ok {
-		t.Fatalf("candidate should require auth file snapshot")
-	}
-	event.AuthFileSnapshot = "codex-auth.json"
-	event.FailBody = `{"error":{"code":"quota_exhausted"}}`
-	if _, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now); ok {
-		t.Fatalf("candidate should require reset time")
-	}
-}
-
-func TestQuotaResetTimeParsesCommonShapes(t *testing.T) {
-	now := time.Unix(1_700_000_000, 0)
 	cases := []struct {
-		name string
-		text string
-		want int64
+		name   string
+		mutate func(*usage.Event)
 	}{
 		{
-			name: "codex nested reset_at",
-			text: `{"rate_limit":{"primary":{"reset_at":1700000600}}}`,
-			want: 1_700_000_600,
+			name: "broad quota exhausted text is ignored",
+			mutate: func(event *usage.Event) {
+				event.FailBody = `{"error":{"code":"quota_exhausted","message":"quota exhausted","resets_in_seconds":60}}`
+			},
 		},
 		{
-			name: "retry after header array",
-			text: `{"response_headers":{"Retry-After":["30"]}}`,
-			want: 1_700_000_030,
+			name: "non 429 is ignored",
+			mutate: func(event *usage.Event) {
+				event.FailStatusCode = http.StatusPaymentRequired
+			},
 		},
 		{
-			name: "milliseconds",
-			text: `{"resetAt":1700000900000}`,
-			want: 1_700_000_900,
+			name: "non codex provider is ignored",
+			mutate: func(event *usage.Event) {
+				event.Provider = "openai"
+			},
 		},
 		{
-			name: "plain text",
-			text: `quota exhausted, reset_at: 1700001200`,
-			want: 1_700_001_200,
+			name: "missing explicit reset is ignored",
+			mutate: func(event *usage.Event) {
+				event.FailBody = `{"error":{"type":"usage_limit_reached"}}`
+			},
+		},
+		{
+			name: "legacy reset_at is ignored",
+			mutate: func(event *usage.Event) {
+				event.FailBody = `{"error":{"type":"usage_limit_reached","reset_at":1700000060}}`
+			},
+		},
+		{
+			name: "auth file snapshot required",
+			mutate: func(event *usage.Event) {
+				event.AuthFileSnapshot = ""
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := resetTimeFromText(tc.text, now)
-			if !ok {
-				t.Fatalf("reset time not parsed")
-			}
-			if got.Unix() != tc.want {
-				t.Fatalf("reset unix = %d, want %d", got.Unix(), tc.want)
+			event := base
+			tc.mutate(&event)
+			if _, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now); ok {
+				t.Fatalf("candidate should not be detected")
 			}
 		})
 	}
 }
 
-func TestRateLimitAutoDisableWorkerDisablesThenEnablesAtReset(t *testing.T) {
+func TestRateLimitAutoDisableWorkerPersistsAndRecoversAfterRestart(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
 	var mu sync.Mutex
+	disabled := false
 	type action struct {
 		Name     string `json:"name"`
 		Disabled bool   `json:"disabled"`
 	}
 	actions := make([]action, 0)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch || r.URL.Path != "/auth-files" {
-			http.NotFound(w, r)
-			return
-		}
 		if r.Header.Get("Authorization") != "Bearer test-management-key" {
 			http.Error(w, "missing auth", http.StatusUnauthorized)
 			return
 		}
-		var item action
-		if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		if r.URL.Path != "/auth-files" {
+			http.NotFound(w, r)
 			return
 		}
-		mu.Lock()
-		actions = append(actions, item)
-		mu.Unlock()
-		w.WriteHeader(http.StatusOK)
+		switch r.Method {
+		case http.MethodGet:
+			mu.Lock()
+			currentDisabled := disabled
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"name":      "codex-auth.json",
+				"authIndex": "auth-1",
+				"disabled":  currentDisabled,
+			}})
+		case http.MethodPatch:
+			var item action
+			if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			disabled = item.Disabled
+			actions = append(actions, item)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
-	worker := NewRateLimitAutoDisableWorker(nil)
-	worker.enableCheckInterval = 10 * time.Millisecond
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	worker.Start(ctx)
-
-	worker.HandleUsageEvents(ctx, collectorpkg.RuntimeConfig{
-		CPAUpstreamURL: server.URL,
+	ctx := context.Background()
+	worker := NewRateLimitAutoDisableWorker(st, collectorpkg.RuntimeConfig{CPAUpstreamURL: server.URL, ManagementKey: "test-management-key"})
+	worker.handleCandidate(ctx, quotaAutoDisableCandidate{
+		BaseURL:        server.URL,
 		ManagementKey:  "test-management-key",
-	}, []usage.Event{{
-		EventHash:        "evt-quota",
-		Failed:           true,
-		FailStatusCode:   http.StatusTooManyRequests,
-		FailBody:         `{"error":{"code":"quota_exhausted","reset_at":1}}`,
-		AuthFileSnapshot: "codex-auth.json",
-		AccountSnapshot:  "user@example.com",
-	}})
+		FileName:       "codex-auth.json",
+		AuthIndex:      "auth-1",
+		DisplayAccount: "user@example.com",
+		Provider:       "codex",
+		ResetAt:        time.Now().Add(time.Minute),
+		EventHash:      "evt-quota",
+	})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		count := len(actions)
-		mu.Unlock()
-		if count >= 2 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	if len(actions) != 1 || actions[0].Name != "codex-auth.json" || !actions[0].Disabled || !disabled {
+		t.Fatalf("disable actions = %#v disabled=%v", actions, disabled)
 	}
+	mu.Unlock()
+	active, err := st.QuotaCooldowns.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("list active cooldowns: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("active cooldowns = %#v", active)
+	}
+	if active[0].Owner != model.QuotaCooldownOwnerUsage429 || active[0].PreDisabledState {
+		t.Fatalf("cooldown ownership = %#v", active[0])
+	}
+
+	// Simulate a process restart: a fresh worker recovers from the persisted record.
+	restarted := NewRateLimitAutoDisableWorker(st, collectorpkg.RuntimeConfig{CPAUpstreamURL: server.URL, ManagementKey: "test-management-key"})
+	restarted.enableDue(ctx, time.Now().Add(2*time.Minute))
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(actions) < 2 {
+	if len(actions) != 2 {
 		t.Fatalf("actions = %#v, want disable and enable", actions)
 	}
-	if actions[0].Name != "codex-auth.json" || !actions[0].Disabled {
-		t.Fatalf("disable action = %#v", actions[0])
-	}
-	if actions[1].Name != "codex-auth.json" || actions[1].Disabled {
-		t.Fatalf("enable action = %#v", actions[1])
+	if actions[1].Name != "codex-auth.json" || actions[1].Disabled || disabled {
+		t.Fatalf("enable action = %#v disabled=%v", actions[1], disabled)
 	}
 }

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -1,0 +1,159 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestQuotaAutoDisableCandidateRequiresQuotaResetAndFile(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	event := usage.Event{
+		EventHash:        "evt-1",
+		Failed:           true,
+		FailStatusCode:   http.StatusTooManyRequests,
+		FailBody:         `{"error":{"code":"quota_exhausted","message":"quota exhausted","reset_at":1700000360}}`,
+		AuthFileSnapshot: "codex-auth.json",
+		AccountSnapshot:  "user@example.com",
+		Provider:         "codex",
+	}
+
+	candidate, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now)
+	if !ok {
+		t.Fatalf("candidate not detected")
+	}
+	if candidate.FileName != "codex-auth.json" || candidate.DisplayAccount != "user@example.com" {
+		t.Fatalf("candidate identity = %#v", candidate)
+	}
+	if got := candidate.ResetAt.Unix(); got != 1_700_000_360 {
+		t.Fatalf("reset unix = %d", got)
+	}
+
+	event.AuthFileSnapshot = ""
+	if _, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now); ok {
+		t.Fatalf("candidate should require auth file snapshot")
+	}
+	event.AuthFileSnapshot = "codex-auth.json"
+	event.FailBody = `{"error":{"code":"quota_exhausted"}}`
+	if _, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now); ok {
+		t.Fatalf("candidate should require reset time")
+	}
+}
+
+func TestQuotaResetTimeParsesCommonShapes(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cases := []struct {
+		name string
+		text string
+		want int64
+	}{
+		{
+			name: "codex nested reset_at",
+			text: `{"rate_limit":{"primary":{"reset_at":1700000600}}}`,
+			want: 1_700_000_600,
+		},
+		{
+			name: "retry after header array",
+			text: `{"response_headers":{"Retry-After":["30"]}}`,
+			want: 1_700_000_030,
+		},
+		{
+			name: "milliseconds",
+			text: `{"resetAt":1700000900000}`,
+			want: 1_700_000_900,
+		},
+		{
+			name: "plain text",
+			text: `quota exhausted, reset_at: 1700001200`,
+			want: 1_700_001_200,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := resetTimeFromText(tc.text, now)
+			if !ok {
+				t.Fatalf("reset time not parsed")
+			}
+			if got.Unix() != tc.want {
+				t.Fatalf("reset unix = %d, want %d", got.Unix(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitAutoDisableWorkerDisablesThenEnablesAtReset(t *testing.T) {
+	var mu sync.Mutex
+	type action struct {
+		Name     string `json:"name"`
+		Disabled bool   `json:"disabled"`
+	}
+	actions := make([]action, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/auth-files" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-management-key" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		var item action
+		if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		actions = append(actions, item)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	worker := NewRateLimitAutoDisableWorker(nil)
+	worker.enableCheckInterval = 10 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	worker.Start(ctx)
+
+	worker.HandleUsageEvents(ctx, collectorpkg.RuntimeConfig{
+		CPAUpstreamURL: server.URL,
+		ManagementKey:  "test-management-key",
+	}, []usage.Event{{
+		EventHash:        "evt-quota",
+		Failed:           true,
+		FailStatusCode:   http.StatusTooManyRequests,
+		FailBody:         `{"error":{"code":"quota_exhausted","reset_at":1}}`,
+		AuthFileSnapshot: "codex-auth.json",
+		AccountSnapshot:  "user@example.com",
+	}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		count := len(actions)
+		mu.Unlock()
+		if count >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(actions) < 2 {
+		t.Fatalf("actions = %#v, want disable and enable", actions)
+	}
+	if actions[0].Name != "codex-auth.json" || !actions[0].Disabled {
+		t.Fatalf("disable action = %#v", actions[0])
+	}
+	if actions[1].Name != "codex-auth.json" || actions[1].Disabled {
+		t.Fatalf("enable action = %#v", actions[1])
+	}
+}

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	collectorservice "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -89,6 +91,108 @@ func TestQuotaAutoDisableCandidateRequiresStrictCodexUsageLimit(t *testing.T) {
 				t.Fatalf("candidate should not be detected")
 			}
 		})
+	}
+}
+
+func TestRateLimitAutoDisableWorkerRecoversDueCooldownFromManagerRuntimeConfigAfterRestart(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	var mu sync.Mutex
+	disabled := true
+	patches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer db-management-key" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/auth-files", "/v0/management/auth-files":
+			switch r.Method {
+			case http.MethodGet:
+				mu.Lock()
+				currentDisabled := disabled
+				mu.Unlock()
+				_ = json.NewEncoder(w).Encode([]map[string]any{{
+					"name":       "codex-auth.json",
+					"auth_index": "auth-1",
+					"disabled":   currentDisabled,
+				}})
+			case http.MethodPatch:
+				var item struct {
+					Name     string `json:"name"`
+					Disabled bool   `json:"disabled"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				mu.Lock()
+				disabled = item.Disabled
+				patches++
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+			default:
+				http.NotFound(w, r)
+			}
+		case "/v0/management/usage-queue":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := st.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
+		AuthFileName:     "codex-auth.json",
+		AuthIndex:        "auth-1",
+		Provider:         "codex",
+		RecoverAtMS:      time.Now().Add(-time.Minute).UnixMilli(),
+		Owner:            model.QuotaCooldownOwnerUsage429,
+		EventHash:        "evt-due",
+		PreDisabledState: false,
+		DisabledAtMS:     time.Now().Add(-2 * time.Minute).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("upsert due cooldown: %v", err)
+	}
+	if err := st.SaveManagerConfig(ctx, store.ManagerConfig{
+		CPAConnection: store.ManagerCPAConnectionConfig{
+			CPABaseURL:    server.URL,
+			ManagementKey: "db-management-key",
+		},
+		Collector: store.ManagerCollectorConfig{
+			CollectorMode:  "http",
+			BatchSize:      10,
+			PollIntervalMS: 10,
+		},
+	}); err != nil {
+		t.Fatalf("save manager config: %v", err)
+	}
+
+	manager := collectorpkg.NewManager(config.Config{CollectorMode: "http", PollInterval: 10 * time.Millisecond}, st)
+	rateLimitWorker := NewRateLimitAutoDisableWorker(st)
+	manager.SetUsageEventHandler(rateLimitWorker)
+	collectorWorker := NewCollectorWorker(config.Config{CollectorMode: "http", PollInterval: 10 * time.Millisecond}, st, collectorservice.New(manager))
+	collectorWorker.Start(ctx)
+
+	waitForWorkerTest(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return patches == 1 && !disabled
+	})
+
+	active, err := st.QuotaCooldowns.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("list active cooldowns: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("active cooldowns = %#v, want recovered", active)
 	}
 }
 
@@ -183,4 +287,16 @@ func TestRateLimitAutoDisableWorkerPersistsAndRecoversAfterRestart(t *testing.T)
 	if actions[1].Name != "codex-auth.json" || actions[1].Disabled || disabled {
 		t.Fatalf("enable action = %#v disabled=%v", actions[1], disabled)
 	}
+}
+
+func waitForWorkerTest(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition was not met before deadline")
 }


### PR DESCRIPTION
## Summary

- 基于 request-monitoring 中真实新插入的 Codex 短窗口使用限制事件触发 cooldown，而不是轮询历史事件或依赖宽泛文本匹配。
- 仅处理满足以下条件的事件：`provider=codex`、`status_code=429`、JSON `error.type=usage_limit_reached`，并且必须包含明确的 `resets_at` 或 `resets_in_seconds`。
- 在显式启用 `USAGE_QUOTA_COOLDOWN_ENABLED` / `quotaCooldownEnabled` 后，自动将命中的 CPA auth file 临时 PATCH 为 `disabled=true`。
- 新增本地持久化表 `quota_cooldowns`，记录 `owner=cpamp_usage_429`、auth file/index、account snapshot、event hash、`recover_at_ms`、`pre_disabled_state` 和恢复状态。
- 恢复流程由 DB 中的 `quota_cooldowns.active` 驱动；服务重启后仍可继续恢复 due cooldown。
- 恢复前会重新读取 CPA auth files 并校验 auth file/auth index/current disabled state；只恢复 CPAMP 拥有且 `pre_disabled_state=false` 的临时禁用，避免覆盖用户手动禁用。
- cooldown worker 会同步 collector 实际运行时 `RuntimeConfig`，支持 env 为空但 CPA 连接来自 DB ManagerConfig/setup 的重启恢复场景。
- collector 只把本批实际新插入成功的 usage events 传给 handler，避免 duplicate/skipped 429 在同批次中再次触发 disable。
- 当前 PR 保持最小范围：不包含 pending account queue，不增加 Pending Accounts page，不联动账号巡检或 UI 派生状态。

## Tests

- `cd apps/manager-server && go test ./internal/collector ./internal/worker ./internal/repository/usageevent ./internal/repository/quotacooldown ./internal/store ./internal/config`
- `cd apps/manager-server && go test ./internal/worker ./internal/repository/quotacooldown ./internal/store ./internal/config`
- `cd apps/manager-server && go test ./...`
  - 除当前 Windows 环境中的既有文件权限问题外，其余通过：
    `internal/security TestLoadOrCreateDataKeyCreatesStableRestrictedFile` 期望权限 `0600`，但文件系统报告 `0666`。
- `git diff --check`
  - 通过；仅有 Windows 下 LF/CRLF 提示。
