### PR TITLE
fix: handle deactivated Codex workspaces in inspections

### DIFF
--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -1032,10 +1032,27 @@ func (l runLogger) log(ctx context.Context, level string, message string, detail
 }
 
 func resolveProbeAction(item account, statusCode int, bodyText string, rateLimit *codexRateLimit, usedPercent *float64, isQuota bool, threshold float64) inspectionDecision {
+	if isDeactivatedWorkspaceResponse(statusCode, bodyText) {
+		return resolveDeactivatedWorkspaceProbeAction(usedPercent)
+	}
 	if decision := resolveWindowAwareProbeAction(item, statusCode, bodyText, rateLimit, threshold); decision != nil {
 		return *decision
 	}
 	return resolveLegacyProbeAction(item, statusCode, bodyText, usedPercent, isQuota, threshold)
+}
+
+func isDeactivatedWorkspaceResponse(statusCode int, bodyText string) bool {
+	return statusCode == http.StatusPaymentRequired &&
+		strings.Contains(strings.ToLower(bodyText), "deactivated_workspace")
+}
+
+func resolveDeactivatedWorkspaceProbeAction(usedPercent *float64) inspectionDecision {
+	return inspectionDecision{
+		Action:       "delete",
+		ActionReason: "接口返回 402，工作区已停用，建议删除账号",
+		UsedPercent:  usedPercent,
+		IsQuota:      false,
+	}
 }
 
 func resolveWindowAwareProbeAction(item account, statusCode int, bodyText string, rateLimit *codexRateLimit, threshold float64) *inspectionDecision {

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -453,6 +453,32 @@ func TestResolveProbeActionUsesMonthlyWindowAsLongQuota(t *testing.T) {
 	item := account{DisplayAccount: "user@example.test"}
 	threshold := 100.0
 
+	t.Run("deletes deactivated workspace payment required response", func(t *testing.T) {
+		rateLimit := &codexRateLimit{
+			PrimaryWindow: &codexWindow{
+				UsedPercent:        ptrFloat(5),
+				LimitWindowSeconds: ptrFloat(codexMonthWindow),
+			},
+		}
+		decision := resolveProbeAction(
+			item,
+			http.StatusPaymentRequired,
+			`{"detail":{"code":"deactivated_workspace"}}`,
+			rateLimit,
+			deriveRateLimitUsedPercent(rateLimit),
+			true,
+			threshold,
+		)
+
+		if decision.Action != "delete" ||
+			decision.ActionReason != "接口返回 402，工作区已停用，建议删除账号" ||
+			decision.UsedPercent == nil ||
+			*decision.UsedPercent != 5 ||
+			decision.IsQuota {
+			t.Fatalf("decision = %#v, want delete deactivated workspace", decision)
+		}
+	})
+
 	t.Run("keeps healthy monthly quota", func(t *testing.T) {
 		rateLimit := &codexRateLimit{
 			PrimaryWindow: &codexWindow{
@@ -510,6 +536,42 @@ func TestResolveProbeActionUsesMonthlyWindowAsLongQuota(t *testing.T) {
 			t.Fatalf("decision = %#v, want keep exhausted short window with healthy monthly quota", decision)
 		}
 	})
+}
+
+func TestRunSuggestsDeleteForDeactivatedWorkspace(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
+		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"status_code":402,"body":{"detail":{"code":"deactivated_workspace"}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	db := newCodexInspectionTestStore(t)
+	managerCfg := newCodexInspectionManagerConfig(upstream.URL)
+	managerCfg.CodexInspection.AutoActionMode = model.CodexInspectionAutoActionNone
+	if err := db.SaveManagerConfig(context.Background(), managerCfg); err != nil {
+		t.Fatalf("save manager config: %v", err)
+	}
+	svc := newCodexInspectionTestService(t, db)
+
+	result, err := svc.Run(context.Background(), RunRequest{TriggerType: "manual", TriggerKey: "manual"})
+	if err != nil {
+		t.Fatalf("run inspection: %v", err)
+	}
+	if result.Run.DeleteCount != 1 || result.Run.DisableCount != 0 || result.Run.KeepCount != 0 {
+		t.Fatalf("run counts delete=%d disable=%d keep=%d, want 1/0/0", result.Run.DeleteCount, result.Run.DisableCount, result.Run.KeepCount)
+	}
+	if len(result.Results) != 1 ||
+		result.Results[0].Action != "delete" ||
+		result.Results[0].ActionReason != "接口返回 402，工作区已停用，建议删除账号" ||
+		result.Results[0].IsQuota {
+		t.Fatalf("result = %#v, want delete deactivated workspace", result.Results)
+	}
 }
 
 func TestRunFallsBackToManagementAPICallPath(t *testing.T) {

--- a/apps/web/src/features/monitoring/model/codexInspectionProbe.test.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionProbe.test.ts
@@ -101,4 +101,43 @@ describe('inspectSingleAccount', () => {
     expect(result.usedPercent).toBe(5);
     expect(result.isQuota).toBe(false);
   });
+
+  it('deletes an account when the workspace is deactivated', async () => {
+    mockRequestCodexUsageRaw.mockResolvedValue({
+      result: {
+        statusCode: 402,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '{"detail":{"code":"deactivated_workspace"}}',
+        body: { detail: { code: 'deactivated_workspace' } },
+      },
+      payload: null,
+    });
+
+    const result = await inspectSingleAccount(baseAccount, settings);
+
+    expect(result.action).toBe('delete');
+    expect(result.actionReason).toBe('接口返回 402，工作区已停用，建议删除账号');
+    expect(result.usedPercent).toBe(null);
+    expect(result.isQuota).toBe(false);
+  });
+
+  it('keeps regular 402 quota responses as disable suggestions', async () => {
+    mockRequestCodexUsageRaw.mockResolvedValue({
+      result: {
+        statusCode: 402,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '{"message":"limit reached"}',
+        body: { message: 'limit reached' },
+      },
+      payload: null,
+    });
+
+    const result = await inspectSingleAccount(baseAccount, settings);
+
+    expect(result.action).toBe('disable');
+    expect(result.actionReason).toBe('额度已耗尽，建议禁用账号');
+    expect(result.isQuota).toBe(true);
+  });
 });

--- a/apps/web/src/features/monitoring/model/codexInspectionProbe.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionProbe.ts
@@ -75,6 +75,18 @@ type CodexInspectionDecision = Pick<
 
 type UnauthorizedReason = 'unknown' | 'expired' | 'invalidated';
 
+const isDeactivatedWorkspaceResponse = (statusCode: number, bodyText: string): boolean =>
+  statusCode === 402 && bodyText.toLowerCase().includes('deactivated_workspace');
+
+const resolveDeactivatedWorkspaceProbeAction = (
+  usedPercent: number | null
+): CodexInspectionDecision => ({
+  action: 'delete',
+  actionReason: '接口返回 402，工作区已停用，建议删除账号',
+  usedPercent,
+  isQuota: false,
+});
+
 const classifyUnauthorizedReason = (bodyText: string): UnauthorizedReason => {
   const normalized = bodyText.trim().toLowerCase();
   if (
@@ -245,6 +257,10 @@ const resolveProbeAction = (
   isQuota: boolean,
   threshold: number
 ): CodexInspectionDecision => {
+  if (isDeactivatedWorkspaceResponse(statusCode, bodyText)) {
+    return resolveDeactivatedWorkspaceProbeAction(usedPercent);
+  }
+
   const windowAwareDecision = resolveWindowAwareProbeAction(
     account,
     statusCode,


### PR DESCRIPTION
## Summary
Fix local and server Codex inspections to treat 402 deactivated_workspace responses as delete suggestions.

## Cause
Inspection logic classified every 402 response as quota exhaustion before checking workspace deactivation.

## Solution
- Add deactivated workspace detection in server inspection decisions.
- Add matching local inspection detection.
- Cover the delete path and regular quota 402 regression in tests.

## Testing
- [x] npm --workspace apps/web run test -- src/features/monitoring/model/codexInspectionProbe.test.ts
- [x] npm --workspace apps/web run type-check
- [x] npm --workspace apps/web run lint
- [x] go test -run 'TestResolveProbeActionUsesMonthlyWindowAsLongQuota|TestRunSuggestsDeleteForDeactivatedWorkspace|TestRunFallsBackToManagementAuthFileStatusActionPath|TestExecuteManualActionsRejectsMissingAuthFile' ./internal/service/codexinspection
- [x] npm run manager-server:test