### PR TITLE
Fix auth file batch upload request size failures

### DIFF
--- a/apps/web/src/services/api/authFiles.test.ts
+++ b/apps/web/src/services/api/authFiles.test.ts
@@ -176,6 +176,80 @@ describe('authFilesApi save auth file upload contracts', () => {
     );
   });
 
+  it('uploadFiles sends multi-file selections as separate requests', async () => {
+    // Arrange
+    mocks.postForm
+      .mockResolvedValueOnce({
+        status: 'ok',
+        uploaded: 1,
+        files: ['first-auth.json'],
+        failed: [],
+      })
+      .mockResolvedValueOnce({
+        status: 'ok',
+        uploaded: 1,
+        files: ['second-auth.json'],
+        failed: [],
+      });
+
+    const firstFile = new File(['{"type":"codex"}'], 'first-auth.json', {
+      type: 'application/json',
+    });
+    const secondFile = new File(['{"type":"claude"}'], 'second-auth.json', {
+      type: 'application/json',
+    });
+
+    // Act
+    const result = await authFilesApi.uploadFiles([firstFile, secondFile]);
+
+    // Assert
+    expect(result).toEqual({
+      status: 'ok',
+      uploaded: 2,
+      files: ['first-auth.json', 'second-auth.json'],
+      failed: [],
+    });
+    expect(mocks.postForm).toHaveBeenCalledTimes(2);
+
+    const firstFormData = mocks.postForm.mock.calls[0]?.[1] as FormData;
+    const secondFormData = mocks.postForm.mock.calls[1]?.[1] as FormData;
+    expect(Array.from(firstFormData.getAll('file'))).toHaveLength(1);
+    expect(Array.from(secondFormData.getAll('file'))).toHaveLength(1);
+    expect((firstFormData.get('file') as File).name).toBe('first-auth.json');
+    expect((secondFormData.get('file') as File).name).toBe('second-auth.json');
+  });
+
+  it('uploadFiles aggregates per-file upload failures after successful uploads', async () => {
+    // Arrange
+    mocks.postForm
+      .mockResolvedValueOnce({
+        status: 'ok',
+        uploaded: 1,
+        files: ['first-auth.json'],
+        failed: [],
+      })
+      .mockRejectedValueOnce(new Error('request body too large'));
+
+    const firstFile = new File(['{"type":"codex"}'], 'first-auth.json', {
+      type: 'application/json',
+    });
+    const secondFile = new File(['{"type":"claude"}'], 'second-auth.json', {
+      type: 'application/json',
+    });
+
+    // Act
+    const result = await authFilesApi.uploadFiles([firstFile, secondFile]);
+
+    // Assert
+    expect(result).toEqual({
+      status: 'partial',
+      uploaded: 1,
+      files: ['first-auth.json'],
+      failed: [{ name: 'second-auth.json', error: 'request body too large' }],
+    });
+    expect(mocks.postForm).toHaveBeenCalledTimes(2);
+  });
+
   it('saveJsonObject throws Upload failed when backend reports zero uploaded files without explicit failures', async () => {
     // Arrange
     mocks.postForm.mockResolvedValue({

--- a/apps/web/src/services/api/authFiles.ts
+++ b/apps/web/src/services/api/authFiles.ts
@@ -143,6 +143,44 @@ const normalizeBatchUploadResponse = (
   };
 };
 
+const readUploadErrorMessage = (err: unknown): string => {
+  if (err instanceof Error && err.message.trim()) return err.message;
+  if (typeof err === 'string' && err.trim()) return err.trim();
+  return 'Upload failed';
+};
+
+const uploadSingleAuthFile = async (file: File): Promise<AuthFileBatchUploadResult> => {
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+  const payload = await apiClient.postForm<AuthFileBatchUploadResponse>('/auth-files', formData);
+  return normalizeBatchUploadResponse(payload, [file.name]);
+};
+
+const mergeBatchUploadResults = (
+  results: AuthFileBatchUploadResult[],
+  requestedNames: string[]
+): AuthFileBatchUploadResult => {
+  const uploaded = results.reduce((total, result) => total + Math.max(0, result.uploaded), 0);
+  const files = results.flatMap((result) => result.files);
+  const failed = results.flatMap((result) => result.failed);
+  const hasFailureStatus = results.some((result) => {
+    const status = result.status.trim().toLowerCase();
+    return status === 'error' || status === 'failed' || status === 'partial';
+  });
+
+  return {
+    status:
+      failed.length > 0 || hasFailureStatus || uploaded < requestedNames.length
+        ? uploaded > 0
+          ? 'partial'
+          : 'error'
+        : 'ok',
+    uploaded,
+    files,
+    failed,
+  };
+};
+
 const normalizeBatchDeleteResponse = (
   payload: AuthFileBatchDeleteResponse | undefined,
   requestedNames: string[]
@@ -614,12 +652,24 @@ export const authFilesApi = {
       return { status: 'ok', uploaded: 0, files: [], failed: [] };
     }
 
-    const formData = new FormData();
-    files.forEach((file) => {
-      formData.append('file', file, file.name);
-    });
-    const payload = await apiClient.postForm<AuthFileBatchUploadResponse>('/auth-files', formData);
-    return normalizeBatchUploadResponse(payload, requestedNames);
+    if (files.length === 1) {
+      return uploadSingleAuthFile(files[0]);
+    }
+
+    const results: AuthFileBatchUploadResult[] = [];
+    for (const file of files) {
+      try {
+        results.push(await uploadSingleAuthFile(file));
+      } catch (err) {
+        results.push({
+          status: 'error',
+          uploaded: 0,
+          files: [],
+          failed: [{ name: file.name, error: readUploadErrorMessage(err) }],
+        });
+      }
+    }
+    return mergeBatchUploadResults(results, requestedNames);
   },
 
   upload: (file: File) => authFilesApi.uploadFiles([file]),


### PR DESCRIPTION
## Summary
Fix batch auth file uploads failing when the combined multipart request exceeds upstream request body limits.

## Cause
The UI previously appended all selected auth files to one FormData payload and sent a single POST to `/auth-files`, so multiple valid files could exceed the per-request upload limit.

## Solution
Send one multipart POST per selected auth file and aggregate the per-file upload results into the existing batch result shape.

## Testing
- `npm --workspace apps/web run test -- src/services/api/authFiles.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run test`