### PR TITLE
Generate readable default auth file names

### DIFF
--- a/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
@@ -484,7 +484,7 @@ describe('AuthFilesPage real auth JSON paste flow', () => {
 
     await vi.waitFor(() => {
       expect(mocks.saveJsonObject).toHaveBeenCalledWith(
-        'session-user-tag-example-com.codex.json',
+        'codex-session-session.user+tag@example.com.json',
         expect.objectContaining({
           type: 'codex',
           email: 'Session.User+tag@example.com',
@@ -495,7 +495,7 @@ describe('AuthFilesPage real auth JSON paste flow', () => {
     });
     await vi.waitFor(() => {
       expect(mocks.showNotification).toHaveBeenCalledWith(
-        'auth_files.paste_success:session-user-tag-example-com.codex.json',
+        'auth_files.paste_success:codex-session-session.user+tag@example.com.json',
         'success'
       );
       expect(renderer!.root.findAllByProps({ id: 'auth-json-paste-content' })).toHaveLength(0);

--- a/apps/web/src/features/authFiles/hooks/useAuthFilesData.test.ts
+++ b/apps/web/src/features/authFiles/hooks/useAuthFilesData.test.ts
@@ -147,7 +147,7 @@ describe('buildPastedAuthJsonPayload', () => {
       })
     );
 
-    expect(result.resolvedFileName).toBe('session-user-tag-example-com.codex.json');
+    expect(result.resolvedFileName).toBe('codex-session-session.user+tag@example.com.json');
     expect(result.authJson).toMatchObject({
       type: 'codex',
       email: 'Session.User+tag@example.com',
@@ -215,9 +215,9 @@ describe('useAuthFilesData savePastedAuthJson', () => {
       .getCurrent()
       .savePastedAuthJson('session', 'codex-account.json', sessionInput);
 
-    expect(savedName).toBe('session-user-tag-example-com.codex.json');
+    expect(savedName).toBe('codex-session-session.user+tag@example.com.json');
     expect(mocks.saveJsonObject).toHaveBeenCalledWith(
-      'session-user-tag-example-com.codex.json',
+      'codex-session-session.user+tag@example.com.json',
       expect.objectContaining({
         type: 'codex',
         email: 'Session.User+tag@example.com',
@@ -226,7 +226,7 @@ describe('useAuthFilesData savePastedAuthJson', () => {
       })
     );
     expect(mocks.showNotification).toHaveBeenCalledWith(
-      'auth_files.paste_success:session-user-tag-example-com.codex.json',
+      'auth_files.paste_success:codex-session-session.user+tag@example.com.json',
       'success'
     );
     expect(mocks.list).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/authFiles/sessionAuthConverter.test.ts
+++ b/apps/web/src/features/authFiles/sessionAuthConverter.test.ts
@@ -1266,9 +1266,33 @@ describe('convertAuthJsonInput', () => {
     const authJson = {
       type: 'codex',
       email: 'User.Name+tag@example.com',
+      account_id: '0ded482d-team-account',
+      plan_type: 'team',
     };
 
-    expect(getDefaultSessionAuthFileName(authJson)).toBe('user-name-tag-example-com.codex.json');
+    expect(getDefaultSessionAuthFileName(authJson)).toBe(
+      'codex-0ded482d-user.name+tag@example.com-team.json'
+    );
+  });
+
+  it('uses a stable metadata fingerprint when account identity has no id', () => {
+    const authJson = {
+      type: 'codex',
+      email: 'User.Name+tag@example.com',
+      access_token: 'token-one',
+    };
+    const sameIdentityWithDifferentToken = {
+      type: 'codex',
+      email: 'User.Name+tag@example.com',
+      access_token: 'token-two',
+    };
+
+    expect(getDefaultSessionAuthFileName(authJson)).toMatch(
+      /^codex-[a-f0-9]{8}-user\.name\+tag@example\.com\.json$/
+    );
+    expect(getDefaultSessionAuthFileName(sameIdentityWithDifferentToken)).toBe(
+      getDefaultSessionAuthFileName(authJson)
+    );
   });
 
   it.each(['con', 'AUX', 'lpt1'])(
@@ -1279,8 +1303,8 @@ describe('convertAuthJsonInput', () => {
         email: identity,
       };
 
-      expect(getDefaultSessionAuthFileName(authJson)).toBe(
-        `${identity.toLowerCase()}-account.codex.json`
+      expect(getDefaultSessionAuthFileName(authJson)).toMatch(
+        new RegExp(`^codex-[a-f0-9]{8}-${identity.toLowerCase()}-account\\.json$`)
       );
     }
   );

--- a/apps/web/src/features/authFiles/sessionAuthConverter.ts
+++ b/apps/web/src/features/authFiles/sessionAuthConverter.ts
@@ -923,29 +923,85 @@ export const convertAuthJsonInput = (
   return convertSessionToCpaAuthJson(sessions[0].value, now);
 };
 
-const buildSafeDefaultAuthFileName = (rawName: unknown) => {
-  const safeName = String(rawName)
-    .replace(/\.json$/iu, '')
-    .replace(/[\\/:*?"<>|]+/g, '-')
-    .replace(/[^a-z0-9]+/gi, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .toLowerCase()
-    .slice(0, 80);
-  const safeBaseName = WINDOWS_RESERVED_BASE_NAMES.has(safeName) ? `${safeName}-account` : safeName;
+const stableStringifyForFingerprint = (value: unknown): string => {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringifyForFingerprint).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .filter((key) => !GENERIC_CREDENTIAL_KEYS.has(key.toLowerCase()))
+      .map((key) => `${JSON.stringify(key)}:${stableStringifyForFingerprint(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? String(value);
+};
 
-  return `${safeBaseName || 'codex-account'}.codex.json`;
+const buildAuthFileFingerprint = (value: unknown) => {
+  const text = stableStringifyForFingerprint(value);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};
+
+const buildSafeFileNameSegment = (
+  value: unknown,
+  {
+    fallback = '',
+    maxLength = 80,
+    preserveEmailSymbols = false,
+  }: { fallback?: string; maxLength?: number; preserveEmailSymbols?: boolean } = {}
+) => {
+  const raw = String(value ?? '')
+    .trim()
+    .replace(/\.json$/iu, '')
+    .toLowerCase();
+  const unsupportedPattern = preserveEmailSymbols ? /[^a-z0-9@._+-]+/g : /[^a-z0-9]+/g;
+  const safeName = raw
+    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(unsupportedPattern, '-')
+    .replace(/-+/g, '-')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^[.-]+|[.-]+$/g, '')
+    .slice(0, maxLength)
+    .replace(/[.-]+$/g, '');
+  const safeBaseName = WINDOWS_RESERVED_BASE_NAMES.has(safeName) ? `${safeName}-account` : safeName;
+  return safeBaseName || fallback;
+};
+
+const getDefaultAuthFileIdSegment = (authJson: JsonRecord) => {
+  const rawId = firstNonEmpty(
+    authJson.account_id,
+    authJson.chatgpt_account_id,
+    authJson.organization_id
+  );
+  return buildSafeFileNameSegment(rawId, { maxLength: 8 }) || buildAuthFileFingerprint(authJson);
 };
 
 export const getDefaultSessionAuthFileName = (authJson: JsonRecord) => {
-  const rawName = firstNonEmpty(
-    authJson.email,
-    authJson.name,
-    authJson.account_id,
-    'codex-account'
+  const provider = buildSafeFileNameSegment(firstNonEmpty(authJson.type, authJson.provider), {
+    fallback: 'codex',
+    maxLength: 24,
+  });
+  const id = getDefaultAuthFileIdSegment(authJson);
+  const identity = buildSafeFileNameSegment(
+    firstNonEmpty(authJson.email, authJson.name, authJson.account_id, 'account'),
+    {
+      fallback: 'account',
+      maxLength: 96,
+      preserveEmailSymbols: true,
+    }
   );
+  const plan = buildSafeFileNameSegment(firstNonEmpty(authJson.plan_type, authJson.chatgpt_plan_type), {
+    maxLength: 32,
+  });
+  const baseName = [provider, id, identity, plan].filter(Boolean).join('-');
 
-  return buildSafeDefaultAuthFileName(rawName);
+  return `${baseName}.json`;
 };
 
 export const getDefaultSub2ApiAuthFileName = (authJson: AuthJsonConversionResult) => {


### PR DESCRIPTION
## Summary
Generate readable default auth file names for pasted auth JSON when users keep the default file name.

## Changes
- Build default names from provider, account identity, email/name, and plan metadata.
- Keep manually entered file names unchanged and keep multi-account sub2api exports as one aggregate file.
- Use a stable non-token metadata fingerprint when no account identifier is available.
- Update paste flow and converter tests for the new naming behavior.

## Testing
- `npm --workspace apps/web run test -- src/features/authFiles/sessionAuthConverter.test.ts src/features/authFiles/hooks/useAuthFilesData.test.ts src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx`
- `npm run type-check`
- `npm run lint`
- `npm run test`