### PR TITLE
docs(release): add v1.3.0 notes

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -438,6 +438,10 @@ go run ./cmd/cpa-manager-plus
 - **管理员密钥丢失**：已有 `settings.admin_credential_v1` 时，单独设置 `CPA_MANAGER_ADMIN_KEY` 不会覆盖旧凭证。请先停止 Manager Server、备份 `/data`，再按 [重置 Manager Server 管理员密钥](docs/reset-admin-key.zh-CN.md) 处理。
 - **完整 FAQ**：查看 [CPA Manager Plus 常见问题与解决方案](https://github.com/seakee/CPA-Manager-Plus/wiki/CPA%E2%80%90Manager-%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98%E4%B8%8E%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88) 或 [English FAQ and Troubleshooting](https://github.com/seakee/CPA-Manager-Plus/wiki/CPA-Manager-Plus-FAQ-and-Troubleshooting)。
 
+## 社区与反馈
+
+- Telegram 交流群: https://t.me/cpa_mp
+
 ## 参考
 
 - CLIProxyAPI: https://github.com/router-for-me/CLIProxyAPI

--- a/docs/release-notes/v1.3.0-en.md
+++ b/docs/release-notes/v1.3.0-en.md
@@ -1,0 +1,31 @@
+# CPA Manager Plus v1.3.0
+
+> 7 commits · 28 files changed · +1819 / -296
+
+> [中文 ->](./v1.3.0-zh.md)
+
+## Overview
+
+This release continues improving the Auth Files management experience with account-level batch controls, account patch primitives, and more readable default authentication filenames, reducing repeated work when importing, editing, and identifying auth files. Codex inspection now also handles deactivated workspaces correctly, while configuration and inspection pages share the new segmented tabs component for more consistent mode switching.
+
+## Highlights
+
+### Features
+
+- Auth Files adds account-level batch controls for handling authentication file operations at the account level. (`auth-files`)
+- Auth Files adds account-level patch primitives as the foundation for more granular authentication account updates. (`auth-files`)
+- Auth Files now generates more readable default authentication filenames to make imported accounts and sources easier to identify. (`auth-files`)
+- Added a reusable Segmented Tabs component and applied the shared mode switcher to configuration and Codex inspection pages. (`ui`)
+
+### Fixes
+
+- Auth Files batch uploads now save files one at a time, avoiding cross-file interference when multiple files are submitted together. (`auth-files`)
+- Web and Manager Server Codex workspace handling now supports deactivated workspaces, avoiding inspection or display failures. (`web`, `manager-server`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.2.1...v1.3.0

--- a/docs/release-notes/v1.3.0-zh.md
+++ b/docs/release-notes/v1.3.0-zh.md
@@ -1,0 +1,31 @@
+# CPA Manager Plus v1.3.0
+
+> 7 commits · 28 files changed · +1819 / -296
+
+> [English ->](./v1.3.0-en.md)
+
+## Overview
+
+本次发布继续增强 Auth Files 管理体验，新增账号级批量控制、账号补丁基础能力和更可读的默认认证文件名，减少批量导入、编辑和识别认证文件时的重复操作。同时，Codex 巡检会正确处理已停用 workspace，配置与巡检页面复用新的 segmented tabs 组件，提升多模式切换的一致性。
+
+## Highlights
+
+### Features
+
+- Auth Files 新增账号级批量控制，可在账号维度批量处理认证文件相关操作。(`auth-files`)
+- Auth Files 增加账号级 patch primitives，为更细粒度的认证账号更新提供基础能力。(`auth-files`)
+- Auth Files 生成更可读的默认认证文件名，降低导入后识别账号和来源的成本。(`auth-files`)
+- 新增复用型 Segmented Tabs 组件，并在配置与 Codex 巡检相关页面使用统一的模式切换控件。(`ui`)
+
+### Fixes
+
+- Auth Files 批量上传改为逐个文件保存，避免一次提交多文件时互相影响。(`auth-files`)
+- Web 端和 Manager Server 的 Codex workspace 处理逻辑兼容已停用 workspace，避免巡检或展示异常。(`web`, `manager-server`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.2.1...v1.3.0


### PR DESCRIPTION
## Purpose

- Add curated release notes for CPA Manager Plus v1.3.0 in Chinese and English.
- Add the Telegram community group link to the Chinese README.

## Tests

- `git diff --check`

## Affected Modes

- docs-only

## Release

- Planned tag: `v1.3.0`
- Previous tag: `v1.2.1`