### PR TITLE
feat: 为待处理账户操作增加可选自动禁用

### DIFF
--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -89,10 +89,10 @@ func runServer() {
 		log.Printf("quota cooldown worker disabled (set USAGE_QUOTA_COOLDOWN_ENABLED=1 to enable)")
 	}
 	if cfg.AccountActionsEnabled {
-		accountActionWorker := worker.NewAccountActionCandidateWorker(db)
+		accountActionWorker := worker.NewAccountActionCandidateWorker(db, cfg.AccountActionsAutoDisable)
 		usageHandlers = append(usageHandlers, accountActionWorker)
 		accountActionWorker.Start(ctx)
-		log.Printf("account action worker enabled (queue-only)")
+		log.Printf("account action worker enabled (auto-disable=%t)", cfg.AccountActionsAutoDisable)
 	} else {
 		log.Printf("account action worker disabled (set USAGE_ACCOUNT_ACTIONS_ENABLED=1 to enable)")
 	}

--- a/apps/manager-server/internal/config/config.go
+++ b/apps/manager-server/internal/config/config.go
@@ -19,25 +19,26 @@ const defaultAdminSecretFile = "/run/secrets/cpa_admin_key"
 const defaultDataKeySecretFile = "/run/secrets/cpa_data_key"
 
 type Config struct {
-	HTTPAddr              string
-	DataDir               string
-	DBPath                string
-	CPAUpstreamURL        string
-	ManagementKey         string
-	AdminKey              string
-	DataKey               string
-	DataKeyPath           string
-	CollectorMode         string
-	Queue                 string
-	PopSide               string
-	BatchSize             int
-	PollInterval          time.Duration
-	QueryLimit            int
-	PanelPath             string
-	CORSOrigins           []string
-	TLSSkipVerify         bool
-	QuotaCooldownEnabled  bool
-	AccountActionsEnabled bool
+	HTTPAddr                  string
+	DataDir                   string
+	DBPath                    string
+	CPAUpstreamURL            string
+	ManagementKey             string
+	AdminKey                  string
+	DataKey                   string
+	DataKeyPath               string
+	CollectorMode             string
+	Queue                     string
+	PopSide                   string
+	BatchSize                 int
+	PollInterval              time.Duration
+	QueryLimit                int
+	PanelPath                 string
+	CORSOrigins               []string
+	TLSSkipVerify             bool
+	QuotaCooldownEnabled      bool
+	AccountActionsEnabled     bool
+	AccountActionsAutoDisable bool
 }
 
 type LoadOptions struct {
@@ -45,25 +46,26 @@ type LoadOptions struct {
 }
 
 type fileConfig struct {
-	HTTPAddr              string   `json:"httpAddr,omitempty"`
-	DataDir               string   `json:"dataDir,omitempty"`
-	DBPath                string   `json:"dbPath,omitempty"`
-	CPAUpstreamURL        string   `json:"cpaUpstreamUrl,omitempty"`
-	ManagementKeyFile     string   `json:"managementKeyFile,omitempty"`
-	AdminKeyFile          string   `json:"adminKeyFile,omitempty"`
-	DataKeyFile           string   `json:"dataKeyFile,omitempty"`
-	DataKeyPath           string   `json:"dataKeyPath,omitempty"`
-	CollectorMode         string   `json:"collectorMode,omitempty"`
-	Queue                 string   `json:"queue,omitempty"`
-	PopSide               string   `json:"popSide,omitempty"`
-	BatchSize             int      `json:"batchSize,omitempty"`
-	PollIntervalMS        int      `json:"pollIntervalMs,omitempty"`
-	QueryLimit            int      `json:"queryLimit,omitempty"`
-	PanelPath             string   `json:"panelPath,omitempty"`
-	CORSOrigins           []string `json:"corsOrigins,omitempty"`
-	TLSSkipVerify         bool     `json:"tlsSkipVerify,omitempty"`
-	QuotaCooldownEnabled  bool     `json:"quotaCooldownEnabled,omitempty"`
-	AccountActionsEnabled bool     `json:"accountActionsEnabled,omitempty"`
+	HTTPAddr                  string   `json:"httpAddr,omitempty"`
+	DataDir                   string   `json:"dataDir,omitempty"`
+	DBPath                    string   `json:"dbPath,omitempty"`
+	CPAUpstreamURL            string   `json:"cpaUpstreamUrl,omitempty"`
+	ManagementKeyFile         string   `json:"managementKeyFile,omitempty"`
+	AdminKeyFile              string   `json:"adminKeyFile,omitempty"`
+	DataKeyFile               string   `json:"dataKeyFile,omitempty"`
+	DataKeyPath               string   `json:"dataKeyPath,omitempty"`
+	CollectorMode             string   `json:"collectorMode,omitempty"`
+	Queue                     string   `json:"queue,omitempty"`
+	PopSide                   string   `json:"popSide,omitempty"`
+	BatchSize                 int      `json:"batchSize,omitempty"`
+	PollIntervalMS            int      `json:"pollIntervalMs,omitempty"`
+	QueryLimit                int      `json:"queryLimit,omitempty"`
+	PanelPath                 string   `json:"panelPath,omitempty"`
+	CORSOrigins               []string `json:"corsOrigins,omitempty"`
+	TLSSkipVerify             bool     `json:"tlsSkipVerify,omitempty"`
+	QuotaCooldownEnabled      bool     `json:"quotaCooldownEnabled,omitempty"`
+	AccountActionsEnabled     bool     `json:"accountActionsEnabled,omitempty"`
+	AccountActionsAutoDisable bool     `json:"accountActionsAutoDisable,omitempty"`
 }
 
 func Load() (Config, error) {
@@ -113,25 +115,26 @@ func LoadWithOptions(options LoadOptions) (Config, error) {
 	}
 
 	return Config{
-		HTTPAddr:              env("HTTP_ADDR", stringFallback(cfgFile.HTTPAddr, "0.0.0.0:18317")),
-		DataDir:               dataDir,
-		DBPath:                env("USAGE_DB_PATH", dbPathFallback),
-		CPAUpstreamURL:        env("CPA_UPSTREAM_URL", cfgFile.CPAUpstreamURL),
-		ManagementKey:         readSecret("CPA_MANAGEMENT_KEY", "CPA_MANAGEMENT_KEY_FILE", managementKeyFile),
-		AdminKey:              readSecret("CPA_MANAGER_ADMIN_KEY", "CPA_MANAGER_ADMIN_KEY_FILE", adminKeyFile),
-		DataKey:               readSecret("CPA_MANAGER_DATA_KEY", "CPA_MANAGER_DATA_KEY_FILE", dataKeyFile),
-		DataKeyPath:           env("CPA_MANAGER_DATA_KEY_PATH", dataKeyPath),
-		CollectorMode:         normalizeCollectorMode(env("USAGE_COLLECTOR_MODE", stringFallback(cfgFile.CollectorMode, "auto"))),
-		Queue:                 env("USAGE_RESP_QUEUE", stringFallback(cfgFile.Queue, "usage")),
-		PopSide:               env("USAGE_RESP_POP_SIDE", stringFallback(cfgFile.PopSide, "right")),
-		BatchSize:             envInt("USAGE_BATCH_SIZE", intFallback(cfgFile.BatchSize, 100)),
-		PollInterval:          time.Duration(envInt("USAGE_POLL_INTERVAL_MS", intFallback(cfgFile.PollIntervalMS, 500))) * time.Millisecond,
-		QueryLimit:            envInt("USAGE_QUERY_LIMIT", intFallback(cfgFile.QueryLimit, 50000)),
-		PanelPath:             env("PANEL_PATH", resolveConfigPath(cfgFile.PanelPath, cfgDir)),
-		CORSOrigins:           splitCSV(env("USAGE_CORS_ORIGINS", strings.Join(sliceFallback(cfgFile.CORSOrigins, []string{"*"}), ","))),
-		TLSSkipVerify:         envBool("USAGE_RESP_TLS_SKIP_VERIFY", cfgFile.TLSSkipVerify),
-		QuotaCooldownEnabled:  envBool("USAGE_QUOTA_COOLDOWN_ENABLED", cfgFile.QuotaCooldownEnabled),
-		AccountActionsEnabled: envBool("USAGE_ACCOUNT_ACTIONS_ENABLED", cfgFile.AccountActionsEnabled),
+		HTTPAddr:                  env("HTTP_ADDR", stringFallback(cfgFile.HTTPAddr, "0.0.0.0:18317")),
+		DataDir:                   dataDir,
+		DBPath:                    env("USAGE_DB_PATH", dbPathFallback),
+		CPAUpstreamURL:            env("CPA_UPSTREAM_URL", cfgFile.CPAUpstreamURL),
+		ManagementKey:             readSecret("CPA_MANAGEMENT_KEY", "CPA_MANAGEMENT_KEY_FILE", managementKeyFile),
+		AdminKey:                  readSecret("CPA_MANAGER_ADMIN_KEY", "CPA_MANAGER_ADMIN_KEY_FILE", adminKeyFile),
+		DataKey:                   readSecret("CPA_MANAGER_DATA_KEY", "CPA_MANAGER_DATA_KEY_FILE", dataKeyFile),
+		DataKeyPath:               env("CPA_MANAGER_DATA_KEY_PATH", dataKeyPath),
+		CollectorMode:             normalizeCollectorMode(env("USAGE_COLLECTOR_MODE", stringFallback(cfgFile.CollectorMode, "auto"))),
+		Queue:                     env("USAGE_RESP_QUEUE", stringFallback(cfgFile.Queue, "usage")),
+		PopSide:                   env("USAGE_RESP_POP_SIDE", stringFallback(cfgFile.PopSide, "right")),
+		BatchSize:                 envInt("USAGE_BATCH_SIZE", intFallback(cfgFile.BatchSize, 100)),
+		PollInterval:              time.Duration(envInt("USAGE_POLL_INTERVAL_MS", intFallback(cfgFile.PollIntervalMS, 500))) * time.Millisecond,
+		QueryLimit:                envInt("USAGE_QUERY_LIMIT", intFallback(cfgFile.QueryLimit, 50000)),
+		PanelPath:                 env("PANEL_PATH", resolveConfigPath(cfgFile.PanelPath, cfgDir)),
+		CORSOrigins:               splitCSV(env("USAGE_CORS_ORIGINS", strings.Join(sliceFallback(cfgFile.CORSOrigins, []string{"*"}), ","))),
+		TLSSkipVerify:             envBool("USAGE_RESP_TLS_SKIP_VERIFY", cfgFile.TLSSkipVerify),
+		QuotaCooldownEnabled:      envBool("USAGE_QUOTA_COOLDOWN_ENABLED", cfgFile.QuotaCooldownEnabled),
+		AccountActionsEnabled:     envBool("USAGE_ACCOUNT_ACTIONS_ENABLED", cfgFile.AccountActionsEnabled),
+		AccountActionsAutoDisable: envBool("USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE", cfgFile.AccountActionsAutoDisable),
 	}, nil
 }
 

--- a/apps/manager-server/internal/config/config_test.go
+++ b/apps/manager-server/internal/config/config_test.go
@@ -75,7 +75,8 @@ func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
   "corsOrigins": ["http://panel.local"],
   "tlsSkipVerify": true,
   "quotaCooldownEnabled": true,
-  "accountActionsEnabled": true
+  "accountActionsEnabled": true,
+  "accountActionsAutoDisable": true
 }`), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -117,6 +118,9 @@ func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
 	}
 	if !cfg.AccountActionsEnabled {
 		t.Fatal("AccountActionsEnabled = false")
+	}
+	if !cfg.AccountActionsAutoDisable {
+		t.Fatal("AccountActionsAutoDisable = false")
 	}
 }
 
@@ -197,6 +201,7 @@ func clearConfigEnv(t *testing.T) {
 		"USAGE_RESP_TLS_SKIP_VERIFY",
 		"USAGE_QUOTA_COOLDOWN_ENABLED",
 		"USAGE_ACCOUNT_ACTIONS_ENABLED",
+		"USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE",
 		"PANEL_PATH",
 	} {
 		t.Setenv(key, "")

--- a/apps/manager-server/internal/service/accountaction/service.go
+++ b/apps/manager-server/internal/service/accountaction/service.go
@@ -1,21 +1,15 @@
 package accountaction
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
-	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 	managerconfigsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/managerconfig"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
@@ -35,15 +29,7 @@ type ListResponse struct {
 	PendingCount int64                          `json:"pendingCount"`
 }
 
-type authFile struct {
-	Name            string
-	AuthIndex       string
-	Provider        string
-	AccountSnapshot string
-	AccountID       string
-	Disabled        bool
-	Raw             map[string]any
-}
+type authFile = cpaauthfiles.File
 
 func New(st *store.Store, managerConfigService *managerconfigsvc.Service, clients ...*http.Client) *Service {
 	client := &http.Client{Timeout: 15 * time.Second}
@@ -149,238 +135,29 @@ func (s *Service) resolveCandidateAndSetup(ctx context.Context, id int64) (model
 }
 
 func (s *Service) verifyCurrentAuthFile(ctx context.Context, setup store.Setup, item model.AccountActionCandidate) (authFile, error) {
-	files, err := s.fetchAuthFiles(ctx, setup)
+	files, err := cpaauthfiles.New(s.client).Fetch(ctx, setup.CPAUpstreamURL, setup.ManagementKey)
 	if err != nil {
 		_ = s.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
 		return authFile{}, err
 	}
-	for _, file := range files {
-		if file.Name != item.AuthFileName {
-			continue
-		}
-		if item.AuthIndex != "" && file.AuthIndex != item.AuthIndex {
-			continue
-		}
-		if item.AccountIDSnapshot != "" && file.AccountID != item.AccountIDSnapshot {
-			return authFile{}, ErrCandidateConflict
-		}
-		if item.Provider != "" && !strings.EqualFold(file.Provider, item.Provider) {
-			return authFile{}, ErrCandidateConflict
-		}
-		if item.AccountSnapshot != "" && file.AccountSnapshot != item.AccountSnapshot {
-			return authFile{}, ErrCandidateConflict
-		}
-		return file, nil
+	file, err := cpaauthfiles.VerifyIdentity(files, cpaauthfiles.Identity{
+		AuthFileName:      item.AuthFileName,
+		AuthIndex:         item.AuthIndex,
+		Provider:          item.Provider,
+		AccountSnapshot:   item.AccountSnapshot,
+		AccountIDSnapshot: item.AccountIDSnapshot,
+	})
+	if err != nil {
+		return authFile{}, ErrCandidateConflict
 	}
-	return authFile{}, ErrCandidateConflict
-}
+	return file, nil
 
-func (s *Service) fetchAuthFiles(ctx context.Context, setup store.Setup) ([]authFile, error) {
-	base := cpa.NormalizeBaseURL(setup.CPAUpstreamURL)
-	paths := []string{"/auth-files", "/v0/management/auth-files"}
-	var errs []error
-	for _, path := range paths {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+path, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Authorization", "Bearer "+setup.ManagementKey)
-		res, err := s.client.Do(req)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
-		res.Body.Close()
-		if res.StatusCode < 200 || res.StatusCode >= 300 {
-			errs = append(errs, fmt.Errorf("GET %s: %s %s", path, res.Status, strings.TrimSpace(string(body))))
-			if shouldFallbackManagement(res.StatusCode) {
-				continue
-			}
-			break
-		}
-		var decoded any
-		decoder := json.NewDecoder(bytes.NewReader(body))
-		decoder.UseNumber()
-		if err := decoder.Decode(&decoded); err != nil {
-			return nil, err
-		}
-		return authFilesFromJSON(decoded), nil
-	}
-	return nil, combineEndpointErrors(errs...)
-}
-
-func authFilesFromJSON(value any) []authFile {
-	switch typed := value.(type) {
-	case []any:
-		files := make([]authFile, 0, len(typed))
-		for _, item := range typed {
-			if m, ok := item.(map[string]any); ok {
-				files = append(files, authFileFromMap(m))
-			}
-		}
-		return files
-	case map[string]any:
-		for _, key := range []string{"auth_files", "authFiles", "files", "items", "data"} {
-			if child, ok := typed[key]; ok {
-				if files := authFilesFromJSON(child); len(files) > 0 {
-					return files
-				}
-			}
-		}
-		if name := stringField(typed, "name", "file_name", "fileName", "id"); name != "" {
-			return []authFile{authFileFromMap(typed)}
-		}
-	}
-	return nil
-}
-
-func authFileFromMap(file map[string]any) authFile {
-	return authFile{
-		Name:            stringField(file, "name", "file_name", "fileName", "id"),
-		AuthIndex:       stringField(file, "auth_index", "authIndex", "auth-index"),
-		Provider:        strings.ToLower(stringField(file, "provider", "type")),
-		AccountSnapshot: stringField(file, "account", "email", "label", "display_account", "displayAccount"),
-		AccountID: stringField(
-			file,
-			"account_id", "accountId", "chatgpt_account_id", "chatgptAccountId",
-			"project_id", "projectId", "gemini_virtual_project", "geminiVirtualProject",
-			"sub", "id",
-		),
-		Disabled: boolField(file, "disabled"),
-		Raw:      file,
-	}
-}
-
-func stringField(file map[string]any, keys ...string) string {
-	for _, key := range keys {
-		if raw, ok := file[key]; ok {
-			value := strings.TrimSpace(fmt.Sprint(raw))
-			if value != "" && value != "<nil>" {
-				return value
-			}
-		}
-	}
-	return ""
-}
-
-func boolField(file map[string]any, keys ...string) bool {
-	for _, key := range keys {
-		if raw, ok := file[key]; ok {
-			switch value := raw.(type) {
-			case bool:
-				return value
-			case json.Number:
-				parsed, _ := strconv.ParseInt(value.String(), 10, 64)
-				return parsed != 0
-			case float64:
-				return value != 0
-			case string:
-				return strings.EqualFold(value, "true") || value == "1" || strings.EqualFold(value, "disabled") || strings.EqualFold(value, "inactive")
-			}
-		}
-	}
-	return false
 }
 
 func (s *Service) patchAuthFile(ctx context.Context, setup store.Setup, fileName string, disabled bool) error {
-	payload := map[string]any{"name": fileName, "disabled": disabled}
-	primaryErr, primaryStatus := s.patchAuthFileAt(ctx, setup, "/auth-files", payload)
-	if primaryErr == nil {
-		return nil
-	}
-	statusErr, statusCode := s.patchAuthFileAt(ctx, setup, "/auth-files/status", payload)
-	if statusErr == nil {
-		return nil
-	}
-	if shouldFallbackManagement(primaryStatus) && shouldFallbackManagement(statusCode) {
-		managementErr, _ := s.patchAuthFileAt(ctx, setup, "/v0/management/auth-files", payload)
-		if managementErr == nil {
-			return nil
-		}
-		managementStatusErr, _ := s.patchAuthFileAt(ctx, setup, "/v0/management/auth-files/status", payload)
-		if managementStatusErr == nil {
-			return nil
-		}
-		return combineEndpointErrors(primaryErr, statusErr, managementErr, managementStatusErr)
-	}
-	return combineEndpointErrors(primaryErr, statusErr)
-}
-
-func (s *Service) patchAuthFileAt(ctx context.Context, setup store.Setup, path string, payload map[string]any) (error, int) {
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return err, 0
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, cpa.NormalizeBaseURL(setup.CPAUpstreamURL)+path, bytes.NewReader(data))
-	if err != nil {
-		return err, 0
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return s.doCPAAction(req, setup.ManagementKey)
+	return cpaauthfiles.New(s.client).PatchDisabled(ctx, setup.CPAUpstreamURL, setup.ManagementKey, fileName, disabled)
 }
 
 func (s *Service) deleteAuthFile(ctx context.Context, setup store.Setup, fileName string) error {
-	primaryErr, primaryStatus := s.deleteAuthFileAt(ctx, setup, "/auth-files", fileName)
-	if primaryErr == nil {
-		return nil
-	}
-	if shouldFallbackManagement(primaryStatus) {
-		managementErr, _ := s.deleteAuthFileAt(ctx, setup, "/v0/management/auth-files", fileName)
-		if managementErr == nil {
-			return nil
-		}
-		return combineEndpointErrors(primaryErr, managementErr)
-	}
-	return primaryErr
-}
-
-func (s *Service) deleteAuthFileAt(ctx context.Context, setup store.Setup, path string, fileName string) (error, int) {
-	endpoint := cpa.NormalizeBaseURL(setup.CPAUpstreamURL) + path + "?name=" + url.QueryEscape(fileName)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
-	if err != nil {
-		return err, 0
-	}
-	return s.doCPAAction(req, setup.ManagementKey)
-}
-
-func (s *Service) doCPAAction(req *http.Request, managementKey string) (error, int) {
-	req.Header.Set("Authorization", "Bearer "+managementKey)
-	client := s.client
-	if client == nil {
-		client = http.DefaultClient
-	}
-	res, err := client.Do(req)
-	if err != nil {
-		return err, 0
-	}
-	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return fmt.Errorf("%s %s", res.Status, strings.TrimSpace(string(body))), res.StatusCode
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err == nil {
-		if failed, ok := payload["failed"].([]any); ok && len(failed) > 0 {
-			return fmt.Errorf("CPA action failed: %s", fmt.Sprint(failed[0])), res.StatusCode
-		}
-	}
-	return nil, res.StatusCode
-}
-
-func shouldFallbackManagement(status int) bool {
-	return status == http.StatusNotFound || status == http.StatusMethodNotAllowed
-}
-
-func combineEndpointErrors(errs ...error) error {
-	parts := make([]string, 0, len(errs))
-	for _, err := range errs {
-		if err != nil {
-			parts = append(parts, err.Error())
-		}
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	return errors.New(strings.Join(parts, "; "))
+	return cpaauthfiles.New(s.client).Delete(ctx, setup.CPAUpstreamURL, setup.ManagementKey, fileName)
 }

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -18,6 +18,8 @@ import (
 
 const DefaultTimeout = 15 * time.Second
 
+var ErrAuthFileNotFound = errors.New("CPA auth file not found")
+
 var ErrIdentityMismatch = errors.New("CPA auth file identity mismatch")
 
 type Client struct {
@@ -120,25 +122,20 @@ func Find(files []File, fileName string, authIndex string) (File, bool) {
 }
 
 func VerifyIdentity(files []File, identity Identity) (File, error) {
-	for _, file := range files {
-		if file.Name != strings.TrimSpace(identity.AuthFileName) {
-			continue
-		}
-		if identity.AuthIndex != "" && file.AuthIndex != strings.TrimSpace(identity.AuthIndex) {
-			continue
-		}
-		if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
-			return File{}, ErrIdentityMismatch
-		}
-		if identity.Provider != "" && !strings.EqualFold(file.Provider, strings.TrimSpace(identity.Provider)) {
-			return File{}, ErrIdentityMismatch
-		}
-		if identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
-			return File{}, ErrIdentityMismatch
-		}
-		return file, nil
+	file, ok := Find(files, identity.AuthFileName, identity.AuthIndex)
+	if !ok {
+		return File{}, ErrAuthFileNotFound
 	}
-	return File{}, ErrIdentityMismatch
+	if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
+		return File{}, fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountIDSnapshot), file.AccountID)
+	}
+	if identity.Provider != "" && !strings.EqualFold(file.Provider, strings.TrimSpace(identity.Provider)) {
+		return File{}, fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
+	}
+	if identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
+		return File{}, fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
+	}
+	return file, nil
 }
 
 func (c *Client) PatchDisabled(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -1,0 +1,307 @@
+package cpaauthfiles
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+)
+
+const DefaultTimeout = 15 * time.Second
+
+var ErrIdentityMismatch = errors.New("CPA auth file identity mismatch")
+
+type Client struct {
+	httpClient *http.Client
+	timeout    time.Duration
+}
+
+type File struct {
+	Name            string
+	AuthIndex       string
+	Provider        string
+	AccountSnapshot string
+	AccountID       string
+	Disabled        bool
+	Raw             map[string]any
+}
+
+type Identity struct {
+	AuthFileName      string
+	AuthIndex         string
+	Provider          string
+	AccountSnapshot   string
+	AccountIDSnapshot string
+}
+
+func New(client *http.Client, timeout ...time.Duration) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	d := DefaultTimeout
+	if len(timeout) > 0 && timeout[0] > 0 {
+		d = timeout[0]
+	}
+	return &Client{httpClient: client, timeout: d}
+}
+
+func (c *Client) Fetch(ctx context.Context, baseURL string, managementKey string) ([]File, error) {
+	base := cpa.NormalizeBaseURL(baseURL)
+	paths := []string{"/auth-files", "/v0/management/auth-files"}
+	var endpointErrors []error
+	for _, path := range paths {
+		reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+path, nil)
+		if err != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: %w", path, err))
+			continue
+		}
+		req.Header.Set("Authorization", "Bearer "+managementKey)
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: %w", path, err))
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
+		_ = res.Body.Close()
+		cancel()
+		if res.StatusCode < 200 || res.StatusCode >= 300 {
+			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: HTTP %d %s", path, res.StatusCode, strings.TrimSpace(string(body))))
+			continue
+		}
+		files, err := Parse(body)
+		if err != nil {
+			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: %w", path, err))
+			continue
+		}
+		return files, nil
+	}
+	return nil, combineErrors(endpointErrors...)
+}
+
+func Parse(body []byte) ([]File, error) {
+	var decoded any
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	files := filesFromJSON(decoded)
+	if files == nil {
+		return []File{}, nil
+	}
+	return files, nil
+}
+
+func Find(files []File, fileName string, authIndex string) (File, bool) {
+	fileName = strings.TrimSpace(fileName)
+	authIndex = strings.TrimSpace(authIndex)
+	for _, file := range files {
+		if file.Name != fileName {
+			continue
+		}
+		if authIndex != "" && file.AuthIndex != authIndex {
+			continue
+		}
+		return file, true
+	}
+	return File{}, false
+}
+
+func VerifyIdentity(files []File, identity Identity) (File, error) {
+	for _, file := range files {
+		if file.Name != strings.TrimSpace(identity.AuthFileName) {
+			continue
+		}
+		if identity.AuthIndex != "" && file.AuthIndex != strings.TrimSpace(identity.AuthIndex) {
+			continue
+		}
+		if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
+			return File{}, ErrIdentityMismatch
+		}
+		if identity.Provider != "" && !strings.EqualFold(file.Provider, strings.TrimSpace(identity.Provider)) {
+			return File{}, ErrIdentityMismatch
+		}
+		if identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
+			return File{}, ErrIdentityMismatch
+		}
+		return file, nil
+	}
+	return File{}, ErrIdentityMismatch
+}
+
+func (c *Client) PatchDisabled(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {
+	payload := map[string]any{"name": fileName, "disabled": disabled}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	base := cpa.NormalizeBaseURL(baseURL)
+	paths := []string{"/auth-files", "/auth-files/status", "/v0/management/auth-files", "/v0/management/auth-files/status"}
+	var endpointErrors []error
+	for _, path := range paths {
+		reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodPatch, base+path, bytes.NewReader(data))
+		if err != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Errorf("PATCH %s: %w", path, err))
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+managementKey)
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Errorf("PATCH %s: %w", path, err))
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		_ = res.Body.Close()
+		cancel()
+		if res.StatusCode >= 200 && res.StatusCode < 300 {
+			return nil
+		}
+		endpointErrors = append(endpointErrors, fmt.Errorf("PATCH %s: HTTP %d %s", path, res.StatusCode, strings.TrimSpace(string(body))))
+	}
+	return combineErrors(endpointErrors...)
+}
+
+func (c *Client) Delete(ctx context.Context, baseURL string, managementKey string, fileName string) error {
+	base := cpa.NormalizeBaseURL(baseURL)
+	paths := []string{"/auth-files", "/v0/management/auth-files"}
+	var endpointErrors []error
+	for _, path := range paths {
+		reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+		endpoint := base + path + "?name=" + url.QueryEscape(fileName)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodDelete, endpoint, nil)
+		if err != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: %w", path, err))
+			continue
+		}
+		req.Header.Set("Authorization", "Bearer "+managementKey)
+		res, err := c.httpClient.Do(req)
+		if err != nil {
+			cancel()
+			endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: %w", path, err))
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		_ = res.Body.Close()
+		cancel()
+		if res.StatusCode >= 200 && res.StatusCode < 300 {
+			if actionFailed(body) {
+				endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: CPA action failed", path))
+				continue
+			}
+			return nil
+		}
+		endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: HTTP %d %s", path, res.StatusCode, strings.TrimSpace(string(body))))
+	}
+	return combineErrors(endpointErrors...)
+}
+
+func filesFromJSON(value any) []File {
+	switch typed := value.(type) {
+	case []any:
+		files := make([]File, 0, len(typed))
+		for _, item := range typed {
+			if m, ok := item.(map[string]any); ok {
+				files = append(files, FromMap(m))
+			}
+		}
+		return files
+	case map[string]any:
+		for _, key := range []string{"auth_files", "authFiles", "files", "items", "data"} {
+			if child, ok := typed[key]; ok {
+				if files := filesFromJSON(child); files != nil {
+					return files
+				}
+			}
+		}
+		if name := stringField(typed, "name", "file_name", "fileName", "id"); name != "" {
+			return []File{FromMap(typed)}
+		}
+	}
+	return nil
+}
+
+func FromMap(file map[string]any) File {
+	return File{
+		Name:            stringField(file, "name", "file_name", "fileName", "id"),
+		AuthIndex:       stringField(file, "auth_index", "authIndex", "auth-index"),
+		Provider:        strings.ToLower(stringField(file, "provider", "type")),
+		AccountSnapshot: stringField(file, "account", "email", "label", "display_account", "displayAccount"),
+		AccountID: stringField(
+			file,
+			"account_id", "accountId", "chatgpt_account_id", "chatgptAccountId",
+			"project_id", "projectId", "gemini_virtual_project", "geminiVirtualProject",
+			"sub", "id",
+		),
+		Disabled: disabledField(file),
+		Raw:      file,
+	}
+}
+
+func disabledField(file map[string]any) bool {
+	if raw, ok := file["disabled"]; ok {
+		switch value := raw.(type) {
+		case bool:
+			return value
+		case json.Number:
+			parsed, _ := strconv.ParseFloat(value.String(), 64)
+			return parsed != 0
+		case float64:
+			return value != 0
+		case string:
+			return strings.EqualFold(strings.TrimSpace(value), "true") || strings.TrimSpace(value) == "1"
+		}
+	}
+	status := strings.ToLower(stringField(file, "status", "state"))
+	return status == "disabled" || status == "inactive"
+}
+
+func stringField(file map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if raw, ok := file[key]; ok && raw != nil {
+			value := strings.TrimSpace(fmt.Sprint(raw))
+			if value != "" && value != "<nil>" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func actionFailed(body []byte) bool {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	failed, ok := payload["failed"].([]any)
+	return ok && len(failed) > 0
+}
+
+func combineErrors(errs ...error) error {
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			parts = append(parts, err.Error())
+		}
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(parts, "; "))
+}

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -30,8 +31,17 @@ func TestParseAndVerifyIdentity(t *testing.T) {
 	if !file.Disabled || file.AuthIndex != "7" || file.Provider != "codex" {
 		t.Fatalf("file = %#v", file)
 	}
-	if _, err := VerifyIdentity(files, Identity{AuthFileName: "codex-auth.json", AuthIndex: "7", AccountIDSnapshot: "acct-456"}); !errors.Is(err, ErrIdentityMismatch) {
-		t.Fatalf("mismatch err = %v", err)
+	if _, err := VerifyIdentity(files, Identity{AuthFileName: "missing.json", AuthIndex: "7"}); !errors.Is(err, ErrAuthFileNotFound) {
+		t.Fatalf("not found err = %v", err)
+	}
+	if _, err := VerifyIdentity(files, Identity{AuthFileName: "codex-auth.json", AuthIndex: "7", AccountIDSnapshot: "acct-456"}); !errors.Is(err, ErrIdentityMismatch) || !strings.Contains(err.Error(), "account_id mismatch") {
+		t.Fatalf("account id mismatch err = %v", err)
+	}
+	if _, err := VerifyIdentity(files, Identity{AuthFileName: "codex-auth.json", AuthIndex: "7", Provider: "gemini"}); !errors.Is(err, ErrIdentityMismatch) || !strings.Contains(err.Error(), "provider mismatch") {
+		t.Fatalf("provider mismatch err = %v", err)
+	}
+	if _, err := VerifyIdentity(files, Identity{AuthFileName: "codex-auth.json", AuthIndex: "7", AccountSnapshot: "other@example.com"}); !errors.Is(err, ErrIdentityMismatch) || !strings.Contains(err.Error(), "account_snapshot mismatch") {
+		t.Fatalf("account snapshot mismatch err = %v", err)
 	}
 }
 

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -1,0 +1,92 @@
+package cpaauthfiles
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseAndVerifyIdentity(t *testing.T) {
+	files, err := Parse([]byte(`{"auth_files":[{"name":"codex-auth.json","auth_index":"7","provider":"codex","account":"user@example.com","account_id":"acct-123","disabled":"true"}]}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("files = %#v", files)
+	}
+	file, err := VerifyIdentity(files, Identity{
+		AuthFileName:      "codex-auth.json",
+		AuthIndex:         "7",
+		Provider:          "CODEX",
+		AccountSnapshot:   "user@example.com",
+		AccountIDSnapshot: "acct-123",
+	})
+	if err != nil {
+		t.Fatalf("verify identity: %v", err)
+	}
+	if !file.Disabled || file.AuthIndex != "7" || file.Provider != "codex" {
+		t.Fatalf("file = %#v", file)
+	}
+	if _, err := VerifyIdentity(files, Identity{AuthFileName: "codex-auth.json", AuthIndex: "7", AccountIDSnapshot: "acct-456"}); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("mismatch err = %v", err)
+	}
+}
+
+func TestClientPatchDisabledAndDelete(t *testing.T) {
+	var patched bool
+	var deleted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer mgmt" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		switch r.Method + " " + r.URL.Path {
+		case "GET /auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "codex-auth.json", "auth_index": "7"}})
+		case "PATCH /auth-files":
+			var payload struct {
+				Name     string `json:"name"`
+				Disabled bool   `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if payload.Name != "codex-auth.json" || !payload.Disabled {
+				t.Fatalf("patch payload = %#v", payload)
+			}
+			patched = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "DELETE /auth-files":
+			if r.URL.Query().Get("name") != "codex-auth.json" {
+				t.Fatalf("delete query = %s", r.URL.RawQuery)
+			}
+			deleted = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := New(server.Client())
+	files, err := client.Fetch(context.Background(), server.URL, "mgmt")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if _, ok := Find(files, "codex-auth.json", "7"); !ok {
+		t.Fatalf("find files = %#v", files)
+	}
+	if err := client.PatchDisabled(context.Background(), server.URL, "mgmt", "codex-auth.json", true); err != nil {
+		t.Fatalf("patch disabled: %v", err)
+	}
+	if err := client.Delete(context.Background(), server.URL, "mgmt", "codex-auth.json"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !patched || !deleted {
+		t.Fatalf("patched=%t deleted=%t", patched, deleted)
+	}
+}

--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -11,6 +11,7 @@ import (
 
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -18,11 +19,14 @@ import (
 const accountActionCandidateQueueSize = 256
 
 type AccountActionCandidateWorker struct {
-	store *store.Store
-	jobs  chan accountActionCandidate
+	store       *store.Store
+	jobs        chan accountActionCandidate
+	autoDisable bool
 }
 
 type accountActionCandidate struct {
+	BaseURL        string
+	ManagementKey  string
 	FileName       string
 	AuthIndex      string
 	DisplayAccount string
@@ -36,10 +40,15 @@ type accountActionCandidate struct {
 	SeenAtMS       int64
 }
 
-func NewAccountActionCandidateWorker(st *store.Store) *AccountActionCandidateWorker {
+func NewAccountActionCandidateWorker(st *store.Store, autoDisable ...bool) *AccountActionCandidateWorker {
+	enabled := false
+	if len(autoDisable) > 0 {
+		enabled = autoDisable[0]
+	}
 	return &AccountActionCandidateWorker{
-		store: st,
-		jobs:  make(chan accountActionCandidate, accountActionCandidateQueueSize),
+		store:       st,
+		jobs:        make(chan accountActionCandidate, accountActionCandidateQueueSize),
+		autoDisable: enabled,
 	}
 }
 
@@ -47,16 +56,20 @@ func (w *AccountActionCandidateWorker) Start(ctx context.Context) {
 	go w.run(ctx)
 }
 
-func (w *AccountActionCandidateWorker) HandleUsageEvents(ctx context.Context, _ collectorpkg.RuntimeConfig, events []usage.Event) {
+func (w *AccountActionCandidateWorker) HandleUsageEvents(ctx context.Context, cfg collectorpkg.RuntimeConfig, events []usage.Event) {
 	if w == nil || len(events) == 0 {
 		return
 	}
+	baseURL := strings.TrimSpace(cfg.CPAUpstreamURL)
+	managementKey := strings.TrimSpace(cfg.ManagementKey)
 	now := time.Now()
 	for _, event := range events {
 		candidate, ok := accountActionCandidateFromEvent(event, now)
 		if !ok {
 			continue
 		}
+		candidate.BaseURL = baseURL
+		candidate.ManagementKey = managementKey
 		select {
 		case w.jobs <- candidate:
 		case <-ctx.Done():
@@ -103,6 +116,62 @@ func (w *AccountActionCandidateWorker) handleCandidate(ctx context.Context, cand
 		return
 	}
 	log.Printf("[account-action] saved pending %s candidate %d for auth file %q", candidate.ActionType, item.ID, candidate.FileName)
+	w.maybeAutoDisable(ctx, item, candidate)
+}
+
+func (w *AccountActionCandidateWorker) maybeAutoDisable(ctx context.Context, item model.AccountActionCandidate, candidate accountActionCandidate) {
+	if w == nil || !w.autoDisable {
+		return
+	}
+	if !accountActionAutoDisableEligible(item.ActionType) {
+		log.Printf("[account-action] pending candidate %d action=%q is not eligible for auto-disable", item.ID, item.ActionType)
+		return
+	}
+	baseURL := strings.TrimSpace(candidate.BaseURL)
+	managementKey := strings.TrimSpace(candidate.ManagementKey)
+	if baseURL == "" || managementKey == "" {
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, "CPA runtime config is unavailable for auto-disable")
+		log.Printf("[account-action] pending candidate %d saved, but runtime config is unavailable for auto-disable", item.ID)
+		return
+	}
+	client := cpaauthfiles.New(nil)
+	files, err := client.Fetch(ctx, baseURL, managementKey)
+	if err != nil {
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
+		log.Printf("[account-action] pending candidate %d saved, but auth file verification failed for %q: %v", item.ID, item.AuthFileName, err)
+		return
+	}
+	current, err := cpaauthfiles.VerifyIdentity(files, cpaauthfiles.Identity{
+		AuthFileName:      item.AuthFileName,
+		AuthIndex:         item.AuthIndex,
+		Provider:          item.Provider,
+		AccountSnapshot:   item.AccountSnapshot,
+		AccountIDSnapshot: item.AccountIDSnapshot,
+	})
+	if err != nil {
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, "current CPA auth file identity mismatch; skipped auto-disable")
+		log.Printf("[account-action] pending candidate %d saved, but auth file identity mismatch for %q; skip auto-disable", item.ID, item.AuthFileName)
+		return
+	}
+	if current.Disabled {
+		log.Printf("[account-action] pending candidate %d saved; auth file %q already disabled", item.ID, item.AuthFileName)
+		return
+	}
+	if err := client.PatchDisabled(ctx, baseURL, managementKey, item.AuthFileName, true); err != nil {
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
+		log.Printf("[account-action] pending candidate %d saved, but failed to auto-disable auth file %q: %v", item.ID, item.AuthFileName, err)
+		return
+	}
+	log.Printf("[account-action] auto-disabled auth file %q for pending %s candidate %d", item.AuthFileName, item.ActionType, item.ID)
+}
+
+func accountActionAutoDisableEligible(actionType string) bool {
+	switch actionType {
+	case model.AccountActionTypeDelete, model.AccountActionTypeReauth:
+		return true
+	default:
+		return false
+	}
 }
 
 func accountActionCandidateFromEvent(event usage.Event, now time.Time) (accountActionCandidate, bool) {

--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -149,8 +149,9 @@ func (w *AccountActionCandidateWorker) maybeAutoDisable(ctx context.Context, ite
 		AccountIDSnapshot: item.AccountIDSnapshot,
 	})
 	if err != nil {
-		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, "current CPA auth file identity mismatch; skipped auto-disable")
-		log.Printf("[account-action] pending candidate %d saved, but auth file identity mismatch for %q; skip auto-disable", item.ID, item.AuthFileName)
+		reason := "current CPA auth file identity verification failed: " + err.Error()
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, reason)
+		log.Printf("[account-action] pending candidate %d saved, but auth file identity verification failed for %q: %v; skip auto-disable", item.ID, item.AuthFileName, err)
 		return
 	}
 	if current.Disabled {

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -3,6 +3,8 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -79,6 +81,154 @@ func TestAccountActionCandidateWorkerSavesQueueOnly(t *testing.T) {
 		t.Fatalf("list candidates: %v", err)
 	}
 	if len(items) != 1 || items[0].AuthFileName != "codex-auth.json" || items[0].ActionType != model.AccountActionTypeDelete {
+		t.Fatalf("items = %#v", items)
+	}
+	if items[0].LastError != "" {
+		t.Fatalf("last error = %q", items[0].LastError)
+	}
+}
+
+func TestAccountActionCandidateWorkerAutoDisablesMatchingIdentity(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	var patched bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer mgmt" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		switch r.Method + " " + r.URL.Path {
+		case "GET /auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"name":       "codex-auth.json",
+				"auth_index": "7",
+				"provider":   "codex",
+				"account":    "user@example.com",
+				"account_id": "acct-123",
+				"disabled":   false,
+			}})
+		case "PATCH /auth-files":
+			var payload struct {
+				Name     string `json:"name"`
+				Disabled bool   `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if payload.Name != "codex-auth.json" || !payload.Disabled {
+				t.Fatalf("patch payload = %#v", payload)
+			}
+			patched = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		BaseURL:        server.URL,
+		ManagementKey:  "mgmt",
+		FileName:       "codex-auth.json",
+		AuthIndex:      "7",
+		DisplayAccount: "user@example.com",
+		AccountID:      "acct-123",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeDelete,
+		Reason:         "token revoked",
+	})
+
+	if !patched {
+		t.Fatal("expected auto-disable PATCH")
+	}
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || items[0].Status != model.AccountActionStatusPending || items[0].LastError != "" {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestAccountActionCandidateWorkerAutoDisableRejectsIdentityMismatch(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	var patched bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"name":       "codex-auth.json",
+				"auth_index": "7",
+				"provider":   "codex",
+				"account":    "different@example.com",
+				"account_id": "acct-456",
+			}})
+		case "PATCH /auth-files":
+			patched = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		BaseURL:        server.URL,
+		ManagementKey:  "mgmt",
+		FileName:       "codex-auth.json",
+		AuthIndex:      "7",
+		DisplayAccount: "user@example.com",
+		AccountID:      "acct-123",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeDelete,
+		Reason:         "token revoked",
+	})
+
+	if patched {
+		t.Fatal("PATCH should not be called on identity mismatch")
+	}
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || !strings.Contains(items[0].LastError, "identity mismatch") {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestAccountActionCandidateWorkerAutoDisableSkipsReview(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		FileName:       "codex-auth.json",
+		DisplayAccount: "user@example.com",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeReview,
+		Reason:         "manual review",
+	})
+
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || items[0].LastError != "" {
 		t.Fatalf("items = %#v", items)
 	}
 }

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -208,6 +208,139 @@ func TestAccountActionCandidateWorkerAutoDisableRejectsIdentityMismatch(t *testi
 	}
 }
 
+func TestAccountActionCandidateWorkerAutoDisablesReauth(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	var patched bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"name":       "codex-auth.json",
+				"auth_index": "7",
+				"provider":   "codex",
+				"account":    "user@example.com",
+				"account_id": "acct-123",
+				"disabled":   false,
+			}})
+		case "PATCH /auth-files":
+			patched = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		BaseURL:        server.URL,
+		ManagementKey:  "mgmt",
+		FileName:       "codex-auth.json",
+		AuthIndex:      "7",
+		DisplayAccount: "user@example.com",
+		AccountID:      "acct-123",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeReauth,
+		Reason:         "reauth required",
+	})
+
+	if !patched {
+		t.Fatal("expected reauth candidate to auto-disable")
+	}
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || items[0].ActionType != model.AccountActionTypeReauth || items[0].LastError != "" {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestAccountActionCandidateWorkerAutoDisableSkipsAlreadyDisabled(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	var patched bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"name":       "codex-auth.json",
+				"auth_index": "7",
+				"provider":   "codex",
+				"account":    "user@example.com",
+				"account_id": "acct-123",
+				"disabled":   true,
+			}})
+		case "PATCH /auth-files":
+			patched = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		BaseURL:        server.URL,
+		ManagementKey:  "mgmt",
+		FileName:       "codex-auth.json",
+		AuthIndex:      "7",
+		DisplayAccount: "user@example.com",
+		AccountID:      "acct-123",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeDelete,
+		Reason:         "token revoked",
+	})
+
+	if patched {
+		t.Fatal("PATCH should not be called when auth file is already disabled")
+	}
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || items[0].LastError != "" {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
+func TestAccountActionCandidateWorkerAutoDisableRecordsMissingRuntimeConfig(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		FileName:       "codex-auth.json",
+		AuthIndex:      "7",
+		DisplayAccount: "user@example.com",
+		AccountID:      "acct-123",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeDelete,
+		Reason:         "token revoked",
+	})
+
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || !strings.Contains(items[0].LastError, "runtime config") {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
 func TestAccountActionCandidateWorkerAutoDisableSkipsReview(t *testing.T) {
 	st, err := store.Open(t.TempDir() + "/usage.sqlite")
 	if err != nil {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -1,12 +1,9 @@
 package worker
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -17,6 +14,7 @@ import (
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -56,7 +54,7 @@ type quotaAutoDisableCandidate struct {
 	Reason         string
 }
 
-type authFile map[string]any
+type authFile = cpaauthfiles.File
 
 func NewRateLimitAutoDisableWorker(st *store.Store, initial ...collectorpkg.RuntimeConfig) *RateLimitAutoDisableWorker {
 	w := &RateLimitAutoDisableWorker{
@@ -177,7 +175,7 @@ func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candid
 		log.Printf("[quota-auto-disable] auth file %q authIndex=%q not found/currently mismatched, skip auto disable", candidate.FileName, candidate.AuthIndex)
 		return
 	}
-	preDisabled := authFileDisabled(current)
+	preDisabled := current.Disabled
 	if preDisabled {
 		if w.extendExistingCooldown(ctx, candidate, current) {
 			return
@@ -194,7 +192,7 @@ func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candid
 
 	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:     candidate.FileName,
-		AuthIndex:        firstNonEmpty(candidate.AuthIndex, authFileAuthIndex(current)),
+		AuthIndex:        firstNonEmpty(candidate.AuthIndex, current.AuthIndex),
 		AccountSnapshot:  candidate.DisplayAccount,
 		Provider:         strings.ToLower(strings.TrimSpace(candidate.Provider)),
 		RecoverAtMS:      candidate.ResetAt.UnixMilli(),
@@ -229,14 +227,14 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 	if existing.ID == 0 {
 		return false
 	}
-	currentIndex := authFileAuthIndex(current)
+	currentIndex := current.AuthIndex
 	if existing.AuthIndex != "" && currentIndex != existing.AuthIndex {
 		log.Printf("[quota-auto-disable] active cooldown auth index mismatch for auth file %q: stored=%q current=%q", candidate.FileName, existing.AuthIndex, currentIndex)
 		return false
 	}
 	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:     candidate.FileName,
-		AuthIndex:        firstNonEmpty(candidate.AuthIndex, existing.AuthIndex, authFileAuthIndex(current)),
+		AuthIndex:        firstNonEmpty(candidate.AuthIndex, existing.AuthIndex, current.AuthIndex),
 		AccountSnapshot:  firstNonEmpty(candidate.DisplayAccount, existing.AccountSnapshot),
 		Provider:         strings.ToLower(strings.TrimSpace(firstNonEmpty(candidate.Provider, existing.Provider))),
 		RecoverAtMS:      candidate.ResetAt.UnixMilli(),
@@ -291,7 +289,7 @@ func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseUR
 		log.Printf("[quota-auto-disable] auth file %q authIndex=%q missing/mismatched, skip auto-enable", item.AuthFileName, item.AuthIndex)
 		return
 	}
-	if !authFileDisabled(current) {
+	if !current.Disabled {
 		_ = w.store.MarkQuotaCooldownRecovered(ctx, item.ID, now.UnixMilli())
 		log.Printf("[quota-auto-disable] auth file %q already enabled; marked cooldown recovered", item.AuthFileName)
 		return
@@ -483,139 +481,12 @@ func parseCommonTime(text string) (time.Time, bool) {
 }
 
 func (w *RateLimitAutoDisableWorker) currentAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, authIndex string) (authFile, bool, error) {
-	files, err := w.fetchAuthFiles(ctx, baseURL, managementKey)
+	files, err := cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).Fetch(ctx, baseURL, managementKey)
 	if err != nil {
-		return nil, false, err
+		return authFile{}, false, err
 	}
-	fileName = strings.TrimSpace(fileName)
-	authIndex = strings.TrimSpace(authIndex)
-	for _, file := range files {
-		if authFileName(file) != fileName {
-			continue
-		}
-		if authIndex != "" && authFileAuthIndex(file) != authIndex {
-			continue
-		}
-		return file, true, nil
-	}
-	return nil, false, nil
-}
-
-func (w *RateLimitAutoDisableWorker) fetchAuthFiles(ctx context.Context, baseURL string, managementKey string) ([]authFile, error) {
-	base := cpa.NormalizeBaseURL(baseURL)
-	paths := []string{
-		base + "/auth-files",
-		base + "/v0/management/auth-files",
-	}
-	client := w.client
-	if client == nil {
-		client = http.DefaultClient
-	}
-	var endpointErrors []string
-	for _, endpoint := range paths {
-		reqCtx, cancel := context.WithTimeout(ctx, quotaAutoDisableActionTimeout)
-		req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
-		if reqErr != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, reqErr))
-			continue
-		}
-		req.Header.Set("Authorization", "Bearer "+managementKey)
-		res, doErr := client.Do(req)
-		cancel()
-		if doErr != nil {
-			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, doErr))
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
-		_ = res.Body.Close()
-		if res.StatusCode < 200 || res.StatusCode >= 300 {
-			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: HTTP %d %s", endpoint, res.StatusCode, strings.TrimSpace(string(body))))
-			continue
-		}
-		files, err := parseAuthFiles(body)
-		if err != nil {
-			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, err))
-			continue
-		}
-		return files, nil
-	}
-	if len(endpointErrors) == 0 {
-		return nil, errors.New("no auth-file endpoint attempted")
-	}
-	return nil, fmt.Errorf("all auth-file endpoints failed: %s", strings.Join(endpointErrors, "; "))
-}
-
-func parseAuthFiles(body []byte) ([]authFile, error) {
-	var decoded any
-	decoder := json.NewDecoder(bytes.NewReader(body))
-	decoder.UseNumber()
-	if err := decoder.Decode(&decoded); err != nil {
-		return nil, err
-	}
-	files := authFilesFromJSON(decoded)
-	if files == nil {
-		return []authFile{}, nil
-	}
-	return files, nil
-}
-
-func authFilesFromJSON(value any) []authFile {
-	switch typed := value.(type) {
-	case []any:
-		files := make([]authFile, 0, len(typed))
-		for _, item := range typed {
-			if m, ok := item.(map[string]any); ok {
-				files = append(files, authFile(m))
-			}
-		}
-		return files
-	case map[string]any:
-		for _, key := range []string{"auth_files", "authFiles", "files", "items", "data"} {
-			if child, ok := typed[key]; ok {
-				if files := authFilesFromJSON(child); files != nil {
-					return files
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func authFileName(file authFile) string {
-	return firstNonEmpty(stringField(file, "name"), stringField(file, "file_name"), stringField(file, "fileName"), stringField(file, "id"))
-}
-
-func authFileAuthIndex(file authFile) string {
-	return firstNonEmpty(stringField(file, "auth_index"), stringField(file, "authIndex"), stringField(file, "auth-index"))
-}
-
-func authFileDisabled(file authFile) bool {
-	if raw, ok := file["disabled"]; ok {
-		switch value := raw.(type) {
-		case bool:
-			return value
-		case json.Number:
-			parsed, _ := strconv.ParseFloat(value.String(), 64)
-			return parsed != 0
-		case float64:
-			return value != 0
-		case string:
-			return strings.EqualFold(strings.TrimSpace(value), "true") || strings.TrimSpace(value) == "1"
-		}
-	}
-	status := strings.ToLower(firstNonEmpty(stringField(file, "status"), stringField(file, "state")))
-	return status == "disabled" || status == "inactive"
-}
-
-func stringField(file authFile, key string) string {
-	if file == nil {
-		return ""
-	}
-	if value, ok := file[key]; ok && value != nil {
-		return strings.TrimSpace(fmt.Sprint(value))
-	}
-	return ""
+	file, ok := cpaauthfiles.Find(files, fileName, authIndex)
+	return file, ok, nil
 }
 
 func (w *RateLimitAutoDisableWorker) disableAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string) error {
@@ -627,55 +498,7 @@ func (w *RateLimitAutoDisableWorker) enableAuthFile(ctx context.Context, baseURL
 }
 
 func (w *RateLimitAutoDisableWorker) patchAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {
-	payload := map[string]any{"name": fileName, "disabled": disabled}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("marshal payload: %w", err)
-	}
-
-	base := cpa.NormalizeBaseURL(baseURL)
-	paths := []string{
-		base + "/auth-files",
-		base + "/auth-files/status",
-		base + "/v0/management/auth-files",
-		base + "/v0/management/auth-files/status",
-	}
-
-	client := w.client
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	var endpointErrors []string
-	for _, endpoint := range paths {
-		reqCtx, cancel := context.WithTimeout(ctx, quotaAutoDisableActionTimeout)
-		req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodPatch, endpoint, bytes.NewReader(data))
-		if reqErr != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, reqErr))
-			continue
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+managementKey)
-
-		res, doErr := client.Do(req)
-		cancel()
-		if doErr != nil {
-			endpointErrors = append(endpointErrors, fmt.Sprintf("%s: %v", endpoint, doErr))
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
-		_ = res.Body.Close()
-
-		if res.StatusCode >= 200 && res.StatusCode < 300 {
-			return nil
-		}
-		endpointErrors = append(endpointErrors, fmt.Sprintf("%s: HTTP %d %s", endpoint, res.StatusCode, strings.TrimSpace(string(body))))
-	}
-	if len(endpointErrors) == 0 {
-		return errors.New("no auth-file status endpoint attempted")
-	}
-	return fmt.Errorf("all auth-file status endpoints failed: %s", strings.Join(endpointErrors, "; "))
+	return cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).PatchDisabled(ctx, baseURL, managementKey, fileName, disabled)
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
## 背景

这是 #141 合并后的后续 PR，为 Pending account actions 增加 **显式 opt-in 的自动禁用能力**。

#141 已经把认证异常记录为 pending candidate，并保持 queue-only，不自动修改 CPA auth file。这个 PR 在保持默认安全行为不变的前提下，增加一个新的显式开关：只有用户主动开启后，才会在记录候选项后尝试自动禁用对应 auth file。

## 主要变更

### 1. 抽取公共 CPA auth file helper

新增：

```text
apps/manager-server/internal/service/cpaauthfiles
```

该 helper 统一提供：

- `Fetch`：读取 CPA auth files；
- `Parse`：解析多种 auth files 响应形态；
- `Find`：按 auth file name / auth index 查找；
- `VerifyIdentity`：统一身份校验；
- `PatchDisabled`：设置 auth file disabled 状态；
- `Delete`：删除 auth file。

同时让现有逻辑复用该 helper：

- quota cooldown worker 复用 fetch / find / patch disabled 等底层能力；
- account action service 复用同一套 identity validation 和 patch/delete 能力。

注意：这里只复用底层 auth file 操作，不混用业务语义。quota cooldown 仍然使用 `quota_cooldowns`、`owner=cpamp_usage_429` 和自动恢复；account action auto-disable 不写入 `quota_cooldowns`，也不会自动恢复。

### 2. 新增 opt-in auto-disable 配置

新增默认关闭配置：

```bash
USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE=false
```

配置文件字段：

```json
{
  "accountActionsAutoDisable": false
}
```

只有同时开启 pending account actions 和 auto-disable 时才会生效：

```bash
USAGE_ACCOUNT_ACTIONS_ENABLED=true
USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE=true
```

默认行为仍然是只记录 pending candidate，不自动禁用。

### 3. account action 自动禁用逻辑

当 auto-disable 显式开启后：

```text
发现认证异常
-> upsert pending candidate
-> 仅对高置信度 action type 尝试自动禁用
-> 重新读取当前 CPA auth files
-> 使用与手动 enable/delete 相同的 identity validation
-> 校验通过后 PATCH disabled=true
-> candidate 保持 pending，等待用户处理
```

当前 eligible action type：

- `delete`
- `reauth`

不会自动禁用：

- `review`
- 普通 payment/quota 402
- 任何身份校验失败的候选项

### 4. 安全边界

- 默认关闭，必须显式开启；
- 只自动禁用，不自动删除；
- 不自动恢复，后续仍由用户手动处理；
- 不复用 #132 的 quota cooldown ownership；
- 不写入 `quota_cooldowns`；
- 不使用 `owner=cpamp_usage_429`；
- 自动禁用前会校验：
  - `auth_file_name`
  - `auth_index`
  - `account_snapshot`
  - `account_id_snapshot`
  - `provider`
  - 当前 CPA auth file 仍是同一个账号
- 校验失败或 PATCH 失败时只记录 `last_error`，保持 candidate 为 pending，不修改 auth file。

## 提交

本 PR 拆成两个提交：

1. `refactor: extract CPA auth file helper`
2. `feat: add opt-in account action auto-disable`

## 测试

已执行：

```bash
cd apps/manager-server
go test ./internal/worker ./internal/service/accountaction ./internal/config ./internal/service/cpaauthfiles
```

通过。

已执行：

```bash
cd apps/manager-server
go test ./internal/repository/accountaction ./internal/store ./internal/repository/quotacooldown ./internal/repository/usageevent
```

通过。

已执行：

```bash
cd apps/manager-server
go test ./...
```

除既有 Windows 权限测试 caveat 外通过：

```text
internal/security:
TestLoadOrCreateDataKeyCreatesStableRestrictedFile
data key permissions = 666, want 600
```

该问题与本 PR 无关，和 #132 / #141 验证时看到的是同一个 Windows 文件权限差异。

已执行：

```bash
git diff --check HEAD
```

通过。

## 关联 Issue

Closes #144

说明：#144 中提到的 Codex 429 `usage_limit_reached` 自动禁用/恢复已经由 #132 处理；本 PR 补齐认证异常侧的 opt-in auto-disable，包括 401/403 的 revoked / reauth 类候选，以及 `402 + deactivated_workspace`。
