### PR TITLE
docs(release): add v1.4.0 notes

### DIFF
--- a/docs/release-notes/v1.4.0-en.md
+++ b/docs/release-notes/v1.4.0-en.md
@@ -1,0 +1,39 @@
+# CPA Manager Plus v1.4.0
+
+> 14 commits · 84 files changed · +10267 / -3832
+
+> [中文 ->](./v1.4.0-zh.md)
+
+## Overview
+
+This release moves Monitoring from usage visibility toward actionable account governance. It adds the Pending Account Actions page, account-action APIs, quota-exhausted account auto-disable handling, and persisted cooldowns so operators can identify authentication accounts that need attention as CPA usage continues flowing into Manager Server. The AI Providers page is also rebuilt around a table-based management flow with a health-check drawer, bringing provider configuration, sorting, diagnostics, and detail review into one focused surface.
+
+## Highlights
+
+### Features
+
+- Monitoring adds the Pending Account Actions page and account-action candidate flow for reviewing account operations that need manual confirmation. (`monitoring`, `manager-server`)
+- Manager Server adds a quota-exhausted auth-file auto-disable worker backed by quota cooldown records and usage event fanout, reducing repeated traffic to exhausted accounts. (`manager-server`)
+- AI Providers is rebuilt with a unified provider table, toolbar, and detail drawer, making Claude, Codex, Gemini, OpenAI, and Vertex provider configuration easier to scan and manage. (`ai-providers`)
+- Added a provider health-check drawer for running provider checks and reviewing model/authentication diagnostics. (`ai-providers`)
+
+### Fixes
+
+- Pending Account Actions review feedback and pending copy are clearer, reducing ambiguity while handling account actions. (`monitoring`)
+- Manager Server now matches account actions by auth project id, avoiding candidates being associated with the wrong project. (`manager-server`)
+- Monitoring analytics avoids overlapping refreshes and includes the pagination cursor in the in-flight identity, reducing duplicate or mismatched page refreshes. (`monitoring`)
+- Quota cooldown state now persists ownership and keeps runtime/filter-inserted event handling in sync. (`manager-server`)
+- The auth issues entry moved into the monitoring toolbar so related issue handling stays with the monitoring action area. (`monitoring`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @MuziIsabel - Advanced the Pending Account Actions and quota-exhausted auto-disable flows, including cooldown ownership/runtime fixes.
+- @Arkuna - Improved monitoring analytics refresh and pagination request stability, with related hook coverage.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.3.0...v1.4.0

--- a/docs/release-notes/v1.4.0-zh.md
+++ b/docs/release-notes/v1.4.0-zh.md
@@ -1,0 +1,39 @@
+# CPA Manager Plus v1.4.0
+
+> 14 commits · 84 files changed · +10267 / -3832
+
+> [English ->](./v1.4.0-en.md)
+
+## Overview
+
+本次发布把监控中心从单纯展示用量推进到可执行的账号治理流程：新增 Pending Account Actions 页面、账号动作 API、配额耗尽账号自动停用和 cooldown 持久化，帮助在 CPA 使用量持续进入 Manager Server 后更快定位需要处理的认证账号。同时，AI Providers 页面完成表格化重构并加入健康检查抽屉，provider 配置、排序、诊断和详情查看更加集中。
+
+## Highlights
+
+### Features
+
+- 监控中心新增 Pending Account Actions 页面和账号动作候选流程，可集中查看需要人工复核的账号操作。(`monitoring`, `manager-server`)
+- Manager Server 新增配额耗尽 auth file 自动停用 worker，结合 quota cooldown 记录和 usage event fanout，降低重复触发耗尽账号的风险。(`manager-server`)
+- AI Providers 页面重构为统一的 provider table、toolbar 和详情抽屉，跨 Claude、Codex、Gemini、OpenAI 与 Vertex 的 provider 配置更易扫描和管理。(`ai-providers`)
+- 新增 provider health check drawer，可对 provider 执行健康检查并展示模型与认证状态诊断。(`ai-providers`)
+
+### Fixes
+
+- Pending Account Actions 的评审反馈和待处理文案更清晰，减少处理账号动作时的歧义。(`monitoring`)
+- Manager Server 按 auth project id 匹配账号动作，避免候选项关联到错误项目。(`manager-server`)
+- 监控分析刷新避免重叠请求，并把 pagination cursor 纳入 in-flight identity，降低分页或刷新时的重复与错位风险。(`monitoring`)
+- Quota cooldown 状态会持久化 ownership，并同步 runtime 与插入事件过滤逻辑。(`manager-server`)
+- Auth issues 入口移动到监控工具栏，相关问题入口与监控操作区保持一致。(`monitoring`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @MuziIsabel - 推进 Pending Account Actions 与 quota-exhausted auto-disable 流程，并修复 cooldown ownership/runtime 同步问题。
+- @Arkuna - 修复监控分析刷新与分页请求稳定性，并补齐相关 hook 覆盖。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.3.0...v1.4.0


### PR DESCRIPTION
## Summary

- Add curated Chinese and English release notes for `v1.4.0`.
- Cover Pending Account Actions, quota-exhausted auto-disable handling, AI Providers management updates, health checks, and monitoring fixes.

## Verification

- Release preflight confirmed local `main` matches `origin/main` at `865dadaa2275b3aa2828978dab50fcdb29a08e7a`.
- Confirmed no existing remote `v1.4.0` tag or `release/v1.4.0` branch before creating the branch.
- Not run locally; docs-only release note update.