### PR TITLE
🐛 fix(worker): decode all JSON values in concatenated fail body text

### DIFF
--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -167,17 +167,17 @@ func classifyAccountActionEvent(event usage.Event) (string, string, bool) {
 
 func accountActionErrorCodeAndType(event usage.Event) (string, string) {
 	for _, text := range []string{event.FailBody, event.RawJSON, event.FailSummary} {
-		text = strings.TrimSpace(text)
-		if text == "" {
-			continue
-		}
-		var decoded any
-		decoder := json.NewDecoder(strings.NewReader(text))
-		decoder.UseNumber()
-		if err := decoder.Decode(&decoded); err != nil {
-			continue
-		}
-		if code, typ, ok := accountActionErrorCodeAndTypeFromJSON(decoded); ok {
+		var code, typ string
+		found := false
+		forEachJSONValue(text, func(decoded any) bool {
+			if c, t, ok := accountActionErrorCodeAndTypeFromJSON(decoded); ok {
+				code, typ = c, t
+				found = true
+				return true
+			}
+			return false
+		})
+		if found {
 			return code, typ
 		}
 	}

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -342,21 +342,55 @@ func codexUsageLimitResetTimeFromEvent(event usage.Event, now time.Time) (time.T
 		return time.Time{}, false
 	}
 	for _, text := range []string{event.FailBody, event.RawJSON, event.FailSummary} {
-		text = strings.TrimSpace(text)
-		if text == "" {
-			continue
-		}
-		var decoded any
-		decoder := json.NewDecoder(strings.NewReader(text))
-		decoder.UseNumber()
-		if err := decoder.Decode(&decoded); err != nil {
-			continue
-		}
-		if resetAt, ok := usageLimitResetFromJSON(decoded, now); ok {
+		var resetAt time.Time
+		found := false
+		forEachJSONValue(text, func(decoded any) bool {
+			if at, ok := usageLimitResetFromJSON(decoded, now); ok {
+				resetAt = at
+				found = true
+				return true
+			}
+			return false
+		})
+		if found {
 			return resetAt, true
 		}
 	}
 	return time.Time{}, false
+}
+
+// forEachJSONValue decodes every JSON value found in text, calling fn for each.
+// It handles concatenated JSON values (e.g. body + headers) and text with
+// non-JSON prefixes (HTML, plain text) by scanning for embedded JSON objects.
+func forEachJSONValue(text string, fn func(any) bool) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if tryDecodeAllJSON(text, fn) {
+		return
+	}
+	for i := 0; i < len(text); i++ {
+		if text[i] == '{' || text[i] == '[' {
+			if tryDecodeAllJSON(text[i:], fn) {
+				return
+			}
+		}
+	}
+}
+
+func tryDecodeAllJSON(text string, fn func(any) bool) bool {
+	decoder := json.NewDecoder(strings.NewReader(text))
+	decoder.UseNumber()
+	for {
+		var decoded any
+		if err := decoder.Decode(&decoded); err != nil {
+			return false
+		}
+		if fn(decoded) {
+			return true
+		}
+	}
 }
 
 func usageLimitResetFromJSON(value any, now time.Time) (time.Time, bool) {


### PR DESCRIPTION
## Summary

`readFailFields` concatenates response body and response headers into `fail_body`, creating text with multiple JSON values (e.g. `{error body}\n{headers}`). The existing `json.NewDecoder.Decode()` only reads the **first** JSON value, silently ignoring the headers. Worse, when the body is not JSON (HTML, plain text), the entire parsing fails without trying the headers.

- Add `forEachJSONValue` that decodes **all** JSON values in a text stream, falling back to scanning for embedded `{...}` or `[...]` when the text doesn't start with JSON
- Add `tryDecodeAllJSON` helper that loops `json.Decoder.Decode()` until the stream is exhausted
- Apply to both `codexUsageLimitResetTimeFromEvent` and `accountActionErrorCodeAndType`

## Test plan

- [x] `go build ./internal/worker/...` passes
- [x] `go test -run "RateLimit|Quota|Codex|usageLimit" ./internal/worker/` passes
- [x] `go test -run "FailSummary|readFail|FailBody|NormalizeRaw" ./internal/usage/` passes