### PR TITLE
feat(providers): convert add/edit forms to drawer-based UI

### DIFF
--- a/apps/web/src/components/providers/ProviderEditDrawer/AmpcodeEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/AmpcodeEditDrawer.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { Drawer } from '@/components/ui/Drawer';
+import { Input } from '@/components/ui/Input';
+import { ModelInputList } from '@/components/ui/ModelInputList';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { ampcodeApi } from '@/services/api';
+import { useConfigStore, useNotificationStore } from '@/stores';
+import type { AmpcodeConfig } from '@/types';
+import { maskApiKey } from '@/utils/format';
+import { areStringArraysEqual } from '@/utils/compare';
+import { buildAmpcodeFormState, entriesToAmpcodeMappings, entriesToAmpcodeUpstreamApiKeys } from '@/components/providers/utils';
+import type { AmpcodeFormState } from '@/components/providers';
+import layoutStyles from '@/features/aiProviders/AiProvidersEditLayout.module.scss';
+
+interface AmpcodeEditDrawerProps {
+  open: boolean;
+  disabled: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '';
+};
+
+const normalizeMappingEntries = (entries: Array<{ name: string; alias: string }>) =>
+  (entries ?? []).reduce<Array<{ from: string; to: string }>>((acc, entry) => {
+    const from = String(entry?.name ?? '').trim();
+    const to = String(entry?.alias ?? '').trim();
+    if (!from && !to) return acc;
+    acc.push({ from, to });
+    return acc;
+  }, []);
+
+const buildAmpcodeBaseline = (form: AmpcodeFormState) => ({
+  upstreamUrl: String(form.upstreamUrl ?? '').trim(),
+  upstreamApiKey: String(form.upstreamApiKey ?? '').trim(),
+  forceModelMappings: Boolean(form.forceModelMappings),
+  upstreamApiKeys: entriesToAmpcodeUpstreamApiKeys(form.upstreamApiKeyEntries),
+  modelMappings: normalizeMappingEntries(form.mappingEntries),
+});
+
+const areUpstreamApiKeysEqual = (
+  a: readonly { upstreamApiKey: string; apiKeys: readonly string[] }[],
+  b: readonly { upstreamApiKey: string; apiKeys: readonly string[] }[]
+) => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i]; const right = b[i];
+    if (!left || !right) return false;
+    if (left.upstreamApiKey !== right.upstreamApiKey) return false;
+    if (!areStringArraysEqual(left.apiKeys, right.apiKeys)) return false;
+  }
+  return true;
+};
+
+const areModelMappingsEqual = (a: readonly { from: string; to: string }[], b: readonly { from: string; to: string }[]) => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i]; const right = b[i];
+    if (!left || !right) return false;
+    if (left.from !== right.from || left.to !== right.to) return false;
+  }
+  return true;
+};
+
+export function AmpcodeEditDrawer({ open, disabled, onClose, onSaved }: AmpcodeEditDrawerProps) {
+  const { t } = useTranslation();
+  const { showNotification, showConfirmation } = useNotificationStore();
+
+  const config = useConfigStore((state) => state.config);
+  const updateConfigValue = useConfigStore((state) => state.updateConfigValue);
+  const clearCache = useConfigStore((state) => state.clearCache);
+
+  const [form, setForm] = useState<AmpcodeFormState>(() => buildAmpcodeFormState(null));
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [modelMappingsDirty, setModelMappingsDirty] = useState(false);
+  const [upstreamApiKeysDirty, setUpstreamApiKeysDirty] = useState(false);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [baseline, setBaseline] = useState(() => buildAmpcodeBaseline(buildAmpcodeFormState(null)));
+  const initializedRef = useRef(false);
+  const mountedRef = useRef(false);
+
+  const title = useMemo(() => t('ai_providers.ampcode_modal_title'), [t]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!open || initializedRef.current) return;
+    initializedRef.current = true;
+    setLoading(true);
+    setLoaded(false);
+    setModelMappingsDirty(false);
+    setUpstreamApiKeysDirty(false);
+    setError('');
+    const initialForm = buildAmpcodeFormState(useConfigStore.getState().config?.ampcode ?? null);
+    setForm(initialForm);
+    setBaseline(buildAmpcodeBaseline(initialForm));
+    void (async () => {
+      try {
+        const ampcode = await ampcodeApi.getAmpcode();
+        if (!mountedRef.current) return;
+        setLoaded(true);
+        updateConfigValue('ampcode', ampcode);
+        clearCache('ampcode');
+        const nextForm = buildAmpcodeFormState(ampcode);
+        setForm(nextForm);
+        setBaseline(buildAmpcodeBaseline(nextForm));
+      } catch (err: unknown) {
+        if (!mountedRef.current) return;
+        setError(getErrorMessage(err) || t('notification.refresh_failed'));
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    })();
+  }, [open, clearCache, t, updateConfigValue]);
+
+  useEffect(() => {
+    if (!open) {
+      initializedRef.current = false;
+    }
+  }, [open]);
+
+  const normalizedUpstreamApiKeys = useMemo(() => entriesToAmpcodeUpstreamApiKeys(form.upstreamApiKeyEntries), [form.upstreamApiKeyEntries]);
+  const normalizedModelMappings = useMemo(() => normalizeMappingEntries(form.mappingEntries), [form.mappingEntries]);
+  const isUpstreamApiKeysDirty = useMemo(() => !areUpstreamApiKeysEqual(baseline.upstreamApiKeys, normalizedUpstreamApiKeys), [baseline.upstreamApiKeys, normalizedUpstreamApiKeys]);
+  const isModelMappingsDirtyNormalized = useMemo(() => !areModelMappingsEqual(baseline.modelMappings, normalizedModelMappings), [baseline.modelMappings, normalizedModelMappings]);
+
+  const isDirty =
+    baseline.upstreamUrl !== form.upstreamUrl.trim() ||
+    baseline.upstreamApiKey !== form.upstreamApiKey.trim() ||
+    baseline.forceModelMappings !== Boolean(form.forceModelMappings) ||
+    isUpstreamApiKeysDirty ||
+    isModelMappingsDirtyNormalized;
+
+  const canSave = !disabled && !saving && !loading;
+
+  const clearAmpcodeUpstreamApiKey = async () => {
+    showConfirmation({
+      title: t('ai_providers.ampcode_clear_upstream_api_key_title', { defaultValue: 'Clear Upstream API Key' }),
+      message: t('ai_providers.ampcode_clear_upstream_api_key_confirm'),
+      variant: 'danger', confirmText: t('common.confirm'),
+      onConfirm: async () => {
+        setSaving(true);
+        setError('');
+        try {
+          await ampcodeApi.clearUpstreamApiKey();
+          const previous = config?.ampcode ?? {};
+          const next: AmpcodeConfig = { ...previous };
+          delete next.upstreamApiKey;
+          updateConfigValue('ampcode', next);
+          clearCache('ampcode');
+          showNotification(t('notification.ampcode_upstream_api_key_cleared'), 'success');
+        } catch (err: unknown) {
+          setError(getErrorMessage(err));
+          showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+        } finally { setSaving(false); }
+      },
+    });
+  };
+
+  const performSave = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const upstreamUrl = form.upstreamUrl.trim();
+      const overrideKey = form.upstreamApiKey.trim();
+      const upstreamApiKeys = entriesToAmpcodeUpstreamApiKeys(form.upstreamApiKeyEntries);
+      const modelMappings = entriesToAmpcodeMappings(form.mappingEntries);
+      if (upstreamUrl) await ampcodeApi.updateUpstreamUrl(upstreamUrl);
+      else await ampcodeApi.clearUpstreamUrl();
+      await ampcodeApi.updateForceModelMappings(form.forceModelMappings);
+      if (loaded || upstreamApiKeysDirty) {
+        if (upstreamApiKeys.length) await ampcodeApi.saveUpstreamApiKeys(upstreamApiKeys);
+        else await ampcodeApi.deleteUpstreamApiKeys([]);
+      }
+      if (loaded || modelMappingsDirty) {
+        if (modelMappings.length) await ampcodeApi.saveModelMappings(modelMappings);
+        else await ampcodeApi.clearModelMappings();
+      }
+      if (overrideKey) await ampcodeApi.updateUpstreamApiKey(overrideKey);
+      const previous = config?.ampcode ?? {};
+      const next: AmpcodeConfig = { ...previous, forceModelMappings: form.forceModelMappings };
+      if (upstreamUrl) next.upstreamUrl = upstreamUrl; else delete next.upstreamUrl;
+      if (overrideKey) next.upstreamApiKey = overrideKey;
+      if (loaded || upstreamApiKeysDirty) {
+        if (upstreamApiKeys.length) next.upstreamApiKeys = upstreamApiKeys; else delete next.upstreamApiKeys;
+      }
+      if (loaded || modelMappingsDirty) {
+        if (modelMappings.length) next.modelMappings = modelMappings; else delete next.modelMappings;
+      }
+      updateConfigValue('ampcode', next);
+      clearCache('ampcode');
+      showNotification(t('notification.ampcode_updated'), 'success');
+      setBaseline(buildAmpcodeBaseline(form));
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+      showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+    } finally { setSaving(false); }
+  };
+
+  const saveAmpcode = async () => {
+    if (!loaded && (modelMappingsDirty || upstreamApiKeysDirty)) {
+      showConfirmation({
+        title: t('ai_providers.ampcode_lists_overwrite_title'),
+        message: t('ai_providers.ampcode_lists_overwrite_confirm'),
+        variant: 'secondary', confirmText: t('common.confirm'),
+        onConfirm: performSave,
+      });
+      return;
+    }
+    await performSave();
+  };
+
+  const handleClose = useCallback(() => {
+    if (isDirty && !saving) {
+      if (!window.confirm(t('common.unsaved_changes_message'))) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving, t]);
+
+  const footer = (
+    <>
+      <Button variant="secondary" size="sm" onClick={handleClose} disabled={saving}>
+        {t('common.cancel')}
+      </Button>
+      <Button size="sm" onClick={() => void saveAmpcode()} loading={saving} disabled={!canSave}>
+        {t('common.save')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Drawer open={open} onClose={handleClose} width={820} footer={footer} title={title}>
+      {error && <div className="error-box">{error}</div>}
+      {loading && <div style={{ padding: '16px 0', color: 'var(--text-secondary)', fontSize: '13px' }}>{t('common.loading')}</div>}
+      {!loading && (
+        <>
+          <Input label={t('ai_providers.ampcode_upstream_url_label')} placeholder={t('ai_providers.ampcode_upstream_url_placeholder')}
+            value={form.upstreamUrl} onChange={(e) => setForm((prev) => ({ ...prev, upstreamUrl: e.target.value }))}
+            disabled={loading || saving || disabled} hint={t('ai_providers.ampcode_upstream_url_hint')} />
+          <Input label={t('ai_providers.ampcode_upstream_api_key_label')} placeholder={t('ai_providers.ampcode_upstream_api_key_placeholder')}
+            type="password" value={form.upstreamApiKey}
+            onChange={(e) => setForm((prev) => ({ ...prev, upstreamApiKey: e.target.value }))}
+            disabled={loading || saving || disabled} hint={t('ai_providers.ampcode_upstream_api_key_hint')} />
+          <div className={layoutStyles.upstreamApiKeyRow}>
+            <div className={layoutStyles.upstreamApiKeyHint}>
+              {t('ai_providers.ampcode_upstream_api_key_current', {
+                key: config?.ampcode?.upstreamApiKey ? maskApiKey(config.ampcode.upstreamApiKey) : t('common.not_set'),
+              })}
+            </div>
+            <Button variant="danger" size="sm" onClick={() => void clearAmpcodeUpstreamApiKey()}
+              disabled={loading || saving || disabled || !config?.ampcode?.upstreamApiKey}>
+              {t('ai_providers.ampcode_clear_upstream_api_key')}
+            </Button>
+          </div>
+          <div className="form-group">
+            <div className={layoutStyles.ampcodeUpstreamMappingsHeader}>
+              <label>{t('ai_providers.ampcode_upstream_api_keys_label')}</label>
+              <Button variant="secondary" size="sm" onClick={() => {
+                setUpstreamApiKeysDirty(true);
+                setForm((prev) => ({ ...prev, upstreamApiKeyEntries: [...prev.upstreamApiKeyEntries, { upstreamApiKey: '', clientApiKeysText: '' }] }));
+              }} disabled={loading || saving || disabled}>
+                {t('ai_providers.ampcode_upstream_api_keys_add_btn')}
+              </Button>
+            </div>
+            <div className={layoutStyles.ampcodeUpstreamMappingsList}>
+              {(form.upstreamApiKeyEntries.length ? form.upstreamApiKeyEntries : [{ upstreamApiKey: '', clientApiKeysText: '' }]).map((entry, index, entries) => (
+                <div key={index} className={layoutStyles.ampcodeUpstreamMappingCard}>
+                  <div className={layoutStyles.ampcodeUpstreamMappingCardTop}>
+                    <span className={layoutStyles.ampcodeUpstreamMappingTitle}>
+                      {t('ai_providers.ampcode_upstream_api_keys_item_title', { index: index + 1 })}
+                    </span>
+                    <Button variant="ghost" size="sm" onClick={() => {
+                      setUpstreamApiKeysDirty(true);
+                      setForm((prev) => {
+                        const nextEntries = prev.upstreamApiKeyEntries.filter((_, i) => i !== index);
+                        return { ...prev, upstreamApiKeyEntries: nextEntries.length ? nextEntries : [{ upstreamApiKey: '', clientApiKeysText: '' }] };
+                      });
+                    }} disabled={loading || saving || disabled || entries.length <= 1}>
+                      {t('common.delete')}
+                    </Button>
+                  </div>
+                  <input className="input" placeholder={t('ai_providers.ampcode_upstream_api_keys_upstream_placeholder')}
+                    aria-label={t('ai_providers.ampcode_upstream_api_keys_upstream_placeholder')}
+                    value={entry.upstreamApiKey} onChange={(e) => {
+                      setUpstreamApiKeysDirty(true);
+                      setForm((prev) => ({ ...prev, upstreamApiKeyEntries: prev.upstreamApiKeyEntries.map((item, i) => i === index ? { ...item, upstreamApiKey: e.target.value } : item) }));
+                    }} disabled={loading || saving || disabled} />
+                  <textarea className="input" placeholder={t('ai_providers.ampcode_upstream_api_keys_clients_placeholder')}
+                    aria-label={t('ai_providers.ampcode_upstream_api_keys_clients_placeholder')}
+                    value={entry.clientApiKeysText} onChange={(e) => {
+                      setUpstreamApiKeysDirty(true);
+                      setForm((prev) => ({ ...prev, upstreamApiKeyEntries: prev.upstreamApiKeyEntries.map((item, i) => i === index ? { ...item, clientApiKeysText: e.target.value } : item) }));
+                    }} rows={3} disabled={loading || saving || disabled} />
+                </div>
+              ))}
+            </div>
+            <div className="hint">{t('ai_providers.ampcode_upstream_api_keys_hint')}</div>
+          </div>
+          <div className="form-group">
+            <ToggleSwitch label={t('ai_providers.ampcode_force_model_mappings_label')}
+              checked={form.forceModelMappings} onChange={(value) => setForm((prev) => ({ ...prev, forceModelMappings: value }))}
+              disabled={loading || saving || disabled} />
+            <div className="hint">{t('ai_providers.ampcode_force_model_mappings_hint')}</div>
+          </div>
+          <div className="form-group">
+            <label>{t('ai_providers.ampcode_model_mappings_label')}</label>
+            <ModelInputList entries={form.mappingEntries} onChange={(entries) => {
+              setModelMappingsDirty(true);
+              setForm((prev) => ({ ...prev, mappingEntries: entries }));
+            }} addLabel={t('ai_providers.ampcode_model_mappings_add_btn')}
+              namePlaceholder={t('ai_providers.ampcode_model_mappings_from_placeholder')}
+              aliasPlaceholder={t('ai_providers.ampcode_model_mappings_to_placeholder')}
+              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+              disabled={loading || saving || disabled} />
+            <div className="hint">{t('ai_providers.ampcode_model_mappings_hint')}</div>
+          </div>
+        </>
+      )}
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/providers/ProviderEditDrawer/ClaudeEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/ClaudeEditDrawer.tsx
@@ -1,0 +1,489 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { Drawer } from '@/components/ui/Drawer';
+import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
+import { HeaderInputList } from '@/components/ui/HeaderInputList';
+import { ModelInputList } from '@/components/ui/ModelInputList';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { apiCallApi, getApiCallErrorMessage, providersApi } from '@/services/api';
+import { useConfigStore, useNotificationStore } from '@/stores';
+import type { ProviderKeyConfig } from '@/types';
+import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import { areKeyValueEntriesEqual, areModelEntriesEqual, areStringArraysEqual } from '@/utils/compare';
+import { excludedModelsToText, parseExcludedModels, buildClaudeMessagesEndpoint, parseTextList } from '@/components/providers/utils';
+import { modelsToEntries } from '@/components/ui/modelInputListUtils';
+import type { ProviderFormState } from '@/components/providers';
+import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
+
+interface ClaudeEditDrawerProps {
+  open: boolean;
+  editIndex: number | null;
+  disabled: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+type ClaudeFormBaseline = ReturnType<typeof buildClaudeBaseline>;
+
+const CLAUDE_TEST_TIMEOUT_MS = 30_000;
+const DEFAULT_ANTHROPIC_VERSION = '2023-06-01';
+
+const buildEmptyForm = (): ProviderFormState => ({
+  apiKey: '',
+  authIndex: '',
+  priority: undefined,
+  prefix: '',
+  baseUrl: '',
+  proxyUrl: '',
+  headers: [],
+  models: [],
+  excludedModels: [],
+  modelEntries: [{ name: '', alias: '' }],
+  excludedText: '',
+});
+
+const normalizeClaudeModelEntries = (entries: Array<{ name: string; alias: string }>) =>
+  (entries ?? []).reduce<Array<{ name: string; alias: string }>>((acc, entry) => {
+    const name = String(entry?.name ?? '').trim();
+    let alias = String(entry?.alias ?? '').trim();
+    if (name) alias = alias || name;
+    if (!name && !alias) return acc;
+    acc.push({ name, alias });
+    return acc;
+  }, []);
+
+const normalizeCloakConfig = (cloak: ProviderFormState['cloak']) => {
+  if (!cloak) return null;
+  const mode = String(cloak.mode ?? '').trim().toLowerCase() || 'auto';
+  const strictMode = Boolean(cloak.strictMode);
+  const sensitiveWords = Array.isArray(cloak.sensitiveWords)
+    ? cloak.sensitiveWords.map((word) => String(word ?? '').trim()).filter(Boolean)
+    : [];
+  return { mode, strictMode, sensitiveWords: sensitiveWords.length ? sensitiveWords : null };
+};
+
+const areCloakConfigsEqual = (left: ReturnType<typeof normalizeCloakConfig>, right: ReturnType<typeof normalizeCloakConfig>) => {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  if (left.mode !== right.mode || left.strictMode !== right.strictMode) return false;
+  if (left.sensitiveWords === null || right.sensitiveWords === null) return left.sensitiveWords === right.sensitiveWords;
+  return areStringArraysEqual(left.sensitiveWords, right.sensitiveWords);
+};
+
+const buildClaudeBaseline = (form: ProviderFormState) => ({
+  apiKey: String(form.apiKey ?? '').trim(),
+  authIndex: normalizeAuthIndex(form.authIndex) ?? '',
+  priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null,
+  prefix: String(form.prefix ?? '').trim(),
+  baseUrl: String(form.baseUrl ?? '').trim(),
+  proxyUrl: String(form.proxyUrl ?? '').trim(),
+  headers: normalizeHeaderEntries(form.headers),
+  models: normalizeClaudeModelEntries(form.modelEntries),
+  excludedModels: parseExcludedModels(form.excludedText ?? ''),
+  cloak: normalizeCloakConfig(form.cloak),
+});
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '';
+};
+
+const hasHeader = (headers: Record<string, string>, name: string) => {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === target);
+};
+
+const resolveBearerTokenFromAuthorization = (headers: Record<string, string>): string => {
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === 'authorization');
+  if (!entry) return '';
+  const value = String(entry[1] ?? '').trim();
+  if (!value) return '';
+  const match = value.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || '';
+};
+
+export function ClaudeEditDrawer({ open, editIndex, disabled, onClose, onSaved }: ClaudeEditDrawerProps) {
+  const { t } = useTranslation();
+  const { showNotification } = useNotificationStore();
+  const fetchConfig = useConfigStore((state) => state.fetchConfig);
+  const updateConfigValue = useConfigStore((state) => state.updateConfigValue);
+  const clearCache = useConfigStore((state) => state.clearCache);
+
+  const [configs, setConfigs] = useState<ProviderKeyConfig[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<ProviderFormState>(buildEmptyForm);
+  const [baseline, setBaseline] = useState<ClaudeFormBaseline>(buildClaudeBaseline(buildEmptyForm()));
+  const [loaded, setLoaded] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [testModel, setTestModel] = useState('');
+  const [testStatus, setTestStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [testMessage, setTestMessage] = useState('');
+  const lastCloakConfigRef = useRef<typeof form.cloak>(null);
+
+  const initialData = useMemo(() => {
+    if (editIndex === null) return undefined;
+    return configs[editIndex];
+  }, [configs, editIndex]);
+  const invalidIndex = editIndex !== null && !initialData;
+
+  const title = editIndex !== null ? t('ai_providers.claude_edit_modal_title') : t('ai_providers.claude_add_modal_title');
+
+  const availableModels = useMemo(
+    () => form.modelEntries.map((entry) => entry.name.trim()).filter(Boolean),
+    [form.modelEntries]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    fetchConfig('claude-api-key')
+      .then((value) => {
+        if (cancelled) return;
+        setConfigs(Array.isArray(value) ? (value as ProviderKeyConfig[]) : []);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        showNotification(`${t('notification.load_failed')}: ${getErrorMessage(err)}`, 'error');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        setLoaded(true);
+      });
+    return () => { cancelled = true; };
+  }, [open, fetchConfig, t]);
+
+  useEffect(() => {
+    if (!open || !loaded) return;
+    if (initialData) {
+      const seededForm: ProviderFormState = {
+        ...initialData,
+        headers: headersToEntries(initialData.headers),
+        modelEntries: modelsToEntries(initialData.models),
+        excludedText: excludedModelsToText(initialData.excludedModels),
+      };
+      setForm(seededForm);
+      setBaseline(buildClaudeBaseline(seededForm));
+      const available = seededForm.modelEntries.map((entry) => entry.name.trim()).filter(Boolean);
+      setTestModel(available[0] || '');
+    } else {
+      const emptyForm = buildEmptyForm();
+      setForm(emptyForm);
+      setBaseline(buildClaudeBaseline(emptyForm));
+      setTestModel('');
+    }
+    setTestStatus('idle');
+    setTestMessage('');
+  }, [open, loaded, initialData]);
+
+  useEffect(() => { if (!form.cloak) return; lastCloakConfigRef.current = form.cloak; }, [form.cloak]);
+
+  const canSave = !disabled && !loading && !saving && !invalidIndex && !isTesting;
+
+  const isDirty = useMemo(() => {
+    const normalizedPriority = form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null;
+    return (
+      baseline.apiKey !== form.apiKey.trim() ||
+      baseline.authIndex !== (normalizeAuthIndex(form.authIndex) ?? '') ||
+      baseline.priority !== normalizedPriority ||
+      baseline.prefix !== String(form.prefix ?? '').trim() ||
+      baseline.baseUrl !== String(form.baseUrl ?? '').trim() ||
+      baseline.proxyUrl !== String(form.proxyUrl ?? '').trim() ||
+      !areKeyValueEntriesEqual(baseline.headers, normalizeHeaderEntries(form.headers)) ||
+      !areModelEntriesEqual(baseline.models, normalizeClaudeModelEntries(form.modelEntries)) ||
+      !areStringArraysEqual(baseline.excludedModels, parseExcludedModels(form.excludedText ?? '')) ||
+      !areCloakConfigsEqual(baseline.cloak, normalizeCloakConfig(form.cloak))
+    );
+  }, [baseline, form]);
+
+  const modelSelectOptions = useMemo(() => {
+    const seen = new Set<string>();
+    return form.modelEntries.reduce<Array<{ value: string; label: string }>>((acc, entry) => {
+      const name = entry.name.trim();
+      if (!name || seen.has(name)) return acc;
+      seen.add(name);
+      const alias = entry.alias.trim();
+      acc.push({ value: name, label: alias && alias !== name ? `${name} (${alias})` : name });
+      return acc;
+    }, []);
+  }, [form.modelEntries]);
+
+  const cloakModeOptions = useMemo(() => [
+    { value: 'auto', label: t('ai_providers.claude_cloak_mode_auto') },
+    { value: 'always', label: t('ai_providers.claude_cloak_mode_always') },
+    { value: 'never', label: t('ai_providers.claude_cloak_mode_never') },
+  ], [t]);
+
+  const resolvedCloakMode = useMemo(() => {
+    const mode = (form.cloak?.mode ?? '').trim().toLowerCase();
+    if (!mode) return 'auto';
+    if (mode === 'provider') return 'auto';
+    if (mode === 'auto' || mode === 'always' || mode === 'never') return mode;
+    return 'auto';
+  }, [form.cloak?.mode]);
+
+  const runConnectivityTest = useCallback(async () => {
+    if (isTesting) return;
+    const modelName = testModel.trim() || availableModels[0] || '';
+    if (!modelName) {
+      showNotification(t('ai_providers.claude_test_model_required'), 'error');
+      return;
+    }
+    const customHeaders = buildHeaderObject(form.headers);
+    const apiKey = form.apiKey.trim();
+    const keyAuthIndex = normalizeAuthIndex(form.authIndex) ?? undefined;
+    const hasApiKeyHeader = hasHeader(customHeaders, 'x-api-key');
+    const apiKeyFromAuthorization = resolveBearerTokenFromAuthorization(customHeaders);
+    const resolvedApiKey = apiKey || apiKeyFromAuthorization;
+    if (!resolvedApiKey && !hasApiKeyHeader && !keyAuthIndex) {
+      showNotification(t('ai_providers.claude_test_key_required'), 'error');
+      return;
+    }
+    const endpoint = buildClaudeMessagesEndpoint(form.baseUrl ?? '');
+    if (!endpoint) {
+      showNotification(t('ai_providers.claude_test_endpoint_invalid'), 'error');
+      return;
+    }
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...customHeaders };
+    if (!hasHeader(headers, 'anthropic-version')) headers['anthropic-version'] = DEFAULT_ANTHROPIC_VERSION;
+    if (!Object.prototype.hasOwnProperty.call(headers, 'Anthropic-Version')) headers['Anthropic-Version'] = headers['anthropic-version'] ?? DEFAULT_ANTHROPIC_VERSION;
+    const tokenValue = resolvedApiKey || (keyAuthIndex ? '$TOKEN$' : '');
+    if (!hasApiKeyHeader && tokenValue) headers['x-api-key'] = tokenValue;
+    if (!Object.prototype.hasOwnProperty.call(headers, 'X-Api-Key') && tokenValue) headers['X-Api-Key'] = tokenValue;
+
+    setIsTesting(true);
+    setTestStatus('loading');
+    setTestMessage(t('ai_providers.claude_test_running'));
+    try {
+      const result = await apiCallApi.request({
+        method: 'POST', authIndex: keyAuthIndex, url: endpoint, header: headers,
+        data: JSON.stringify({ model: modelName, max_tokens: 8, messages: [{ role: 'user', content: 'Hi' }] }),
+      }, { timeout: CLAUDE_TEST_TIMEOUT_MS });
+      if (result.statusCode < 200 || result.statusCode >= 300) throw new Error(getApiCallErrorMessage(result));
+      const message = t('ai_providers.claude_test_success');
+      setTestStatus('success');
+      setTestMessage(message);
+      showNotification(message, 'success');
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      const errorCode = typeof err === 'object' && err !== null && 'code' in err ? String((err as { code?: string }).code) : '';
+      const isTimeout = errorCode === 'ECONNABORTED' || message.toLowerCase().includes('timeout');
+      const resolvedMessage = isTimeout
+        ? t('ai_providers.claude_test_timeout', { seconds: CLAUDE_TEST_TIMEOUT_MS / 1000 })
+        : `${t('ai_providers.claude_test_failed')}: ${message || t('common.unknown_error')}`;
+      setTestStatus('error');
+      setTestMessage(resolvedMessage);
+      showNotification(resolvedMessage, 'error');
+    } finally {
+      setIsTesting(false);
+    }
+  }, [availableModels, form.apiKey, form.authIndex, form.baseUrl, form.headers, isTesting, showNotification, t, testModel]);
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    const apiKey = form.apiKey.trim();
+    if (!apiKey && !normalizeAuthIndex(form.authIndex)) {
+      showNotification(t('ai_providers.claude_key_required', { defaultValue: 'Please enter a Claude API Key' }), 'error');
+      return;
+    }
+    const baseUrl = (form.baseUrl ?? '').trim();
+    if (!baseUrl) {
+      showNotification(t('ai_providers.claude_base_url_required', { defaultValue: 'Please enter the Claude Base URL' }), 'error');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: ProviderKeyConfig = {
+        apiKey: form.apiKey.trim(),
+        priority: form.priority !== undefined ? Math.trunc(form.priority) : undefined,
+        prefix: form.prefix?.trim() || undefined,
+        baseUrl: (form.baseUrl ?? '').trim() || undefined,
+        proxyUrl: form.proxyUrl?.trim() || undefined,
+        headers: buildHeaderObject(form.headers),
+        models: form.modelEntries.map((entry) => {
+          const name = entry.name.trim();
+          if (!name) return null;
+          const alias = entry.alias.trim();
+          return { name, alias: alias || name };
+        }).filter(Boolean) as ProviderKeyConfig['models'],
+        excludedModels: parseExcludedModels(form.excludedText),
+        cloak: form.cloak,
+        authIndex: normalizeAuthIndex(form.authIndex) ?? undefined,
+      };
+      const nextList = editIndex !== null
+        ? configs.map((item, idx) => (idx === editIndex ? payload : item))
+        : [...configs, payload];
+      await providersApi.saveClaudeConfigs(nextList);
+      updateConfigValue('claude-api-key', nextList);
+      clearCache('claude-api-key');
+      showNotification(editIndex !== null ? t('notification.claude_config_updated') : t('notification.claude_config_added'), 'success');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, clearCache, configs, editIndex, form, onClose, onSaved, showNotification, t, updateConfigValue]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty && !saving) {
+      if (!window.confirm(t('common.unsaved_changes_message'))) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving, t]);
+
+  const footer = (
+    <>
+      <Button variant="secondary" size="sm" onClick={handleClose} disabled={saving || isTesting}>
+        {t('common.cancel')}
+      </Button>
+      <Button size="sm" onClick={handleSave} loading={saving} disabled={!canSave}>
+        {t('common.save')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Drawer open={open} onClose={handleClose} width={820} footer={footer} title={title}>
+      <div className={styles.openaiEditForm}>
+        {loading && <div className={styles.sectionHint}>{t('common.loading')}</div>}
+        {invalidIndex && <div className={styles.sectionHint}>{t('common.invalid_provider_index')}</div>}
+        {!loading && !invalidIndex && (
+          <>
+            <Input label={t('ai_providers.claude_add_modal_key_label')}
+              value={form.apiKey} onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
+              disabled={saving || disabled || isTesting} required />
+            <Input label={t('ai_providers.claude_add_modal_url_label')}
+              value={form.baseUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
+              disabled={saving || disabled || isTesting} required />
+            <Input label={t('ai_providers.priority_label')} hint={t('ai_providers.priority_hint')}
+              type="number" step={1} value={form.priority ?? ''}
+              onChange={(e) => { const raw = e.target.value; const parsed = raw.trim() === '' ? undefined : Number(raw); setForm((prev) => ({ ...prev, priority: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined })); }}
+              disabled={saving || disabled || isTesting} />
+            <Input label={t('ai_providers.prefix_label')} placeholder={t('ai_providers.prefix_placeholder')}
+              value={form.prefix ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
+              hint={t('ai_providers.prefix_hint')} disabled={saving || disabled || isTesting} />
+            <Input label={t('ai_providers.claude_add_modal_proxy_label')}
+              value={form.proxyUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, proxyUrl: e.target.value }))}
+              disabled={saving || disabled || isTesting} />
+            <HeaderInputList entries={form.headers}
+              onChange={(entries) => setForm((prev) => ({ ...prev, headers: entries }))}
+              addLabel={t('common.custom_headers_add')} keyPlaceholder={t('common.custom_headers_key_placeholder')}
+              valuePlaceholder={t('common.custom_headers_value_placeholder')}
+              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+              disabled={saving || disabled || isTesting} />
+
+            <div className={styles.modelConfigSection}>
+              <div className={styles.modelConfigHeader}>
+                <label className={styles.modelConfigTitle}>{t('ai_providers.claude_models_label')}</label>
+                <div className={styles.modelConfigToolbar}>
+                  <Button variant="secondary" size="sm"
+                    onClick={() => setForm((prev) => ({ ...prev, modelEntries: [...prev.modelEntries, { name: '', alias: '' }] }))}
+                    disabled={saving || disabled || isTesting}>
+                    {t('ai_providers.claude_models_add_btn')}
+                  </Button>
+                </div>
+              </div>
+              <div className={styles.sectionHint}>{t('ai_providers.claude_models_hint')}</div>
+              <ModelInputList entries={form.modelEntries}
+                onChange={(entries) => setForm((prev) => ({ ...prev, modelEntries: entries }))}
+                namePlaceholder={t('common.model_name_placeholder')} aliasPlaceholder={t('common.model_alias_placeholder')}
+                disabled={saving || disabled || isTesting} hideAddButton
+                className={styles.modelInputList} rowClassName={styles.modelInputRow} inputClassName={styles.modelInputField}
+                removeButtonClassName={styles.modelRowRemoveButton}
+                removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')} />
+
+              <div className={styles.modelTestPanel}>
+                <div className={styles.modelTestMeta}>
+                  <label className={styles.modelTestLabel}>{t('ai_providers.claude_test_title')}</label>
+                  <span className={styles.modelTestHint}>{t('ai_providers.claude_test_hint')}</span>
+                </div>
+                <div className={styles.modelTestControls}>
+                  <Select value={testModel} options={modelSelectOptions}
+                    onChange={(value) => { setTestModel(value); setTestStatus('idle'); setTestMessage(''); }}
+                    placeholder={availableModels.length ? t('ai_providers.claude_test_select_placeholder') : t('ai_providers.claude_test_select_empty')}
+                    className={styles.openaiTestSelect} ariaLabel={t('ai_providers.claude_test_title')}
+                    disabled={saving || disabled || isTesting || testStatus === 'loading' || availableModels.length === 0} />
+                  <Button variant={testStatus === 'error' ? 'danger' : 'secondary'} size="sm"
+                    onClick={() => void runConnectivityTest()} loading={testStatus === 'loading'}
+                    disabled={saving || disabled || isTesting || testStatus === 'loading' || availableModels.length === 0}
+                    className={styles.modelTestAllButton}>
+                    {t('ai_providers.claude_test_action')}
+                  </Button>
+                </div>
+              </div>
+              {testMessage && (
+                <div className={`status-badge ${testStatus === 'error' ? 'error' : testStatus === 'success' ? 'success' : 'muted'}`}>
+                  {testMessage}
+                </div>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label>{t('ai_providers.excluded_models_label')}</label>
+              <textarea className="input" placeholder={t('ai_providers.excluded_models_placeholder')}
+                value={form.excludedText} onChange={(e) => setForm((prev) => ({ ...prev, excludedText: e.target.value }))}
+                rows={4} disabled={saving || disabled || isTesting} />
+              <div className="hint">{t('ai_providers.excluded_models_hint')}</div>
+            </div>
+
+            <div className={styles.modelConfigSection}>
+              <div className={styles.modelConfigHeader}>
+                <label className={styles.modelConfigTitle}>{t('ai_providers.claude_cloak_title')}</label>
+                <div className={styles.modelConfigToolbar}>
+                  <ToggleSwitch checked={Boolean(form.cloak)}
+                    onChange={(enabled) => setForm((prev) => {
+                      if (!enabled) {
+                        if (prev.cloak) lastCloakConfigRef.current = prev.cloak;
+                        return { ...prev, cloak: undefined };
+                      }
+                      const restored = prev.cloak ?? lastCloakConfigRef.current ?? { mode: 'auto', strictMode: false, sensitiveWords: [] };
+                      return { ...prev, cloak: { mode: String(restored.mode ?? 'auto').trim() || 'auto', strictMode: restored.strictMode ?? false, sensitiveWords: restored.sensitiveWords ?? [] } };
+                    })}
+                    disabled={saving || disabled || isTesting} ariaLabel={t('ai_providers.claude_cloak_toggle_aria')}
+                    label={t('ai_providers.claude_cloak_toggle_label')} />
+                </div>
+              </div>
+              <div className={styles.sectionHint}>{t('ai_providers.claude_cloak_hint')}</div>
+              {form.cloak ? (
+                <>
+                  <div className="form-group">
+                    <label>{t('ai_providers.claude_cloak_mode_label')}</label>
+                    <Select value={resolvedCloakMode} options={cloakModeOptions}
+                      onChange={(value) => setForm((prev) => ({ ...prev, cloak: { ...(prev.cloak ?? {}), mode: value } }))}
+                      ariaLabel={t('ai_providers.claude_cloak_mode_label')} disabled={saving || disabled || isTesting} />
+                    <div className="hint">{t('ai_providers.claude_cloak_mode_hint')}</div>
+                  </div>
+                  <div className="form-group">
+                    <label>{t('ai_providers.claude_cloak_strict_label')}</label>
+                    <ToggleSwitch checked={Boolean(form.cloak.strictMode)}
+                      onChange={(value) => setForm((prev) => ({ ...prev, cloak: { ...(prev.cloak ?? {}), strictMode: value } }))}
+                      disabled={saving || disabled || isTesting} ariaLabel={t('ai_providers.claude_cloak_strict_label')} />
+                    <div className="hint">{t('ai_providers.claude_cloak_strict_hint')}</div>
+                  </div>
+                  <div className="form-group">
+                    <label>{t('ai_providers.claude_cloak_sensitive_words_label')}</label>
+                    <textarea className="input" placeholder={t('ai_providers.claude_cloak_sensitive_words_placeholder')}
+                      value={(form.cloak.sensitiveWords ?? []).join('\n')}
+                      onChange={(e) => {
+                        const nextWords = parseTextList(e.target.value);
+                        setForm((prev) => ({ ...prev, cloak: { ...(prev.cloak ?? {}), sensitiveWords: nextWords.length ? nextWords : undefined } }));
+                      }} rows={3} disabled={saving || disabled || isTesting} />
+                    <div className="hint">{t('ai_providers.claude_cloak_sensitive_words_hint')}</div>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/providers/ProviderEditDrawer/CodexEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/CodexEditDrawer.tsx
@@ -1,0 +1,424 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { Drawer } from '@/components/ui/Drawer';
+import { Input } from '@/components/ui/Input';
+import { HeaderInputList } from '@/components/ui/HeaderInputList';
+import { ModelInputList } from '@/components/ui/ModelInputList';
+import { Modal } from '@/components/ui/Modal';
+import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
+import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
+import { modelsApi, providersApi } from '@/services/api';
+import { useConfigStore, useNotificationStore } from '@/stores';
+import type { ProviderKeyConfig } from '@/types';
+import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import { areKeyValueEntriesEqual, areModelEntriesEqual, areStringArraysEqual } from '@/utils/compare';
+import { entriesToModels, modelsToEntries } from '@/components/ui/modelInputListUtils';
+import { excludedModelsToText, parseExcludedModels } from '@/components/providers/utils';
+import type { ProviderFormState } from '@/components/providers';
+import type { ModelInfo } from '@/utils/models';
+import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
+
+interface CodexEditDrawerProps {
+  open: boolean;
+  editIndex: number | null;
+  disabled: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+type CodexFormBaseline = ReturnType<typeof buildCodexBaseline>;
+
+const buildEmptyForm = (): ProviderFormState => ({
+  apiKey: '',
+  priority: undefined,
+  prefix: '',
+  baseUrl: '',
+  websockets: false,
+  proxyUrl: '',
+  headers: [],
+  models: [],
+  excludedModels: [],
+  modelEntries: [{ name: '', alias: '' }],
+  excludedText: '',
+});
+
+const normalizeModelEntries = (entries: Array<{ name: string; alias: string }>) =>
+  (entries ?? []).reduce<Array<{ name: string; alias: string }>>((acc, entry) => {
+    const name = String(entry?.name ?? '').trim();
+    let alias = String(entry?.alias ?? '').trim();
+    if (name && alias === name) alias = '';
+    if (!name && !alias) return acc;
+    acc.push({ name, alias });
+    return acc;
+  }, []);
+
+const buildCodexBaseline = (form: ProviderFormState) => ({
+  apiKey: String(form.apiKey ?? '').trim(),
+  authIndex: normalizeAuthIndex(form.authIndex) ?? '',
+  priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null,
+  prefix: String(form.prefix ?? '').trim(),
+  baseUrl: String(form.baseUrl ?? '').trim(),
+  websockets: Boolean(form.websockets),
+  proxyUrl: String(form.proxyUrl ?? '').trim(),
+  headers: normalizeHeaderEntries(form.headers),
+  models: normalizeModelEntries(form.modelEntries),
+  excludedModels: parseExcludedModels(form.excludedText ?? ''),
+});
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '';
+};
+
+export function CodexEditDrawer({ open, editIndex, disabled, onClose, onSaved }: CodexEditDrawerProps) {
+  const { t } = useTranslation();
+  const { showNotification } = useNotificationStore();
+  const fetchConfig = useConfigStore((state) => state.fetchConfig);
+  const updateConfigValue = useConfigStore((state) => state.updateConfigValue);
+  const clearCache = useConfigStore((state) => state.clearCache);
+
+  const [configs, setConfigs] = useState<ProviderKeyConfig[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState<ProviderFormState>(buildEmptyForm);
+  const [baseline, setBaseline] = useState<CodexFormBaseline>(buildCodexBaseline(buildEmptyForm()));
+  const [loaded, setLoaded] = useState(false);
+
+  const [modelDiscoveryOpen, setModelDiscoveryOpen] = useState(false);
+  const [modelDiscoveryFetching, setModelDiscoveryFetching] = useState(false);
+  const [modelDiscoveryError, setModelDiscoveryError] = useState('');
+  const [discoveredModels, setDiscoveredModels] = useState<ModelInfo[]>([]);
+  const [modelDiscoverySearch, setModelDiscoverySearch] = useState('');
+  const [modelDiscoverySelected, setModelDiscoverySelected] = useState<Set<string>>(new Set());
+
+  const initialData = useMemo(() => {
+    if (editIndex === null) return undefined;
+    return configs[editIndex];
+  }, [configs, editIndex]);
+  const invalidIndex = editIndex !== null && !initialData;
+
+  const title = editIndex !== null ? t('ai_providers.codex_edit_modal_title') : t('ai_providers.codex_add_modal_title');
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    fetchConfig('codex-api-key')
+      .then((value) => {
+        if (cancelled) return;
+        setConfigs(Array.isArray(value) ? (value as ProviderKeyConfig[]) : []);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(getErrorMessage(err) || t('notification.refresh_failed'));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        setLoaded(true);
+      });
+    return () => { cancelled = true; };
+  }, [open, fetchConfig, t]);
+
+  useEffect(() => {
+    if (!open || !loaded) return;
+    if (initialData) {
+      const nextForm: ProviderFormState = {
+        ...initialData,
+        websockets: Boolean(initialData.websockets),
+        headers: headersToEntries(initialData.headers),
+        modelEntries: modelsToEntries(initialData.models),
+        excludedText: excludedModelsToText(initialData.excludedModels),
+      };
+      setForm(nextForm);
+      setBaseline(buildCodexBaseline(nextForm));
+    } else {
+      const nextForm = buildEmptyForm();
+      setForm(nextForm);
+      setBaseline(buildCodexBaseline(nextForm));
+    }
+  }, [open, loaded, initialData]);
+
+  const canSave = !disabled && !saving && !loading && !invalidIndex;
+
+  const isDirty = useMemo(() => {
+    const normalizedPriority = form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null;
+    return (
+      baseline.apiKey !== form.apiKey.trim() ||
+      baseline.authIndex !== (normalizeAuthIndex(form.authIndex) ?? '') ||
+      baseline.priority !== normalizedPriority ||
+      baseline.prefix !== String(form.prefix ?? '').trim() ||
+      baseline.baseUrl !== String(form.baseUrl ?? '').trim() ||
+      baseline.websockets !== Boolean(form.websockets) ||
+      baseline.proxyUrl !== String(form.proxyUrl ?? '').trim() ||
+      !areKeyValueEntriesEqual(baseline.headers, normalizeHeaderEntries(form.headers)) ||
+      !areModelEntriesEqual(baseline.models, normalizeModelEntries(form.modelEntries)) ||
+      !areStringArraysEqual(baseline.excludedModels, parseExcludedModels(form.excludedText ?? ''))
+    );
+  }, [baseline, form]);
+
+  const discoveredModelsFiltered = useMemo(() => {
+    const filter = modelDiscoverySearch.trim().toLowerCase();
+    if (!filter) return discoveredModels;
+    return discoveredModels.filter((model) => {
+      const name = (model.name || '').toLowerCase();
+      const alias = (model.alias || '').toLowerCase();
+      const description = (model.description || '').toLowerCase();
+      return name.includes(filter) || alias.includes(filter) || description.includes(filter);
+    });
+  }, [discoveredModels, modelDiscoverySearch]);
+
+  const mergeDiscoveredModels = useCallback((selectedModels: ModelInfo[]) => {
+    if (!selectedModels.length) return;
+    let addedCount = 0;
+    setForm((prev) => {
+      const mergedMap = new Map<string, { name: string; alias: string }>();
+      prev.modelEntries.forEach((entry) => {
+        const name = entry.name.trim();
+        if (!name) return;
+        mergedMap.set(name.toLowerCase(), { name, alias: entry.alias?.trim() || '' });
+      });
+      selectedModels.forEach((model) => {
+        const name = String(model.name ?? '').trim();
+        if (!name) return;
+        const key = name.toLowerCase();
+        if (mergedMap.has(key)) return;
+        mergedMap.set(key, { name, alias: model.alias ?? '' });
+        addedCount += 1;
+      });
+      const mergedEntries = Array.from(mergedMap.values());
+      return { ...prev, modelEntries: mergedEntries.length ? mergedEntries : [{ name: '', alias: '' }] };
+    });
+    if (addedCount > 0) {
+      showNotification(t('ai_providers.codex_models_fetch_added', { count: addedCount }), 'success');
+    }
+  }, [showNotification, t]);
+
+  const fetchModelDiscovery = useCallback(async () => {
+    setModelDiscoveryFetching(true);
+    setModelDiscoveryError('');
+    try {
+      const headerObject = buildHeaderObject(form.headers);
+      const hasCustomAuthorization = Object.keys(headerObject).some((key) => key.toLowerCase() === 'authorization');
+      const apiKey = form.apiKey.trim() || undefined;
+      const list = await modelsApi.fetchV1ModelsViaApiCall(
+        form.baseUrl ?? '', hasCustomAuthorization ? undefined : apiKey, headerObject,
+        normalizeAuthIndex(form.authIndex) ?? undefined
+      );
+      setDiscoveredModels(list);
+    } catch (err: unknown) {
+      setDiscoveredModels([]);
+      setModelDiscoveryError(`${t('ai_providers.codex_models_fetch_error')}: ${getErrorMessage(err)}`);
+    } finally {
+      setModelDiscoveryFetching(false);
+    }
+  }, [form.apiKey, form.authIndex, form.baseUrl, form.headers, t]);
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    const apiKey = form.apiKey.trim();
+    if (!apiKey && !normalizeAuthIndex(form.authIndex)) {
+      showNotification(t('ai_providers.codex_key_required', { defaultValue: 'Please enter a Codex API Key' }), 'error');
+      return;
+    }
+    const trimmedBaseUrl = (form.baseUrl ?? '').trim();
+    if (!trimmedBaseUrl) {
+      showNotification(t('notification.codex_base_url_required'), 'error');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      const payload: ProviderKeyConfig = {
+        apiKey: form.apiKey.trim(),
+        priority: form.priority !== undefined ? Math.trunc(form.priority) : undefined,
+        prefix: form.prefix?.trim() || undefined,
+        baseUrl: trimmedBaseUrl,
+        websockets: Boolean(form.websockets),
+        proxyUrl: form.proxyUrl?.trim() || undefined,
+        headers: buildHeaderObject(form.headers),
+        models: entriesToModels(form.modelEntries),
+        excludedModels: parseExcludedModels(form.excludedText),
+        authIndex: normalizeAuthIndex(form.authIndex) ?? undefined,
+      };
+      const nextList = editIndex !== null
+        ? configs.map((item, idx) => (idx === editIndex ? payload : item))
+        : [...configs, payload];
+      await providersApi.saveCodexConfigs(nextList);
+      updateConfigValue('codex-api-key', nextList);
+      clearCache('codex-api-key');
+      showNotification(editIndex !== null ? t('notification.codex_config_updated') : t('notification.codex_config_added'), 'success');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+      showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, clearCache, configs, editIndex, form, onClose, onSaved, showNotification, t, updateConfigValue]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty && !saving) {
+      if (!window.confirm(t('common.unsaved_changes_message'))) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving, t]);
+
+  useEffect(() => {
+    if (!modelDiscoveryOpen) return;
+    setDiscoveredModels([]);
+    setModelDiscoverySearch('');
+    setModelDiscoverySelected(new Set());
+    setModelDiscoveryError('');
+    void fetchModelDiscovery();
+  }, [modelDiscoveryOpen, fetchModelDiscovery]);
+
+  const canOpenModelDiscovery = !disabled && !saving && !loading && !invalidIndex && Boolean((form.baseUrl ?? '').trim());
+  const canApplyModelDiscovery = !disabled && !saving && !modelDiscoveryFetching && modelDiscoverySelected.size > 0;
+
+  const footer = (
+    <>
+      <Button variant="secondary" size="sm" onClick={handleClose} disabled={saving}>
+        {t('common.cancel')}
+      </Button>
+      <Button size="sm" onClick={handleSave} loading={saving} disabled={!canSave}>
+        {t('common.save')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Drawer open={open} onClose={handleClose} width={820} footer={footer} title={title}>
+      <div className={styles.openaiEditForm}>
+        {error && <div className="error-box">{error}</div>}
+        {loading && <div className={styles.sectionHint}>{t('common.loading')}</div>}
+        {invalidIndex && <div className="hint">{t('common.invalid_provider_index')}</div>}
+        {!loading && !invalidIndex && (
+          <>
+            <Input label={t('ai_providers.codex_add_modal_key_label')}
+              value={form.apiKey} onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
+              disabled={disabled || saving} required />
+            <Input label={t('ai_providers.codex_add_modal_url_label')}
+              value={form.baseUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
+              disabled={disabled || saving} required />
+            <Input label={t('ai_providers.priority_label')} hint={t('ai_providers.priority_hint')}
+              type="number" step={1} value={form.priority ?? ''}
+              onChange={(e) => { const raw = e.target.value; const parsed = raw.trim() === '' ? undefined : Number(raw); setForm((prev) => ({ ...prev, priority: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined })); }}
+              disabled={disabled || saving} />
+            <Input label={t('ai_providers.prefix_label')} placeholder={t('ai_providers.prefix_placeholder')}
+              value={form.prefix ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
+              hint={t('ai_providers.prefix_hint')} disabled={disabled || saving} />
+            <Input label={t('ai_providers.codex_add_modal_proxy_label')}
+              value={form.proxyUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, proxyUrl: e.target.value }))}
+              disabled={disabled || saving} />
+            <HeaderInputList entries={form.headers}
+              onChange={(entries) => setForm((prev) => ({ ...prev, headers: entries }))}
+              addLabel={t('common.custom_headers_add')} keyPlaceholder={t('common.custom_headers_key_placeholder')}
+              valuePlaceholder={t('common.custom_headers_value_placeholder')}
+              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+              disabled={disabled || saving} />
+
+            <div className={styles.modelConfigSection}>
+              <div className={styles.modelConfigHeader}>
+                <label className={styles.modelConfigTitle}>{t('ai_providers.codex_models_label')}</label>
+                <div className={styles.modelConfigToolbar}>
+                  <Button variant="secondary" size="sm"
+                    onClick={() => setForm((prev) => ({ ...prev, modelEntries: [...prev.modelEntries, { name: '', alias: '' }] }))}
+                    disabled={disabled || saving}>
+                    {t('ai_providers.codex_models_add_btn')}
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={() => setModelDiscoveryOpen(true)} disabled={!canOpenModelDiscovery}>
+                    {t('ai_providers.codex_models_fetch_button')}
+                  </Button>
+                </div>
+              </div>
+              <div className={styles.sectionHint}>{t('ai_providers.codex_models_hint')}</div>
+              <ModelInputList entries={form.modelEntries}
+                onChange={(entries) => setForm((prev) => ({ ...prev, modelEntries: entries }))}
+                namePlaceholder={t('common.model_name_placeholder')} aliasPlaceholder={t('common.model_alias_placeholder')}
+                disabled={disabled || saving} hideAddButton
+                className={styles.modelInputList} rowClassName={styles.modelInputRow} inputClassName={styles.modelInputField}
+                removeButtonClassName={styles.modelRowRemoveButton}
+                removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')} />
+            </div>
+
+            <div className="form-group">
+              <label>{t('ai_providers.codex_websockets_label')}</label>
+              <ToggleSwitch checked={Boolean(form.websockets)}
+                onChange={(value) => setForm((prev) => ({ ...prev, websockets: value }))}
+                disabled={disabled || saving} ariaLabel={t('ai_providers.codex_websockets_label')} />
+              <div className="hint">{t('ai_providers.codex_websockets_hint')}</div>
+            </div>
+
+            <div className="form-group">
+              <label>{t('ai_providers.excluded_models_label')}</label>
+              <textarea className="input" placeholder={t('ai_providers.excluded_models_placeholder')}
+                value={form.excludedText} onChange={(e) => setForm((prev) => ({ ...prev, excludedText: e.target.value }))}
+                rows={4} disabled={disabled || saving} />
+              <div className="hint">{t('ai_providers.excluded_models_hint')}</div>
+            </div>
+
+            <Modal open={modelDiscoveryOpen} title={t('ai_providers.codex_models_fetch_title')}
+              onClose={() => setModelDiscoveryOpen(false)} width={720}
+              footer={
+                <>
+                  <Button variant="secondary" size="sm" onClick={() => setModelDiscoveryOpen(false)} disabled={modelDiscoveryFetching}>
+                    {t('common.cancel')}
+                  </Button>
+                  <Button size="sm" onClick={() => { const selectedModels = discoveredModels.filter((m) => modelDiscoverySelected.has(m.name)); mergeDiscoveredModels(selectedModels); setModelDiscoveryOpen(false); }}
+                    disabled={!canApplyModelDiscovery}>
+                    {t('ai_providers.codex_models_fetch_apply')}
+                  </Button>
+                </>
+              }>
+              <div className={styles.openaiModelsContent}>
+                <div className={styles.sectionHint}>{t('ai_providers.codex_models_fetch_hint')}</div>
+                <Input label={t('ai_providers.codex_models_search_label')} placeholder={t('ai_providers.codex_models_search_placeholder')}
+                  value={modelDiscoverySearch} onChange={(e) => setModelDiscoverySearch(e.target.value)} disabled={modelDiscoveryFetching} />
+                {modelDiscoveryError && <div className="error-box">{modelDiscoveryError}</div>}
+                {modelDiscoveryFetching ? <div className={styles.sectionHint}>{t('ai_providers.codex_models_fetch_loading')}</div>
+                  : discoveredModels.length === 0 ? <div className={styles.sectionHint}>{t('ai_providers.codex_models_fetch_empty')}</div>
+                    : (
+                      <div className={styles.modelDiscoveryList}>
+                        {discoveredModelsFiltered.map((model) => {
+                          const checked = modelDiscoverySelected.has(model.name);
+                          return (
+                            <SelectionCheckbox key={model.name} checked={checked}
+                              onChange={() => {
+                                setModelDiscoverySelected((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(model.name)) next.delete(model.name);
+                                  else next.add(model.name);
+                                  return next;
+                                });
+                              }}
+                              disabled={disabled || saving || modelDiscoveryFetching} ariaLabel={model.name}
+                              className={`${styles.modelDiscoveryRow} ${checked ? styles.modelDiscoveryRowSelected : ''}`}
+                              labelClassName={styles.modelDiscoverySelectionLabel}
+                              label={
+                                <div className={styles.modelDiscoveryMeta}>
+                                  <div className={styles.modelDiscoveryName}>
+                                    {model.name}
+                                    {model.alias && <span className={styles.modelDiscoveryAlias}>{model.alias}</span>}
+                                  </div>
+                                  {model.description && <div className={styles.modelDiscoveryDesc}>{model.description}</div>}
+                                </div>
+                              } />
+                          );
+                        })}
+                      </div>
+                    )}
+              </div>
+            </Modal>
+          </>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/providers/ProviderEditDrawer/GeminiEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/GeminiEditDrawer.tsx
@@ -1,0 +1,410 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { Drawer } from '@/components/ui/Drawer';
+import { Input } from '@/components/ui/Input';
+import { HeaderInputList } from '@/components/ui/HeaderInputList';
+import { ModelInputList } from '@/components/ui/ModelInputList';
+import { Modal } from '@/components/ui/Modal';
+import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
+import { modelsApi, providersApi } from '@/services/api';
+import { useConfigStore, useNotificationStore } from '@/stores';
+import type { GeminiKeyConfig } from '@/types';
+import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import { areKeyValueEntriesEqual, areModelEntriesEqual, areStringArraysEqual } from '@/utils/compare';
+import type { ModelInfo } from '@/utils/models';
+import { entriesToModels, modelsToEntries } from '@/components/ui/modelInputListUtils';
+import { excludedModelsToText, parseExcludedModels } from '@/components/providers/utils';
+import type { GeminiFormState } from '@/components/providers';
+import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
+
+interface GeminiEditDrawerProps {
+  open: boolean;
+  editIndex: number | null;
+  disabled: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+type GeminiFormBaseline = ReturnType<typeof buildGeminiBaseline>;
+
+const buildEmptyForm = (): GeminiFormState => ({
+  apiKey: '',
+  priority: undefined,
+  prefix: '',
+  baseUrl: '',
+  proxyUrl: '',
+  headers: [],
+  modelEntries: [{ name: '', alias: '' }],
+  excludedModels: [],
+  excludedText: '',
+});
+
+const stripGeminiModelResourceName = (value: string) =>
+  String(value ?? '').trim().replace(/^\/?models\//i, '');
+
+const normalizeModelEntries = (entries: Array<{ name: string; alias: string }>) =>
+  (entries ?? []).reduce<Array<{ name: string; alias: string }>>((acc, entry) => {
+    const name = stripGeminiModelResourceName(entry?.name ?? '').trim();
+    let alias = String(entry?.alias ?? '').trim();
+    if (name && alias === name) alias = '';
+    if (!name && !alias) return acc;
+    acc.push({ name, alias });
+    return acc;
+  }, []);
+
+const buildGeminiBaseline = (form: GeminiFormState) => ({
+  apiKey: String(form.apiKey ?? '').trim(),
+  authIndex: normalizeAuthIndex(form.authIndex) ?? '',
+  priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null,
+  prefix: String(form.prefix ?? '').trim(),
+  baseUrl: String(form.baseUrl ?? '').trim(),
+  proxyUrl: String(form.proxyUrl ?? '').trim(),
+  headers: normalizeHeaderEntries(form.headers),
+  models: normalizeModelEntries(form.modelEntries),
+  excludedModels: parseExcludedModels(form.excludedText ?? ''),
+});
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '';
+};
+
+export function GeminiEditDrawer({ open, editIndex, disabled, onClose, onSaved }: GeminiEditDrawerProps) {
+  const { t } = useTranslation();
+  const { showNotification } = useNotificationStore();
+  const fetchConfig = useConfigStore((state) => state.fetchConfig);
+  const updateConfigValue = useConfigStore((state) => state.updateConfigValue);
+  const clearCache = useConfigStore((state) => state.clearCache);
+
+  const [configs, setConfigs] = useState<GeminiKeyConfig[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState<GeminiFormState>(buildEmptyForm);
+  const [baseline, setBaseline] = useState<GeminiFormBaseline>(buildGeminiBaseline(buildEmptyForm()));
+  const [loaded, setLoaded] = useState(false);
+
+  const [modelDiscoveryOpen, setModelDiscoveryOpen] = useState(false);
+  const [modelDiscoveryFetching, setModelDiscoveryFetching] = useState(false);
+  const [modelDiscoveryError, setModelDiscoveryError] = useState('');
+  const [discoveredModels, setDiscoveredModels] = useState<ModelInfo[]>([]);
+  const [modelDiscoverySearch, setModelDiscoverySearch] = useState('');
+  const [modelDiscoverySelected, setModelDiscoverySelected] = useState<Set<string>>(new Set());
+
+  const initialData = useMemo(() => {
+    if (editIndex === null) return undefined;
+    return configs[editIndex];
+  }, [configs, editIndex]);
+  const invalidIndex = editIndex !== null && !initialData;
+
+  const title = editIndex !== null ? t('ai_providers.gemini_edit_modal_title') : t('ai_providers.gemini_add_modal_title');
+
+  // Load configs on open
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    fetchConfig('gemini-api-key')
+      .then((value) => {
+        if (cancelled) return;
+        setConfigs(Array.isArray(value) ? (value as GeminiKeyConfig[]) : []);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(getErrorMessage(err) || t('notification.refresh_failed'));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        setLoaded(true);
+      });
+    return () => { cancelled = true; };
+  }, [open, fetchConfig, t]);
+
+  // Init form when configs loaded
+  useEffect(() => {
+    if (!open || !loaded) return;
+    if (initialData) {
+      const { headers, models, ...rest } = initialData;
+      const nextForm: GeminiFormState = {
+        ...rest,
+        headers: headersToEntries(headers),
+        modelEntries: modelsToEntries(models).map((entry) => ({ ...entry, name: stripGeminiModelResourceName(entry.name) })),
+        excludedText: excludedModelsToText(initialData.excludedModels),
+      };
+      setForm(nextForm);
+      setBaseline(buildGeminiBaseline(nextForm));
+    } else {
+      const nextForm = buildEmptyForm();
+      setForm(nextForm);
+      setBaseline(buildGeminiBaseline(nextForm));
+    }
+  }, [open, loaded, initialData]);
+
+  const canSave = !disabled && !saving && !loading && !invalidIndex;
+
+  const isDirty = useMemo(() => {
+    const normalizedPriority = form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null;
+    return (
+      baseline.apiKey !== form.apiKey.trim() ||
+      baseline.authIndex !== (normalizeAuthIndex(form.authIndex) ?? '') ||
+      baseline.priority !== normalizedPriority ||
+      baseline.prefix !== String(form.prefix ?? '').trim() ||
+      baseline.baseUrl !== String(form.baseUrl ?? '').trim() ||
+      baseline.proxyUrl !== String(form.proxyUrl ?? '').trim() ||
+      !areKeyValueEntriesEqual(baseline.headers, normalizeHeaderEntries(form.headers)) ||
+      !areModelEntriesEqual(baseline.models, normalizeModelEntries(form.modelEntries)) ||
+      !areStringArraysEqual(baseline.excludedModels, parseExcludedModels(form.excludedText ?? ''))
+    );
+  }, [baseline, form]);
+
+  const discoveredModelsFiltered = useMemo(() => {
+    const filter = modelDiscoverySearch.trim().toLowerCase();
+    if (!filter) return discoveredModels;
+    return discoveredModels.filter((model) => {
+      const name = (model.name || '').toLowerCase();
+      const alias = (model.alias || '').toLowerCase();
+      const description = (model.description || '').toLowerCase();
+      return name.includes(filter) || alias.includes(filter) || description.includes(filter);
+    });
+  }, [discoveredModels, modelDiscoverySearch]);
+
+  const mergeDiscoveredModels = useCallback((selectedModels: ModelInfo[]) => {
+    if (!selectedModels.length) return;
+    let addedCount = 0;
+    setForm((prev) => {
+      const mergedMap = new Map<string, { name: string; alias: string }>();
+      prev.modelEntries.forEach((entry) => {
+        const name = stripGeminiModelResourceName(entry.name);
+        if (!name) return;
+        mergedMap.set(name, { name, alias: entry.alias?.trim() || '' });
+      });
+      selectedModels.forEach((model) => {
+        const name = stripGeminiModelResourceName(model.name);
+        if (!name || mergedMap.has(name)) return;
+        mergedMap.set(name, { name, alias: model.alias ?? '' });
+        addedCount += 1;
+      });
+      const mergedEntries = Array.from(mergedMap.values());
+      return { ...prev, modelEntries: mergedEntries.length ? mergedEntries : [{ name: '', alias: '' }] };
+    });
+    if (addedCount > 0) {
+      showNotification(t('ai_providers.gemini_models_fetch_added', { count: addedCount }), 'success');
+    }
+  }, [showNotification, t]);
+
+  const fetchModelDiscovery = useCallback(async () => {
+    setModelDiscoveryFetching(true);
+    setModelDiscoveryError('');
+    const headerObject = buildHeaderObject(form.headers);
+    try {
+      const list = await modelsApi.fetchGeminiModelsViaApiCall(
+        form.baseUrl ?? '', form.apiKey.trim() || undefined, headerObject,
+        normalizeAuthIndex(form.authIndex) ?? undefined
+      );
+      setDiscoveredModels(list);
+    } catch (err: unknown) {
+      setDiscoveredModels([]);
+      setModelDiscoveryError(`${t('ai_providers.gemini_models_fetch_error')}: ${getErrorMessage(err)}`);
+    } finally {
+      setModelDiscoveryFetching(false);
+    }
+  }, [form.apiKey, form.authIndex, form.baseUrl, form.headers, t]);
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    const apiKey = form.apiKey.trim();
+    if (!apiKey && !normalizeAuthIndex(form.authIndex)) {
+      showNotification(t('ai_providers.gemini_key_required', { defaultValue: 'Please enter a Gemini API Key' }), 'error');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      const normalizedModelEntries = form.modelEntries.map((entry) => ({ ...entry, name: stripGeminiModelResourceName(entry.name) }));
+      const payload: GeminiKeyConfig = {
+        apiKey: form.apiKey.trim(),
+        priority: form.priority !== undefined ? Math.trunc(form.priority) : undefined,
+        prefix: form.prefix?.trim() || undefined,
+        baseUrl: form.baseUrl?.trim() || undefined,
+        proxyUrl: form.proxyUrl?.trim() || undefined,
+        headers: buildHeaderObject(form.headers),
+        models: entriesToModels(normalizedModelEntries),
+        excludedModels: parseExcludedModels(form.excludedText),
+        authIndex: normalizeAuthIndex(form.authIndex) ?? undefined,
+      };
+      const nextList = editIndex !== null
+        ? configs.map((item, idx) => (idx === editIndex ? payload : item))
+        : [...configs, payload];
+      await providersApi.saveGeminiKeys(nextList);
+      updateConfigValue('gemini-api-key', nextList);
+      clearCache('gemini-api-key');
+      showNotification(editIndex !== null ? t('notification.gemini_key_updated') : t('notification.gemini_key_added'), 'success');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+      showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, clearCache, configs, editIndex, form, onClose, onSaved, showNotification, t, updateConfigValue]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty && !saving) {
+      if (!window.confirm(t('common.unsaved_changes_message'))) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving, t]);
+
+  useEffect(() => {
+    if (!modelDiscoveryOpen) return;
+    setDiscoveredModels([]);
+    setModelDiscoverySearch('');
+    setModelDiscoverySelected(new Set());
+    setModelDiscoveryError('');
+    void fetchModelDiscovery();
+  }, [modelDiscoveryOpen, fetchModelDiscovery]);
+
+  const toggleModelDiscoverySelection = (name: string) => {
+    setModelDiscoverySelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const canOpenModelDiscovery = !disabled && !saving && !loading && !invalidIndex;
+  const canApplyModelDiscovery = !disabled && !saving && !modelDiscoveryFetching && modelDiscoverySelected.size > 0;
+
+  const footer = (
+    <>
+      <Button variant="secondary" size="sm" onClick={handleClose} disabled={saving}>
+        {t('common.cancel')}
+      </Button>
+      <Button size="sm" onClick={handleSave} loading={saving} disabled={!canSave}>
+        {t('common.save')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Drawer open={open} onClose={handleClose} width={820} footer={footer} title={title}>
+      <div className={styles.openaiEditForm}>
+        {error && <div className="error-box">{error}</div>}
+        {loading && <div className={styles.sectionHint}>{t('common.loading')}</div>}
+        {invalidIndex && <div className="hint">{t('common.invalid_provider_index')}</div>}
+        {!loading && !invalidIndex && (
+          <>
+            <Input label={t('ai_providers.gemini_add_modal_key_label')}
+              placeholder={t('ai_providers.gemini_add_modal_key_placeholder')}
+              value={form.apiKey} onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
+              disabled={disabled || saving} required />
+            <Input label={t('ai_providers.gemini_base_url_label')} placeholder={t('ai_providers.gemini_base_url_placeholder')}
+              value={form.baseUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
+              disabled={disabled || saving} />
+            <Input label={t('ai_providers.priority_label')} hint={t('ai_providers.priority_hint')}
+              type="number" step={1} value={form.priority ?? ''}
+              onChange={(e) => { const raw = e.target.value; const parsed = raw.trim() === '' ? undefined : Number(raw); setForm((prev) => ({ ...prev, priority: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined })); }}
+              disabled={disabled || saving} />
+            <Input label={t('ai_providers.prefix_label')} placeholder={t('ai_providers.prefix_placeholder')}
+              value={form.prefix ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
+              hint={t('ai_providers.prefix_hint')} disabled={disabled || saving} />
+            <Input label={t('ai_providers.gemini_add_modal_proxy_label')} placeholder={t('ai_providers.gemini_add_modal_proxy_placeholder')}
+              value={form.proxyUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, proxyUrl: e.target.value }))}
+              disabled={disabled || saving} />
+            <HeaderInputList entries={form.headers}
+              onChange={(entries) => setForm((prev) => ({ ...prev, headers: entries }))}
+              addLabel={t('common.custom_headers_add')} keyPlaceholder={t('common.custom_headers_key_placeholder')}
+              valuePlaceholder={t('common.custom_headers_value_placeholder')}
+              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+              disabled={disabled || saving} />
+
+            <div className={styles.modelConfigSection}>
+              <div className={styles.modelConfigHeader}>
+                <label className={styles.modelConfigTitle}>{t('ai_providers.gemini_models_label')}</label>
+                <div className={styles.modelConfigToolbar}>
+                  <Button variant="secondary" size="sm"
+                    onClick={() => setForm((prev) => ({ ...prev, modelEntries: [...prev.modelEntries, { name: '', alias: '' }] }))}
+                    disabled={disabled || saving}>
+                    {t('ai_providers.gemini_models_add_btn')}
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={() => setModelDiscoveryOpen(true)} disabled={!canOpenModelDiscovery}>
+                    {t('ai_providers.gemini_models_fetch_button')}
+                  </Button>
+                </div>
+              </div>
+              <div className={styles.sectionHint}>{t('ai_providers.gemini_models_hint')}</div>
+              <ModelInputList entries={form.modelEntries}
+                onChange={(entries) => setForm((prev) => ({ ...prev, modelEntries: entries }))}
+                namePlaceholder={t('common.model_name_placeholder')} aliasPlaceholder={t('common.model_alias_placeholder')}
+                disabled={disabled || saving} hideAddButton
+                className={styles.modelInputList} rowClassName={styles.modelInputRow} inputClassName={styles.modelInputField}
+                removeButtonClassName={styles.modelRowRemoveButton}
+                removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')} />
+            </div>
+
+            <div className="form-group">
+              <label>{t('ai_providers.excluded_models_label')}</label>
+              <textarea className="input" placeholder={t('ai_providers.excluded_models_placeholder')}
+                value={form.excludedText} onChange={(e) => setForm((prev) => ({ ...prev, excludedText: e.target.value }))}
+                rows={4} disabled={disabled || saving} />
+              <div className="hint">{t('ai_providers.excluded_models_hint')}</div>
+            </div>
+
+            <Modal open={modelDiscoveryOpen} title={t('ai_providers.gemini_models_fetch_title')}
+              onClose={() => setModelDiscoveryOpen(false)} width={720}
+              footer={
+                <>
+                  <Button variant="secondary" size="sm" onClick={() => setModelDiscoveryOpen(false)} disabled={modelDiscoveryFetching}>
+                    {t('common.cancel')}
+                  </Button>
+                  <Button size="sm" onClick={() => { const selectedModels = discoveredModels.filter((m) => modelDiscoverySelected.has(m.name)); mergeDiscoveredModels(selectedModels); setModelDiscoveryOpen(false); }}
+                    disabled={!canApplyModelDiscovery}>
+                    {t('ai_providers.gemini_models_fetch_apply')}
+                  </Button>
+                </>
+              }>
+              <div className={styles.openaiModelsContent}>
+                <div className={styles.sectionHint}>{t('ai_providers.gemini_models_fetch_hint')}</div>
+                <Input label={t('ai_providers.gemini_models_search_label')} placeholder={t('ai_providers.gemini_models_search_placeholder')}
+                  value={modelDiscoverySearch} onChange={(e) => setModelDiscoverySearch(e.target.value)} disabled={modelDiscoveryFetching} />
+                {modelDiscoveryError && <div className="error-box">{modelDiscoveryError}</div>}
+                {modelDiscoveryFetching ? <div className={styles.sectionHint}>{t('ai_providers.gemini_models_fetch_loading')}</div>
+                  : discoveredModelsFiltered.length === 0 ? <div className={styles.sectionHint}>{t('ai_providers.gemini_models_fetch_empty')}</div>
+                    : (
+                      <div className={styles.modelDiscoveryList}>
+                        {discoveredModelsFiltered.map((model) => {
+                          const checked = modelDiscoverySelected.has(model.name);
+                          return (
+                            <SelectionCheckbox key={model.name} checked={checked}
+                              onChange={() => toggleModelDiscoverySelection(model.name)}
+                              disabled={disabled || saving || modelDiscoveryFetching} ariaLabel={model.name}
+                              className={`${styles.modelDiscoveryRow} ${checked ? styles.modelDiscoveryRowSelected : ''}`}
+                              labelClassName={styles.modelDiscoverySelectionLabel}
+                              label={
+                                <div className={styles.modelDiscoveryMeta}>
+                                  <div className={styles.modelDiscoveryName}>
+                                    {model.name}
+                                    {model.alias && <span className={styles.modelDiscoveryAlias}>{model.alias}</span>}
+                                  </div>
+                                  {model.description && <div className={styles.modelDiscoveryDesc}>{model.description}</div>}
+                                </div>
+                              } />
+                          );
+                        })}
+                      </div>
+                    )}
+              </div>
+            </Modal>
+          </>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.tsx
@@ -1,0 +1,662 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { Drawer } from '@/components/ui/Drawer';
+import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
+import { HeaderInputList } from '@/components/ui/HeaderInputList';
+import { ModelInputList } from '@/components/ui/ModelInputList';
+import { Modal } from '@/components/ui/Modal';
+import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
+import { apiCallApi, getApiCallErrorMessage, modelsApi, providersApi } from '@/services/api';
+import { useConfigStore, useNotificationStore } from '@/stores';
+import type { ApiKeyEntry, OpenAIProviderConfig } from '@/types';
+import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import { areKeyValueEntriesEqual, areModelEntriesEqual } from '@/utils/compare';
+import { entriesToModels, modelsToEntries } from '@/components/ui/modelInputListUtils';
+import { buildApiKeyEntry, buildOpenAIChatCompletionsEndpoint } from '@/components/providers/utils';
+import type { ModelInfo } from '@/utils/models';
+import type { OpenAIFormState } from '@/components/providers';
+import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
+
+interface OpenAIEditDrawerProps {
+  open: boolean;
+  editIndex: number | null;
+  disabled: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+type OpenAIFormBaseline = ReturnType<typeof buildOpenAIBaseline>;
+
+const OPENAI_TEST_TIMEOUT_MS = 30_000;
+
+const buildEmptyForm = (): OpenAIFormState => ({
+  name: '',
+  priority: undefined,
+  prefix: '',
+  baseUrl: '',
+  headers: [],
+  apiKeyEntries: [buildApiKeyEntry()],
+  modelEntries: [{ name: '', alias: '' }],
+  testModel: undefined,
+});
+
+const normalizeModelEntries = (entries: Array<{ name: string; alias: string }>) =>
+  (entries ?? []).reduce<Array<{ name: string; alias: string }>>((acc, entry) => {
+    const name = String(entry?.name ?? '').trim();
+    let alias = String(entry?.alias ?? '').trim();
+    if (name && (alias === '' || alias === name)) alias = '';
+    if (!name && !alias) return acc;
+    acc.push({ name, alias });
+    return acc;
+  }, []);
+
+const normalizeKeyHeaders = (headers: ApiKeyEntry['headers']) => {
+  if (!headers || typeof headers !== 'object') return [];
+  return Object.entries(headers)
+    .map(([key, value]) => ({ key: String(key ?? '').trim(), value: String(value ?? '').trim() }))
+    .filter((entry) => entry.key || entry.value)
+    .sort((a, b) => { const byKey = a.key.toLowerCase().localeCompare(b.key.toLowerCase()); return byKey !== 0 ? byKey : a.value.localeCompare(b.value); });
+};
+
+const normalizeApiKeyEntries = (entries: ApiKeyEntry[]) =>
+  (entries ?? []).reduce<Array<{ apiKey: string; proxyUrl: string; authIndex: string; headers: ReturnType<typeof normalizeKeyHeaders> }>>((acc, entry) => {
+    const apiKey = String(entry?.apiKey ?? '').trim();
+    const proxyUrl = String(entry?.proxyUrl ?? '').trim();
+    const authIndex = normalizeAuthIndex(entry?.authIndex) ?? '';
+    const headers = normalizeKeyHeaders(entry?.headers);
+    if (!apiKey && !proxyUrl && !authIndex && headers.length === 0) return acc;
+    acc.push({ apiKey, proxyUrl, authIndex, headers });
+    return acc;
+  }, []);
+
+const buildOpenAIBaseline = (form: OpenAIFormState) => ({
+  name: String(form.name ?? '').trim(),
+  priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null,
+  prefix: String(form.prefix ?? '').trim(),
+  baseUrl: String(form.baseUrl ?? '').trim(),
+  headers: normalizeHeaderEntries(form.headers),
+  apiKeyEntries: normalizeApiKeyEntries(form.apiKeyEntries),
+  models: normalizeModelEntries(form.modelEntries),
+});
+
+const areNormalizedApiKeyEntriesEqual = (a: ReturnType<typeof normalizeApiKeyEntries>, b: ReturnType<typeof normalizeApiKeyEntries>) => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i];
+    const right = b[i];
+    if (!left || !right) return false;
+    if (left.apiKey !== right.apiKey || left.proxyUrl !== right.proxyUrl || left.authIndex !== right.authIndex) return false;
+    if (!areKeyValueEntriesEqual(left.headers, right.headers)) return false;
+  }
+  return true;
+};
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '';
+};
+
+const hasHeader = (headers: Record<string, string>, name: string) => {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === target);
+};
+
+function StatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case 'loading': return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none" className={styles.statusIconSpin}><circle cx="8" cy="8" r="7" stroke="currentColor" strokeOpacity="0.25" strokeWidth="2" /><path d="M8 1A7 7 0 0 1 8 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" /></svg>);
+    case 'success': return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="8" fill="var(--success-color, #22c55e)" /><path d="M4.5 8L7 10.5L11.5 6" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>);
+    case 'error': return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="8" fill="var(--danger-color, #f56c6c)" /><path d="M5 5L11 11M11 5L5 11" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>);
+    default: return (<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="var(--text-tertiary, #9ca3af)" strokeWidth="2" /></svg>);
+  }
+}
+
+export function OpenAIEditDrawer({ open, editIndex, disabled, onClose, onSaved }: OpenAIEditDrawerProps) {
+  const { t } = useTranslation();
+  const { showNotification } = useNotificationStore();
+  const config = useConfigStore((state) => state.config);
+  const updateConfigValue = useConfigStore((state) => state.updateConfigValue);
+
+  const [providers, setProviders] = useState<OpenAIProviderConfig[]>(() => config?.openaiCompatibility ?? []);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState<OpenAIFormState>(buildEmptyForm);
+  const [baseline, setBaseline] = useState<OpenAIFormBaseline>(buildOpenAIBaseline(buildEmptyForm()));
+  const [loaded, setLoaded] = useState(false);
+  const [isTestingKeys, setIsTestingKeys] = useState(false);
+  const [testModel, setTestModel] = useState('');
+  const [testStatus, setTestStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [testMessage, setTestMessage] = useState('');
+  const [keyTestStatuses, setKeyTestStatuses] = useState<Array<{ status: string; message: string }>>([]);
+
+  const [modelDiscoveryOpen, setModelDiscoveryOpen] = useState(false);
+  const [modelDiscoveryFetching, setModelDiscoveryFetching] = useState(false);
+  const [modelDiscoveryError, setModelDiscoveryError] = useState('');
+  const [discoveredModels, setDiscoveredModels] = useState<ModelInfo[]>([]);
+  const [modelDiscoverySearch, setModelDiscoverySearch] = useState('');
+  const [modelDiscoverySelected, setModelDiscoverySelected] = useState<Set<string>>(new Set());
+
+  const initialData = useMemo(() => {
+    if (editIndex === null) return undefined;
+    return providers[editIndex];
+  }, [editIndex, providers]);
+  const invalidIndex = editIndex !== null && !initialData;
+
+  const title = editIndex !== null ? t('ai_providers.openai_edit_modal_title') : t('ai_providers.openai_add_modal_title');
+
+  const availableModels = useMemo(() => form.modelEntries.map((e) => e.name.trim()).filter(Boolean), [form.modelEntries]);
+  const hasConfiguredModels = form.modelEntries.some((entry) => entry.name.trim());
+  const hasTestableKeys = form.apiKeyEntries.some((entry) => entry.apiKey?.trim() || normalizeAuthIndex(entry.authIndex));
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    providersApi.getOpenAIProviders()
+      .then((value) => {
+        if (cancelled) return;
+        const nextProviders = value || [];
+        setProviders(nextProviders);
+        updateConfigValue('openai-compatibility', nextProviders);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(getErrorMessage(err) || t('notification.refresh_failed'));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        setLoaded(true);
+      });
+    return () => { cancelled = true; };
+  }, [open, t, updateConfigValue]);
+
+  useEffect(() => {
+    if (!open || !loaded) return;
+    if (initialData) {
+      const modelEntries = modelsToEntries(initialData.models);
+      const seededForm: OpenAIFormState = {
+        name: initialData.name,
+        priority: initialData.priority,
+        prefix: initialData.prefix ?? '',
+        baseUrl: initialData.baseUrl,
+        headers: headersToEntries(initialData.headers),
+        modelEntries,
+        apiKeyEntries: initialData.apiKeyEntries?.length ? initialData.apiKeyEntries : [buildApiKeyEntry()],
+      };
+      setForm(seededForm);
+      setBaseline(buildOpenAIBaseline(seededForm));
+      const available = modelEntries.map((e) => e.name.trim()).filter(Boolean);
+      const initialTestModel = initialData.testModel && available.includes(initialData.testModel) ? initialData.testModel : available[0] || '';
+      setTestModel(initialTestModel);
+    } else {
+      const emptyForm = buildEmptyForm();
+      setForm(emptyForm);
+      setBaseline(buildOpenAIBaseline(emptyForm));
+      setTestModel('');
+    }
+    setTestStatus('idle');
+    setTestMessage('');
+    setKeyTestStatuses([]);
+  }, [open, loaded, initialData]);
+
+  useEffect(() => {
+    if (loaded && availableModels.length > 0 && (!testModel || !availableModels.includes(testModel))) {
+      setTestModel(availableModels[0]);
+    }
+  }, [availableModels, loaded, testModel]);
+
+  const canSave = !disabled && !loading && !saving && !invalidIndex && !isTestingKeys;
+
+  const isDirty = useMemo(() => {
+    const normalizedPriority = form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null;
+    return (
+      baseline.name !== form.name.trim() ||
+      baseline.priority !== normalizedPriority ||
+      baseline.prefix !== form.prefix.trim() ||
+      baseline.baseUrl !== form.baseUrl.trim() ||
+      !areKeyValueEntriesEqual(baseline.headers, normalizeHeaderEntries(form.headers)) ||
+      !areNormalizedApiKeyEntriesEqual(baseline.apiKeyEntries, normalizeApiKeyEntries(form.apiKeyEntries)) ||
+      !areModelEntriesEqual(baseline.models, normalizeModelEntries(form.modelEntries))
+    );
+  }, [baseline, form]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty && !saving) {
+      if (!window.confirm(t('common.unsaved_changes_message'))) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving, t]);
+
+  // Model discovery
+  const fetchModelDiscovery = useCallback(async () => {
+    setModelDiscoveryFetching(true);
+    setModelDiscoveryError('');
+    const headerObject = buildHeaderObject(form.headers);
+    try {
+      const firstKey = form.apiKeyEntries[0];
+      const keyAuthIndex = normalizeAuthIndex(firstKey?.authIndex) ?? undefined;
+      const list = await modelsApi.fetchModelsViaApiCall(
+        form.baseUrl.trim(), firstKey?.apiKey?.trim() || undefined, headerObject, keyAuthIndex
+      );
+      setDiscoveredModels(list);
+    } catch (err: unknown) {
+      setDiscoveredModels([]);
+      setModelDiscoveryError(`${t('ai_providers.openai_models_fetch_error')}: ${getErrorMessage(err)}`);
+    } finally {
+      setModelDiscoveryFetching(false);
+    }
+  }, [form.apiKeyEntries, form.baseUrl, form.headers, t]);
+
+  useEffect(() => {
+    if (!modelDiscoveryOpen) return;
+    setDiscoveredModels([]);
+    setModelDiscoverySearch('');
+    setModelDiscoverySelected(new Set());
+    setModelDiscoveryError('');
+    void fetchModelDiscovery();
+  }, [modelDiscoveryOpen, fetchModelDiscovery]);
+
+  const discoveredModelsFiltered = useMemo(() => {
+    const filter = modelDiscoverySearch.trim().toLowerCase();
+    if (!filter) return discoveredModels;
+    return discoveredModels.filter((model) => {
+      const name = (model.name || '').toLowerCase();
+      const alias = (model.alias || '').toLowerCase();
+      const description = (model.description || '').toLowerCase();
+      return name.includes(filter) || alias.includes(filter) || description.includes(filter);
+    });
+  }, [discoveredModels, modelDiscoverySearch]);
+
+  const mergeDiscoveredModels = useCallback((selectedModels: ModelInfo[]) => {
+    if (!selectedModels.length) return;
+    let addedCount = 0;
+    setForm((prev) => {
+      const mergedMap = new Map<string, { name: string; alias: string }>();
+      prev.modelEntries.forEach((entry) => {
+        const name = entry.name.trim();
+        if (!name) return;
+        mergedMap.set(name, { name, alias: entry.alias?.trim() || '' });
+      });
+      selectedModels.forEach((model) => {
+        const name = model.name.trim();
+        if (!name || mergedMap.has(name)) return;
+        mergedMap.set(name, { name, alias: model.alias ?? '' });
+        addedCount += 1;
+      });
+      const mergedEntries = Array.from(mergedMap.values());
+      return { ...prev, modelEntries: mergedEntries.length ? mergedEntries : [{ name: '', alias: '' }] };
+    });
+    if (addedCount > 0) showNotification(t('ai_providers.openai_models_fetch_added', { count: addedCount }), 'success');
+  }, [showNotification, t]);
+
+  // Key testing
+  const runSingleKeyTest = useCallback(async (keyIndex: number): Promise<boolean> => {
+    const baseUrl = form.baseUrl.trim();
+    if (!baseUrl) {
+      showNotification(t('notification.openai_test_url_required'), 'error');
+      return false;
+    }
+    const endpoint = buildOpenAIChatCompletionsEndpoint(baseUrl);
+    if (!endpoint) {
+      showNotification(t('notification.openai_test_url_required'), 'error');
+      return false;
+    }
+    const keyEntry = form.apiKeyEntries[keyIndex];
+    const keyAuthIndex = normalizeAuthIndex(keyEntry?.authIndex) ?? undefined;
+    if (!keyEntry?.apiKey?.trim() && !keyAuthIndex) {
+      setKeyTestStatuses((prev) => {
+        const next = [...prev];
+        next[keyIndex] = { status: 'error', message: t('notification.openai_test_key_required') };
+        return next;
+      });
+      return false;
+    }
+    const modelName = testModel.trim() || availableModels[0] || '';
+    if (!modelName) {
+      showNotification(t('notification.openai_test_model_required'), 'error');
+      return false;
+    }
+    const customHeaders = buildHeaderObject(form.headers);
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...customHeaders };
+    if (!hasHeader(headers, 'authorization')) {
+      headers.Authorization = keyAuthIndex ? 'Bearer $TOKEN$' : `Bearer ${keyEntry.apiKey.trim()}`;
+    }
+    setKeyTestStatuses((prev) => {
+      const next = [...prev];
+      next[keyIndex] = { status: 'loading', message: '' };
+      return next;
+    });
+    try {
+      const result = await apiCallApi.request({
+        authIndex: keyAuthIndex, method: 'POST', url: endpoint,
+        header: Object.keys(headers).length ? headers : undefined,
+        data: JSON.stringify({ model: modelName, messages: [{ role: 'user', content: 'Hi' }], stream: false, max_tokens: 5 }),
+      }, { timeout: OPENAI_TEST_TIMEOUT_MS });
+      if (result.statusCode < 200 || result.statusCode >= 300) throw new Error(getApiCallErrorMessage(result));
+      setKeyTestStatuses((prev) => {
+        const next = [...prev];
+        next[keyIndex] = { status: 'success', message: '' };
+        return next;
+      });
+      return true;
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      const errorCode = typeof err === 'object' && err !== null && 'code' in err ? String((err as { code?: string }).code) : '';
+      const isTimeout = errorCode === 'ECONNABORTED' || message.toLowerCase().includes('timeout');
+      setKeyTestStatuses((prev) => {
+        const next = [...prev];
+        next[keyIndex] = { status: 'error', message: isTimeout ? t('ai_providers.openai_test_timeout', { seconds: OPENAI_TEST_TIMEOUT_MS / 1000 }) : message };
+        return next;
+      });
+      return false;
+    }
+  }, [availableModels, form.apiKeyEntries, form.baseUrl, form.headers, showNotification, t, testModel]);
+
+  const testSingleKey = useCallback(async (keyIndex: number): Promise<boolean> => {
+    if (isTestingKeys) return false;
+    setIsTestingKeys(true);
+    try { return await runSingleKeyTest(keyIndex); }
+    finally { setIsTestingKeys(false); }
+  }, [isTestingKeys, runSingleKeyTest]);
+
+  const testAllKeys = useCallback(async () => {
+    if (isTestingKeys) return;
+    const baseUrl = form.baseUrl.trim();
+    if (!baseUrl) { showNotification(t('notification.openai_test_url_required'), 'error'); return; }
+    const modelName = testModel.trim() || availableModels[0] || '';
+    if (!modelName) { showNotification(t('ai_providers.openai_test_model_required'), 'error'); return; }
+    const validKeyIndexes = form.apiKeyEntries.map((entry, index) => (entry.apiKey?.trim() || normalizeAuthIndex(entry.authIndex) ? index : -1)).filter((index) => index >= 0);
+    if (validKeyIndexes.length === 0) { showNotification(t('notification.openai_test_key_required'), 'error'); return; }
+    setIsTestingKeys(true);
+    setTestStatus('loading');
+    setTestMessage(t('ai_providers.openai_test_running'));
+    setKeyTestStatuses([]);
+    try {
+      const results = await Promise.all(validKeyIndexes.map((index) => runSingleKeyTest(index)));
+      const successCount = results.filter(Boolean).length;
+      const failCount = validKeyIndexes.length - successCount;
+      if (failCount === 0) { setTestStatus('success'); setTestMessage(t('ai_providers.openai_test_all_success', { count: successCount })); }
+      else if (successCount === 0) { setTestStatus('error'); setTestMessage(t('ai_providers.openai_test_all_failed', { count: failCount })); }
+      else { setTestStatus('error'); setTestMessage(t('ai_providers.openai_test_all_partial', { success: successCount, failed: failCount })); }
+    } finally { setIsTestingKeys(false); }
+  }, [availableModels, form.apiKeyEntries, form.baseUrl, isTestingKeys, runSingleKeyTest, showNotification, t, testModel]);
+
+  const handleSave = useCallback(async () => {
+    const name = form.name.trim();
+    const baseUrl = form.baseUrl.trim();
+    if (!name || !baseUrl) { showNotification(t('notification.openai_provider_required'), 'error'); return; }
+    const hasValidKey = form.apiKeyEntries.some((entry) => entry.apiKey?.trim() || normalizeAuthIndex(entry.authIndex));
+    if (!hasValidKey) { showNotification(t('ai_providers.openai_key_required', { defaultValue: 'Please add at least one API key' }), 'error'); return; }
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const payload: OpenAIProviderConfig = {
+        name, prefix: form.prefix?.trim() || undefined, baseUrl,
+        headers: buildHeaderObject(form.headers),
+        apiKeyEntries: form.apiKeyEntries.map((entry: ApiKeyEntry) => ({
+          apiKey: entry.apiKey.trim(), proxyUrl: entry.proxyUrl?.trim() || undefined,
+          authIndex: normalizeAuthIndex(entry.authIndex) ?? undefined, headers: entry.headers,
+        })),
+      };
+      if (form.priority !== undefined && Number.isFinite(form.priority)) payload.priority = Math.trunc(form.priority);
+      if (initialData?.disabled !== undefined) payload.disabled = initialData.disabled;
+      const resolvedTestModel = testModel.trim();
+      if (resolvedTestModel) payload.testModel = resolvedTestModel;
+      const models = entriesToModels(form.modelEntries);
+      if (models.length) payload.models = models;
+      const nextList = editIndex !== null
+        ? providers.map((item, idx) => (idx === editIndex ? payload : item))
+        : [...providers, payload];
+      await providersApi.saveOpenAIProviders(nextList);
+      let syncedProviders = nextList;
+      try { syncedProviders = await providersApi.getOpenAIProviders(); } catch { /* fallback */ }
+      setProviders(syncedProviders);
+      updateConfigValue('openai-compatibility', syncedProviders);
+      showNotification(editIndex !== null ? t('notification.openai_provider_updated') : t('notification.openai_provider_added'), 'success');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+    } finally { setSaving(false); }
+  }, [canSave, editIndex, form, initialData?.disabled, onClose, onSaved, providers, showNotification, t, testModel, updateConfigValue]);
+
+  const modelSelectOptions = useMemo(() => {
+    const seen = new Set<string>();
+    return form.modelEntries.reduce<Array<{ value: string; label: string }>>((acc, entry) => {
+      const name = entry.name.trim();
+      if (!name || seen.has(name)) return acc;
+      seen.add(name);
+      const alias = entry.alias.trim();
+      acc.push({ value: name, label: alias && alias !== name ? `${name} (${alias})` : name });
+      return acc;
+    }, []);
+  }, [form.modelEntries]);
+
+  const renderKeyEntries = () => {
+    const list = form.apiKeyEntries.length ? form.apiKeyEntries : [buildApiKeyEntry()];
+    const updateEntry = (idx: number, field: keyof ApiKeyEntry, value: string) => {
+      const next = list.map((entry, i) => (i === idx ? { ...entry, [field]: value } : entry));
+      setForm((prev) => ({ ...prev, apiKeyEntries: next }));
+      setKeyTestStatuses((prev) => {
+        const nextStatuses = [...prev];
+        nextStatuses[idx] = { status: 'idle', message: '' };
+        return nextStatuses;
+      });
+    };
+    const removeEntry = (idx: number) => {
+      const next = list.filter((_, i) => i !== idx);
+      setForm((prev) => ({ ...prev, apiKeyEntries: next.length ? next : [buildApiKeyEntry()] }));
+    };
+    const addEntry = () => { setForm((prev) => ({ ...prev, apiKeyEntries: [...list, buildApiKeyEntry()] })); };
+
+    return (
+      <div className={styles.keyEntriesList}>
+        <div className={styles.keyEntriesToolbar}>
+          <span className={styles.keyEntriesCount}>{t('ai_providers.openai_keys_count')}: {list.length}</span>
+          <Button variant="secondary" size="sm" onClick={addEntry} disabled={saving || disabled || isTestingKeys} className={styles.addKeyButton}>
+            {t('ai_providers.openai_keys_add_btn')}
+          </Button>
+        </div>
+        <div className={styles.keyTableShell}>
+          <div className={styles.keyTableHeader}>
+            <div className={styles.keyTableColIndex}>#</div>
+            <div className={styles.keyTableColStatus}>{t('common.status')}</div>
+            <div className={styles.keyTableColKey}>{t('common.api_key')}</div>
+            <div className={styles.keyTableColProxy}>{t('common.proxy_url')}</div>
+            <div className={styles.keyTableColAction}>{t('common.action')}</div>
+          </div>
+          {list.map((entry, index) => {
+            const keyStatus = keyTestStatuses[index]?.status ?? 'idle';
+            const canTestKey = Boolean(entry.apiKey?.trim() || normalizeAuthIndex(entry.authIndex)) && hasConfiguredModels;
+            return (
+              <div key={index} className={styles.keyTableRow}>
+                <div className={styles.keyTableColIndex}>{index + 1}</div>
+                <div className={styles.keyTableColStatus} title={keyTestStatuses[index]?.message || ''}><StatusIcon status={keyStatus} /></div>
+                <div className={styles.keyTableColKey}>
+                  <input type="text" value={entry.apiKey} onChange={(e) => updateEntry(index, 'apiKey', e.target.value)}
+                    disabled={saving || disabled || isTestingKeys} className={`input ${styles.keyTableInput}`} placeholder={t('ai_providers.openai_key_placeholder')} />
+                </div>
+                <div className={styles.keyTableColProxy}>
+                  <input type="text" value={entry.proxyUrl ?? ''} onChange={(e) => updateEntry(index, 'proxyUrl', e.target.value)}
+                    disabled={saving || disabled || isTestingKeys} className={`input ${styles.keyTableInput}`} placeholder={t('ai_providers.openai_proxy_placeholder')} />
+                </div>
+                <div className={styles.keyTableColAction}>
+                  <Button variant="secondary" size="xs" onClick={() => void testSingleKey(index)}
+                    disabled={saving || disabled || isTestingKeys || !canTestKey} loading={keyStatus === 'loading'}>
+                    {t('ai_providers.openai_test_single_action')}
+                  </Button>
+                  <Button variant="ghost" size="xs" onClick={() => removeEntry(index)}
+                    disabled={saving || disabled || isTestingKeys || list.length <= 1}>
+                    {t('common.delete')}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  const canOpenModelDiscovery = !disabled && !saving && !isTestingKeys && Boolean(form.baseUrl?.trim());
+  const canApplyModelDiscovery = !disabled && !saving && !modelDiscoveryFetching && modelDiscoverySelected.size > 0;
+
+  const footer = (
+    <>
+      <Button variant="secondary" size="sm" onClick={handleClose} disabled={saving || isTestingKeys}>
+        {t('common.cancel')}
+      </Button>
+      <Button size="sm" onClick={handleSave} loading={saving} disabled={!canSave}>
+        {t('common.save')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Drawer open={open} onClose={handleClose} width={820} footer={footer} title={title}>
+      <div className={styles.openaiEditForm}>
+        {error && <div className="error-box">{error}</div>}
+        {loading && <div className={styles.sectionHint}>{t('common.loading')}</div>}
+        {invalidIndex && <div className={styles.sectionHint}>{t('common.invalid_provider_index')}</div>}
+        {!loading && !invalidIndex && (
+          <>
+            <Input label={t('ai_providers.openai_add_modal_name_label')} value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              disabled={saving || disabled || isTestingKeys} required />
+            <Input label={t('ai_providers.openai_add_modal_url_label')} value={form.baseUrl}
+              onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
+              disabled={saving || disabled || isTestingKeys} required />
+            <Input label={t('ai_providers.priority_label')} hint={t('ai_providers.priority_hint')}
+              type="number" step={1} value={form.priority ?? ''}
+              onChange={(e) => { const raw = e.target.value; const parsed = raw.trim() === '' ? undefined : Number(raw); setForm((prev) => ({ ...prev, priority: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined })); }}
+              disabled={saving || disabled || isTestingKeys} />
+            <Input label={t('ai_providers.prefix_label')} placeholder={t('ai_providers.prefix_placeholder')}
+              value={form.prefix ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
+              hint={t('ai_providers.prefix_hint')} disabled={saving || disabled || isTestingKeys} />
+            <HeaderInputList entries={form.headers}
+              onChange={(entries) => setForm((prev) => ({ ...prev, headers: entries }))}
+              addLabel={t('common.custom_headers_add')} keyPlaceholder={t('common.custom_headers_key_placeholder')}
+              valuePlaceholder={t('common.custom_headers_value_placeholder')}
+              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+              disabled={saving || disabled || isTestingKeys} />
+
+            <div className={styles.keyEntriesSection}>
+              <div className={styles.keyEntriesHeader}>
+                <label className={styles.keyEntriesTitle}>{t('ai_providers.openai_add_modal_keys_label')}</label>
+                <span className={styles.keyEntriesHint}>{t('ai_providers.openai_keys_hint')}</span>
+              </div>
+              {renderKeyEntries()}
+            </div>
+
+            <div className={styles.modelConfigSection}>
+              <div className={styles.modelConfigHeader}>
+                <label className={styles.modelConfigTitle}>
+                  {editIndex !== null ? t('ai_providers.openai_edit_modal_models_label') : t('ai_providers.openai_add_modal_models_label')}
+                </label>
+                <div className={styles.modelConfigToolbar}>
+                  <Button variant="secondary" size="sm"
+                    onClick={() => setForm((prev) => ({ ...prev, modelEntries: [...prev.modelEntries, { name: '', alias: '' }] }))}
+                    disabled={saving || disabled || isTestingKeys}>
+                    {t('ai_providers.openai_models_add_btn')}
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={() => setModelDiscoveryOpen(true)} disabled={!canOpenModelDiscovery}>
+                    {t('ai_providers.openai_models_fetch_button')}
+                  </Button>
+                </div>
+              </div>
+              <div className={styles.sectionHint}>{t('ai_providers.openai_models_hint')}</div>
+              <ModelInputList entries={form.modelEntries}
+                onChange={(entries) => setForm((prev) => ({ ...prev, modelEntries: entries }))}
+                namePlaceholder={t('common.model_name_placeholder')} aliasPlaceholder={t('common.model_alias_placeholder')}
+                disabled={saving || disabled || isTestingKeys} hideAddButton
+                className={styles.modelInputList} rowClassName={styles.modelInputRow} inputClassName={styles.modelInputField}
+                removeButtonClassName={styles.modelRowRemoveButton}
+                removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')} />
+              <div className={styles.modelTestPanel}>
+                <div className={styles.modelTestMeta}>
+                  <label className={styles.modelTestLabel}>{t('ai_providers.openai_test_title')}</label>
+                  <span className={styles.modelTestHint}>{t('ai_providers.openai_test_hint')}</span>
+                </div>
+                <div className={styles.modelTestControls}>
+                  <Select value={testModel} options={modelSelectOptions}
+                    onChange={(value) => { setTestModel(value); setTestStatus('idle'); setTestMessage(''); }}
+                    placeholder={availableModels.length ? t('ai_providers.openai_test_select_placeholder') : t('ai_providers.openai_test_select_empty')}
+                    className={styles.openaiTestSelect} ariaLabel={t('ai_providers.openai_test_title')}
+                    disabled={saving || disabled || isTestingKeys || testStatus === 'loading' || availableModels.length === 0} />
+                  <Button variant={testStatus === 'error' ? 'danger' : 'secondary'} size="sm"
+                    onClick={() => void testAllKeys()} loading={testStatus === 'loading'}
+                    disabled={saving || disabled || isTestingKeys || testStatus === 'loading' || !hasConfiguredModels || !hasTestableKeys}
+                    className={styles.modelTestAllButton}>
+                    {t('ai_providers.openai_test_all_action')}
+                  </Button>
+                </div>
+              </div>
+              {testMessage && (
+                <div className={`status-badge ${testStatus === 'error' ? 'error' : testStatus === 'success' ? 'success' : 'muted'}`}>
+                  {testMessage}
+                </div>
+              )}
+            </div>
+
+            <Modal open={modelDiscoveryOpen} title={t('ai_providers.openai_models_fetch_title')}
+              onClose={() => setModelDiscoveryOpen(false)} width={720}
+              footer={
+                <>
+                  <Button variant="secondary" size="sm" onClick={() => setModelDiscoveryOpen(false)} disabled={modelDiscoveryFetching}>
+                    {t('common.cancel')}
+                  </Button>
+                  <Button size="sm" onClick={() => { const selected = discoveredModels.filter((m) => modelDiscoverySelected.has(m.name)); mergeDiscoveredModels(selected); setModelDiscoveryOpen(false); }}
+                    disabled={!canApplyModelDiscovery}>
+                    {t('ai_providers.openai_models_fetch_apply')}
+                  </Button>
+                </>
+              }>
+              <div className={styles.openaiModelsContent}>
+                <div className={styles.sectionHint}>{t('ai_providers.openai_models_fetch_hint')}</div>
+                <Input label={t('ai_providers.openai_models_search_label')} placeholder={t('ai_providers.openai_models_search_placeholder')}
+                  value={modelDiscoverySearch} onChange={(e) => setModelDiscoverySearch(e.target.value)} disabled={modelDiscoveryFetching} />
+                {modelDiscoveryError && <div className="error-box">{modelDiscoveryError}</div>}
+                {modelDiscoveryFetching ? <div className={styles.sectionHint}>{t('ai_providers.openai_models_fetch_loading')}</div>
+                  : discoveredModels.length === 0 ? <div className={styles.sectionHint}>{t('ai_providers.openai_models_fetch_empty')}</div>
+                    : (
+                      <div className={styles.modelDiscoveryList}>
+                        {discoveredModelsFiltered.map((model) => {
+                          const checked = modelDiscoverySelected.has(model.name);
+                          return (
+                            <SelectionCheckbox key={model.name} checked={checked}
+                              onChange={() => setModelDiscoverySelected((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(model.name)) next.delete(model.name); else next.add(model.name);
+                                return next;
+                              })}
+                              disabled={saving || disabled || modelDiscoveryFetching} ariaLabel={model.name}
+                              className={`${styles.modelDiscoveryRow} ${checked ? styles.modelDiscoveryRowSelected : ''}`}
+                              labelClassName={styles.modelDiscoverySelectionLabel}
+                              label={
+                                <div className={styles.modelDiscoveryMeta}>
+                                  <div className={styles.modelDiscoveryName}>
+                                    {model.name}
+                                    {model.alias && <span className={styles.modelDiscoveryAlias}>{model.alias}</span>}
+                                  </div>
+                                  {model.description && <div className={styles.modelDiscoveryDesc}>{model.description}</div>}
+                                </div>
+                              } />
+                          );
+                        })}
+                      </div>
+                    )}
+              </div>
+            </Modal>
+          </>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/providers/ProviderEditDrawer/VertexEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/VertexEditDrawer.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/Button';
+import { Drawer } from '@/components/ui/Drawer';
+import { Input } from '@/components/ui/Input';
+import { HeaderInputList } from '@/components/ui/HeaderInputList';
+import { ModelInputList } from '@/components/ui/ModelInputList';
+import { providersApi } from '@/services/api';
+import { useConfigStore, useNotificationStore } from '@/stores';
+import type { ProviderKeyConfig } from '@/types';
+import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
+import { areKeyValueEntriesEqual, areModelEntriesEqual, areStringArraysEqual } from '@/utils/compare';
+import { excludedModelsToText, parseExcludedModels } from '@/components/providers/utils';
+import type { VertexFormState } from '@/components/providers';
+import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
+
+interface VertexEditDrawerProps {
+  open: boolean;
+  editIndex: number | null;
+  disabled: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+type VertexFormBaseline = ReturnType<typeof buildVertexBaseline>;
+
+const buildEmptyForm = (): VertexFormState => ({
+  apiKey: '',
+  prefix: '',
+  baseUrl: '',
+  proxyUrl: '',
+  headers: [],
+  models: [],
+  excludedModels: [],
+  modelEntries: [{ name: '', alias: '' }],
+  excludedText: '',
+});
+
+const normalizeModelEntries = (entries: Array<{ name: string; alias: string }>) =>
+  (entries ?? []).reduce<Array<{ name: string; alias: string }>>((acc, entry) => {
+    const name = String(entry?.name ?? '').trim();
+    const alias = String(entry?.alias ?? '').trim();
+    if (!name && !alias) return acc;
+    acc.push({ name, alias });
+    return acc;
+  }, []);
+
+const buildVertexBaseline = (form: VertexFormState) => ({
+  apiKey: String(form.apiKey ?? '').trim(),
+  priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null,
+  prefix: String(form.prefix ?? '').trim(),
+  baseUrl: String(form.baseUrl ?? '').trim(),
+  proxyUrl: String(form.proxyUrl ?? '').trim(),
+  headers: normalizeHeaderEntries(form.headers),
+  models: normalizeModelEntries(form.modelEntries),
+  excludedModels: parseExcludedModels(form.excludedText ?? ''),
+});
+
+const getErrorMessage = (err: unknown) => {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '';
+};
+
+export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }: VertexEditDrawerProps) {
+  const { t } = useTranslation();
+  const { showNotification } = useNotificationStore();
+  const fetchConfig = useConfigStore((state) => state.fetchConfig);
+  const updateConfigValue = useConfigStore((state) => state.updateConfigValue);
+  const clearCache = useConfigStore((state) => state.clearCache);
+
+  const [configs, setConfigs] = useState<ProviderKeyConfig[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState<VertexFormState>(buildEmptyForm);
+  const [baseline, setBaseline] = useState<VertexFormBaseline>(buildVertexBaseline(buildEmptyForm()));
+  const [loaded, setLoaded] = useState(false);
+
+  const initialData = useMemo(() => {
+    if (editIndex === null) return undefined;
+    return configs[editIndex];
+  }, [configs, editIndex]);
+  const invalidIndex = editIndex !== null && !initialData;
+
+  const title = editIndex !== null ? t('ai_providers.vertex_edit_modal_title') : t('ai_providers.vertex_add_modal_title');
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    Promise.all([fetchConfig('vertex-api-key'), providersApi.getVertexConfigs()])
+      .then(([configResult, vertexResult]) => {
+        if (cancelled) return;
+        const list = Array.isArray(vertexResult) ? (vertexResult as ProviderKeyConfig[])
+          : Array.isArray(configResult) ? (configResult as ProviderKeyConfig[]) : [];
+        setConfigs(list);
+        updateConfigValue('vertex-api-key', list);
+        clearCache('vertex-api-key');
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(getErrorMessage(err) || t('notification.refresh_failed'));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        setLoaded(true);
+      });
+    return () => { cancelled = true; };
+  }, [open, clearCache, fetchConfig, t, updateConfigValue]);
+
+  useEffect(() => {
+    if (!open || !loaded) return;
+    if (initialData) {
+      const nextForm: VertexFormState = {
+        ...initialData,
+        headers: headersToEntries(initialData.headers),
+        modelEntries: initialData.models?.map((m) => ({ name: m.name, alias: m.alias ?? '' })) ?? [{ name: '', alias: '' }],
+        excludedText: excludedModelsToText(initialData.excludedModels),
+      };
+      setForm(nextForm);
+      setBaseline(buildVertexBaseline(nextForm));
+    } else {
+      const nextForm = buildEmptyForm();
+      setForm(nextForm);
+      setBaseline(buildVertexBaseline(nextForm));
+    }
+  }, [open, loaded, initialData]);
+
+  const canSave = !disabled && !saving && !loading && !invalidIndex;
+
+  const isDirty = useMemo(() => {
+    const normalizedPriority = form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null;
+    return (
+      baseline.apiKey !== form.apiKey.trim() ||
+      baseline.priority !== normalizedPriority ||
+      baseline.prefix !== String(form.prefix ?? '').trim() ||
+      baseline.baseUrl !== String(form.baseUrl ?? '').trim() ||
+      baseline.proxyUrl !== String(form.proxyUrl ?? '').trim() ||
+      !areKeyValueEntriesEqual(baseline.headers, normalizeHeaderEntries(form.headers)) ||
+      !areModelEntriesEqual(baseline.models, normalizeModelEntries(form.modelEntries)) ||
+      !areStringArraysEqual(baseline.excludedModels, parseExcludedModels(form.excludedText ?? ''))
+    );
+  }, [baseline, form]);
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    const apiKey = form.apiKey.trim();
+    if (!apiKey) {
+      showNotification(t('ai_providers.vertex_key_required', { defaultValue: 'Please enter a Vertex API Key' }), 'error');
+      return;
+    }
+    const baseUrl = (form.baseUrl ?? '').trim();
+    if (!baseUrl) {
+      showNotification(t('ai_providers.vertex_base_url_required', { defaultValue: 'Please enter the Vertex Base URL' }), 'error');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      const payload: ProviderKeyConfig = {
+        apiKey: form.apiKey.trim(),
+        priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : undefined,
+        prefix: form.prefix?.trim() || undefined,
+        baseUrl: (form.baseUrl ?? '').trim() || undefined,
+        proxyUrl: form.proxyUrl?.trim() || undefined,
+        headers: buildHeaderObject(form.headers),
+        models: form.modelEntries.map((entry) => {
+          const name = entry.name.trim();
+          const alias = entry.alias.trim();
+          if (!name || !alias) return null;
+          return { name, alias };
+        }).filter(Boolean) as ProviderKeyConfig['models'],
+        excludedModels: parseExcludedModels(form.excludedText),
+      };
+      const nextList = editIndex !== null
+        ? configs.map((item, idx) => (idx === editIndex ? payload : item))
+        : [...configs, payload];
+      await providersApi.saveVertexConfigs(nextList);
+      updateConfigValue('vertex-api-key', nextList);
+      clearCache('vertex-api-key');
+      showNotification(editIndex !== null ? t('notification.vertex_config_updated') : t('notification.vertex_config_added'), 'success');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+      showNotification(`${t('notification.update_failed')}: ${getErrorMessage(err)}`, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, clearCache, configs, editIndex, form, onClose, onSaved, showNotification, t, updateConfigValue]);
+
+  const handleClose = useCallback(() => {
+    if (isDirty && !saving) {
+      if (!window.confirm(t('common.unsaved_changes_message'))) return;
+    }
+    onClose();
+  }, [isDirty, onClose, saving, t]);
+
+  const footer = (
+    <>
+      <Button variant="secondary" size="sm" onClick={handleClose} disabled={saving}>
+        {t('common.cancel')}
+      </Button>
+      <Button size="sm" onClick={handleSave} loading={saving} disabled={!canSave}>
+        {t('common.save')}
+      </Button>
+    </>
+  );
+
+  return (
+    <Drawer open={open} onClose={handleClose} width={820} footer={footer} title={title}>
+      <div className={styles.openaiEditForm}>
+        {error && <div className="error-box">{error}</div>}
+        {loading && <div className={styles.sectionHint}>{t('common.loading')}</div>}
+        {invalidIndex && <div className="hint">{t('common.invalid_provider_index')}</div>}
+        {!loading && !invalidIndex && (
+          <>
+            <Input label={t('ai_providers.vertex_add_modal_key_label')} placeholder={t('ai_providers.vertex_add_modal_key_placeholder')}
+              value={form.apiKey} onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
+              disabled={disabled || saving} required />
+            <Input label={t('ai_providers.vertex_add_modal_url_label')} placeholder={t('ai_providers.vertex_add_modal_url_placeholder')}
+              value={form.baseUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
+              disabled={disabled || saving} required />
+            <Input label={t('ai_providers.prefix_label')} placeholder={t('ai_providers.prefix_placeholder')}
+              value={form.prefix ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
+              hint={t('ai_providers.prefix_hint')} disabled={disabled || saving} />
+            <Input label={t('ai_providers.vertex_add_modal_proxy_label')} placeholder={t('ai_providers.vertex_add_modal_proxy_placeholder')}
+              value={form.proxyUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, proxyUrl: e.target.value }))}
+              disabled={disabled || saving} />
+            <HeaderInputList entries={form.headers}
+              onChange={(entries) => setForm((prev) => ({ ...prev, headers: entries }))}
+              addLabel={t('common.custom_headers_add')} keyPlaceholder={t('common.custom_headers_key_placeholder')}
+              valuePlaceholder={t('common.custom_headers_value_placeholder')}
+              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+              disabled={disabled || saving} />
+            <div className="form-group">
+              <label>{t('ai_providers.vertex_models_label')}</label>
+              <ModelInputList entries={form.modelEntries}
+                onChange={(entries) => setForm((prev) => ({ ...prev, modelEntries: entries }))}
+                addLabel={t('ai_providers.vertex_models_add_btn')}
+                namePlaceholder={t('common.model_name_placeholder')} aliasPlaceholder={t('common.model_alias_placeholder')}
+                removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
+                disabled={disabled || saving} />
+            </div>
+            <div className="form-group">
+              <label>{t('ai_providers.excluded_models_label')}</label>
+              <textarea className="input" placeholder={t('ai_providers.excluded_models_placeholder')}
+                value={form.excludedText} onChange={(e) => setForm((prev) => ({ ...prev, excludedText: e.target.value }))}
+                rows={4} disabled={disabled || saving} />
+              <div className="hint">{t('ai_providers.excluded_models_hint')}</div>
+            </div>
+          </>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/providers/ProviderEditDrawer/index.ts
+++ b/apps/web/src/components/providers/ProviderEditDrawer/index.ts
@@ -1,0 +1,6 @@
+export { GeminiEditDrawer } from './GeminiEditDrawer';
+export { CodexEditDrawer } from './CodexEditDrawer';
+export { VertexEditDrawer } from './VertexEditDrawer';
+export { ClaudeEditDrawer } from './ClaudeEditDrawer';
+export { OpenAIEditDrawer } from './OpenAIEditDrawer';
+export { AmpcodeEditDrawer } from './AmpcodeEditDrawer';

--- a/apps/web/src/components/providers/ProviderToolbar/ProviderToolbar.tsx
+++ b/apps/web/src/components/providers/ProviderToolbar/ProviderToolbar.tsx
@@ -562,13 +562,25 @@ export function ProviderToolbar({
           <IconShield size={14} />
           {t('ai_providers.health_check_button')}
         </Button>
-        <DropdownMenu
-          ariaLabel={t('ai_providers.add_config_menu_aria')}
-          triggerLabel={t('ai_providers.add_config_button')}
-          triggerClassName={styles.addButton}
-          disabled={disabled}
-          items={addMenuItems}
-        />
+        {kind === 'all' ? (
+          <DropdownMenu
+            ariaLabel={t('ai_providers.add_config_menu_aria')}
+            triggerLabel={t('ai_providers.add_config_button')}
+            triggerClassName={styles.addButton}
+            disabled={disabled}
+            items={addMenuItems}
+          />
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => onAdd(kind)}
+            disabled={disabled}
+            className={styles.addButton}
+          >
+            {t('ai_providers.add_kind_button', { name: PROVIDER_KIND_LABELS[kind] })}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/providers/index.ts
+++ b/apps/web/src/components/providers/index.ts
@@ -10,6 +10,7 @@ export type {
   ProviderHealthCheckStatus,
   ProviderHealthCheckSummary,
 } from './ProviderHealthCheckDrawer';
+export * from './ProviderEditDrawer';
 export * from './hooks/useProviderRecentRequests';
 export * from './types';
 export * from './utils';

--- a/apps/web/src/features/aiProviders/AiProvidersPage.tsx
+++ b/apps/web/src/features/aiProviders/AiProvidersPage.tsx
@@ -1,15 +1,20 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import {
   AmpcodeSection,
+  AmpcodeEditDrawer,
   buildProviderRows,
+  ClaudeEditDrawer,
+  CodexEditDrawer,
   filterAndSortProviderRows,
+  GeminiEditDrawer,
+  OpenAIEditDrawer,
   PROVIDER_KIND_LABELS,
   ProviderDetailDrawer,
   ProviderHealthCheckDrawer,
   ProviderTable,
   ProviderToolbar,
+  VertexEditDrawer,
   useProviderRecentRequests,
   type ProviderHealthCheckApplyAction,
   type ProviderKind,
@@ -44,7 +49,6 @@ const DEFAULT_CLOAK_CONFIG: CloakConfig = {
 
 export function AiProvidersPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const { showNotification, showConfirmation } = useNotificationStore();
   const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
   const connectionStatus = useAuthStore((state) => state.connectionStatus);
@@ -85,6 +89,9 @@ export function AiProvidersPage() {
   const [sortDirection, setSortDirection] = useState<ProviderSortDirection>('desc');
   const [detailRowKey, setDetailRowKey] = useState<string | null>(null);
   const [healthCheckOpen, setHealthCheckOpen] = useState(false);
+  const [editDrawerKind, setEditDrawerKind] = useState<ProviderKind | null>(null);
+  const [editDrawerIndex, setEditDrawerIndex] = useState<number | null>(null);
+  const [ampcodeEditOpen, setAmpcodeEditOpen] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(PROVIDER_TABLE_DEFAULT_PAGE_SIZE);
 
@@ -185,12 +192,20 @@ export function AiProvidersPage() {
 
   useHeaderRefresh(handleRecentRequestsRefresh, isCurrentLayer);
 
-  const openEditor = useCallback(
-    (path: string) => {
-      navigate(path, { state: { fromAiProviders: true } });
-    },
-    [navigate]
-  );
+  const openEditorDrawer = useCallback((kind: ProviderKind, editIndex: number | null) => {
+    setDetailRowKey(null);
+    setEditDrawerKind(kind);
+    setEditDrawerIndex(editIndex);
+  }, []);
+
+  const closeEditorDrawer = useCallback(() => {
+    setEditDrawerKind(null);
+    setEditDrawerIndex(null);
+  }, []);
+
+  const handleDrawerSaved = useCallback(() => {
+    void loadConfigs();
+  }, [loadConfigs]);
 
   // 统一行集合与派生数据
   const rows = useMemo(
@@ -815,7 +830,7 @@ export function AiProvidersPage() {
 
   const handleRowEdit = (row: ProviderRow) => {
     setDetailRowKey(null);
-    openEditor(`/ai-providers/${row.kind}/${row.originalIndex}`);
+    openEditorDrawer(row.kind, row.originalIndex);
   };
 
   const handleRowDelete = (row: ProviderRow) => {
@@ -832,7 +847,7 @@ export function AiProvidersPage() {
   };
 
   const handleAdd = (kind: ProviderKind) => {
-    openEditor(`/ai-providers/${kind}/new`);
+    openEditorDrawer(kind, null);
   };
 
   const handlePageSizeChange = (value: string) => {
@@ -970,7 +985,7 @@ export function AiProvidersPage() {
           loading={loading}
           disableControls={disableControls}
           isSwitching={isSwitching}
-          onEdit={() => openEditor('/ai-providers/ampcode')}
+          onEdit={() => setAmpcodeEditOpen(true)}
         />
       </div>
 
@@ -995,6 +1010,47 @@ export function AiProvidersPage() {
         onClose={() => setHealthCheckOpen(false)}
         onApplyResultActions={applyProviderEnabledActions}
         onSetProviderEnabled={setHealthCheckProviderEnabled}
+      />
+      <GeminiEditDrawer
+        open={editDrawerKind === 'gemini'}
+        editIndex={editDrawerIndex}
+        disabled={actionsDisabled}
+        onClose={closeEditorDrawer}
+        onSaved={handleDrawerSaved}
+      />
+      <CodexEditDrawer
+        open={editDrawerKind === 'codex'}
+        editIndex={editDrawerIndex}
+        disabled={actionsDisabled}
+        onClose={closeEditorDrawer}
+        onSaved={handleDrawerSaved}
+      />
+      <VertexEditDrawer
+        open={editDrawerKind === 'vertex'}
+        editIndex={editDrawerIndex}
+        disabled={actionsDisabled}
+        onClose={closeEditorDrawer}
+        onSaved={handleDrawerSaved}
+      />
+      <ClaudeEditDrawer
+        open={editDrawerKind === 'claude'}
+        editIndex={editDrawerIndex}
+        disabled={actionsDisabled}
+        onClose={closeEditorDrawer}
+        onSaved={handleDrawerSaved}
+      />
+      <OpenAIEditDrawer
+        open={editDrawerKind === 'openai'}
+        editIndex={editDrawerIndex}
+        disabled={actionsDisabled}
+        onClose={closeEditorDrawer}
+        onSaved={handleDrawerSaved}
+      />
+      <AmpcodeEditDrawer
+        open={ampcodeEditOpen}
+        disabled={actionsDisabled}
+        onClose={() => setAmpcodeEditOpen(false)}
+        onSaved={handleDrawerSaved}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- **Direct add**: When a specific provider tab is selected, clicking the add button directly opens that provider's configuration drawer
- **Drawer-based editing**: All 6 provider add/edit forms converted from full-page routes to drawer components, matching the `ProviderHealthCheckDrawer` UX
- **Field order optimized**: All provider forms reordered to follow logical flow: auth → endpoint → routing → proxy → headers → models → advanced → filters
- **Required-field validation**: API key mandatory for all providers (or authIndex); base URL mandatory for Codex/Claude/Vertex/OpenAI
- **Backward compatible**: Original full-page edit routes remain accessible

## Files Changed

### New
- `GeminiEditDrawer.tsx` — Gemini add/edit with model discovery modal
- `CodexEditDrawer.tsx` — Codex add/edit with websockets toggle + model discovery
- `VertexEditDrawer.tsx` — Vertex add/edit with required validation
- `ClaudeEditDrawer.tsx` — Claude add/edit with connectivity test + cloak config
- `OpenAIEditDrawer.tsx` — OpenAI add/edit with multi-key management + key testing
- `AmpcodeEditDrawer.tsx` — Ampcode upstream config

### Modified
- `ProviderToolbar.tsx` — Conditional add button: dropdown when "All", direct when specific tab
- `AiProvidersPage.tsx` — Drawer state management replaces route navigation
- `providers/index.ts` — Export new drawer module

## Test plan
- [x] All 53 test files pass (430 tests)
- [x] TypeScript zero errors
- [x] Verify each provider's add/edit drawer opens correctly from toolbar and table row
- [x] Verify save creates/updates config and drawer closes
- [x] Verify unsaved changes prompt on close
- [x] Verify model discovery works in Gemini/Codex/OpenAI drawers
- [x] Verify Claude connectivity test and cloak config
- [x] Verify OpenAI multi-key testing