### PR TITLE
chore: 增强运行时可观测性日志

### DIFF
--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -115,7 +115,7 @@ func (w *AccountActionCandidateWorker) handleCandidate(ctx context.Context, cand
 		log.Printf("[account-action] failed to upsert pending candidate for auth file %q: %v", candidate.FileName, err)
 		return
 	}
-	log.Printf("[account-action] saved pending %s candidate %d for auth file %q", candidate.ActionType, item.ID, candidate.FileName)
+	log.Printf("[account-action] saved pending %s candidate %d for auth file %q authIndex=%q provider=%q hitCount=%d", candidate.ActionType, item.ID, candidate.FileName, item.AuthIndex, item.Provider, item.HitCount)
 	w.maybeAutoDisable(ctx, item, candidate)
 }
 
@@ -124,21 +124,23 @@ func (w *AccountActionCandidateWorker) maybeAutoDisable(ctx context.Context, ite
 		return
 	}
 	if !accountActionAutoDisableEligible(item.ActionType) {
-		log.Printf("[account-action] pending candidate %d action=%q is not eligible for auto-disable", item.ID, item.ActionType)
+		log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q action=%q reason=ineligible_action", item.ID, item.AuthFileName, item.ActionType)
 		return
 	}
+	log.Printf("[account-action] auto-disable eligibility confirmed for pending candidate %d authFile=%q action=%q", item.ID, item.AuthFileName, item.ActionType)
 	baseURL := strings.TrimSpace(candidate.BaseURL)
 	managementKey := strings.TrimSpace(candidate.ManagementKey)
 	if baseURL == "" || managementKey == "" {
-		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, "CPA runtime config is unavailable for auto-disable")
-		log.Printf("[account-action] pending candidate %d saved, but runtime config is unavailable for auto-disable", item.ID)
+		reason := "CPA runtime config is unavailable for auto-disable"
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, reason)
+		log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q reason=%s baseURLSet=%t managementKeySet=%t", item.ID, item.AuthFileName, reason, baseURL != "", managementKey != "")
 		return
 	}
 	client := cpaauthfiles.New(nil)
 	files, err := client.Fetch(ctx, baseURL, managementKey)
 	if err != nil {
 		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
-		log.Printf("[account-action] pending candidate %d saved, but auth file verification failed for %q: %v", item.ID, item.AuthFileName, err)
+		log.Printf("[account-action] auto-disable verification failed for pending candidate %d authFile=%q: %v", item.ID, item.AuthFileName, err)
 		return
 	}
 	current, err := cpaauthfiles.VerifyIdentity(files, cpaauthfiles.Identity{
@@ -151,19 +153,19 @@ func (w *AccountActionCandidateWorker) maybeAutoDisable(ctx context.Context, ite
 	if err != nil {
 		reason := "current CPA auth file identity verification failed: " + err.Error()
 		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, reason)
-		log.Printf("[account-action] pending candidate %d saved, but auth file identity verification failed for %q: %v; skip auto-disable", item.ID, item.AuthFileName, err)
+		log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q reason=identity_verification_failed detail=%v", item.ID, item.AuthFileName, err)
 		return
 	}
 	if current.Disabled {
-		log.Printf("[account-action] pending candidate %d saved; auth file %q already disabled", item.ID, item.AuthFileName)
+		log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q reason=already_disabled", item.ID, item.AuthFileName)
 		return
 	}
 	if err := client.PatchDisabled(ctx, baseURL, managementKey, item.AuthFileName, true); err != nil {
 		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
-		log.Printf("[account-action] pending candidate %d saved, but failed to auto-disable auth file %q: %v", item.ID, item.AuthFileName, err)
+		log.Printf("[account-action] auto-disable patch failed for pending candidate %d authFile=%q: %v", item.ID, item.AuthFileName, err)
 		return
 	}
-	log.Printf("[account-action] auto-disabled auth file %q for pending %s candidate %d", item.AuthFileName, item.ActionType, item.ID)
+	log.Printf("[account-action] auto-disable patch succeeded for pending candidate %d authFile=%q action=%q", item.ID, item.AuthFileName, item.ActionType)
 }
 
 func accountActionAutoDisableEligible(actionType string) bool {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -82,7 +82,9 @@ func (w *RateLimitAutoDisableWorker) UpdateRuntimeConfig(ctx context.Context, cf
 	if baseURL == "" || managementKey == "" {
 		return
 	}
-	w.setRuntimeConfig(baseURL, managementKey)
+	if w.setRuntimeConfig(baseURL, managementKey) {
+		log.Printf("[quota-auto-disable] runtime config synced baseURL=%q managementKeySet=%t", baseURL, managementKey != "")
+	}
 	w.enableDue(ctx, time.Now())
 }
 
@@ -98,7 +100,9 @@ func (w *RateLimitAutoDisableWorker) HandleUsageEvents(ctx context.Context, cfg 
 	if baseURL == "" || managementKey == "" {
 		return
 	}
-	w.setRuntimeConfig(baseURL, managementKey)
+	if w.setRuntimeConfig(baseURL, managementKey) {
+		log.Printf("[quota-auto-disable] runtime config synced baseURL=%q managementKeySet=%t", baseURL, managementKey != "")
+	}
 	if len(events) == 0 {
 		return
 	}
@@ -139,11 +143,15 @@ func (w *RateLimitAutoDisableWorker) run(ctx context.Context) {
 	}
 }
 
-func (w *RateLimitAutoDisableWorker) setRuntimeConfig(baseURL string, managementKey string) {
+func (w *RateLimitAutoDisableWorker) setRuntimeConfig(baseURL string, managementKey string) bool {
+	baseURL = strings.TrimSpace(baseURL)
+	managementKey = strings.TrimSpace(managementKey)
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.baseURL = strings.TrimSpace(baseURL)
-	w.managementKey = strings.TrimSpace(managementKey)
+	changed := w.baseURL != baseURL || w.managementKey != managementKey
+	w.baseURL = baseURL
+	w.managementKey = managementKey
+	return changed
 }
 
 func (w *RateLimitAutoDisableWorker) runtimeConfig() (string, string) {
@@ -271,11 +279,15 @@ func (w *RateLimitAutoDisableWorker) enableDue(ctx context.Context, now time.Tim
 
 func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseURL string, managementKey string, item store.QuotaCooldown, now time.Time) {
 	if item.Owner != model.QuotaCooldownOwnerUsage429 {
-		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, "unknown owner")
+		reason := "unknown owner"
+		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
+		log.Printf("[quota-auto-disable] skip cooldown recovery id=%d authFile=%q reason=%s owner=%q", item.ID, item.AuthFileName, reason, item.Owner)
 		return
 	}
 	if item.PreDisabledState {
-		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, "pre-disabled before CPAMP action")
+		reason := "pre-disabled before CPAMP action"
+		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
+		log.Printf("[quota-auto-disable] skip cooldown recovery id=%d authFile=%q reason=%s", item.ID, item.AuthFileName, reason)
 		return
 	}
 	current, ok, err := w.currentAuthFile(ctx, baseURL, managementKey, item.AuthFileName, item.AuthIndex)


### PR DESCRIPTION
## 背景

这是一个低风险的运行日志 / 可观测性增强 PR，基于已经合并的：

- #132 Codex usage-limit quota cooldown
- #146 pending account actions opt-in auto-disable

本 PR 只增强运行时日志和诊断可见性，不改变业务语义、不新增 UI、不改变自动禁用或自动恢复逻辑。

## 主要变更

### quota cooldown worker

- 在 collector runtime config 同步发生变化时记录日志：
  - `baseURL`
  - `managementKeySet`
- 对 cooldown recovery 的跳过原因补充日志：
  - unknown owner
  - pre-disabled before CPAMP action

现有的 cooldown 创建、扩展、恢复成功、恢复失败、auth file missing/mismatched 等日志保持不变。

### pending account action auto-disable

- pending candidate 保存日志增加：
  - `authIndex`
  - `provider`
  - `hitCount`
- auto-disable 增加更明确的诊断日志：
  - ineligible action skip
  - eligibility confirmed
  - runtime config missing
  - auth-file verification failure
  - identity verification failure
  - already disabled skip
  - PATCH failed
  - PATCH succeeded

这些日志不会暴露 token、Authorization header、raw response body 或 raw `FailBody` / `RawJSON`。

## 范围边界

本 PR 不做以下事情：

- 不改变 quota cooldown 触发条件；
- 不改变 `quota_cooldowns` ownership / recovery 语义；
- 不改变 pending account action classifier；
- 不改变 auto-disable eligible action 类型；
- 不新增 UI；
- 不新增 API；
- 不新增自动删除或自动恢复能力。

## 测试

已执行：

```bash
cd apps/manager-server
go test ./internal/worker ./internal/service/cpaauthfiles ./internal/service/accountaction ./internal/config
```

通过。

已执行：

```bash
cd apps/manager-server
go test ./internal/worker
```

通过。

已执行：

```bash
git diff --check
```

通过，仅有 Windows LF/CRLF warning。