### PR TITLE
docs(release): v1.4.1

### DIFF
--- a/docs/release-notes/v1.4.1-en.md
+++ b/docs/release-notes/v1.4.1-en.md
@@ -1,0 +1,45 @@
+# CPA Manager Plus v1.4.1
+
+> 9 commits · 23 files changed · +3691 / -603
+
+> [中文 ->](./v1.4.1-zh.md)
+
+## Overview
+
+Building on v1.4.0, this patch tightens the diagnostics and observability of opt-in account action auto-disable, unifies the auth file parsing path, and documents the quota cooldown configuration. The AI Providers add/edit flow is folded into the drawer and tab interaction to remove the redundant entry-point choice. The worker and collector sync paths gain clearer runtime logs to make quota rate-limit and auto-disable behavior easier to triage.
+
+## Highlights
+
+### Improvements
+
+- AI Providers add/edit moved into a drawer-based configuration, and when a provider tab is already selected, providers can be created directly without the extra entry-point choice. (`ai-providers`)
+
+### Fixes
+
+- Account action opt-in auto-disable gains clearer diagnostics covering hit, skip, success, and failure paths. (`account-actions`)
+- Monitoring account status no longer leaks auth file metadata across providers, keeping identity consistent when switching providers. (`monitoring`)
+- Worker decodes every JSON value in concatenated fail body text so partial objects no longer skew failure attribution. (`worker`)
+
+### Refactor
+
+- Extract the shared CPA auth file helper so account action auto-disable and quota cooldown share one parsing path. (`manager-server`, `account-actions`)
+
+### Chore
+
+- Runtime observability: the quota cooldown worker now logs `baseURL` and `managementKeySet` only when the runtime config actually changes, and adds explicit reason logs for the cooldown-recovery skip paths (unknown owner, pre-disabled); the account action auto-disable path adds structured logs at the save-candidate, eligibility, runtime-config-missing, auth-file/identity-verification-failure, already-disabled, and patch success/failure steps. None of the new logs expose tokens, Authorization headers, or raw `FailBody`/`RawJSON`. (`manager-server`)
+
+### Docs
+
+- Document the quota cooldown configuration, including ownership, runtime sync, and retention constraints. (`docs`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @MuziIsabel - Drove the opt-in account action auto-disable feature with clearer diagnostics, extracted the shared CPA auth file helper to unify parsing, authored the quota cooldown configuration docs, and added the structured runtime logs for both quota cooldown and account action auto-disable in this release.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.4.0...v1.4.1

--- a/docs/release-notes/v1.4.1-zh.md
+++ b/docs/release-notes/v1.4.1-zh.md
@@ -1,0 +1,45 @@
+# CPA Manager Plus v1.4.1
+
+> 9 commits · 23 files changed · +3691 / -603
+
+> [English ->](./v1.4.1-en.md)
+
+## Overview
+
+本次发布在 v1.4.0 的基础上收尾账号动作自动停用的诊断与可观测细节，统一 auth file 解析路径，并补齐 quota cooldown 的配置文档。AI Providers 的新增/编辑交互顺势合并到 drawer 与 tab 联动的流程中，进一步减少冗余入口切换；worker 与 collector 同步路径补充更明确的运行时日志，便于复盘配额限流与 auto-disable 行为。
+
+## Highlights
+
+### Improvements
+
+- AI Providers 新增/编辑配置改为 drawer 形式，并在已选中 provider tab 时支持直接新增，减少冗余入口切换。(`ai-providers`)
+
+### Fixes
+
+- 账号动作 opt-in 自动停用补齐诊断日志，覆盖命中/跳过/成功/失败路径，便于复盘。(`account-actions`)
+- 监控账号状态停止跨 provider 串扰 auth file 元数据，provider 切换时身份信息保持一致。(`monitoring`)
+- Worker 解析拼接后的 fail body 文本时对所有 JSON 值完整 decode，避免半截对象影响失败归因。(`worker`)
+
+### Refactor
+
+- 抽出 CPA auth file 公共 helper，统一 provider 间 auth 解析入口，账号动作自动停用与 quota cooldown 共用同一 helper 路径。(`manager-server`, `account-actions`)
+
+### Chore
+
+- 运行时可观测性增强：quota cooldown worker 在 runtime config 真正发生变化时输出 `baseURL` 与 `managementKeySet` 日志，并在 cooldown recovery 跳过路径（unknown owner / pre-disabled）补充原因；account action auto-disable 路径在保存候选、eligibility、runtime config 缺失、auth file / identity 校验失败、已禁用、patch 成功/失败等节点补齐结构化日志，且不暴露 token、Authorization、raw `FailBody` 或 `RawJSON`。(`manager-server`)
+
+### Docs
+
+- 补充 quota cooldown 配置说明，记录 ownership、runtime 同步与 retention 约束。(`docs`)
+
+## Upgrade Notes
+
+None.
+
+## Acknowledgements
+
+- @MuziIsabel - 推进账号动作 opt-in 自动停用能力并补齐诊断日志，抽取 CPA auth file 公共 helper 统一解析路径，完成 quota cooldown 配置文档，并在本次为 quota cooldown 与 account action auto-disable 补齐结构化运行时日志。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.4.0...v1.4.1


### PR DESCRIPTION
## Release Notes for v1.4.1

This release PR adds curated release notes for `v1.4.1`.

- `docs/release-notes/v1.4.1-zh.md` — 中文发布说明（authoured source）
- `docs/release-notes/v1.4.1-en.md` — English mirror

Source: `docs/release.md` template. CI tag-push workflow will pick up these files for the GitHub Release body.

### Range

- Previous tag: `v1.4.0` (`b4c93d1`)
- 9 non-merge commits · 23 files changed · +3691 / -603
- Includes merged PR #154 (chore: improve runtime observability logs)

### Stats

- Conventional types: feat ×3 · fix ×3 · docs ×1 · refactor ×1 · chore ×1
- Authors: seakee (4), MuziIsabel (5)

### Upgrade Notes

None.