### PR TITLE
docs(release): v1.4.2

### DIFF
--- a/docs/release-notes/v1.4.2-en.md
+++ b/docs/release-notes/v1.4.2-en.md
@@ -1,0 +1,25 @@
+# CPA Manager Plus v1.4.2
+
+> 6 commits · 35 files changed · +2598 / -755
+
+> [中文 ->](./v1.4.2-zh.md)
+
+## Overview
+
+This release focuses on the Codex quota experience and provider configuration compatibility. Manager Server now recognizes Codex Team monthly quota windows so exhausted short windows are not misclassified as unavailable accounts. The web app also adds the reset-credit consume action and preserves new CPA v1.16 provider fields during edits, reducing the risk of losing configuration after a save.
+
+## Highlights
+
+### Features
+
+- Codex quota cards now support the reset-credit consume action with confirmation, state refresh, reset availability, subscription metadata rendering, localized copy, and focused test coverage. (`quota`, `web`)
+- Manager Server now passes Codex `plan_type` into quota window classification, treating Team secondary windows without durations as monthly quotas and avoiding account disablement when short windows are exhausted but monthly quota remains available. (`manager-server`, `codexinspection`)
+- Provider edit drawers, full edit pages, API transformers, and model entry helpers now preserve CPA v1.16 disable-cooling, Claude CCH signing, cloak cache-user-id, image/thinking model metadata, and merge unknown raw fields back into save payloads. (`ai-providers`, `web`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.4.1...v1.4.2

--- a/docs/release-notes/v1.4.2-zh.md
+++ b/docs/release-notes/v1.4.2-zh.md
@@ -1,0 +1,25 @@
+# CPA Manager Plus v1.4.2
+
+> 6 commits · 35 files changed · +2598 / -755
+
+> [English ->](./v1.4.2-en.md)
+
+## Overview
+
+本次发布聚焦 Codex 配额体验与 provider 配置兼容性。管理端现在能识别 Codex Team 的月度配额窗口，避免短窗口耗尽时误判为账号不可用；前端补齐 reset-credit 消耗入口，并在 provider 编辑流程中保留 v1.16 新增字段，减少保存后配置丢失风险。
+
+## Highlights
+
+### Features
+
+- Codex 配额卡片支持 reset-credit 消耗操作，包含确认流程、状态刷新、reset 可用性与订阅元数据展示，以及本地化文案和测试覆盖。(`quota`, `web`)
+- Manager Server 将 Codex `plan_type` 纳入配额窗口分类，Team secondary window 缺少 duration 时会按月度配额处理，避免短窗口耗尽但月度配额仍可用时误停账号。(`manager-server`, `codexinspection`)
+- Provider 编辑 drawer、完整编辑页、API transformer 与 model entry helper 现在会保留 CPA v1.16 的 disable-cooling、Claude CCH signing、cloak cache-user-id、图片/思考模型元数据，并把未知原始字段合并回保存 payload。(`ai-providers`, `web`)
+
+## Upgrade Notes
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.4.1...v1.4.2


### PR DESCRIPTION
Purpose: add curated v1.4.2 release notes in zh/en before tagging. Tests: git diff --check. Affected modes: release notes only.