### PR TITLE
fix(monitoring): preserve shared source labels

### DIFF
--- a/apps/web/src/features/monitoring/model/eventRows.test.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { buildRealtimeSourceDisplay } from '@/features/monitoring/realtimeSourceDisplay';
 import type { UsageDetailWithEndpoint } from '@/utils/usage';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { buildEventRows } from './eventRows';
 
 const buildRows = (overrides: Partial<UsageDetailWithEndpoint> = {}) =>
@@ -74,5 +76,61 @@ describe('buildEventRows', () => {
     expect(row.searchText).toContain('codex');
     expect(row.searchText).toContain('priority');
     expect(row.searchText).toContain('medium');
+  });
+
+  it('keeps shared provider display names available to realtime source cells', () => {
+    const sharedKey = 'sk-shared1234567890abcdef';
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: sharedKey,
+          prefix: 'Shared Relay',
+          baseUrl: 'https://api.shared.example/v1',
+        },
+      ],
+      claudeApiKeys: [
+        {
+          apiKey: sharedKey,
+          prefix: 'Shared Relay',
+          baseUrl: 'https://api.shared.example/v1',
+        },
+      ],
+    });
+    const [row] = buildEventRows(
+      [
+        {
+          timestamp: '2026-05-19T10:00:00Z',
+          source: 'm:sk-s...cdef',
+          auth_index: null,
+          auth_provider_snapshot: 'codex',
+          latency_ms: 1500,
+          tokens: {
+            input_tokens: 10,
+            output_tokens: 20,
+            total_tokens: 30,
+          },
+          failed: false,
+          __modelName: 'gpt-5.4',
+          __endpoint: 'POST /v1/chat/completions',
+          __endpointMethod: 'POST',
+          __endpointPath: '/v1/chat/completions',
+          __timestampMs: Date.parse('2026-05-19T10:00:00Z'),
+        },
+      ],
+      new Map(),
+      new Map(),
+      sourceInfoMap,
+      new Map(),
+      {},
+      new Map()
+    );
+
+    const t = ((key: string) => key) as Parameters<typeof buildRealtimeSourceDisplay>[1];
+    const display = buildRealtimeSourceDisplay(row, t);
+
+    expect(row.source).toBe('Shared Relay');
+    expect(row.sourceKey).toBe('shared:m:sk-s...cdef');
+    expect(row.provider).toBe('codex');
+    expect(display.primary).toBe('Shared Relay');
   });
 });

--- a/apps/web/src/utils/sourceResolver.test.ts
+++ b/apps/web/src/utils/sourceResolver.test.ts
@@ -20,6 +20,33 @@ describe('source resolver', () => {
     expect(resolved.identityKey).toBe('codex:0');
   });
 
+  it('keeps shared upstream names when one key is registered under Codex and Claude', () => {
+    const sharedKey = 'sk-shared1234567890abcdef';
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: sharedKey,
+          prefix: 'Shared Relay',
+          baseUrl: 'https://api.shared.example/v1',
+        },
+      ],
+      claudeApiKeys: [
+        {
+          apiKey: sharedKey,
+          prefix: 'Shared Relay',
+          baseUrl: 'https://api.shared.example/v1',
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('m:sk-s...cdef', '', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('Shared Relay');
+    expect(resolved.type).toBe('');
+    expect(resolved.identityKey).toBe('shared:m:sk-s...cdef');
+    expect(resolved.displayName).not.toContain('sk-shared');
+  });
+
   it('distinguishes multiple keys from the same base URL without exposing raw keys', () => {
     const sourceInfoMap = buildSourceInfoMap({
       codexApiKeys: [

--- a/apps/web/src/utils/sourceResolver.ts
+++ b/apps/web/src/utils/sourceResolver.ts
@@ -33,6 +33,14 @@ const registerIdentity = (
   }
 
   if (existing === null || existing.identityKey === entry.identityKey) return;
+  if (existing.displayName === entry.displayName) {
+    map.set(key, {
+      displayName: existing.displayName,
+      type: existing.type === entry.type ? existing.type : '',
+      identityKey: `shared:${key}`,
+    });
+    return;
+  }
   map.set(key, null);
 };
 


### PR DESCRIPTION
## Summary
- keep readable monitoring source labels when the same upstream key is registered under multiple provider categories with the same display name
- resolve same-name source conflicts to a neutral shared identity instead of falling back to masked API-key source strings
- add regression coverage for the resolver and realtime monitoring event rows

## Root cause
`buildSourceInfoMap()` treated any source candidate registered by different provider identities as ambiguous and nulled the mapping. When one upstream API key was configured under both Codex and Claude, request monitoring could no longer resolve the masked usage source and fell back to values such as `m:sk-...` instead of the configured channel name or host.

## Notes
- This is a focused follow-up to #43.
- Different display names for the same source remain ambiguous; this only preserves labels when both registrations resolve to the same readable name.
- The shared conflict keeps a neutral `shared:` source identity so it does not incorrectly attribute the source to only Codex or only Claude.

## Verification
- `npm --workspace apps/web run test -- src/utils/sourceResolver.test.ts src/features/monitoring/model/eventRows.test.ts src/features/monitoring/MonitoringCenterPage.test.tsx`
- `npm --workspace apps/web run type-check`
- `npm --workspace apps/web run lint -- --max-warnings=0`
- `npm --workspace apps/web run build`
- `git diff --check`