### PR TITLE
🐛 fix: extend request timeout to 30s

### DIFF
--- a/apps/manager-server/internal/service/accountaction/service.go
+++ b/apps/manager-server/internal/service/accountaction/service.go
@@ -32,7 +32,7 @@ type ListResponse struct {
 type authFile = cpaauthfiles.File
 
 func New(st *store.Store, managerConfigService *managerconfigsvc.Service, clients ...*http.Client) *Service {
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := &http.Client{Timeout: 30 * time.Second}
 	if len(clients) > 0 && clients[0] != nil {
 		client = clients[0]
 	}

--- a/apps/manager-server/internal/service/cpa/client.go
+++ b/apps/manager-server/internal/service/cpa/client.go
@@ -28,7 +28,7 @@ func ValidateManagementAPI(ctx context.Context, baseURL string, key string) erro
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+key)
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := &http.Client{Timeout: 30 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func FetchManagementConfig(ctx context.Context, baseURL string, key string) (Man
 		return ManagementConfig{}, err
 	}
 	req.Header.Set("Authorization", "Bearer "+key)
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := &http.Client{Timeout: 30 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
 		return ManagementConfig{}, err
@@ -100,7 +100,7 @@ func SetUsageStatisticsEnabled(ctx context.Context, baseURL string, key string, 
 	}
 	req.Header.Set("Authorization", "Bearer "+key)
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := &http.Client{Timeout: 30 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
 		return err

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
 )
 
-const DefaultTimeout = 15 * time.Second
+const DefaultTimeout = 30 * time.Second
 
 var ErrAuthFileNotFound = errors.New("CPA auth file not found")
 

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -22,7 +22,7 @@ import (
 const (
 	quotaAutoDisableQueueSize     = 256
 	quotaAutoDisableDefaultTick   = 15 * time.Second
-	quotaAutoDisableActionTimeout = 15 * time.Second
+	quotaAutoDisableActionTimeout = 30 * time.Second
 	quotaCooldownDueLimit         = 100
 )
 

--- a/apps/web/src/services/api/apiKeyUsage.ts
+++ b/apps/web/src/services/api/apiKeyUsage.ts
@@ -1,7 +1,7 @@
 import { apiClient } from './client';
 import type { ApiKeyUsageResponse } from '@/utils/recentRequests';
 
-const API_KEY_USAGE_TIMEOUT_MS = 15 * 1000;
+const API_KEY_USAGE_TIMEOUT_MS = 30 * 1000;
 
 export const apiKeyUsageApi = {
   getUsage: () =>

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -803,7 +803,7 @@ export interface MonitoringAnalyticsResponse {
   events?: MonitoringAnalyticsEventsResponse;
 }
 
-const USAGE_SERVICE_TIMEOUT_MS = 15 * 1000;
+const USAGE_SERVICE_TIMEOUT_MS = 30 * 1000;
 const USAGE_SERVICE_TRANSFER_TIMEOUT_MS = 60 * 1000;
 const CODEX_INSPECTION_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 export const USAGE_SERVICE_ID = 'cpa-manager-plus';


### PR DESCRIPTION
## Summary

Raise HTTP client / axios request timeouts from 15s to 30s across the web frontend and the manager-server, so slow but legitimate responses from the upstream CPA :8317 management API are not truncated mid-flight.

Aligns both layers with the existing global web default `REQUEST_TIMEOUT_MS = 30 * 1000` in `apps/web/src/utils/constants.ts`.

## Changes

**web (commit `b286be8`)**
- `apps/web/src/services/api/apiKeyUsage.ts` — `API_KEY_USAGE_TIMEOUT_MS`: 15s → 30s
- `apps/web/src/services/api/usageService.ts` — `USAGE_SERVICE_TIMEOUT_MS`: 15s → 30s (21 call-sites pick up the new value automatically)

**manager-server (commit `fb98279`)**
- `apps/manager-server/internal/service/cpa/client.go` — 3 inline `http.Client{Timeout: 15s}` → 30s (`ValidateManagementAPI`, `FetchManagementConfig`, `SetUsageStatisticsEnabled`)
- `apps/manager-server/internal/service/cpaauthfiles/client.go` — `DefaultTimeout`: 15s → 30s
- `apps/manager-server/internal/service/accountaction/service.go` — default `http.Client`: 15s → 30s
- `apps/manager-server/internal/worker/rate_limit_auto_disable.go` — `quotaAutoDisableActionTimeout`: 15s → 30s

## Scope (intentionally NOT touched)

- Codex inspection business timeout (`15000` in `codexInspectionSettings.ts`, `ServerCodexInspectionPage.tsx`, `codex_inspection.go` and related test assertions) — different semantics ("per-account probe timeout"), kept at 15s as agreed.
- `RealtimeEventsPanel.tsx` UI warn-color threshold (15s) and `dashboard/service.go` latency anomaly threshold (15s) — UI/business heuristics, not request timeouts.
- `quotaAutoDisableDefaultTick` — ticker interval, not HTTP timeout.

## Risk

- Failure detection latency on truly stuck requests grows from 15s to 30s on affected endpoints.
- No protocol, contract, or schema changes; pure client-side timeout relaxation.
- No new dependencies; no migrations.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/service/cpa/... ./internal/service/cpaauthfiles/... ./internal/service/accountaction/... ./internal/worker/...` — 3 OK, 1 no-test-file
- [x] `npm run test` — 57 files / 451 tests passed
- [x] `grep -E '15 \* (1000|time\.Second)' apps apps/manager-server` only matches `quotaAutoDisableDefaultTick` (ticker, out of scope)
- [x] `grep -E '\b15000\b' apps` only matches Codex inspection config, UI warn-color threshold, and dashboard anomaly threshold (all out of scope)