### PR TITLE
refactor(manager-server): drop CPA short-path probing and harden reverse proxy

### DIFF
--- a/apps/manager-server/internal/http/controller/proxy/handler.go
+++ b/apps/manager-server/internal/http/controller/proxy/handler.go
@@ -19,11 +19,8 @@ func (h *Handler) Management(w http.ResponseWriter, r *http.Request) {
 	h.App.ProxyService.ProxyManagement(w, r, response.Error)
 }
 
-func (h *Handler) CPA(w http.ResponseWriter, r *http.Request) {
-	if !middleware.AuthorizeAdmin(w, r, h.App.AdminAuthService) {
-		return
-	}
-	h.App.ProxyService.ProxyCPA(w, r, response.Error)
+func (h *Handler) ModelList(w http.ResponseWriter, r *http.Request) {
+	h.App.ProxyService.ProxyModelList(w, r, response.Error, response.MethodNotAllowed)
 }
 
 func (h *Handler) CPAResource(w http.ResponseWriter, r *http.Request) {
@@ -31,9 +28,5 @@ func (h *Handler) CPAResource(w http.ResponseWriter, r *http.Request) {
 		response.MethodNotAllowed(w)
 		return
 	}
-	h.App.ProxyService.ProxyCPA(w, r, response.Error)
-}
-
-func (h *Handler) ModelList(w http.ResponseWriter, r *http.Request) {
-	h.App.ProxyService.ProxyModelList(w, r, response.Error, response.MethodNotAllowed)
+	h.App.ProxyService.ProxyManagement(w, r, response.Error)
 }

--- a/apps/manager-server/internal/http/router/router.go
+++ b/apps/manager-server/internal/http/router/router.go
@@ -99,16 +99,13 @@ func rootHandler(
 			middleware.WithCORS(appCtx.Config, proxyHandler.Management)(w, r)
 			return
 		}
-		if proxysvc.IsModelListPath(r.URL.Path) {
+		if r.URL.Path == "/v1/models" || r.URL.Path == "/v1/models/" ||
+			r.URL.Path == "/models" || r.URL.Path == "/models/" {
 			middleware.WithCORS(appCtx.Config, proxyHandler.ModelList)(w, r)
 			return
 		}
 		if proxysvc.IsCPAPluginResourcePath(r.URL.Path) {
 			middleware.WithCORS(appCtx.Config, proxyHandler.CPAResource)(w, r)
-			return
-		}
-		if proxysvc.IsCPAProxyPath(r.URL.Path) {
-			middleware.WithCORS(appCtx.Config, proxyHandler.CPA)(w, r)
 			return
 		}
 		if r.URL.Path == "/" {

--- a/apps/manager-server/internal/httpapi/codex_inspection_test.go
+++ b/apps/manager-server/internal/httpapi/codex_inspection_test.go
@@ -47,11 +47,11 @@ func TestCodexInspectionManualActionsRoute(t *testing.T) {
 	var patchCalled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","disabled":true,"status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":200,"body":{"ok":true}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
 			patchCalled = true
 			var payload struct {
 				Name     string `json:"name"`

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -504,16 +504,6 @@ func TestServerCompatProxyRoutes(t *testing.T) {
 		t.Fatalf("reload proxy request = %#v", reloadReq)
 	}
 
-	configRR := testutil.Request(t, handler, http.MethodGet, "/config", "", testutil.AdminKey)
-	testutil.RequireStatus(t, configRR, http.StatusOK)
-	configReq, ok := cpa.LastRequest("/config")
-	if !ok {
-		t.Fatal("CPA mock did not receive /config")
-	}
-	if configReq.Authorization != "Bearer management-key" {
-		t.Fatalf("config proxy request = %#v", configReq)
-	}
-
 	modelsReq := httptest.NewRequest(http.MethodGet, "/v1/models?limit=20", nil)
 	modelsReq.Header.Set("Authorization", "Bearer upstream-key")
 	modelsRR := httptest.NewRecorder()
@@ -537,7 +527,7 @@ func TestServerCompatPluginProxyRoutes(t *testing.T) {
 		body          string
 	}
 
-	observed := make(chan observedRequest, 6)
+	observed := make(chan observedRequest, 4)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		observed <- observedRequest{
@@ -571,46 +561,6 @@ func TestServerCompatPluginProxyRoutes(t *testing.T) {
 			t.Fatalf("CPA upstream did not receive %s", path)
 		}
 	}
-
-	listRR := testutil.Request(t, handler, http.MethodGet, "/plugins?scope=all", "", testutil.AdminKey)
-	testutil.RequireStatus(t, listRR, http.StatusOK)
-	assertObserved("/plugins", observedRequest{
-		method:        http.MethodGet,
-		path:          "/plugins",
-		query:         "scope=all",
-		authorization: "Bearer management-key",
-	})
-
-	configRR := testutil.Request(
-		t,
-		handler,
-		http.MethodPut,
-		"/plugins/demo/config",
-		`{"enabled":true}`,
-		testutil.AdminKey,
-	)
-	testutil.RequireStatus(t, configRR, http.StatusOK)
-	assertObserved("/plugins/demo/config", observedRequest{
-		method:        http.MethodPut,
-		path:          "/plugins/demo/config",
-		authorization: "Bearer management-key",
-		body:          `{"enabled":true}`,
-	})
-
-	installRR := testutil.Request(
-		t,
-		handler,
-		http.MethodPost,
-		"/plugin-store/demo/install",
-		"",
-		testutil.AdminKey,
-	)
-	testutil.RequireStatus(t, installRR, http.StatusOK)
-	assertObserved("/plugin-store/demo/install", observedRequest{
-		method:        http.MethodPost,
-		path:          "/plugin-store/demo/install",
-		authorization: "Bearer management-key",
-	})
 
 	managementInstallRR := testutil.Request(
 		t,

--- a/apps/manager-server/internal/service/accountaction/service_test.go
+++ b/apps/manager-server/internal/service/accountaction/service_test.go
@@ -26,7 +26,7 @@ func TestEnableValidatesCurrentAuthFileBeforePatch(t *testing.T) {
 	var patched bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "codex-auth.json",
 				"auth_index": "7",
@@ -35,7 +35,7 @@ func TestEnableValidatesCurrentAuthFileBeforePatch(t *testing.T) {
 				"account_id": "acct-123",
 				"disabled":   true,
 			}})
-		case "PATCH /auth-files":
+		case "PATCH /v0/management/auth-files/status":
 			patched = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
@@ -66,7 +66,7 @@ func TestEnableValidatesCurrentAuthFileBeforePatch(t *testing.T) {
 		t.Fatalf("enable: %v", err)
 	}
 	if !patched {
-		t.Fatal("expected PATCH /auth-files")
+		t.Fatal("expected PATCH /v0/management/auth-files/status")
 	}
 	if updated.Status != model.AccountActionStatusResolved {
 		t.Fatalf("status = %q", updated.Status)
@@ -84,7 +84,7 @@ func TestDeleteRejectsMismatchedCurrentAuthFile(t *testing.T) {
 	var deleted bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "codex-auth.json",
 				"auth_index": "7",
@@ -92,7 +92,7 @@ func TestDeleteRejectsMismatchedCurrentAuthFile(t *testing.T) {
 				"account":    "different@example.com",
 				"account_id": "acct-456",
 			}})
-		case "DELETE /auth-files":
+		case "DELETE /v0/management/auth-files":
 			deleted = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
@@ -145,7 +145,7 @@ func TestDeleteAcceptsCurrentAuthFileProjectID(t *testing.T) {
 	var deleted bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "gemini-auth.json",
 				"auth_index": "gemini-1",
@@ -153,7 +153,7 @@ func TestDeleteAcceptsCurrentAuthFileProjectID(t *testing.T) {
 				"account":    "vertex@example.com",
 				"project_id": "vertex-project-42",
 			}})
-		case "DELETE /auth-files":
+		case "DELETE /v0/management/auth-files":
 			deleted = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
@@ -184,7 +184,7 @@ func TestDeleteAcceptsCurrentAuthFileProjectID(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 	if !deleted {
-		t.Fatal("expected DELETE /auth-files")
+		t.Fatal("expected DELETE /v0/management/auth-files")
 	}
 	if updated.Status != model.AccountActionStatusDeleted {
 		t.Fatalf("status = %q", updated.Status)

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -116,11 +116,6 @@ type fileActionGroup struct {
 	Mixed    bool
 }
 
-type actionEndpointError struct {
-	Endpoint string
-	Err      error
-}
-
 type unauthorizedReason string
 
 const (
@@ -474,15 +469,8 @@ func (s *Service) failRun(ctx context.Context, run model.CodexInspectionRun, cau
 }
 
 func (s *Service) fetchAuthFiles(ctx context.Context, setup store.Setup) ([]authFile, error) {
-	files, status, err := s.fetchAuthFilesAt(ctx, setup, "/auth-files")
-	if err == nil {
-		return files, nil
-	}
-	if status == http.StatusNotFound || status == http.StatusMethodNotAllowed {
-		files, _, err := s.fetchAuthFilesAt(ctx, setup, "/v0/management/auth-files")
-		return files, err
-	}
-	return nil, err
+	files, _, err := s.fetchAuthFilesAt(ctx, setup, "/v0/management/auth-files")
+	return files, err
 }
 
 func (s *Service) fetchAuthFilesAt(ctx context.Context, setup store.Setup, path string) ([]authFile, int, error) {
@@ -678,15 +666,8 @@ func (s *Service) requestCodexUsage(
 	settings model.ManagerCodexInspectionConfig,
 	item account,
 ) (apiCallResponse, error) {
-	result, status, err := s.requestCodexUsageAt(ctx, setup, settings, item, "/api-call")
-	if err == nil {
-		return result, nil
-	}
-	if status == http.StatusNotFound || status == http.StatusMethodNotAllowed {
-		result, _, err := s.requestCodexUsageAt(ctx, setup, settings, item, "/v0/management/api-call")
-		return result, err
-	}
-	return apiCallResponse{}, err
+	result, _, err := s.requestCodexUsageAt(ctx, setup, settings, item, "/v0/management/api-call")
+	return result, err
 }
 
 func (s *Service) requestCodexUsageAt(
@@ -881,44 +862,12 @@ func collectActionOutcomes(outcomes <-chan ActionOutcome, capacity int) []Action
 func (s *Service) executeAction(ctx context.Context, setup store.Setup, item model.CodexInspectionResult) error {
 	switch item.Action {
 	case "delete":
-		if err, status := s.deleteAuthFile(ctx, setup, "/auth-files", item.FileName); err != nil {
-			if shouldFallbackManagement(status) {
-				return s.deleteAuthFileOnly(ctx, setup, "/v0/management/auth-files", item.FileName)
-			}
-			return err
-		}
-		return nil
+		return s.deleteAuthFileOnly(ctx, setup, "/v0/management/auth-files", item.FileName)
 	case "disable", "enable":
 		disabled := item.Action == "disable"
 		payload := map[string]any{"name": item.FileName, "disabled": disabled}
-		primaryErr, primaryStatus := s.patchAuthFile(ctx, setup, "/auth-files", payload)
-		if primaryErr == nil {
-			return nil
-		}
-		statusErr, statusCode := s.patchAuthFile(ctx, setup, "/auth-files/status", payload)
-		if statusErr == nil {
-			return nil
-		}
-		if shouldFallbackManagement(primaryStatus) && shouldFallbackManagement(statusCode) {
-			managementErr, _ := s.patchAuthFile(ctx, setup, "/v0/management/auth-files", payload)
-			if managementErr == nil {
-				return nil
-			}
-			managementStatusErr, _ := s.patchAuthFile(ctx, setup, "/v0/management/auth-files/status", payload)
-			if managementStatusErr == nil {
-				return nil
-			}
-			return combineActionEndpointErrors(
-				actionEndpointError{Endpoint: "/auth-files", Err: primaryErr},
-				actionEndpointError{Endpoint: "/auth-files/status", Err: statusErr},
-				actionEndpointError{Endpoint: "/v0/management/auth-files", Err: managementErr},
-				actionEndpointError{Endpoint: "/v0/management/auth-files/status", Err: managementStatusErr},
-			)
-		}
-		return combineActionEndpointErrors(
-			actionEndpointError{Endpoint: "/auth-files", Err: primaryErr},
-			actionEndpointError{Endpoint: "/auth-files/status", Err: statusErr},
-		)
+		err, _ := s.patchAuthFile(ctx, setup, "/v0/management/auth-files/status", payload)
+		return err
 	default:
 		return nil
 	}
@@ -936,25 +885,6 @@ func (s *Service) deleteAuthFile(ctx context.Context, setup store.Setup, path st
 		return err, 0
 	}
 	return s.doCPAAction(req, setup.ManagementKey)
-}
-
-func (s *Service) patchAuthFileOnly(ctx context.Context, setup store.Setup, path string, payload map[string]any) error {
-	err, _ := s.patchAuthFile(ctx, setup, path, payload)
-	return err
-}
-
-func combineActionEndpointErrors(items ...actionEndpointError) error {
-	parts := make([]string, 0, len(items))
-	for _, item := range items {
-		if item.Err == nil {
-			continue
-		}
-		parts = append(parts, fmt.Sprintf("%s: %v", item.Endpoint, item.Err))
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	return errors.New(strings.Join(parts, "; "))
 }
 
 func (s *Service) patchAuthFile(ctx context.Context, setup store.Setup, path string, payload map[string]any) (error, int) {
@@ -993,10 +923,6 @@ func (s *Service) doCPAAction(req *http.Request, managementKey string) (error, i
 		}
 	}
 	return nil, res.StatusCode
-}
-
-func shouldFallbackManagement(status int) bool {
-	return status == http.StatusNotFound || status == http.StatusMethodNotAllowed
 }
 
 type runLogger struct {

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -22,11 +22,11 @@ import (
 func TestRunPersistsLogsResultsAndDetail(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"unauthorized"}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -88,11 +88,11 @@ func TestRunAutoActionNoneDoesNotExecuteActions(t *testing.T) {
 	var patchCalled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","disabled":true,"status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":200,"body":{"ok":true}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
 			patchCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -129,11 +129,11 @@ func TestRunAutoActionEnableEnablesRecoveredDisabledAccount(t *testing.T) {
 	var patchedDisabled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","disabled":true,"status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":200,"body":{"ok":true}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
 			patchCalled = true
 			var payload struct {
 				Name     string `json:"name"`
@@ -191,11 +191,11 @@ func TestRunAutoActionDisableExecutesDeleteSuggestionAsDisable(t *testing.T) {
 	var patchedDisabled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"Your authentication token has been invalidated."}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
 			patchCalled = true
 			var payload struct {
 				Name     string `json:"name"`
@@ -209,7 +209,7 @@ func TestRunAutoActionDisableExecutesDeleteSuggestionAsDisable(t *testing.T) {
 			}
 			patchedDisabled = payload.Disabled
 			_, _ = w.Write([]byte(`{"ok":true}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			deleteCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -254,11 +254,11 @@ func TestRunAutoActionSkipsDuplicateFileNameResults(t *testing.T) {
 	var deleteCalls int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"},{"name":"auth-a.json","auth_index":"auth-2","provider":"codex","account":"bob@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"Your authentication token has been invalidated."}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			deleteCalls++
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -376,11 +376,11 @@ func TestRunClassifiesExpiredUnauthorizedAsReauth(t *testing.T) {
 	var deleteCalled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"Provided authentication token is expired. Please try signing in again."}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			deleteCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -416,9 +416,9 @@ func TestRunClassifiesExpiredUnauthorizedAsReauth(t *testing.T) {
 func TestRunClassifiesInvalidatedUnauthorizedAsDelete(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"Your authentication token has been invalidated. Please try signing in again."}}`))
 		default:
 			http.NotFound(w, r)
@@ -561,9 +561,9 @@ func TestResolveProbeActionUsesMonthlyWindowAsLongQuota(t *testing.T) {
 func TestRunSuggestsDeleteForDeactivatedWorkspace(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":402,"body":{"detail":{"code":"deactivated_workspace"}}}`))
 		default:
 			http.NotFound(w, r)
@@ -594,55 +594,14 @@ func TestRunSuggestsDeleteForDeactivatedWorkspace(t *testing.T) {
 	}
 }
 
-func TestRunFallsBackToManagementAPICallPath(t *testing.T) {
-	var legacyAPICalls int
-	var managementAPICalls int
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
-			legacyAPICalls++
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
-			managementAPICalls++
-			_, _ = w.Write([]byte(`{"status_code":200,"body":{"ok":true}}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(upstream.Close)
-
-	db := newCodexInspectionTestStore(t)
-	if err := db.SaveManagerConfig(context.Background(), newCodexInspectionManagerConfig(upstream.URL)); err != nil {
-		t.Fatalf("save manager config: %v", err)
-	}
-	svc := newCodexInspectionTestService(t, db)
-
-	result, err := svc.Run(context.Background(), RunRequest{
-		TriggerType: "manual",
-		TriggerKey:  "manual",
-	})
-	if err != nil {
-		t.Fatalf("run inspection: %v", err)
-	}
-	if result.Run.Status != model.CodexInspectionStatusCompleted {
-		t.Fatalf("run status = %q", result.Run.Status)
-	}
-	if legacyAPICalls != 1 || managementAPICalls != 1 {
-		t.Fatalf("api-call counts legacy=%d management=%d, want 1/1", legacyAPICalls, managementAPICalls)
-	}
-}
 
 func TestRunSendsDirectCodexAccountIDHeader(t *testing.T) {
 	var accountIDHeader string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account_id":"acct-direct","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			var payload struct {
 				Header map[string]string `json:"header"`
 			}
@@ -674,144 +633,17 @@ func TestRunSendsDirectCodexAccountIDHeader(t *testing.T) {
 	}
 }
 
-func TestRunFallsBackToManagementAuthFileActionPath(t *testing.T) {
-	var legacyDeleteCalls int
-	var managementDeleteCalls int
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"unauthorized"}}`))
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodDelete:
-			legacyDeleteCalls++
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodDelete:
-			managementDeleteCalls++
-			if r.URL.Query().Get("name") != "auth-a.json" {
-				t.Fatalf("delete name = %q, want auth-a.json", r.URL.Query().Get("name"))
-			}
-			_, _ = w.Write([]byte(`{"ok":true}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(upstream.Close)
 
-	db := newCodexInspectionTestStore(t)
-	if err := db.SaveManagerConfig(context.Background(), newCodexInspectionManagerConfig(upstream.URL)); err != nil {
-		t.Fatalf("save manager config: %v", err)
-	}
-	svc := newCodexInspectionTestService(t, db)
-
-	result, err := svc.Run(context.Background(), RunRequest{
-		TriggerType: "manual",
-		TriggerKey:  "manual",
-	})
-	if err != nil {
-		t.Fatalf("run inspection: %v", err)
-	}
-	if result.Run.DeleteCount != 1 || result.Run.KeepCount != 0 {
-		t.Fatalf("run counts delete=%d keep=%d, want 1/0", result.Run.DeleteCount, result.Run.KeepCount)
-	}
-	if result.Results[0].Action != "delete" ||
-		result.Results[0].ActionStatus != model.CodexInspectionActionStatusSuccess ||
-		result.Results[0].ExecutedAction != "delete" {
-		t.Fatalf("result after delete = %#v", result.Results[0])
-	}
-	if result.Run.Error != "" {
-		t.Fatalf("run error = %q", result.Run.Error)
-	}
-	if legacyDeleteCalls != 1 || managementDeleteCalls != 1 {
-		t.Fatalf("delete counts legacy=%d management=%d, want 1/1", legacyDeleteCalls, managementDeleteCalls)
-	}
-}
-
-func TestRunFallsBackToManagementAuthFileStatusActionPath(t *testing.T) {
-	var legacyPatchCalls int
-	var managementPatchCalls int
-	var patchedDisabled bool
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
-			_, _ = w.Write([]byte(`{"status_code":402,"body":{"message":"limit reached"}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
-			legacyPatchCalls++
-			http.NotFound(w, r)
-		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodPatch:
-			managementPatchCalls++
-			var payload struct {
-				Name     string `json:"name"`
-				Disabled bool   `json:"disabled"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode patch payload: %v", err)
-			}
-			if payload.Name != "auth-a.json" {
-				t.Fatalf("patch name = %q, want auth-a.json", payload.Name)
-			}
-			patchedDisabled = payload.Disabled
-			_, _ = w.Write([]byte(`{"ok":true}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(upstream.Close)
-
-	db := newCodexInspectionTestStore(t)
-	if err := db.SaveManagerConfig(context.Background(), newCodexInspectionManagerConfig(upstream.URL)); err != nil {
-		t.Fatalf("save manager config: %v", err)
-	}
-	svc := newCodexInspectionTestService(t, db)
-
-	result, err := svc.Run(context.Background(), RunRequest{
-		TriggerType: "manual",
-		TriggerKey:  "manual",
-	})
-	if err != nil {
-		t.Fatalf("run inspection: %v", err)
-	}
-	if result.Run.DisableCount != 1 || result.Run.KeepCount != 0 {
-		t.Fatalf("run counts disable=%d keep=%d, want 1/0", result.Run.DisableCount, result.Run.KeepCount)
-	}
-	if result.Run.DisabledCount != 1 {
-		t.Fatalf("disabled count = %d, want 1", result.Run.DisabledCount)
-	}
-	if result.Run.Error != "" {
-		t.Fatalf("run error = %q", result.Run.Error)
-	}
-	if legacyPatchCalls != 2 || managementPatchCalls != 1 {
-		t.Fatalf("patch counts legacy=%d management=%d, want 2/1", legacyPatchCalls, managementPatchCalls)
-	}
-	if !patchedDisabled {
-		t.Fatal("management patch did not disable the auth file")
-	}
-	if result.Results[0].Action != "disable" ||
-		result.Results[0].ActionStatus != model.CodexInspectionActionStatusSuccess ||
-		result.Results[0].ExecutedAction != "disable" {
-		t.Fatalf("result after disable = %#v", result.Results[0])
-	}
-}
 
 func TestExecuteManualActionsProcessesCompletedRunResults(t *testing.T) {
 	var patchCalled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","disabled":true,"status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":200,"body":{"ok":true}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
 			patchCalled = true
 			var payload struct {
 				Name     string `json:"name"`
@@ -877,16 +709,16 @@ func TestExecuteManualActionsRejectsChangedAuthIndex(t *testing.T) {
 	var deleteCalled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			authFilesCalls++
 			if authFilesCalls == 1 {
 				_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-2","provider":"codex","account":"bob@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"Your authentication token has been invalidated."}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			deleteCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -935,16 +767,16 @@ func TestExecuteManualActionsRejectsMissingAuthFile(t *testing.T) {
 	var patchCalled bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			authFilesCalls++
 			if authFilesCalls == 1 {
 				_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
 				return
 			}
 			_, _ = w.Write([]byte(`{"files":[]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":402,"body":{"message":"limit reached"}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
 			patchCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -991,11 +823,11 @@ func TestExecuteManualActionsSkipsDuplicateFileNameSelections(t *testing.T) {
 	var deleteCalls int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"},{"name":"auth-a.json","auth_index":"auth-2","provider":"codex","account":"bob@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			_, _ = w.Write([]byte(`{"status_code":401,"body":{"message":"Your authentication token has been invalidated."}}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			deleteCalls++
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:
@@ -1046,9 +878,9 @@ func TestRunFinalizesAfterContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","status":"ok","state":"ready"}]}`))
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			cancel()
 			time.Sleep(20 * time.Millisecond)
 			_, _ = w.Write([]byte(`{"status_code":200,"body":{"ok":true}}`))
@@ -1087,12 +919,10 @@ func TestRunFinalizesAfterContextCancellation(t *testing.T) {
 	}
 }
 
-func TestExecuteActionReturnsCombinedPatchFallbackErrors(t *testing.T) {
+func TestExecuteActionReturnsPatchError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPatch && r.URL.Path == "/auth-files":
-			http.Error(w, "primary patch failed", http.StatusInternalServerError)
-		case r.Method == http.MethodPatch && r.URL.Path == "/auth-files/status":
+		case r.Method == http.MethodPatch && r.URL.Path == "/v0/management/auth-files/status":
 			http.Error(w, "status patch failed", http.StatusInternalServerError)
 		default:
 			http.NotFound(w, r)
@@ -1109,14 +939,11 @@ func TestExecuteActionReturnsCombinedPatchFallbackErrors(t *testing.T) {
 		Action:   "disable",
 	})
 	if err == nil {
-		t.Fatal("execute action succeeded, want combined patch error")
+		t.Fatal("execute action succeeded, want patch error")
 	}
 	message := err.Error()
-	if !strings.Contains(message, "/auth-files:") ||
-		!strings.Contains(message, "primary patch failed") ||
-		!strings.Contains(message, "/auth-files/status:") ||
-		!strings.Contains(message, "status patch failed") {
-		t.Fatalf("combined patch error = %q", message)
+	if !strings.Contains(message, "status patch failed") {
+		t.Fatalf("patch error = %q", message)
 	}
 }
 
@@ -1195,7 +1022,7 @@ func newMixedAutoActionServer(
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/auth-files" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			switch fixture {
 			case mixedAutoActionFixtureEnableDelete:
 				_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","account":"alice@example.com","disabled":true,"status":"ok","state":"ready"},{"name":"auth-a.json","auth_index":"auth-2","provider":"codex","account":"bob@example.com","status":"ok","state":"ready"}]}`))
@@ -1204,7 +1031,7 @@ func newMixedAutoActionServer(
 			default:
 				t.Fatalf("unexpected mixed fixture %q", fixture)
 			}
-		case r.URL.Path == "/api-call" && r.Method == http.MethodPost:
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			var payload struct {
 				AuthIndex string `json:"authIndex"`
 			}
@@ -1223,10 +1050,10 @@ func newMixedAutoActionServer(
 			default:
 				t.Fatalf("unexpected authIndex %q", payload.AuthIndex)
 			}
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodDelete:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodDelete:
 			*deleteCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
-		case strings.HasPrefix(r.URL.Path, "/auth-files") && r.Method == http.MethodPatch:
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
 			*patchCalled = true
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		default:

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -56,40 +56,32 @@ func New(client *http.Client, timeout ...time.Duration) *Client {
 	return &Client{httpClient: client, timeout: d}
 }
 
+const authFilesPath = "/v0/management/auth-files"
+const authFilesStatusPath = "/v0/management/auth-files/status"
+
 func (c *Client) Fetch(ctx context.Context, baseURL string, managementKey string) ([]File, error) {
 	base := cpa.NormalizeBaseURL(baseURL)
-	paths := []string{"/auth-files", "/v0/management/auth-files"}
-	var endpointErrors []error
-	for _, path := range paths {
-		reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
-		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+path, nil)
-		if err != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: %w", path, err))
-			continue
-		}
-		req.Header.Set("Authorization", "Bearer "+managementKey)
-		res, err := c.httpClient.Do(req)
-		if err != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: %w", path, err))
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
-		_ = res.Body.Close()
-		cancel()
-		if res.StatusCode < 200 || res.StatusCode >= 300 {
-			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: HTTP %d %s", path, res.StatusCode, strings.TrimSpace(string(body))))
-			continue
-		}
-		files, err := Parse(body)
-		if err != nil {
-			endpointErrors = append(endpointErrors, fmt.Errorf("GET %s: %w", path, err))
-			continue
-		}
-		return files, nil
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+authFilesPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
-	return nil, combineErrors(endpointErrors...)
+	req.Header.Set("Authorization", "Bearer "+managementKey)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
+	}
+	files, err := Parse(body)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	return files, nil
 }
 
 func Parse(body []byte) ([]File, error) {
@@ -145,68 +137,49 @@ func (c *Client) PatchDisabled(ctx context.Context, baseURL string, managementKe
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 	base := cpa.NormalizeBaseURL(baseURL)
-	paths := []string{"/auth-files", "/auth-files/status", "/v0/management/auth-files", "/v0/management/auth-files/status"}
-	var endpointErrors []error
-	for _, path := range paths {
-		reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
-		req, err := http.NewRequestWithContext(reqCtx, http.MethodPatch, base+path, bytes.NewReader(data))
-		if err != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Errorf("PATCH %s: %w", path, err))
-			continue
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+managementKey)
-		res, err := c.httpClient.Do(req)
-		if err != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Errorf("PATCH %s: %w", path, err))
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
-		_ = res.Body.Close()
-		cancel()
-		if res.StatusCode >= 200 && res.StatusCode < 300 {
-			return nil
-		}
-		endpointErrors = append(endpointErrors, fmt.Errorf("PATCH %s: HTTP %d %s", path, res.StatusCode, strings.TrimSpace(string(body))))
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPatch, base+authFilesStatusPath, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("PATCH %s: %w", authFilesStatusPath, err)
 	}
-	return combineErrors(endpointErrors...)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+managementKey)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("PATCH %s: %w", authFilesStatusPath, err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("PATCH %s: HTTP %d %s", authFilesStatusPath, res.StatusCode, strings.TrimSpace(string(body)))
 }
 
 func (c *Client) Delete(ctx context.Context, baseURL string, managementKey string, fileName string) error {
 	base := cpa.NormalizeBaseURL(baseURL)
-	paths := []string{"/auth-files", "/v0/management/auth-files"}
-	var endpointErrors []error
-	for _, path := range paths {
-		reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
-		endpoint := base + path + "?name=" + url.QueryEscape(fileName)
-		req, err := http.NewRequestWithContext(reqCtx, http.MethodDelete, endpoint, nil)
-		if err != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: %w", path, err))
-			continue
-		}
-		req.Header.Set("Authorization", "Bearer "+managementKey)
-		res, err := c.httpClient.Do(req)
-		if err != nil {
-			cancel()
-			endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: %w", path, err))
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
-		_ = res.Body.Close()
-		cancel()
-		if res.StatusCode >= 200 && res.StatusCode < 300 {
-			if actionFailed(body) {
-				endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: CPA action failed", path))
-				continue
-			}
-			return nil
-		}
-		endpointErrors = append(endpointErrors, fmt.Errorf("DELETE %s: HTTP %d %s", path, res.StatusCode, strings.TrimSpace(string(body))))
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	endpoint := base + authFilesPath + "?name=" + url.QueryEscape(fileName)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("DELETE %s: %w", authFilesPath, err)
 	}
-	return combineErrors(endpointErrors...)
+	req.Header.Set("Authorization", "Bearer "+managementKey)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("DELETE %s: %w", authFilesPath, err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		if actionFailed(body) {
+			return fmt.Errorf("DELETE %s: CPA action failed", authFilesPath)
+		}
+		return nil
+	}
+	return fmt.Errorf("DELETE %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
 }
 
 func filesFromJSON(value any) []File {
@@ -288,17 +261,4 @@ func actionFailed(body []byte) bool {
 	}
 	failed, ok := payload["failed"].([]any)
 	return ok && len(failed) > 0
-}
-
-func combineErrors(errs ...error) error {
-	parts := make([]string, 0, len(errs))
-	for _, err := range errs {
-		if err != nil {
-			parts = append(parts, err.Error())
-		}
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	return errors.New(strings.Join(parts, "; "))
 }

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -54,9 +54,9 @@ func TestClientPatchDisabledAndDelete(t *testing.T) {
 			return
 		}
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "codex-auth.json", "auth_index": "7"}})
-		case "PATCH /auth-files":
+		case "PATCH /v0/management/auth-files/status":
 			var payload struct {
 				Name     string `json:"name"`
 				Disabled bool   `json:"disabled"`
@@ -70,7 +70,7 @@ func TestClientPatchDisabledAndDelete(t *testing.T) {
 			}
 			patched = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
-		case "DELETE /auth-files":
+		case "DELETE /v0/management/auth-files":
 			if r.URL.Query().Get("name") != "codex-auth.json" {
 				t.Fatalf("delete query = %s", r.URL.RawQuery)
 			}

--- a/apps/manager-server/internal/service/proxy/service.go
+++ b/apps/manager-server/internal/service/proxy/service.go
@@ -26,11 +26,11 @@ func (s *Service) ProxyManagement(w http.ResponseWriter, r *http.Request, writeE
 	s.proxyWithSavedManagementKey(w, r, writeError)
 }
 
-func (s *Service) ProxyCPA(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
-	s.proxyWithSavedManagementKey(w, r, writeError)
-}
-
 func (s *Service) proxyWithSavedManagementKey(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
+	if !isManagementPath(r.URL.Path) {
+		writeError(w, http.StatusNotFound, errors.New("proxy path must be under /v0/management/"))
+		return
+	}
 	setup, ok, err := s.resolveSetup(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -65,6 +65,10 @@ func (s *Service) ProxyModelList(w http.ResponseWriter, r *http.Request, writeEr
 		methodNotAllowed(w)
 		return
 	}
+	if !isModelListPath(r.URL.Path) {
+		writeError(w, http.StatusNotFound, errors.New("model list proxy path must be /v1/models"))
+		return
+	}
 	setup, ok, err := s.resolveSetup(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -93,82 +97,21 @@ func (s *Service) ProxyModelList(w http.ResponseWriter, r *http.Request, writeEr
 	proxy.ServeHTTP(w, r)
 }
 
-func IsModelListPath(path string) bool {
+func isModelListPath(path string) bool {
 	cleaned := strings.TrimRight(path, "/")
 	return cleaned == "/v1/models" || cleaned == "/models"
 }
 
-func IsCPAProxyPath(path string) bool {
-	cleaned := strings.TrimRight(path, "/")
-	if cleaned == "" {
-		return false
-	}
-	if _, ok := exactCPAProxyPaths[cleaned]; ok {
+func isManagementPath(path string) bool {
+	if path == "/v0/management" || strings.HasPrefix(path, "/v0/management/") {
 		return true
 	}
-	for _, prefix := range cpaProxyPathPrefixes {
-		if cleaned == prefix || strings.HasPrefix(cleaned, prefix+"/") {
-			return true
-		}
-	}
-	return false
+	return IsCPAPluginResourcePath(path)
 }
 
 func IsCPAPluginResourcePath(path string) bool {
 	cleaned := strings.TrimRight(path, "/")
 	return cleaned == cpaPluginResourcePrefix || strings.HasPrefix(cleaned, cpaPluginResourcePrefix+"/")
-}
-
-var exactCPAProxyPaths = map[string]struct{}{
-	"/ampcode":                             {},
-	"/api-call":                            {},
-	"/api-key-usage":                       {},
-	"/api-keys":                            {},
-	"/anthropic-auth-url":                  {},
-	"/antigravity-auth-url":                {},
-	"/claude-api-key":                      {},
-	"/codex-api-key":                       {},
-	"/codex-auth-url":                      {},
-	"/config":                              {},
-	"/config.yaml":                         {},
-	"/debug":                               {},
-	"/force-model-prefix":                  {},
-	"/gemini-api-key":                      {},
-	"/gemini-cli-auth-url":                 {},
-	"/get-auth-status":                     {},
-	"/latest-version":                      {},
-	"/logging-to-file":                     {},
-	"/logs":                                {},
-	"/logs-max-total-size-mb":              {},
-	"/oauth-callback":                      {},
-	"/oauth-excluded-models":               {},
-	"/oauth-model-alias":                   {},
-	"/openai-compatibility":                {},
-	"/plugin-store":                        {},
-	"/plugins":                             {},
-	"/proxy-url":                           {},
-	"/quota-exceeded/switch-preview-model": {},
-	"/quota-exceeded/switch-project":       {},
-	"/request-error-logs":                  {},
-	"/request-log":                         {},
-	"/request-retry":                       {},
-	"/routing/strategy":                    {},
-	"/vertex-api-key":                      {},
-	"/vertex/import":                       {},
-	"/ws-auth":                             {},
-	"/xai-auth-url":                        {},
-}
-
-var cpaProxyPathPrefixes = []string{
-	"/ampcode/",
-	"/auth-files",
-	"/oauth-excluded-models/",
-	"/oauth-model-alias/",
-	"/plugin-store",
-	"/plugins",
-	cpaPluginResourcePrefix,
-	"/request-error-logs",
-	"/request-log-by-id",
 }
 
 func (s *Service) resolveSetup(ctx context.Context) (store.Setup, bool, error) {

--- a/apps/manager-server/internal/service/proxy/service_test.go
+++ b/apps/manager-server/internal/service/proxy/service_test.go
@@ -2,27 +2,55 @@ package proxy
 
 import "testing"
 
-func TestIsCPAProxyPathIncludesPluginRoutes(t *testing.T) {
+func TestIsManagementPath(t *testing.T) {
 	tests := []struct {
 		path string
 		want bool
 	}{
-		{path: "/plugins", want: true},
-		{path: "/plugins/", want: true},
-		{path: "/plugins/example/config", want: true},
-		{path: "/plugin-store", want: true},
-		{path: "/plugin-store/", want: true},
-		{path: "/plugin-store/example/install", want: true},
+		{path: "/v0/management", want: true},
+		{path: "/v0/management/", want: true},
+		{path: "/v0/management/auth-files", want: true},
+		{path: "/v0/management/auth-files/status", want: true},
+		{path: "/v0/management/api-call", want: true},
+		{path: "/v0/management/api-key-usage", want: true},
+		{path: "/v0/resource/plugins", want: true},
 		{path: "/v0/resource/plugins/codex-invite/invite", want: true},
-		{path: "/v0/resource/plugins/codex-invite/assets/app.js", want: true},
-		{path: "/plugin-pages/example/0", want: false},
-		{path: "/plugin", want: false},
+		{path: "/v0/resource/plugin", want: false},
+		{path: "/v0/resource/plugin-store", want: false},
+		{path: "/v1/models", want: false},
+		{path: "/models", want: false},
+		{path: "/auth-files", want: false},
+		{path: "/api-call", want: false},
+		{path: "/", want: false},
+		{path: "", want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			if got := IsCPAProxyPath(tt.path); got != tt.want {
-				t.Fatalf("IsCPAProxyPath(%q) = %v, want %v", tt.path, got, tt.want)
+			if got := isManagementPath(tt.path); got != tt.want {
+				t.Fatalf("isManagementPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsModelListPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/v1/models", want: true},
+		{path: "/v1/models/", want: true},
+		{path: "/models", want: true},
+		{path: "/models/", want: true},
+		{path: "/v1/chat/completions", want: false},
+		{path: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isModelListPath(tt.path); got != tt.want {
+				t.Fatalf("isModelListPath(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -102,7 +102,7 @@ func TestAccountActionCandidateWorkerAutoDisablesMatchingIdentity(t *testing.T) 
 			return
 		}
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "codex-auth.json",
 				"auth_index": "7",
@@ -111,7 +111,7 @@ func TestAccountActionCandidateWorkerAutoDisablesMatchingIdentity(t *testing.T) 
 				"account_id": "acct-123",
 				"disabled":   false,
 			}})
-		case "PATCH /auth-files":
+		case "PATCH /v0/management/auth-files/status":
 			var payload struct {
 				Name     string `json:"name"`
 				Disabled bool   `json:"disabled"`
@@ -166,7 +166,7 @@ func TestAccountActionCandidateWorkerAutoDisableRejectsIdentityMismatch(t *testi
 	var patched bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "codex-auth.json",
 				"auth_index": "7",
@@ -174,7 +174,7 @@ func TestAccountActionCandidateWorkerAutoDisableRejectsIdentityMismatch(t *testi
 				"account":    "different@example.com",
 				"account_id": "acct-456",
 			}})
-		case "PATCH /auth-files":
+		case "PATCH /v0/management/auth-files/status":
 			patched = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
@@ -218,7 +218,7 @@ func TestAccountActionCandidateWorkerAutoDisablesReauth(t *testing.T) {
 	var patched bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "codex-auth.json",
 				"auth_index": "7",
@@ -227,7 +227,7 @@ func TestAccountActionCandidateWorkerAutoDisablesReauth(t *testing.T) {
 				"account_id": "acct-123",
 				"disabled":   false,
 			}})
-		case "PATCH /auth-files":
+		case "PATCH /v0/management/auth-files/status":
 			patched = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
@@ -271,7 +271,7 @@ func TestAccountActionCandidateWorkerAutoDisableSkipsAlreadyDisabled(t *testing.
 	var patched bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method + " " + r.URL.Path {
-		case "GET /auth-files":
+		case "GET /v0/management/auth-files":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
 				"name":       "codex-auth.json",
 				"auth_index": "7",
@@ -280,7 +280,7 @@ func TestAccountActionCandidateWorkerAutoDisableSkipsAlreadyDisabled(t *testing.
 				"account_id": "acct-123",
 				"disabled":   true,
 			}})
-		case "PATCH /auth-files":
+		case "PATCH /v0/management/auth-files/status":
 			patched = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -535,14 +535,6 @@ func (w *RateLimitAutoDisableWorker) currentAuthFile(ctx context.Context, baseUR
 	return file, ok, nil
 }
 
-func (w *RateLimitAutoDisableWorker) disableAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string) error {
-	return w.patchAuthFile(ctx, baseURL, managementKey, fileName, true)
-}
-
-func (w *RateLimitAutoDisableWorker) enableAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string) error {
-	return w.patchAuthFile(ctx, baseURL, managementKey, fileName, false)
-}
-
 func (w *RateLimitAutoDisableWorker) patchAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {
 	return cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).PatchDisabled(ctx, baseURL, managementKey, fileName, disabled)
 }

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -110,34 +110,37 @@ func TestRateLimitAutoDisableWorkerRecoversDueCooldownFromManagerRuntimeConfigAf
 			return
 		}
 		switch r.URL.Path {
-		case "/auth-files", "/v0/management/auth-files":
-			switch r.Method {
-			case http.MethodGet:
-				mu.Lock()
-				currentDisabled := disabled
-				mu.Unlock()
-				_ = json.NewEncoder(w).Encode([]map[string]any{{
-					"name":       "codex-auth.json",
-					"auth_index": "auth-1",
-					"disabled":   currentDisabled,
-				}})
-			case http.MethodPatch:
-				var item struct {
-					Name     string `json:"name"`
-					Disabled bool   `json:"disabled"`
-				}
-				if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
-				}
-				mu.Lock()
-				disabled = item.Disabled
-				patches++
-				mu.Unlock()
-				w.WriteHeader(http.StatusOK)
-			default:
+		case "/v0/management/auth-files":
+			if r.Method != http.MethodGet {
 				http.NotFound(w, r)
+				return
 			}
+			mu.Lock()
+			currentDisabled := disabled
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"name":       "codex-auth.json",
+				"auth_index": "auth-1",
+				"disabled":   currentDisabled,
+			}})
+		case "/v0/management/auth-files/status":
+			if r.Method != http.MethodPatch {
+				http.NotFound(w, r)
+				return
+			}
+			var item struct {
+				Name     string `json:"name"`
+				Disabled bool   `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			disabled = item.Disabled
+			patches++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
 		case "/v0/management/usage-queue":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[]`))
@@ -215,7 +218,7 @@ func TestRateLimitAutoDisableWorkerPersistsAndRecoversAfterRestart(t *testing.T)
 			http.Error(w, "missing auth", http.StatusUnauthorized)
 			return
 		}
-		if r.URL.Path != "/auth-files" {
+		if r.URL.Path != "/v0/management/auth-files" && r.URL.Path != "/v0/management/auth-files/status" {
 			http.NotFound(w, r)
 			return
 		}
@@ -230,6 +233,10 @@ func TestRateLimitAutoDisableWorkerPersistsAndRecoversAfterRestart(t *testing.T)
 				"disabled":  currentDisabled,
 			}})
 		case http.MethodPatch:
+			if r.URL.Path != "/v0/management/auth-files/status" {
+				http.NotFound(w, r)
+				return
+			}
 			var item action
 			if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
## Summary

Codex account inspection, rate-limit auto-disable, and the embedded reverse proxy all used to probe short paths like `/api-call`, `/auth-files`, and `/auth-files/status` against the upstream CPA server before falling back to the long `/v0/management/*` routes. CPA never serves those short paths, so every probe generated a `404 WARN` in the upstream gin log and wasted one round-trip per call.

This refactor removes the short-path probing entirely and replaces the broad proxy allowlist (37 exact paths + 9 prefixes) with explicit long-path predicates.

## Changes

- `cpaauthfiles`: `Fetch` / `PatchDisabled` / `Delete` call a single `/v0/management/auth-files{,/status}` path; drop the `combineErrors` helper.
- `codexinspection`: `fetchAuthFiles`, `requestCodexUsage`, and `executeAction` call long paths directly; remove `shouldFallbackManagement`, `combineActionEndpointErrors`, and `actionEndpointError` types.
- `worker/rate_limit_auto_disable`: remove unused `disableAuthFile` / `enableAuthFile` wrappers and align test mocks with the new `/v0/management/auth-files/status` PATCH contract.
- `proxy/service`: delete `IsCPAProxyPath`, `exactCPAProxyPaths`, and `cpaProxyPathPrefixes`; replace with explicit `isManagementPath` and `isModelListPath` predicates. The reverse proxy director now returns 404 for any non-management / non-resource path before contacting CPA, preventing accidental regression of the short-path bug.
- `proxy/handler`: drop the `CPA` and `CPAResource` short-path handlers (resources still flow through the management proxy).
- `router`: remove the `IsCPAProxyPath` / `IsModelListPath` branches; keep the explicit `/v1/models` and `/models` model list routes plus the `/v0/management/` catch-all.
- `cpaauthfiles_test`, `accountaction_test`, `worker_test`, `httpapi/codex_inspection_test`, `httpapi/server_compat_test`: align upstream mock paths and remove tests that asserted the deleted multi-endpoint fallback contract.

## Testing

- `go build ./...` — clean.
- `go test ./internal/...` — all 22 packages pass.

## Impact

- Eliminates 1 extra round-trip per codex inspection probe.
- Eliminates 1-2 extra round-trips per enable/disable/delete action.
- Clears the false-positive `WARN 404` entries from the upstream CPA log.
- ~377 lines net deletion in the Go service layer.

## Commits

1. `♻️ refactor(cpaauthfiles): drop short-path fallback for CPA auth file API`
2. `♻️ refactor(codexinspection): drop short-path fallback for CPA auth file actions`
3. `♻️ refactor(worker): drop unused enable/disable helpers and align quota auto-disable mocks`
4. `♻️ refactor(proxy): drop CPA short-path allowlist and harden reverse proxy director`
5. `✅ test(httpapi): align compat and codex inspection tests with long-path upstream`