### PR TITLE
docs(release): fix release note language links

### DIFF
--- a/docs/release-notes/v1.1.0-en.md
+++ b/docs/release-notes/v1.1.0-en.md
@@ -2,7 +2,7 @@
 
 > 15 commits · 42 files changed · +1827 / -178
 
-> [中文 ->](./v1.1.0-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.1.0/docs/release-notes/v1.1.0-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.1.0-zh.md
+++ b/docs/release-notes/v1.1.0-zh.md
@@ -2,7 +2,7 @@
 
 > 15 commits · 42 files changed · +1827 / -178
 
-> [English ->](./v1.1.0-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.1.0/docs/release-notes/v1.1.0-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.1.1-en.md
+++ b/docs/release-notes/v1.1.1-en.md
@@ -2,7 +2,7 @@
 
 > 5 commits · 11 files changed · +486 / -95
 
-> [中文 ->](./v1.1.1-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.1.1/docs/release-notes/v1.1.1-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.1.1-zh.md
+++ b/docs/release-notes/v1.1.1-zh.md
@@ -2,7 +2,7 @@
 
 > 5 commits · 11 files changed · +486 / -95
 
-> [English ->](./v1.1.1-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.1.1/docs/release-notes/v1.1.1-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.2.0-en.md
+++ b/docs/release-notes/v1.2.0-en.md
@@ -2,7 +2,7 @@
 
 > 10 commits · 34 files changed · +1307 / -527
 
-> [中文 ->](./v1.2.0-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.2.0/docs/release-notes/v1.2.0-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.2.0-zh.md
+++ b/docs/release-notes/v1.2.0-zh.md
@@ -2,7 +2,7 @@
 
 > 10 commits · 34 files changed · +1307 / -527
 
-> [English ->](./v1.2.0-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.2.0/docs/release-notes/v1.2.0-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.2.1-en.md
+++ b/docs/release-notes/v1.2.1-en.md
@@ -2,7 +2,7 @@
 
 > 7 commits · 17 files changed · +1123 / -615
 
-> [中文 ->](./v1.2.1-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.2.1/docs/release-notes/v1.2.1-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.2.1-zh.md
+++ b/docs/release-notes/v1.2.1-zh.md
@@ -2,7 +2,7 @@
 
 > 7 commits · 17 files changed · +1123 / -615
 
-> [English ->](./v1.2.1-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.2.1/docs/release-notes/v1.2.1-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.3.0-en.md
+++ b/docs/release-notes/v1.3.0-en.md
@@ -2,7 +2,7 @@
 
 > 7 commits · 28 files changed · +1819 / -296
 
-> [中文 ->](./v1.3.0-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.3.0/docs/release-notes/v1.3.0-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.3.0-zh.md
+++ b/docs/release-notes/v1.3.0-zh.md
@@ -2,7 +2,7 @@
 
 > 7 commits · 28 files changed · +1819 / -296
 
-> [English ->](./v1.3.0-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.3.0/docs/release-notes/v1.3.0-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.4.0-en.md
+++ b/docs/release-notes/v1.4.0-en.md
@@ -2,7 +2,7 @@
 
 > 14 commits · 84 files changed · +10267 / -3832
 
-> [中文 ->](./v1.4.0-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.4.0/docs/release-notes/v1.4.0-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.4.0-zh.md
+++ b/docs/release-notes/v1.4.0-zh.md
@@ -2,7 +2,7 @@
 
 > 14 commits · 84 files changed · +10267 / -3832
 
-> [English ->](./v1.4.0-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.4.0/docs/release-notes/v1.4.0-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.4.1-en.md
+++ b/docs/release-notes/v1.4.1-en.md
@@ -2,7 +2,7 @@
 
 > 9 commits · 23 files changed · +3691 / -603
 
-> [中文 ->](./v1.4.1-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.4.1/docs/release-notes/v1.4.1-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.4.1-zh.md
+++ b/docs/release-notes/v1.4.1-zh.md
@@ -2,7 +2,7 @@
 
 > 9 commits · 23 files changed · +3691 / -603
 
-> [English ->](./v1.4.1-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.4.1/docs/release-notes/v1.4.1-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.4.2-en.md
+++ b/docs/release-notes/v1.4.2-en.md
@@ -2,7 +2,7 @@
 
 > 6 commits · 35 files changed · +2598 / -755
 
-> [中文 ->](./v1.4.2-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.4.2/docs/release-notes/v1.4.2-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.4.2-zh.md
+++ b/docs/release-notes/v1.4.2-zh.md
@@ -2,7 +2,7 @@
 
 > 6 commits · 35 files changed · +2598 / -755
 
-> [English ->](./v1.4.2-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.4.2/docs/release-notes/v1.4.2-en.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.5.0-en.md
+++ b/docs/release-notes/v1.5.0-en.md
@@ -2,7 +2,7 @@
 
 > 10 commits · 49 files changed · +6845 / -110
 
-> [中文 ->](./v1.5.0-zh.md)
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.5.0/docs/release-notes/v1.5.0-zh.md)
 
 ## Overview
 

--- a/docs/release-notes/v1.5.0-zh.md
+++ b/docs/release-notes/v1.5.0-zh.md
@@ -2,7 +2,7 @@
 
 > 10 commits · 49 files changed · +6845 / -110
 
-> [English ->](./v1.5.0-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.5.0/docs/release-notes/v1.5.0-en.md)
 
 ## Overview
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -50,14 +50,16 @@ log fallback.
 ## Writing Template
 
 Chinese is the authored source. Other languages should preserve the same
-structure, links, and statistics.
+structure, links, and statistics. Language switch links must be tag-pinned
+GitHub blob URLs under `docs/release-notes/` because GitHub Releases render the
+curated note body outside that directory.
 
 ```markdown
 # CPA Manager Plus <version>
 
 > <n> commits · <files> files changed · +<added> / -<deleted>
 
-> [English ->](./<version>-en.md)
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/<version>/docs/release-notes/<version>-en.md)
 
 ## Overview
 


### PR DESCRIPTION
## Summary
Fix release note language switch links so GitHub Release bodies resolve localized docs under docs/release-notes instead of the repository root.

## Changes
- Update the release note template to require tag-pinned GitHub blob URLs under docs/release-notes.
- Rewrite existing localized release note links from v1.1.0 through v1.5.0 to use the correct tag-pinned docs path.

## Testing
- Verified no tracked release docs still use the old ./v...md language-link pattern.
- Documentation-only change; no runtime tests needed.

## Related
Closes #143
Closes #172