### PR TITLE
fix(manager-server): proxy plugin caller-auth requests

### DIFF
--- a/apps/manager-server/internal/http/controller/proxy/handler.go
+++ b/apps/manager-server/internal/http/controller/proxy/handler.go
@@ -1,11 +1,12 @@
 package proxy
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/app"
-	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/middleware"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/response"
+	proxysvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/proxy"
 )
 
 type Handler struct {
@@ -13,10 +14,24 @@ type Handler struct {
 }
 
 func (h *Handler) Management(w http.ResponseWriter, r *http.Request) {
-	if !middleware.AuthorizeAdmin(w, r, h.App.AdminAuthService) {
+	ok, err := h.App.AdminAuthService.VerifyHeader(r.Context(), r.Header.Get("Authorization"))
+	if err != nil {
+		response.Error(w, http.StatusInternalServerError, err)
 		return
 	}
-	h.App.ProxyService.ProxyManagement(w, r, response.Error)
+	if ok {
+		if proxysvc.IsCPAPluginManagementPath(r.URL.Path) {
+			h.App.ProxyService.ProxyPluginManagement(w, r, response.Error)
+			return
+		}
+		h.App.ProxyService.ProxyManagement(w, r, response.Error)
+		return
+	}
+	if !proxysvc.IsCPAPluginManagementPath(r.URL.Path) {
+		response.Error(w, http.StatusUnauthorized, errors.New("invalid admin key"))
+		return
+	}
+	h.App.ProxyService.ProxyPluginManagementWithCallerAuth(w, r, response.Error)
 }
 
 func (h *Handler) ModelList(w http.ResponseWriter, r *http.Request) {
@@ -24,9 +39,23 @@ func (h *Handler) ModelList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) CPAResource(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+	useSavedManagementKey := true
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		ok, err := h.App.AdminAuthService.VerifyHeader(r.Context(), r.Header.Get("Authorization"))
+		if err != nil {
+			response.Error(w, http.StatusInternalServerError, err)
+			return
+		}
+		useSavedManagementKey = ok
+	default:
 		response.MethodNotAllowed(w)
 		return
 	}
-	h.App.ProxyService.ProxyManagement(w, r, response.Error)
+	if useSavedManagementKey {
+		h.App.ProxyService.ProxyPluginResource(w, r, response.Error)
+		return
+	}
+	h.App.ProxyService.ProxyPluginResourceWithCallerAuth(w, r, response.Error)
 }

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -520,22 +520,26 @@ func TestServerCompatProxyRoutes(t *testing.T) {
 
 func TestServerCompatPluginProxyRoutes(t *testing.T) {
 	type observedRequest struct {
-		method        string
-		path          string
-		query         string
-		authorization string
-		body          string
+		method            string
+		path              string
+		query             string
+		authorization     string
+		codexInviteOrigin string
+		origin            string
+		body              string
 	}
 
-	observed := make(chan observedRequest, 4)
+	observed := make(chan observedRequest, 9)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		observed <- observedRequest{
-			method:        r.Method,
-			path:          r.URL.Path,
-			query:         r.URL.RawQuery,
-			authorization: r.Header.Get("Authorization"),
-			body:          string(body),
+			method:            r.Method,
+			path:              r.URL.Path,
+			query:             r.URL.RawQuery,
+			authorization:     r.Header.Get("Authorization"),
+			codexInviteOrigin: r.Header.Get("X-Codex-Invite-Origin"),
+			origin:            r.Header.Get("Origin"),
+			body:              string(body),
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"ok":true}`))
@@ -560,6 +564,21 @@ func TestServerCompatPluginProxyRoutes(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("CPA upstream did not receive %s", path)
 		}
+	}
+	requestWithHeaders := func(method, target, body, managementKey string, headers map[string]string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, target, strings.NewReader(body))
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if managementKey != "" {
+			req.Header.Set("Authorization", "Bearer "+managementKey)
+		}
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
 	}
 
 	managementInstallRR := testutil.Request(
@@ -595,29 +614,134 @@ func TestServerCompatPluginProxyRoutes(t *testing.T) {
 		body:          `{"refresh":true}`,
 	})
 
+	pluginDynamicManagementRR := requestWithHeaders(
+		http.MethodGet,
+		"/v0/management/codex-invite/accounts",
+		"",
+		"plugin-management-key",
+		map[string]string{
+			"Origin":                "http://localhost:18317",
+			"X-Codex-Invite-Origin": "http://localhost:18317",
+		},
+	)
+	testutil.RequireStatus(t, pluginDynamicManagementRR, http.StatusOK)
+	assertObserved("/v0/management/codex-invite/accounts", observedRequest{
+		method:            http.MethodGet,
+		path:              "/v0/management/codex-invite/accounts",
+		authorization:     "Bearer plugin-management-key",
+		codexInviteOrigin: upstream.URL,
+		origin:            "http://localhost:18317",
+	})
+
+	pluginDynamicInviteRR := requestWithHeaders(
+		http.MethodPost,
+		"/v0/management/codex-invite/invite",
+		`{"management_origin":"http://localhost:18317","refresh":true}`,
+		"plugin-management-key",
+		map[string]string{
+			"Content-Type":          "application/json",
+			"X-Codex-Invite-Origin": "http://localhost:18317",
+		},
+	)
+	testutil.RequireStatus(t, pluginDynamicInviteRR, http.StatusOK)
+	assertObserved("/v0/management/codex-invite/invite", observedRequest{
+		method:            http.MethodPost,
+		path:              "/v0/management/codex-invite/invite",
+		authorization:     "Bearer plugin-management-key",
+		codexInviteOrigin: upstream.URL,
+		body:              `{"management_origin":"` + upstream.URL + `","refresh":true}`,
+	})
+
+	resourcePostNoAuthRR := testutil.Request(
+		t,
+		handler,
+		http.MethodPost,
+		"/v0/resource/plugins/codex-invite/invite",
+		`{"managementKey":"plugin-key"}`,
+		"",
+	)
+	testutil.RequireStatus(t, resourcePostNoAuthRR, http.StatusOK)
+	assertObserved("/v0/resource/plugins/codex-invite/invite", observedRequest{
+		method: http.MethodPost,
+		path:   "/v0/resource/plugins/codex-invite/invite",
+		body:   `{"managementKey":"plugin-key"}`,
+	})
+
+	resourcePostCallerAuthRR := requestWithHeaders(
+		http.MethodPost,
+		"/v0/resource/plugins/codex-invite/invite",
+		`{"refresh":true}`,
+		"plugin-management-key",
+		map[string]string{
+			"X-Codex-Invite-Origin": "http://localhost:18317",
+		},
+	)
+	testutil.RequireStatus(t, resourcePostCallerAuthRR, http.StatusOK)
+	assertObserved("/v0/resource/plugins/codex-invite/invite", observedRequest{
+		method:            http.MethodPost,
+		path:              "/v0/resource/plugins/codex-invite/invite",
+		authorization:     "Bearer plugin-management-key",
+		codexInviteOrigin: upstream.URL,
+		body:              `{"refresh":true}`,
+	})
+
 	resourcePostRR := testutil.Request(
 		t,
 		handler,
 		http.MethodPost,
 		"/v0/resource/plugins/codex-invite/invite",
-		"",
-		"",
+		`{"refresh":true}`,
+		testutil.AdminKey,
 	)
-	testutil.RequireStatus(t, resourcePostRR, http.StatusMethodNotAllowed)
+	testutil.RequireStatus(t, resourcePostRR, http.StatusOK)
+	assertObserved("/v0/resource/plugins/codex-invite/invite", observedRequest{
+		method:        http.MethodPost,
+		path:          "/v0/resource/plugins/codex-invite/invite",
+		authorization: "Bearer management-key",
+		body:          `{"refresh":true}`,
+	})
 
-	resourceRR := testutil.Request(
+	resourcePutRR := testutil.Request(
 		t,
 		handler,
-		http.MethodGet,
+		http.MethodPut,
+		"/v0/resource/plugins/codex-invite/invite",
+		`{"key":"value"}`,
+		testutil.AdminKey,
+	)
+	testutil.RequireStatus(t, resourcePutRR, http.StatusOK)
+	assertObserved("/v0/resource/plugins/codex-invite/invite", observedRequest{
+		method:        http.MethodPut,
+		path:          "/v0/resource/plugins/codex-invite/invite",
+		authorization: "Bearer management-key",
+		body:          `{"key":"value"}`,
+	})
+
+	resourceTraceRR := testutil.Request(
+		t,
+		handler,
+		http.MethodTrace,
 		"/v0/resource/plugins/codex-invite/invite",
 		"",
 		"",
 	)
+	testutil.RequireStatus(t, resourceTraceRR, http.StatusMethodNotAllowed)
+
+	resourceRR := requestWithHeaders(
+		http.MethodGet,
+		"/v0/resource/plugins/codex-invite/invite",
+		"",
+		"",
+		map[string]string{
+			"X-Codex-Invite-Origin": "http://localhost:18317",
+		},
+	)
 	testutil.RequireStatus(t, resourceRR, http.StatusOK)
 	assertObserved("/v0/resource/plugins/codex-invite/invite", observedRequest{
-		method:        http.MethodGet,
-		path:          "/v0/resource/plugins/codex-invite/invite",
-		authorization: "Bearer management-key",
+		method:            http.MethodGet,
+		path:              "/v0/resource/plugins/codex-invite/invite",
+		authorization:     "Bearer management-key",
+		codexInviteOrigin: upstream.URL,
 	})
 }
 

--- a/apps/manager-server/internal/service/proxy/service.go
+++ b/apps/manager-server/internal/service/proxy/service.go
@@ -1,8 +1,11 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -17,6 +20,28 @@ type Service struct {
 }
 
 const cpaPluginResourcePrefix = "/v0/resource/plugins"
+const cpaManagementPrefix = "/v0/management"
+const codexInviteOriginHeader = "X-Codex-Invite-Origin"
+const managementOriginJSONField = "management_origin"
+
+var cpaBuiltinManagementPathHeads = map[string]struct{}{
+	"account-action-candidates": {},
+	"accounts":                  {},
+	"api-call":                  {},
+	"api-key-aliases":           {},
+	"api-key-usage":             {},
+	"auth-files":                {},
+	"codex-inspection":          {},
+	"config":                    {},
+	"dashboard":                 {},
+	"model-prices":              {},
+	"monitoring":                {},
+	"plugin-store":              {},
+	"plugins":                   {},
+	"reload":                    {},
+	"usage":                     {},
+	"usage-statistics-enabled":  {},
+}
 
 func New(managerConfigService *managerconfig.Service) *Service {
 	return &Service{managerConfigService: managerConfigService}
@@ -26,11 +51,47 @@ func (s *Service) ProxyManagement(w http.ResponseWriter, r *http.Request, writeE
 	s.proxyWithSavedManagementKey(w, r, writeError)
 }
 
+func (s *Service) ProxyPluginManagement(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
+	if !IsCPAPluginManagementPath(r.URL.Path) {
+		writeError(w, http.StatusNotFound, errors.New("proxy path must be a CPA plugin management path"))
+		return
+	}
+	s.proxyToSavedSetup(w, r, writeError, true, true)
+}
+
+func (s *Service) ProxyPluginManagementWithCallerAuth(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
+	if !IsCPAPluginManagementPath(r.URL.Path) {
+		writeError(w, http.StatusNotFound, errors.New("proxy path must be a CPA plugin management path"))
+		return
+	}
+	s.proxyToSavedSetup(w, r, writeError, false, true)
+}
+
+func (s *Service) ProxyPluginResource(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
+	if !IsCPAPluginResourcePath(r.URL.Path) {
+		writeError(w, http.StatusNotFound, errors.New("proxy path must be under /v0/resource/plugins/"))
+		return
+	}
+	s.proxyToSavedSetup(w, r, writeError, true, true)
+}
+
+func (s *Service) ProxyPluginResourceWithCallerAuth(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
+	if !IsCPAPluginResourcePath(r.URL.Path) {
+		writeError(w, http.StatusNotFound, errors.New("proxy path must be under /v0/resource/plugins/"))
+		return
+	}
+	s.proxyToSavedSetup(w, r, writeError, false, true)
+}
+
 func (s *Service) proxyWithSavedManagementKey(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
 	if !isManagementPath(r.URL.Path) {
 		writeError(w, http.StatusNotFound, errors.New("proxy path must be under /v0/management/"))
 		return
 	}
+	s.proxyToSavedSetup(w, r, writeError, true, false)
+}
+
+func (s *Service) proxyToSavedSetup(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error), useSavedManagementKey bool, rewritePluginOrigin bool) {
 	setup, ok, err := s.resolveSetup(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -45,6 +106,12 @@ func (s *Service) proxyWithSavedManagementKey(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	if rewritePluginOrigin {
+		if err := rewritePluginManagementOriginBody(r, target); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
@@ -52,12 +119,86 @@ func (s *Service) proxyWithSavedManagementKey(w http.ResponseWriter, r *http.Req
 		req.URL.Scheme = target.Scheme
 		req.URL.Host = target.Host
 		req.Host = target.Host
-		req.Header.Set("Authorization", "Bearer "+setup.ManagementKey)
+		if useSavedManagementKey {
+			req.Header.Set("Authorization", "Bearer "+setup.ManagementKey)
+		}
+		if rewritePluginOrigin {
+			rewriteCodexInviteOrigin(req.Header, target)
+		}
 	}
 	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
 		writeError(w, http.StatusBadGateway, err)
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+func rewriteCodexInviteOrigin(header http.Header, target *url.URL) {
+	if header == nil || target == nil || header.Get(codexInviteOriginHeader) == "" {
+		return
+	}
+	origin := target.Scheme + "://" + target.Host
+	if origin == "://" {
+		return
+	}
+	header.Set(codexInviteOriginHeader, origin)
+}
+
+func rewritePluginManagementOriginBody(r *http.Request, target *url.URL) error {
+	if r == nil || r.Body == nil || target == nil || !isJSONContentType(r.Header.Get("Content-Type")) {
+		return nil
+	}
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if errClose := r.Body.Close(); errClose != nil {
+		return errClose
+	}
+	restoreBody := func(body []byte) {
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+		bodyCopy := append([]byte(nil), body...)
+		r.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyCopy)), nil
+		}
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		restoreBody(raw)
+		return nil
+	}
+
+	var payload map[string]json.RawMessage
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		restoreBody(raw)
+		return nil
+	}
+	if _, ok := payload[managementOriginJSONField]; !ok {
+		restoreBody(raw)
+		return nil
+	}
+	origin := target.Scheme + "://" + target.Host
+	if origin == "://" {
+		restoreBody(raw)
+		return nil
+	}
+	encodedOrigin, errMarshal := json.Marshal(origin)
+	if errMarshal != nil {
+		restoreBody(raw)
+		return errMarshal
+	}
+	payload[managementOriginJSONField] = encodedOrigin
+	next, errMarshal := json.Marshal(payload)
+	if errMarshal != nil {
+		restoreBody(raw)
+		return errMarshal
+	}
+	restoreBody(next)
+	return nil
+}
+
+func isJSONContentType(value string) bool {
+	contentType := strings.ToLower(strings.TrimSpace(strings.Split(value, ";")[0]))
+	return contentType == "application/json" || strings.HasSuffix(contentType, "+json")
 }
 
 func (s *Service) ProxyModelList(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error), methodNotAllowed func(http.ResponseWriter)) {
@@ -103,10 +244,28 @@ func isModelListPath(path string) bool {
 }
 
 func isManagementPath(path string) bool {
-	if path == "/v0/management" || strings.HasPrefix(path, "/v0/management/") {
+	if isStrictManagementPath(path) {
 		return true
 	}
 	return IsCPAPluginResourcePath(path)
+}
+
+func isStrictManagementPath(path string) bool {
+	return path == "/v0/management" || strings.HasPrefix(path, "/v0/management/")
+}
+
+func IsCPAPluginManagementPath(path string) bool {
+	cleaned := strings.TrimRight(path, "/")
+	if !strings.HasPrefix(cleaned, cpaManagementPrefix+"/") {
+		return false
+	}
+	rest := strings.TrimPrefix(cleaned, cpaManagementPrefix+"/")
+	head, _, _ := strings.Cut(rest, "/")
+	if head == "" {
+		return false
+	}
+	_, reserved := cpaBuiltinManagementPathHeads[head]
+	return !reserved
 }
 
 func IsCPAPluginResourcePath(path string) bool {

--- a/apps/manager-server/internal/service/proxy/service_test.go
+++ b/apps/manager-server/internal/service/proxy/service_test.go
@@ -1,6 +1,12 @@
 package proxy
 
-import "testing"
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
 
 func TestIsManagementPath(t *testing.T) {
 	tests := []struct {
@@ -56,6 +62,34 @@ func TestIsModelListPath(t *testing.T) {
 	}
 }
 
+func TestIsCPAPluginManagementPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/v0/management/codex-invite/accounts", want: true},
+		{path: "/v0/management/sample-plugin/custom/action", want: true},
+		{path: "/v0/management/accounts", want: false},
+		{path: "/v0/management/accounts/", want: false},
+		{path: "/v0/management/config", want: false},
+		{path: "/v0/management/reload", want: false},
+		{path: "/v0/management/plugins/demo/custom", want: false},
+		{path: "/v0/management/plugin-store/demo/install", want: false},
+		{path: "/v0/management/usage", want: false},
+		{path: "/v0/resource/plugins/codex-invite/invite", want: false},
+		{path: "/v0/management", want: false},
+		{path: "/v0/management/", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := IsCPAPluginManagementPath(tt.path); got != tt.want {
+				t.Fatalf("IsCPAPluginManagementPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsCPAPluginResourcePath(t *testing.T) {
 	tests := []struct {
 		path string
@@ -76,5 +110,87 @@ func TestIsCPAPluginResourcePath(t *testing.T) {
 				t.Fatalf("IsCPAPluginResourcePath(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRewriteCodexInviteOrigin(t *testing.T) {
+	target, err := url.Parse("http://cpa.local:8317/base")
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+
+	header := http.Header{}
+	header.Set(codexInviteOriginHeader, "http://manager.local:18317")
+	header.Set("Origin", "http://manager.local:18317")
+
+	rewriteCodexInviteOrigin(header, target)
+
+	if got := header.Get(codexInviteOriginHeader); got != "http://cpa.local:8317" {
+		t.Fatalf("%s = %q", codexInviteOriginHeader, got)
+	}
+	if got := header.Get("Origin"); got != "http://manager.local:18317" {
+		t.Fatalf("Origin = %q", got)
+	}
+
+	emptyHeader := http.Header{}
+	rewriteCodexInviteOrigin(emptyHeader, target)
+	if got := emptyHeader.Get(codexInviteOriginHeader); got != "" {
+		t.Fatalf("empty %s = %q", codexInviteOriginHeader, got)
+	}
+}
+
+func TestRewritePluginManagementOriginBody(t *testing.T) {
+	target, err := url.Parse("http://cpa.local:8317")
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"/v0/management/codex-invite/invite",
+		strings.NewReader(`{"management_origin":"http://manager.local:18317","refresh":true}`),
+	)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := rewritePluginManagementOriginBody(req, target); err != nil {
+		t.Fatalf("rewritePluginManagementOriginBody() error = %v", err)
+	}
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	want := `{"management_origin":"http://cpa.local:8317","refresh":true}`
+	if string(raw) != want {
+		t.Fatalf("body = %q, want %q", raw, want)
+	}
+	if req.ContentLength != int64(len(want)) {
+		t.Fatalf("content length = %d, want %d", req.ContentLength, len(want))
+	}
+}
+
+func TestRewritePluginManagementOriginBodyLeavesOtherBodies(t *testing.T) {
+	target, err := url.Parse("http://cpa.local:8317")
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "/v0/resource/plugins/demo", strings.NewReader(`{"refresh":true}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := rewritePluginManagementOriginBody(req, target); err != nil {
+		t.Fatalf("rewritePluginManagementOriginBody() error = %v", err)
+	}
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(raw) != `{"refresh":true}` {
+		t.Fatalf("body = %q", raw)
 	}
 }


### PR DESCRIPTION
## Summary
Fix plugin proxy calls so plugin management/resource requests can reach the CPA origin correctly when CMP and CPA are served from different domains.

## Changes
- Add plugin management and resource proxy paths that preserve caller-provided CPA-compatible authorization when required.
- Rewrite Codex invite origin headers and `management_origin` JSON payload fields to the saved CPA upstream origin.
- Expand proxy service and HTTP compatibility tests for plugin path classification, caller auth, resource methods, and origin rewriting.

## Testing
- [x] `git diff --check`
- [x] `go test ./internal/service/proxy ./internal/httpapi` from `apps/manager-server`

## Affected Modes
- Full Docker
- CPA Panel

Fixes #173