### PR TITLE
✨ feat(web/logs): support cursor pagination on incremental log fetch

### DIFF
--- a/apps/web/src/features/logs/LogsPage.tsx
+++ b/apps/web/src/features/logs/LogsPage.tsx
@@ -25,6 +25,7 @@ import { useHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useAuthStore, useConfigStore, useNotificationStore } from '@/stores';
 import { logsApi } from '@/services/api/logs';
+import type { LogsQuery, LogsResponse } from '@/services/api/logs';
 import { copyToClipboard } from '@/utils/clipboard';
 import { downloadBlob } from '@/utils/download';
 import { MANAGEMENT_API_PREFIX } from '@/utils/constants';
@@ -64,6 +65,20 @@ const getErrorMessage = (err: unknown): string => {
 };
 
 type TabType = 'logs' | 'errors';
+type LogPosition = Pick<LogsQuery, 'after' | 'cursor'>;
+
+const buildLogsQuery = (incremental: boolean, position: LogPosition): LogsQuery => {
+  if (!incremental) return { limit: MAX_BUFFER_LINES };
+
+  const params: LogsQuery = { limit: MAX_BUFFER_LINES };
+  if (position.cursor) {
+    params.cursor = position.cursor;
+  }
+  if (position.after !== undefined && position.after > 0) {
+    params.after = position.after;
+  }
+  return params;
+};
 
 export function LogsPage() {
   const { t } = useTranslation();
@@ -108,8 +123,26 @@ export function LogsPage() {
   const logRequestInFlightRef = useRef(false);
   const pendingFullReloadRef = useRef(false);
 
-  // 保存最新时间戳用于增量获取
-  const latestTimestampRef = useRef<number>(0);
+  // 新版 CPA 优先使用 cursor，旧版接口继续使用 after 时间戳。
+  const logPositionRef = useRef<LogPosition>({});
+
+  const resetLogPosition = () => {
+    logPositionRef.current = {};
+  };
+
+  const updateLogPosition = (data: LogsResponse, incremental: boolean) => {
+    const currentPosition = logPositionRef.current;
+    const nextPosition: LogPosition = {};
+    if (data.nextCursor) {
+      nextPosition.cursor = data.nextCursor;
+    }
+    if (data.latestAfter !== undefined) {
+      nextPosition.after = data.latestAfter;
+    } else if (incremental && currentPosition.after !== undefined) {
+      nextPosition.after = currentPosition.after;
+    }
+    logPositionRef.current = nextPosition;
+  };
 
   const disableControls = connectionStatus !== 'connected';
   const canLoadFileLogs = activeTab === 'logs' && fileLogsAvailable;
@@ -158,18 +191,17 @@ export function LogsPage() {
         scrollerInstance?.requestScrollToBottom();
       }
 
-      const params =
-        incremental && latestTimestampRef.current > 0 ? { after: latestTimestampRef.current } : {};
+      const params = buildLogsQuery(incremental, logPositionRef.current);
       const data = await logsApi.fetchLogs(params);
-
-      // 更新时间戳
-      if (data['latest-timestamp']) {
-        latestTimestampRef.current = data['latest-timestamp'];
-      }
+      updateLogPosition(data, incremental);
 
       const newLines = Array.isArray(data.lines) ? data.lines : [];
 
-      if (incremental && newLines.length > 0) {
+      if (incremental && data.cursorReset) {
+        const buffer = newLines.slice(-MAX_BUFFER_LINES);
+        const visibleFrom = Math.max(buffer.length - INITIAL_DISPLAY_LINES, 0);
+        setLogState({ buffer, visibleFrom });
+      } else if (incremental && newLines.length > 0) {
         // 增量更新：追加新日志并限制缓冲区大小（避免内存与渲染膨胀）
         setLogState((prev) => {
           const prevRenderedCount = prev.buffer.length - prev.visibleFrom;
@@ -218,7 +250,7 @@ export function LogsPage() {
         try {
           await logsApi.clearLogs();
           setLogState({ buffer: [], visibleFrom: 0 });
-          latestTimestampRef.current = 0;
+          resetLogPosition();
           showNotification(t('logs.clear_success'), 'success');
         } catch (err: unknown) {
           const message = getErrorMessage(err);
@@ -298,7 +330,7 @@ export function LogsPage() {
       return;
     }
 
-    latestTimestampRef.current = 0;
+    resetLogPosition();
     loadLogs(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connectionStatus, canLoadFileLogs]);

--- a/apps/web/src/services/api/logs.test.ts
+++ b/apps/web/src/services/api/logs.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    get: vi.fn(),
+    delete: vi.fn(),
+    getRaw: vi.fn(),
+  },
+}));
+
+vi.mock('./client', () => ({
+  apiClient: {
+    get: mocks.get,
+    delete: mocks.delete,
+    getRaw: mocks.getRaw,
+  },
+}));
+
+import { logsApi, normalizeLogsResponse } from './logs';
+
+beforeEach(() => {
+  mocks.get.mockReset();
+  mocks.delete.mockReset();
+  mocks.getRaw.mockReset();
+});
+
+describe('logs API', () => {
+  it('normalizes legacy timestamp-based log responses', () => {
+    expect(
+      normalizeLogsResponse({
+        lines: ['a', 'b'],
+        'line-count': 2,
+        'latest-timestamp': 123,
+      })
+    ).toEqual({
+      lines: ['a', 'b'],
+      'line-count': 2,
+      'latest-timestamp': 123,
+      latestAfter: 123,
+      nextCursor: undefined,
+      cursorReset: false,
+    });
+  });
+
+  it('normalizes cursor-based log responses', () => {
+    expect(
+      normalizeLogsResponse({
+        lines: ['next'],
+        lineCount: '1',
+        latestAfter: '456',
+        'next-cursor': 'cursor-2',
+        'cursor-reset': 'true',
+      })
+    ).toEqual({
+      lines: ['next'],
+      'line-count': 1,
+      'latest-timestamp': 0,
+      latestAfter: 456,
+      nextCursor: 'cursor-2',
+      cursorReset: true,
+    });
+  });
+
+  it('passes cursor, after, and limit query params when fetching logs', async () => {
+    mocks.get.mockResolvedValue({ lines: [] });
+
+    await logsApi.fetchLogs({ cursor: 'cursor-1', after: 123, limit: 100 });
+
+    expect(mocks.get).toHaveBeenCalledWith('/logs', {
+      params: { cursor: 'cursor-1', after: 123, limit: 100 },
+      timeout: expect.any(Number),
+    });
+  });
+});

--- a/apps/web/src/services/api/logs.ts
+++ b/apps/web/src/services/api/logs.ts
@@ -7,12 +7,17 @@ import { LOGS_TIMEOUT_MS } from '@/utils/constants';
 
 export interface LogsQuery {
   after?: number;
+  cursor?: string;
+  limit?: number;
 }
 
 export interface LogsResponse {
   lines: string[];
   'line-count': number;
   'latest-timestamp': number;
+  latestAfter?: number;
+  nextCursor?: string;
+  cursorReset?: boolean;
 }
 
 export interface ErrorLogFile {
@@ -25,9 +30,55 @@ export interface ErrorLogsResponse {
   files?: ErrorLogFile[];
 }
 
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const numberValue = (value: unknown): number | undefined => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const stringValue = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const booleanValue = (value: unknown): boolean =>
+  value === true || (typeof value === 'string' && value.trim().toLowerCase() === 'true');
+
+export const normalizeLogsResponse = (value: unknown): LogsResponse => {
+  const source = asRecord(value);
+  const lines = Array.isArray(source.lines)
+    ? source.lines.map((line) => String(line ?? ''))
+    : [];
+  const lineCount = numberValue(source['line-count'] ?? source.lineCount) ?? lines.length;
+  const latestTimestamp = numberValue(source['latest-timestamp'] ?? source.latestTimestamp) ?? 0;
+  const rawLatestAfter =
+    numberValue(source.latestAfter ?? source.latest_after ?? source['latest-after']) ??
+    latestTimestamp;
+  const latestAfter = rawLatestAfter > 0 ? rawLatestAfter : undefined;
+  const nextCursor = stringValue(source['next-cursor'] ?? source.nextCursor ?? source.next_cursor);
+
+  return {
+    lines,
+    'line-count': lineCount,
+    'latest-timestamp': latestTimestamp,
+    latestAfter,
+    nextCursor,
+    cursorReset: booleanValue(source['cursor-reset'] ?? source.cursorReset ?? source.cursor_reset),
+  };
+};
+
 export const logsApi = {
-  fetchLogs: (params: LogsQuery = {}): Promise<LogsResponse> =>
-    apiClient.get('/logs', { params, timeout: LOGS_TIMEOUT_MS }),
+  async fetchLogs(params: LogsQuery = {}): Promise<LogsResponse> {
+    const data = await apiClient.get('/logs', { params, timeout: LOGS_TIMEOUT_MS });
+    return normalizeLogsResponse(data);
+  },
 
   clearLogs: () => apiClient.delete('/logs'),
 


### PR DESCRIPTION
## Summary

- Extend the logs API surface with `cursor` / `limit` fields and normalize responses from both legacy timestamp-based and cursor-based upstreams.
- `LogsPage` now tracks `cursor` + `after` so the server can stream new lines without replaying the full buffer, and honors `cursorReset` to recover from upstream buffer rotation.
- Existing clients without cursor support continue to work via the legacy `after` timestamp path.
- Added logs API coverage for legacy + cursor normalization and query param passthrough.

## Test plan

- [x] Open the logs page; verify incremental polling continues to append new lines without dupes.
- [x] Click "Clear" and confirm the buffer resets and subsequent polling starts from the latest server timestamp.
- [x] Disconnect / reconnect and confirm the buffer refetches from the top.
- [x] Confirm the upstream contract still works against an older backend that only emits `latest-timestamp`.