### PR TITLE
🐛 fix(web/codex): classify 28–31 day windows as monthly quota

### DIFF
--- a/apps/web/src/utils/quota/codexQuota.test.ts
+++ b/apps/web/src/utils/quota/codexQuota.test.ts
@@ -99,6 +99,34 @@ describe('buildCodexQuotaWindowInfos', () => {
     expect(isCodexRateLimitReached(payload.rate_limit)).toBe(false);
   });
 
+  it('classifies 28 to 31 day windows as monthly quota', () => {
+    const monthLikeDurations = [2_419_200, 2_505_600, 2_592_000, 2_678_400];
+
+    monthLikeDurations.forEach((duration) => {
+      const classified = classifyCodexRateLimitWindows({
+        primary_window: {
+          used_percent: 20,
+          limit_window_seconds: duration,
+        },
+      });
+
+      expect(classified.monthlyWindow?.limit_window_seconds).toBe(duration);
+      expect(classified.weeklyWindow).toBeNull();
+    });
+  });
+
+  it('does not classify windows longer than 31 days as monthly quota', () => {
+    const classified = classifyCodexRateLimitWindows({
+      primary_window: {
+        used_percent: 20,
+        limit_window_seconds: 2_764_800,
+      },
+    });
+
+    expect(classified.monthlyWindow).toBeNull();
+    expect(classified.longWindow?.limit_window_seconds).toBe(2_764_800);
+  });
+
   it('treats a Team secondary window without duration as monthly quota', () => {
     const windows = buildCodexQuotaWindowInfos(
       {

--- a/apps/web/src/utils/quota/codexQuota.ts
+++ b/apps/web/src/utils/quota/codexQuota.ts
@@ -10,6 +10,8 @@ import { normalizeNumberValue, normalizePlanType, normalizeStringValue } from '.
 const FIVE_HOUR_SECONDS = 18_000;
 const WEEK_SECONDS = 604_800;
 const MONTH_SECONDS = 2_592_000;
+const MIN_MONTH_SECONDS = 28 * 24 * 60 * 60;
+const MAX_MONTH_SECONDS = 31 * 24 * 60 * 60;
 
 type CodexQuotaWindowMeta = {
   id: string;
@@ -76,6 +78,11 @@ const formatWindowDuration = (seconds: number | null): string => {
 const hasExplicitWindowSeconds = (window?: CodexUsageWindow | null): boolean =>
   getWindowSeconds(window) !== null;
 
+const isMonthlyWindow = (window?: CodexUsageWindow | null): boolean => {
+  const seconds = getWindowSeconds(window);
+  return seconds !== null && seconds >= MIN_MONTH_SECONDS && seconds <= MAX_MONTH_SECONDS;
+};
+
 const pickClassifiedWindows = (
   limitInfo?: CodexRateLimitInfo | null,
   options?: { allowOrderFallback?: boolean; teamPlan?: boolean }
@@ -106,7 +113,7 @@ const pickClassifiedWindows = (
       fiveHourWindow = window;
     } else if (seconds === WEEK_SECONDS && !weeklyWindow) {
       weeklyWindow = window;
-    } else if (seconds === MONTH_SECONDS && !monthlyWindow) {
+    } else if ((seconds === MONTH_SECONDS || isMonthlyWindow(window)) && !monthlyWindow) {
       monthlyWindow = window;
     } else if (seconds !== null && seconds > FIVE_HOUR_SECONDS && !genericLongWindow) {
       genericLongWindow = window;


### PR DESCRIPTION
## Summary

- Classify rate-limit windows between 28 and 31 days as monthly quota, matching the exact 2,592,000s case older CPAs already reported.
- Windows longer than 31 days stay in the generic long-window bucket so they continue to surface as a separate, non-monthly usage band.
- Tests cover the inclusive boundaries (28d / 29d / 30d / 31d) and the exclusion boundary (32d+ stays in `longWindow`).

## Test plan

- [x] Run `npx vitest run src/utils/quota/codexQuota.test.ts` and confirm 8/8 tests pass.
- [x] Spot-check the Codex quota panel against a fixture that returns `limit_window_seconds: 2_592_000` and confirm the window is labeled `monthly`.
- [x] Spot-check a fixture that returns `limit_window_seconds: 2_764_800` (32d) and confirm it still renders under the long-window bucket.