### PR TITLE
🐛 fix(web/config): widen payload rule row when editing raw JSON

### DIFF
--- a/apps/web/src/components/config/VisualConfigEditor.module.scss
+++ b/apps/web/src/components/config/VisualConfigEditor.module.scss
@@ -717,6 +717,10 @@
   align-items: center;
 }
 
+.payloadRuleRawParamRow {
+  grid-template-columns: minmax(240px, 1fr) minmax(320px, 1fr) auto;
+}
+
 .payloadRuleParamGroup {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/components/config/VisualConfigEditorBlocks.tsx
+++ b/apps/web/src/components/config/VisualConfigEditorBlocks.tsx
@@ -847,7 +847,14 @@ export const PayloadRulesEditor = memo(function PayloadRulesEditor({
 
               return (
                 <div key={param.id} className={styles.payloadRuleParamGroup}>
-                  <div className={styles.payloadRuleParamRow}>
+                  <div
+                    className={[
+                      styles.payloadRuleParamRow,
+                      rawJsonValues ? styles.payloadRuleRawParamRow : '',
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                  >
                     <ExpandableInput
                       placeholder={t('config_management.visual.payload_rules.json_path')}
                       ariaLabel={t('config_management.visual.payload_rules.json_path')}


### PR DESCRIPTION
## Summary

- Apply a wider 3-column grid to payload rule param rows while editing raw JSON so longer key/value pairs don't truncate.
- Uses an additional SCSS class (`payloadRuleRawParamRow`) toggled via the existing `rawJsonValues` flag; non-raw mode is unchanged.

## Test plan

- [x] Open a payload rule and toggle "Raw JSON" on — confirm the row uses the wider columns and doesn't clip long paths or values.
- [x] Toggle "Raw JSON" off — confirm the row reverts to the original 4-column layout.
- [x] Add / remove param rows in both modes to confirm nothing else regresses.