### PR TITLE
Release v1.6.0

### DIFF
--- a/docs/release-notes/v1.6.0-en.md
+++ b/docs/release-notes/v1.6.0-en.md
@@ -1,0 +1,60 @@
+# CPA Manager Plus v1.6.0
+
+> 18 commits · 98 files changed · +2310 / -2233
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.6.0/docs/release-notes/v1.6.0-zh.md)
+
+## Overview
+
+This release tightens the CPA Manager Plus API surface and hardens the plugin ecosystem: the backend drops invalid short-path fallbacks and dead worker helpers, the frontend gates third-party plugin installs behind typed confirmation, and Codex gains a built-in connectivity test alongside the restored Claude model discovery. Outbound HTTP timeouts are unified, and the legacy ampcode provider is fully removed.
+
+## Highlights
+
+### Features
+
+- Logs incremental fetch now supports cursor pagination (`web/logs`).
+- Codex provider edit page gains a connectivity test (`web/codex`).
+- Third-party plugin installs require typing the repo slug or plugin id to confirm (`web/plugins`).
+
+### Fixes
+
+- Widen the payload rule row when editing raw JSON so long key/value pairs no longer truncate (`web/config`).
+- Classify 28–31 day windows as monthly quota (`web/codex`).
+- Proxy plugin management endpoints with caller-provided authorization and rewrite Codex invite origin headers (`manager-server`).
+- Bump outbound HTTP timeouts from 15s to 30s (`manager-server` / `web`).
+- Prevent Codex inspection controls and result tables from overflowing narrow layouts (`monitoring`).
+- Restore Claude model discovery in the provider edit drawer (`web`).
+
+### Refactor
+
+- Drop the CPA short-path allowlist; the reverse proxy director now rejects non-management paths (`proxy`).
+- Remove unused `enable/disable` helpers and align quota auto-disable mocks (`worker`).
+- Drop short-path fallbacks in `codexinspection` for `auth-files` and `api-call` (`codexinspection`).
+- Drop short-path fallbacks in `cpaauthfiles` for `auth-files` and `auth-files/status` (`cpaauthfiles`).
+
+### Chore
+
+- Remove the ampcode integration (`web`).
+
+### Docs
+
+- Remove ampcode provider references.
+- Switch release note language links to tag-pinned GitHub blob URLs.
+
+### Tests
+
+- Align httpapi compatibility and codex inspection tests with the long-path upstream contract.
+
+## Upgrade Notes
+
+- Users relying on the ampcode provider need to switch to a supported provider.
+- Outbound HTTP timeouts are now 30s, so failed calls take longer to surface.
+- Third-party plugin install/update flows add a typed confirmation step that requires the repo slug or plugin id. Official plugins are unchanged.
+
+## Acknowledgements
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.5.0...v1.6.0

--- a/docs/release-notes/v1.6.0-zh.md
+++ b/docs/release-notes/v1.6.0-zh.md
@@ -1,0 +1,60 @@
+# CPA Manager Plus v1.6.0
+
+> 18 commits · 98 files changed · +2310 / -2233
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.6.0/docs/release-notes/v1.6.0-en.md)
+
+## Overview
+
+本次发布聚焦 CPA Manager Plus 的 API 表面收敛与插件生态安全加固:后端清理了无效的短路径回退与多余的 worker helper,前端将第三方插件安装改为强制确认,同时新增 Codex 提供商联通性测试与 Claude 模型发现恢复,统一了出站 HTTP 超时。配套移除了 ampcode 提供商集成,文档同步更新。
+
+## Highlights
+
+### Features
+
+- 日志增量拉取支持 cursor 分页(`web/logs`)。
+- Codex 提供商联通性测试(编辑页)(`web/codex`)。
+- 第三方插件安装需输入 repo slug / plugin id 强制确认(`web/plugins`)。
+
+### Fixes
+
+- 编辑原始 JSON 时放宽 payload 规则行宽,避免长键值截断(`web/config`)。
+- 28–31 天限流窗口归类为月度配额(`web/codex`)。
+- 透传插件管理接口的调用方鉴权,修复 Codex invite 跨域问题(`manager-server`)。
+- 出站 HTTP 客户端超时 15s → 30s(`manager-server` / `web`)。
+- 监控检查控件在窄屏下溢出修复(`monitoring`)。
+- 恢复 Claude 模型发现抽屉(`web`)。
+
+### Refactor
+
+- 移除 CPA 短路径白名单,反向代理 director 拒绝非管理路径(`proxy`)。
+- 删除 `enable/disable` 死代码并对齐 quota auto-disable 测试桩(`worker`)。
+- 移除 `codexinspection` 中对 `auth-files` / `api-call` 的短路径回退(`codexinspection`)。
+- 移除 `cpaauthfiles` 中对 `auth-files` / `auth-files/status` 的短路径回退(`cpaauthfiles`)。
+
+### Chore
+
+- 移除 ampcode 集成(`web`)。
+
+### Docs
+
+- 删除 ampcode 提供商相关文档。
+- 修复 release notes 语言切换链接使用 tag-pinned 形式。
+
+### Tests
+
+- 同步 httpapi 兼容测试与 codex 检查测试到长路径契约。
+
+## Upgrade Notes
+
+- 依赖 ampcode 集成的用户需要切换到受支持的 provider。
+- 出站 HTTP 超时延长到 30s,网络异常场景下错误反馈会更晚返回。
+- 第三方插件的安装/更新路径新增"输入 repo slug 或 plugin id"二次确认,官方插件不受影响。
+
+## Acknowledgements
+
+None.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.5.0...v1.6.0


### PR DESCRIPTION
## Summary

Cut the **v1.6.0** release. Adds the curated release notes that the `Build and Release` workflow picks on tag push.

- 18 non-merge commits since v1.5.0 (3 features, 7 fixes, 4 refactors, 1 chore, 2 docs, 1 test).
- 98 files changed, +2310 / -2233.
- Authored Chinese source at `docs/release-notes/v1.6.0-zh.md`; English mirror at `docs/release-notes/v1.6.0-en.md`.
- Language switch links use tag-pinned GitHub blob URLs so they resolve after the tag is pushed.

The `Build and Release` workflow (`.github/workflows/release.yml`) prefers the curated notes (zh -> zh-CN -> en) on tag push, falling back to `git log` only if none exist.

## Test plan

- [x] Verify `docs/release-notes/v1.6.0-zh.md` and `docs/release-notes/v1.6.0-en.md` render correctly on `main` after merge.
- [x] Confirm the language switch links resolve to tag-pinned blob URLs (`https://github.com/seakee/CPA-Manager-Plus/blob/v1.6.0/docs/release-notes/...`).
- [x] After merge, push the `v1.6.0` tag to trigger the Build and Release workflow; confirm the GitHub Release body matches the curated notes.

**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.5.0...v1.6.0