### PR TITLE
feat: 前端展示 CPAMP quota cooldown 派生徽标

### DIFF
--- a/apps/manager-server/internal/http/controller/quotacooldown/handler.go
+++ b/apps/manager-server/internal/http/controller/quotacooldown/handler.go
@@ -1,0 +1,79 @@
+package quotacooldown
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/app"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/middleware"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/response"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+)
+
+type Handler struct {
+	App *app.Context
+}
+
+// cooldownItem is the minimal, read-only view of an active quota cooldown that
+// the panel needs to render a derived hint on the auth file card. It deliberately
+// omits internal/account-snapshot fields.
+type cooldownItem struct {
+	AuthFileName string `json:"authFileName"`
+	AuthIndex    string `json:"authIndex"`
+	Provider     string `json:"provider"`
+	Owner        string `json:"owner"`
+	RecoverAtMs  int64  `json:"recoverAtMs"`
+	DisabledAtMs int64  `json:"disabledAtMs"`
+	CreatedAtMs  int64  `json:"createdAtMs"`
+}
+
+type listResponse struct {
+	Items []cooldownItem `json:"items"`
+}
+
+// Handle exposes the currently active quota cooldowns so the panel can show a
+// derived "CPAMP cooldown in progress" hint next to the affected auth files.
+// It is read-only and never modifies cooldown ownership or the native CPA
+// disabled state.
+func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	path := strings.TrimRight(r.URL.Path, "/")
+	if path != "/usage-service/quota-cooldowns" {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if r.Method != http.MethodGet {
+		response.MethodNotAllowed(w)
+		return
+	}
+	if !middleware.AuthorizePanel(w, r, h.App.AdminAuthService) {
+		return
+	}
+
+	cooldowns, err := h.App.Store.QuotaCooldowns.ListActive(r.Context())
+	if err != nil {
+		response.Error(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	items := make([]cooldownItem, 0, len(cooldowns))
+	for _, c := range cooldowns {
+		items = append(items, mapCooldown(c))
+	}
+	response.JSON(w, http.StatusOK, listResponse{Items: items})
+}
+
+func mapCooldown(c model.QuotaCooldown) cooldownItem {
+	return cooldownItem{
+		AuthFileName: c.AuthFileName,
+		AuthIndex:    c.AuthIndex,
+		Provider:     c.Provider,
+		Owner:        c.Owner,
+		RecoverAtMs:  c.RecoverAtMS,
+		DisabledAtMs: c.DisabledAtMS,
+		CreatedAtMs:  c.CreatedAtMS,
+	}
+}

--- a/apps/manager-server/internal/http/router/router.go
+++ b/apps/manager-server/internal/http/router/router.go
@@ -16,6 +16,7 @@ import (
 	monitoringcontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/monitoring"
 	panelcontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/panel"
 	proxycontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/proxy"
+	quotacooldowncontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/quotacooldown"
 	setupcontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/setup"
 	systemcontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/system"
 	usagecontroller "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/controller/usage"
@@ -33,6 +34,7 @@ func New(appCtx *app.Context) http.Handler {
 	apiKeyAliasHandler := &apikeyaliascontroller.Handler{App: appCtx}
 	accountActionHandler := &accountactioncontroller.Handler{App: appCtx}
 	automationHandler := automationcontroller.New(appCtx)
+	quotaCooldownHandler := &quotacooldowncontroller.Handler{App: appCtx}
 	codexInspectionHandler := &codexinspectioncontroller.Handler{App: appCtx}
 	dashboardHandler := &dashboardcontroller.Handler{App: appCtx}
 	monitoringHandler := &monitoringcontroller.Handler{App: appCtx}
@@ -45,6 +47,7 @@ func New(appCtx *app.Context) http.Handler {
 	mux.HandleFunc("/usage-service/info", middleware.WithCORS(appCtx.Config, systemHandler.Info))
 	mux.HandleFunc("/usage-service/config", middleware.WithCORS(appCtx.Config, managerConfigHandler.Handle))
 	mux.HandleFunc("/usage-service/account-processing-policy", middleware.WithCORS(appCtx.Config, automationHandler.Handle))
+	mux.HandleFunc("/usage-service/quota-cooldowns", middleware.WithCORS(appCtx.Config, quotaCooldownHandler.Handle))
 	mux.HandleFunc("/setup", middleware.WithCORS(appCtx.Config, setupHandler.Setup))
 	mux.HandleFunc("/management.html", panelHandler.ManagementHTML)
 	mux.HandleFunc("/", rootHandler(appCtx, usageHandler, modelPriceHandler, apiKeyAliasHandler, accountActionHandler, codexInspectionHandler, dashboardHandler, monitoringHandler, proxyHandler))

--- a/apps/manager-server/internal/httpapi/server_quota_cooldown_test.go
+++ b/apps/manager-server/internal/httpapi/server_quota_cooldown_test.go
@@ -1,0 +1,89 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/testutil"
+)
+
+func TestServerCompatQuotaCooldownsList(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	db := testutil.NewStore(t, cfg)
+	manager := collector.NewManager(cfg, db)
+	handler := New(cfg, db, manager).Handler()
+
+	now := int64(1_700_000_000_000)
+	persisted, err := db.QuotaCooldowns.UpsertActive(context.Background(), model.QuotaCooldownUpsert{
+		AuthFileName:    "codex-1.json",
+		AuthIndex:       "0",
+		Provider:        "codex",
+		Owner:           model.QuotaCooldownOwnerUsage429,
+		RecoverAtMS:     now + 3_600_000,
+		DisabledAtMS:    now,
+		AccountSnapshot: "should-not-leak",
+		EventHash:       "should-not-leak",
+	})
+	if err != nil {
+		t.Fatalf("seed cooldown: %v", err)
+	}
+	if persisted.RecoverAtMS != now+3_600_000 {
+		t.Fatalf("seed recoverAtMs = %d", persisted.RecoverAtMS)
+	}
+
+	rr := testutil.Request(t, handler, http.MethodGet, "/usage-service/quota-cooldowns", "", testutil.AdminKey)
+	testutil.RequireStatus(t, rr, http.StatusOK)
+
+	var resp struct {
+		Items []struct {
+			AuthFileName string `json:"authFileName"`
+			AuthIndex    string `json:"authIndex"`
+			Provider     string `json:"provider"`
+			Owner        string `json:"owner"`
+			RecoverAtMs  int64  `json:"recoverAtMs"`
+			DisabledAtMs int64  `json:"disabledAtMs"`
+			CreatedAtMs  int64  `json:"createdAtMs"`
+		} `json:"items"`
+	}
+	testutil.DecodeJSON(t, rr, &resp)
+	if len(resp.Items) != 1 {
+		t.Fatalf("items = %d, want 1, body = %s", len(resp.Items), rr.Body.String())
+	}
+	item := resp.Items[0]
+	if item.AuthFileName != "codex-1.json" || item.Provider != "codex" || item.Owner != model.QuotaCooldownOwnerUsage429 {
+		t.Fatalf("item = %#v", item)
+	}
+	if item.RecoverAtMs != now+3_600_000 || item.DisabledAtMs != now || item.CreatedAtMs <= 0 {
+		t.Fatalf("timestamps = %#v", item)
+	}
+	// The read-only view must not leak internal/account-snapshot fields.
+	if body := rr.Body.String(); containsInternalField(body) {
+		t.Fatalf("response leaked internal fields, body = %s", body)
+	}
+}
+
+func TestServerCompatQuotaCooldownsRequiresPanelAuth(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	db := testutil.NewStore(t, cfg)
+	manager := collector.NewManager(cfg, db)
+	handler := New(cfg, db, manager).Handler()
+
+	noKey := testutil.Request(t, handler, http.MethodGet, "/usage-service/quota-cooldowns", "", "")
+	testutil.RequireStatus(t, noKey, http.StatusUnauthorized)
+
+	post := testutil.Request(t, handler, http.MethodPost, "/usage-service/quota-cooldowns", "", testutil.AdminKey)
+	testutil.RequireStatus(t, post, http.StatusMethodNotAllowed)
+}
+
+func containsInternalField(body string) bool {
+	for _, needle := range []string{"accountSnapshot", "account_snapshot", "eventHash", "event_hash", "preDisabledState", "lastError"} {
+		if strings.Contains(body, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/web/src/features/authFiles/AuthFilesPage.module.scss
+++ b/apps/web/src/features/authFiles/AuthFilesPage.module.scss
@@ -1068,6 +1068,10 @@
   border: 1px solid var(--color-primary-light-7);
 }
 
+.quotaCooldownBadge {
+  cursor: help;
+}
+
 .fileName {
   font-size: 14px;
   font-weight: 800;

--- a/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
@@ -94,22 +94,6 @@ vi.mock('@/components/common/PageTransitionLayer', () => ({
   usePageTransitionLayer: () => ({ status: 'current' }),
 }));
 
-vi.mock('@/hooks/usePanelFeatureAvailability', () => ({
-  usePanelFeatureAvailability: () => ({
-    checking: false,
-    panelHostMode: 'external_panel',
-    panelBase: '',
-    managerServiceBase: '',
-    managerServiceAvailable: false,
-    requestMonitoringAvailable: false,
-    modelPricesAvailable: false,
-    serverCodexInspectionAvailable: false,
-    dockerSetupAvailable: false,
-    externalManagerConfigAvailable: false,
-    reason: 'service_not_configured',
-  }),
-}));
-
 vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn(async () => undefined),
 }));

--- a/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
@@ -94,6 +94,22 @@ vi.mock('@/components/common/PageTransitionLayer', () => ({
   usePageTransitionLayer: () => ({ status: 'current' }),
 }));
 
+vi.mock('@/hooks/usePanelFeatureAvailability', () => ({
+  usePanelFeatureAvailability: () => ({
+    checking: false,
+    panelHostMode: 'external_panel',
+    panelBase: '',
+    managerServiceBase: '',
+    managerServiceAvailable: false,
+    requestMonitoringAvailable: false,
+    modelPricesAvailable: false,
+    serverCodexInspectionAvailable: false,
+    dockerSetupAvailable: false,
+    externalManagerConfigAvailable: false,
+    reason: 'service_not_configured',
+  }),
+}));
+
 vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn(async () => undefined),
 }));

--- a/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
@@ -10,6 +10,7 @@ const { mocks } = vi.hoisted(() => {
   return {
     mocks: {
       connectionStatus: 'connected' as 'connected' | 'disconnected',
+      managementKey: 'test-key' as string,
       list: vi.fn(),
       showNotification: vi.fn(),
       showConfirmation: vi.fn(),
@@ -114,7 +115,7 @@ vi.mock('@/stores', () => ({
     selector({
       connectionStatus: mocks.connectionStatus,
       apiBase: 'http://manager.local:18317',
-      managementKey: 'test-key',
+      managementKey: mocks.managementKey,
     }),
   useThemeStore: (selector: (state: { resolvedTheme: 'dark' }) => unknown) =>
     selector({ resolvedTheme: 'dark' }),
@@ -275,6 +276,21 @@ const setManagerServiceBase = (value: string) => {
   };
 };
 
+const setManagementKey = (value: string) => {
+  mocks.managementKey = value;
+};
+
+// A controllable promise so a test can resolve a cooldown fetch at a chosen
+// moment — used to cover the "request in flight, context changes, stale
+// response lands" race.
+const createDeferred = () => {
+  let resolve!: (value: unknown[]) => void;
+  const promise = new Promise<unknown[]>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
 describe('AuthFilesPage quota cooldown derived badge', () => {
   beforeEach(() => {
     mocks.list.mockReset();
@@ -282,6 +298,7 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     mocks.listCodexInspectionRuns.mockReset();
     mocks.getCodexInspectionRun.mockReset();
     mocks.connectionStatus = 'connected';
+    mocks.managementKey = 'test-key';
 
     mocks.list.mockReturnValue([
       { name: 'codex-one.json', type: 'codex' },
@@ -372,6 +389,96 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     await Promise.resolve();
 
     expect(mocks.getActiveQuotaCooldowns).not.toHaveBeenCalled();
+  });
+
+  it('drops a stale cooldown response that resolves after managerServiceBase becomes empty', async () => {
+    const deferred = createDeferred();
+    mocks.getActiveQuotaCooldowns.mockReturnValue(deferred.promise);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    // A fetch is in flight against the still-live base.
+    await vi.waitFor(() => {
+      expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledTimes(1);
+    });
+
+    // Manager Server becomes unavailable; the clear effect empties the map.
+    setManagerServiceBase('');
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    // The stale response finally lands — it must not resurrect the badge.
+    await act(async () => {
+      deferred.resolve([
+        { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
+      ]);
+      await deferred.promise.catch(() => {});
+    });
+
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('');
+  });
+
+  it('drops a stale cooldown response that resolves after the management key changes', async () => {
+    const first = createDeferred();
+    mocks.getActiveQuotaCooldowns.mockReturnValueOnce(first.promise);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    // Initial fetch fired against the original key.
+    await vi.waitFor(() => {
+      expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledWith(
+        'http://manager.local:18317',
+        'test-key'
+      );
+    });
+
+    // Credentials rotate: a fresh request fires against the new key.
+    setManagementKey('rotated-key');
+    const second = createDeferred();
+    mocks.getActiveQuotaCooldowns.mockReturnValueOnce(second.promise);
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledTimes(2);
+
+    // The new-context request resolves first with its own data — applied.
+    await act(async () => {
+      second.resolve([
+        { authFileName: 'codex-two.json', recoverAtMs: 1_700_000_000_000 },
+      ]);
+      await second.promise.catch(() => {});
+    });
+
+    // The stale (old-key) response lands afterwards and must be ignored.
+    await act(async () => {
+      first.resolve([
+        { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
+      ]);
+      await first.promise.catch(() => {});
+    });
+
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('');
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-two.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('codex-two.json@1700000000000');
   });
 
   it('ignores mocked Select import for sort/plan dropdowns without crashing', () => {

--- a/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
@@ -1,0 +1,380 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Select } from '@/components/ui/Select';
+import { AuthFilesPage } from './AuthFilesPage';
+
+const { mocks } = vi.hoisted(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  return {
+    mocks: {
+      connectionStatus: 'connected' as 'connected' | 'disconnected',
+      list: vi.fn(),
+      showNotification: vi.fn(),
+      showConfirmation: vi.fn(),
+      navigate: vi.fn(),
+      loadExcluded: vi.fn(async () => undefined),
+      loadModelAlias: vi.fn(async () => undefined),
+      listCodexInspectionRuns: vi.fn(),
+      getCodexInspectionRun: vi.fn(),
+      getActiveQuotaCooldowns: vi.fn(),
+      panelFeatureAvailability: {
+        checking: false,
+        panelHostMode: 'manager_embedded' as const,
+        panelBase: 'http://manager.local:18317',
+        managerServiceBase: 'http://manager.local:18317',
+        managerServiceAvailable: true,
+        requestMonitoringAvailable: true,
+        modelPricesAvailable: true,
+        serverCodexInspectionAvailable: true,
+        dockerSetupAvailable: true,
+        externalManagerConfigAvailable: false,
+        reason: '',
+      },
+      t: (key: string, options?: Record<string, unknown>) => {
+        if (options && typeof options.name === 'string') {
+          return `${key}:${options.name}`;
+        }
+        return key;
+      },
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: mocks.t,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('motion/mini', () => ({
+  animate: () => ({ stop: () => {} }),
+}));
+
+vi.mock('@/hooks/useInterval', () => ({
+  useInterval: () => {},
+}));
+
+vi.mock('@/hooks/useHeaderRefresh', () => ({
+  useHeaderRefresh: () => {},
+}));
+
+vi.mock('@/components/common/PageTransitionLayer', () => ({
+  usePageTransitionLayer: () => ({ status: 'current' }),
+}));
+
+vi.mock('@/hooks/usePanelFeatureAvailability', () => ({
+  usePanelFeatureAvailability: () => mocks.panelFeatureAvailability,
+}));
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/services/api', () => ({
+  authFilesApi: {
+    list: mocks.list,
+  },
+}));
+
+vi.mock('@/services/api/usageService', () => ({
+  usageServiceApi: {
+    listCodexInspectionRuns: mocks.listCodexInspectionRuns,
+    getCodexInspectionRun: mocks.getCodexInspectionRun,
+    getActiveQuotaCooldowns: mocks.getActiveQuotaCooldowns,
+  },
+}));
+
+vi.mock('@/stores', () => ({
+  useNotificationStore: (
+    selector?: (state: {
+      showNotification: typeof mocks.showNotification;
+      showConfirmation: typeof mocks.showConfirmation;
+    }) => unknown
+  ) => {
+    const state = {
+      showNotification: mocks.showNotification,
+      showConfirmation: mocks.showConfirmation,
+    };
+    return selector ? selector(state) : state;
+  },
+  useAuthStore: (
+    selector: (state: {
+      connectionStatus: 'connected' | 'disconnected';
+      apiBase: string;
+      managementKey: string;
+    }) => unknown
+  ) =>
+    selector({
+      connectionStatus: mocks.connectionStatus,
+      apiBase: 'http://manager.local:18317',
+      managementKey: 'test-key',
+    }),
+  useThemeStore: (selector: (state: { resolvedTheme: 'dark' }) => unknown) =>
+    selector({ resolvedTheme: 'dark' }),
+  useQuotaStore: (selector: (state: { codexQuota: Record<string, never> }) => unknown) =>
+    selector({ codexQuota: {} }),
+}));
+
+vi.mock('@/features/authFiles/hooks/useAuthFilesData', () => ({
+  useAuthFilesData: () => ({
+    files: mocks.list(),
+    selectedFiles: new Set<string>(),
+    selectionCount: 0,
+    loading: false,
+    error: '',
+    uploading: false,
+    authJsonPasteSaving: false,
+    deleting: {},
+    deletingAll: false,
+    statusUpdating: {},
+    batchStatusUpdating: false,
+    batchFieldsUpdating: false,
+    fileInputRef: { current: null },
+    loadFiles: vi.fn(async () => undefined),
+    handleUploadClick: vi.fn(),
+    handleFileChange: vi.fn(),
+    savePastedAuthJson: vi.fn(async () => undefined),
+    handleDelete: vi.fn(),
+    handleDeleteAll: vi.fn(),
+    handleDownload: vi.fn(),
+    handleStatusToggle: vi.fn(),
+    toggleSelect: vi.fn(),
+    selectAllVisible: vi.fn(),
+    invertVisibleSelection: vi.fn(),
+    deselectAll: vi.fn(),
+    batchDownload: vi.fn(),
+    batchSetStatus: vi.fn(),
+    batchPatchFields: vi.fn(),
+    batchDelete: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/authFiles/hooks/useAuthFilesOauth', () => ({
+  useAuthFilesOauth: () => ({
+    excluded: [],
+    excludedError: '',
+    modelAlias: [],
+    modelAliasError: '',
+    allProviderModels: {},
+    loadExcluded: mocks.loadExcluded,
+    loadModelAlias: mocks.loadModelAlias,
+    deleteExcluded: vi.fn(),
+    deleteModelAlias: vi.fn(),
+    handleMappingUpdate: vi.fn(),
+    handleDeleteLink: vi.fn(),
+    handleToggleFork: vi.fn(),
+    handleRenameAlias: vi.fn(),
+    handleDeleteAlias: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/authFiles/hooks/useAuthFilesModels', () => ({
+  useAuthFilesModels: () => ({
+    modelsModalOpen: false,
+    modelsLoading: false,
+    modelsList: [],
+    modelsFileName: '',
+    modelsFileType: '',
+    modelsError: '',
+    showModels: vi.fn(),
+    closeModelsModal: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/authFiles/hooks/useAuthFilesPrefixProxyEditor', () => ({
+  useAuthFilesPrefixProxyEditor: () => ({
+    prefixProxyEditor: null,
+    prefixProxyUpdatedText: '',
+    prefixProxyDirty: false,
+    openPrefixProxyEditor: vi.fn(),
+    closePrefixProxyEditor: vi.fn(),
+    handlePrefixProxyChange: vi.fn(),
+    handlePrefixProxySave: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/authFiles/hooks/useAuthFilesStatusBarCache', () => ({
+  useAuthFilesStatusBarCache: () => new Map(),
+}));
+
+vi.mock('@/features/monitoring/codexInspection', () => ({
+  createCodexInspectionConnectionFingerprint: () => 'test-fingerprint',
+  loadCodexInspectionLastRun: () => null,
+}));
+
+vi.mock('@/features/authFiles/uiState', () => ({
+  normalizeAuthFilesSortMode: (value: string) => (value === 'default' ? 'default' : null),
+  normalizeAuthFilesViewMode: (value: string) =>
+    value === 'diagram' || value === 'list' ? value : null,
+  readAuthFilesUiState: () => null,
+  readPersistedAuthFilesCompactMode: () => null,
+  writeAuthFilesUiState: vi.fn(),
+  writePersistedAuthFilesCompactMode: vi.fn(),
+}));
+
+vi.mock('@/features/authFiles/components/AuthFileCard', () => ({
+  AuthFileCard: (props: {
+    file: { name: string };
+    quotaCooldown?: { authFileName: string; recoverAtMs: number } | null;
+  }) => {
+    const cooldown = props.quotaCooldown
+      ? `${props.quotaCooldown.authFileName}@${props.quotaCooldown.recoverAtMs}`
+      : '';
+    return <div data-auth-card={props.file.name} data-quota-cooldown={cooldown} />;
+  },
+}));
+
+vi.mock('@/features/authFiles/components/AuthJsonPasteModal', () => ({
+  AuthJsonPasteModal: () => null,
+}));
+
+vi.mock('@/features/authFiles/components/AuthFileModelsModal', () => ({
+  AuthFileModelsModal: () => null,
+}));
+
+vi.mock('@/features/authFiles/components/AuthFilesPrefixProxyEditorModal', () => ({
+  AuthFilesPrefixProxyEditorModal: () => null,
+}));
+
+vi.mock('@/features/authFiles/components/OAuthExcludedCard', () => ({
+  OAuthExcludedCard: () => null,
+}));
+
+vi.mock('@/features/authFiles/components/OAuthModelAliasCard', () => ({
+  OAuthModelAliasCard: () => null,
+}));
+
+vi.mock('@/features/oauth/CodexReauthDialog', () => ({
+  CodexReauthDialog: () => null,
+}));
+
+vi.mock('@/components/ui/EmptyState', () => ({
+  EmptyState: () => null,
+}));
+
+vi.mock('@/components/ui/ToggleSwitch', () => ({
+  ToggleSwitch: () => null,
+}));
+
+vi.mock('@/components/ui/Modal', () => ({
+  Modal: () => null,
+}));
+
+const setManagerServiceBase = (value: string) => {
+  mocks.panelFeatureAvailability = {
+    ...mocks.panelFeatureAvailability,
+    managerServiceBase: value,
+    managerServiceAvailable: Boolean(value),
+  };
+};
+
+describe('AuthFilesPage quota cooldown derived badge', () => {
+  beforeEach(() => {
+    mocks.list.mockReset();
+    mocks.getActiveQuotaCooldowns.mockReset();
+    mocks.listCodexInspectionRuns.mockReset();
+    mocks.getCodexInspectionRun.mockReset();
+    mocks.connectionStatus = 'connected';
+
+    mocks.list.mockReturnValue([
+      { name: 'codex-one.json', type: 'codex' },
+      { name: 'codex-two.json', type: 'codex' },
+    ]);
+    mocks.listCodexInspectionRuns.mockResolvedValue({ items: [] });
+    mocks.getCodexInspectionRun.mockResolvedValue({ run: { id: 1 }, results: [], logs: [] });
+
+    setManagerServiceBase('http://manager.local:18317');
+  });
+
+  it('loads active quota cooldowns when the Manager Server is available', async () => {
+    mocks.getActiveQuotaCooldowns.mockResolvedValue([
+      { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
+    ]);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledWith(
+        'http://manager.local:18317',
+        'test-key'
+      );
+    });
+
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('codex-one.json@2000000000000');
+    // Files without an active cooldown surface an empty badge slot.
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-two.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('');
+  });
+
+  it('clears stale cooldowns when managerServiceBase becomes empty', async () => {
+    mocks.getActiveQuotaCooldowns.mockResolvedValue([
+      { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
+    ]);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    // Cooldown loaded and surfaced on the card.
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+          'data-quota-cooldown'
+        ]
+      ).toBe('codex-one.json@2000000000000');
+    });
+
+    // Manager Server goes away (service down, credentials change, feature flag off).
+    setManagerServiceBase('');
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('');
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-two.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('');
+  });
+
+  it('does not call getActiveQuotaCooldowns while managerServiceBase is empty', async () => {
+    setManagerServiceBase('');
+
+    await act(async () => {
+      create(<AuthFilesPage />);
+    });
+
+    // Flush any pending microtasks; no loader invocation should ever happen.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.getActiveQuotaCooldowns).not.toHaveBeenCalled();
+  });
+
+  it('ignores mocked Select import for sort/plan dropdowns without crashing', () => {
+    expect(Select).toBeDefined();
+  });
+});

--- a/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
@@ -15,6 +15,7 @@ const { mocks } = vi.hoisted(() => {
       showNotification: vi.fn(),
       showConfirmation: vi.fn(),
       navigate: vi.fn(),
+      pageTransitionStatus: 'current' as 'current' | 'exiting' | 'stacked',
       loadExcluded: vi.fn(async () => undefined),
       loadModelAlias: vi.fn(async () => undefined),
       listCodexInspectionRuns: vi.fn(),
@@ -67,7 +68,7 @@ vi.mock('@/hooks/useHeaderRefresh', () => ({
 }));
 
 vi.mock('@/components/common/PageTransitionLayer', () => ({
-  usePageTransitionLayer: () => ({ status: 'current' }),
+  usePageTransitionLayer: () => ({ status: mocks.pageTransitionStatus }),
 }));
 
 vi.mock('@/hooks/usePanelFeatureAvailability', () => ({
@@ -299,6 +300,7 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     mocks.getCodexInspectionRun.mockReset();
     mocks.connectionStatus = 'connected';
     mocks.managementKey = 'test-key';
+    mocks.pageTransitionStatus = 'current';
 
     mocks.list.mockReturnValue([
       { name: 'codex-one.json', type: 'codex' },
@@ -479,6 +481,47 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
         'data-quota-cooldown'
       ]
     ).toBe('codex-two.json@1700000000000');
+  });
+
+  it('drops stale cooldown when base changes before the next loader runs', async () => {
+    const first = createDeferred();
+    mocks.getActiveQuotaCooldowns.mockReturnValueOnce(first.promise);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    // Initial fetch is in flight against the original non-empty base.
+    await vi.waitFor(() => {
+      expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledTimes(1);
+    });
+
+    // Switch to another non-empty base, but mark the page as non-current so the
+    // passive effect that normally kicks off the next load is intentionally
+    // skipped. This isolates the review edge case: the old response returns
+    // after context changes but before any new loader can bump the token.
+    setManagerServiceBase('http://manager-two.local:18317');
+    mocks.pageTransitionStatus = 'stacked';
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+    expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledTimes(1);
+
+    // The old-context response lands before a new loader runs — it must be
+    // dropped by the layout-effect invalidation alone.
+    await act(async () => {
+      first.resolve([
+        { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
+      ]);
+      await first.promise.catch(() => {});
+    });
+
+    expect(
+      renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+        'data-quota-cooldown'
+      ]
+    ).toBe('');
   });
 
   it('ignores mocked Select import for sort/plan dropdowns without crashing', () => {

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -183,6 +183,11 @@ export function AuthFilesPage() {
   const batchActionAnimationRef = useRef<AnimationPlaybackControlsWithThen | null>(null);
   const previousSelectionCountRef = useRef(0);
   const selectionCountRef = useRef(0);
+  // Generation token for in-flight cooldown fetches. Every fetch and every
+  // context reset (Manager Server going unavailable) bump it, so a slow,
+  // superseded response can be detected and dropped — otherwise it would
+  // re-introduce stale badges after the clear effect emptied the map.
+  const cooldownReqId = useRef(0);
 
   const {
     files,
@@ -512,8 +517,15 @@ export function AuthFilesPage() {
   );
 
   const loadQuotaCooldowns = useCallback(async () => {
+    // Stamp this fetch with a fresh id so a later context change (Manager Server
+    // going unavailable or credentials rotating, which re-fire the loader or
+    // trip the clear effect below) can invalidate it. If a newer fetch or reset
+    // has bumped the id by the time we land, we drop the result instead of
+    // writing stale badges back.
+    const id = ++cooldownReqId.current;
     try {
       const items = await usageServiceApi.getActiveQuotaCooldowns(managerServiceBase, managementKey);
+      if (id !== cooldownReqId.current) return;
       const next = new Map<string, QuotaCooldownInfo>();
       for (const item of items) {
         if (!item.authFileName) continue;
@@ -534,6 +546,9 @@ export function AuthFilesPage() {
   // down, or feature availability flips off.
   useEffect(() => {
     if (managerServiceBase) return;
+    // Bump the token to invalidate any in-flight fetch whose request context no
+    // longer applies, then drop the derived state so stale badges don't linger.
+    cooldownReqId.current += 1;
     setQuotaCooldowns((current) => (current.size === 0 ? current : new Map()));
   }, [managerServiceBase]);
 

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -512,10 +512,6 @@ export function AuthFilesPage() {
   );
 
   const loadQuotaCooldowns = useCallback(async () => {
-    if (!managerServiceBase) {
-      setQuotaCooldowns((current) => (current.size === 0 ? current : new Map()));
-      return;
-    }
     try {
       const items = await usageServiceApi.getActiveQuotaCooldowns(managerServiceBase, managementKey);
       const next = new Map<string, QuotaCooldownInfo>();
@@ -531,6 +527,15 @@ export function AuthFilesPage() {
       // The cooldown badge is a derived hint; fail silently and keep the last known state.
     }
   }, [managerServiceBase, managementKey]);
+
+  // Clear stale cooldowns the moment the Manager Server becomes unavailable.
+  // The loader's call sites all guard on managerServiceBase, so without this
+  // the derived badge would linger after credentials change, the service goes
+  // down, or feature availability flips off.
+  useEffect(() => {
+    if (managerServiceBase) return;
+    setQuotaCooldowns((current) => (current.size === 0 ? current : new Map()));
+  }, [managerServiceBase]);
 
   useEffect(() => {
     if (!isCurrentLayer || !managerServiceBase) return;

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -53,7 +53,7 @@ import {
   createCodexReauthTargetFromAuthFile,
   type CodexReauthTarget,
 } from '@/features/oauth/codexReauthModel';
-import { usageServiceApi, type CodexInspectionResult } from '@/services/api/usageService';
+import { usageServiceApi, type CodexInspectionResult, type QuotaCooldownInfo } from '@/services/api/usageService';
 import { useAuthFilesData } from '@/features/authFiles/hooks/useAuthFilesData';
 import { useAuthFilesModels } from '@/features/authFiles/hooks/useAuthFilesModels';
 import { useAuthFilesOauth } from '@/features/authFiles/hooks/useAuthFilesOauth';
@@ -146,6 +146,7 @@ export function AuthFilesPage() {
   const resolvedTheme: ResolvedTheme = useThemeStore((state) => state.resolvedTheme);
   const codexQuota = useQuotaStore((state) => state.codexQuota);
   const featureAvailability = usePanelFeatureAvailability();
+  const managerServiceBase = featureAvailability.managerServiceBase;
   const pageTransitionLayer = usePageTransitionLayer();
   const isCurrentLayer = pageTransitionLayer ? pageTransitionLayer.status === 'current' : true;
   const navigate = useNavigate();
@@ -175,6 +176,9 @@ export function AuthFilesPage() {
   const [lastCodexInspectionResults, setLastCodexInspectionResults] = useState<
     AuthFileCodexInspectionSnapshot[]
   >([]);
+  const [quotaCooldowns, setQuotaCooldowns] = useState<Map<string, QuotaCooldownInfo>>(
+    () => new Map()
+  );
   const floatingBatchActionsRef = useRef<HTMLDivElement>(null);
   const batchActionAnimationRef = useRef<AnimationPlaybackControlsWithThen | null>(null);
   const previousSelectionCountRef = useRef(0);
@@ -505,6 +509,39 @@ export function AuthFilesPage() {
       void loadFiles().catch(() => {});
     },
     isCurrentLayer ? 240_000 : null
+  );
+
+  const loadQuotaCooldowns = useCallback(async () => {
+    if (!managerServiceBase) {
+      setQuotaCooldowns((current) => (current.size === 0 ? current : new Map()));
+      return;
+    }
+    try {
+      const items = await usageServiceApi.getActiveQuotaCooldowns(managerServiceBase, managementKey);
+      const next = new Map<string, QuotaCooldownInfo>();
+      for (const item of items) {
+        if (!item.authFileName) continue;
+        const existing = next.get(item.authFileName);
+        if (!existing || (item.recoverAtMs ?? 0) > (existing.recoverAtMs ?? 0)) {
+          next.set(item.authFileName, item);
+        }
+      }
+      setQuotaCooldowns(next);
+    } catch {
+      // The cooldown badge is a derived hint; fail silently and keep the last known state.
+    }
+  }, [managerServiceBase, managementKey]);
+
+  useEffect(() => {
+    if (!isCurrentLayer || !managerServiceBase) return;
+    void loadQuotaCooldowns();
+  }, [isCurrentLayer, managerServiceBase, loadQuotaCooldowns]);
+
+  useInterval(
+    () => {
+      void loadQuotaCooldowns();
+    },
+    isCurrentLayer && managerServiceBase ? 60_000 : null
   );
 
   const existingTypes = useMemo(() => {
@@ -1255,6 +1292,7 @@ export function AuthFilesPage() {
                       codexStatusBadges={codexStatus?.badges ?? []}
                       codexNeedsReauth={codexStatus?.needsReauth ?? false}
                       antigravitySubscription={antigravitySubscriptions[file.name]}
+                      quotaCooldown={quotaCooldowns.get(file.name)}
                       onShowModels={showModels}
                       onReauth={(targetFile) =>
                         setCodexReauthTarget(createCodexReauthTargetFromAuthFile(targetFile))

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -184,10 +184,14 @@ export function AuthFilesPage() {
   const previousSelectionCountRef = useRef(0);
   const selectionCountRef = useRef(0);
   // Generation token for in-flight cooldown fetches. Every fetch and every
-  // context reset (Manager Server going unavailable) bump it, so a slow,
-  // superseded response can be detected and dropped — otherwise it would
-  // re-introduce stale badges after the clear effect emptied the map.
+  // context identity change bump it, so a slow, superseded response can be
+  // detected and dropped — otherwise it would re-introduce stale badges after
+  // the old context was invalidated.
   const cooldownReqId = useRef(0);
+  // Tracks the context identity so the layout effect can detect cross-context
+  // transitions synchronously (before passive effects fire) and invalidate any
+  // in-flight request that belongs to the old context.
+  const cooldownContextRef = useRef({ managerServiceBase, managementKey });
 
   const {
     files,
@@ -517,11 +521,9 @@ export function AuthFilesPage() {
   );
 
   const loadQuotaCooldowns = useCallback(async () => {
-    // Stamp this fetch with a fresh id so a later context change (Manager Server
-    // going unavailable or credentials rotating, which re-fire the loader or
-    // trip the clear effect below) can invalidate it. If a newer fetch or reset
-    // has bumped the id by the time we land, we drop the result instead of
-    // writing stale badges back.
+    // Stamp this fetch with a fresh id so a later fetch or context identity
+    // invalidation can supersede it. If the generation has changed by the time
+    // we land, we drop the result instead of writing stale badges back.
     const id = ++cooldownReqId.current;
     try {
       const items = await usageServiceApi.getActiveQuotaCooldowns(managerServiceBase, managementKey);
@@ -540,17 +542,22 @@ export function AuthFilesPage() {
     }
   }, [managerServiceBase, managementKey]);
 
-  // Clear stale cooldowns the moment the Manager Server becomes unavailable.
-  // The loader's call sites all guard on managerServiceBase, so without this
-  // the derived badge would linger after credentials change, the service goes
-  // down, or feature availability flips off.
-  useEffect(() => {
-    if (managerServiceBase) return;
-    // Bump the token to invalidate any in-flight fetch whose request context no
-    // longer applies, then drop the derived state so stale badges don't linger.
+  // Synchronously invalidate in-flight cooldown requests when the context
+  // (managerServiceBase or managementKey) changes, regardless of direction
+  // (A→B, A→empty, empty→A). This runs in the layout phase, before any
+  // passive effect that might fire a new loadQuotaCooldowns, so a stale
+  // response that resolves between renders or inside the gap between a
+  // re-render and its passive effects will find its generation token already
+  // invalidated.
+  useLayoutEffect(() => {
+    const prev = cooldownContextRef.current;
+    if (prev.managerServiceBase === managerServiceBase && prev.managementKey === managementKey) {
+      return;
+    }
+    cooldownContextRef.current = { managerServiceBase, managementKey };
     cooldownReqId.current += 1;
     setQuotaCooldowns((current) => (current.size === 0 ? current : new Map()));
-  }, [managerServiceBase]);
+  }, [managerServiceBase, managementKey]);
 
   useEffect(() => {
     if (!isCurrentLayer || !managerServiceBase) return;

--- a/apps/web/src/features/authFiles/components/AuthFileCard.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileCard.tsx
@@ -20,7 +20,7 @@ import {
   normalizeUsageTotal,
   statusBarDataFromRecentRequests,
 } from '@/utils/recentRequests';
-import { formatFileSize } from '@/utils/format';
+import { formatFileSize, formatUnixTimestamp } from '@/utils/format';
 import {
   QUOTA_PROVIDER_TYPES,
   formatModified,
@@ -36,6 +36,7 @@ import {
 import type { AuthFileStatusBarData } from '@/features/authFiles/hooks/useAuthFilesStatusBarCache';
 import type { AntigravitySubscriptionState } from '@/features/authFiles/hooks/useAntigravitySubscriptions';
 import type { AuthFileCodexStatusBadge } from '@/features/authFiles/model/authFilesPageModel';
+import type { QuotaCooldownInfo } from '@/services/api/usageService';
 import { AuthFileQuotaSection } from '@/features/authFiles/components/AuthFileQuotaSection';
 import styles from '@/features/authFiles/AuthFilesPage.module.scss';
 
@@ -53,6 +54,7 @@ export type AuthFileCardProps = {
   codexStatusBadges?: AuthFileCodexStatusBadge[];
   codexNeedsReauth?: boolean;
   antigravitySubscription?: AntigravitySubscriptionState;
+  quotaCooldown?: QuotaCooldownInfo;
   onShowModels: (file: AuthFileItem) => void;
   onReauth?: (file: AuthFileItem) => void;
   onDownload: (name: string) => void;
@@ -88,6 +90,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
     codexStatusBadges = [],
     codexNeedsReauth = false,
     antigravitySubscription,
+    quotaCooldown,
     onShowModels,
     onReauth,
     onDownload,
@@ -263,6 +266,22 @@ export function AuthFileCard(props: AuthFileCardProps) {
                     </span>
                   );
                 })}
+                {quotaCooldown && (
+                  <span
+                    className={`${styles.codexStatusBadge} ${styles.codexStatusBadgeInfo} ${styles.quotaCooldownBadge}`}
+                    title={t('auth_files.quota_cooldown_badge_title', {
+                      recoverAt: formatUnixTimestamp(quotaCooldown.recoverAtMs),
+                      owner: quotaCooldown.owner || 'cpamp_usage_429',
+                      defaultValue:
+                        'This auth file is in a CPAMP-managed quota cooldown and will be recovered automatically. It is not the native CPA disabled state. Owner: {{owner}}. Expected recovery: {{recoverAt}}.',
+                    })}
+                  >
+                    {t('auth_files.quota_cooldown_badge', {
+                      recoverAt: formatUnixTimestamp(quotaCooldown.recoverAtMs),
+                      defaultValue: 'Cooldown until {{recoverAt}}',
+                    })}
+                  </span>
+                )}
               </div>
               <span className={styles.fileName} title={file.name}>
                 {file.name}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -922,7 +922,9 @@
     "prefix_proxy_html_challenge": "Downloaded content is an HTML challenge page, not an auth JSON object. Re-authenticate or replace this auth file before editing fields.",
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",
-    "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}"
+    "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}",
+    "quota_cooldown_badge": "Cooldown until {{recoverAt}}",
+    "quota_cooldown_badge_title": "This auth file is in a CPAMP-managed quota cooldown and will be recovered automatically. It is not the native CPA disabled state. Owner: {{owner}}. Expected recovery: {{recoverAt}}."
   },
   "antigravity_quota": {
     "title": "Antigravity Quota",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -918,7 +918,9 @@
     "quota_refresh_single": "Обновить квоту",
     "quota_refresh_hint": "Обновить квоту только для этих учётных данных",
     "quota_refresh_success": "Квота для \"{{name}}\" обновлена",
-    "quota_refresh_failed": "Не удалось обновить квоту для \"{{name}}\": {{message}}"
+    "quota_refresh_failed": "Не удалось обновить квоту для \"{{name}}\": {{message}}",
+    "quota_cooldown_badge": "Охлаждение до {{recoverAt}}",
+    "quota_cooldown_badge_title": "Этот auth file находится в квотном охлаждении под управлением CPAMP и будет восстановлен автоматически. Это не является нативным отключённым состоянием CPA. Владелец: {{owner}}. Ожидаемое восстановление: {{recoverAt}}."
   },
   "antigravity_quota": {
     "title": "Квота Antigravity",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -911,7 +911,9 @@
     "prefix_proxy_html_challenge": "下载到的是 HTML 验证页面，不是认证 JSON 对象。请重新认证或替换该认证文件后再编辑字段。",
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",
-    "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}"
+    "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}",
+    "quota_cooldown_badge": "冷却至 {{recoverAt}}",
+    "quota_cooldown_badge_title": "此认证文件处于 CPAMP 管理的额度冷却中，将被自动恢复。它不是 CPA 的原生禁用状态。Owner：{{owner}}。预计恢复：{{recoverAt}}。"
   },
   "antigravity_quota": {
     "title": "Antigravity 额度",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -910,7 +910,9 @@
     "prefix_proxy_html_challenge": "下載到的是 HTML 驗證頁面，不是驗證 JSON 物件。請重新驗證或替換該驗證檔案後再編輯欄位。",
     "prefix_proxy_saved_success": "已更新驗證檔案「{{name}}」",
     "quota_refresh_success": "已重新整理「{{name}}」的配額",
-    "quota_refresh_failed": "重新整理「{{name}}」的配額失敗：{{message}}"
+    "quota_refresh_failed": "重新整理「{{name}}」的配額失敗：{{message}}",
+    "quota_cooldown_badge": "冷卻至 {{recoverAt}}",
+    "quota_cooldown_badge_title": "此認證檔案處於 CPAMP 管理的額度冷卻中，將被自動恢復。它不是 CPA 的原生停用狀態。Owner：{{owner}}。預計恢復：{{recoverAt}}。"
   },
   "antigravity_quota": {
     "title": "Antigravity 配額",

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -93,6 +93,20 @@ export interface AccountProcessingPolicyPatch {
   authIssueAutoDisableEnabled?: boolean;
 }
 
+export interface QuotaCooldownInfo {
+  authFileName: string;
+  authIndex?: string;
+  provider?: string;
+  owner?: string;
+  recoverAtMs: number;
+  disabledAtMs?: number;
+  createdAtMs?: number;
+}
+
+export interface QuotaCooldownsResponse {
+  items: QuotaCooldownInfo[];
+}
+
 export interface UsageServiceSetupRequest {
   cpaBaseUrl: string;
   cpaManagementKey: string;
@@ -1299,6 +1313,22 @@ export const usageServiceApi = {
         }
       );
       return response.data;
+    });
+  },
+
+  getActiveQuotaCooldowns: async (
+    base: string,
+    managementKey?: string
+  ): Promise<QuotaCooldownInfo[]> => {
+    return withUsageServiceError(async () => {
+      const response = await axios.get<QuotaCooldownsResponse>(
+        buildUrl(base, '/usage-service/quota-cooldowns'),
+        {
+          timeout: USAGE_SERVICE_TIMEOUT_MS,
+          headers: authHeaders(managementKey),
+        }
+      );
+      return response.data.items ?? [];
     });
   },
 


### PR DESCRIPTION
## Summary

`#132` 的 quota cooldown 机制会让 Manager Server 在 Codex 账号遇到 `usage_limit_reached`(429) 时临时禁用 auth file 并写入 `quota_cooldowns`，到点自动恢复。但这个「临时冷却」状态在前端不可见——用户只看到 `disabled=true`，无法区分是手动禁用还是 CPAMP 管理的冷却，也不知道何时恢复。本 PR 补一个只读派生徽标填补这个信息缺口。

## Scope

- [x] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- **后端只读接口** `GET /usage-service/quota-cooldowns`
  - 新增 `internal/http/controller/quotacooldown/handler.go`，返回 `quota_cooldowns` 中 `status=active` 的记录
  - 响应为最小只读视图，只含徽标需要的字段：`authFileName / authIndex / provider / owner / recoverAtMs / disabledAtMs / createdAtMs`
  - 刻意不泄露内部字段（`accountSnapshot / eventHash / preDisabledState / lastError` 等）
  - 面板鉴权沿用 `middleware.AuthorizePanel`，与其它面板只读接口一致
  - 路由注册于 `router.go` 的 `/usage-service/quota-cooldowns`
- **前端派生徽标**
  - `usageService.ts` 新增 `getActiveQuotaCooldowns()` + `QuotaCooldownInfo` 类型
  - `AuthFilesPage.tsx` 经 `usePanelFeatureAvailability` 取 `managerServiceBase`，拉取 active cooldowns，每 60s 轮询；按 `authFileName` 建映射（同一 auth file 多条记录取 `recoverAtMs` 最大者）；上下文变化时用 generation token 丢弃过期响应
  - `AuthFileCard.tsx` 在已有 badge 行追加 info 色「冷却至 {{recoverAt}}」徽标，复用 `.codexStatusBadge` 布局（`cardBadgeRow` 为 `flex-wrap: wrap`，不会重叠）
- **i18n**：4 语言（en / ru / zh-CN / zh-TW）补充 `auth_files.quota_cooldown_badge` 与 `quota_cooldown_badge_title`

## User Impact

认证文件列表中，处于 CPAMP 临时冷却的 auth file 会额外显示一个 info 色徽标，写明预计恢复时间；hover/title 说明这是 CPAMP 管理的临时冷却、会被自动恢复，并非 CPA 原生禁用。用户因此能区分「手动禁用」与「临时冷却」，不再误判账号状态。

## Compatibility / Runtime Notes

- CPA panel mode: 不涉及，不改 CPA 行为
- Manager Server mode: 新增一个只读面板接口，无写入、无副作用
- Full Docker / native packages: 无配置或部署变更

## Data / Security Notes

接口只读，不触发任何 cooldown 状态变更；沿用 `AuthorizePanel` 面板鉴权；响应刻意裁剪为最小字段集，不泄露 `accountSnapshot / eventHash / preDisabledState / lastError` 等内部数据。

## Risk / Rollback

Risk level: Low

Rollback notes:
- 纯派生展示，不改 CPA 原生 `disabled` 语义，也不改 cooldown 的 owner；回滚只需移除该接口与徽标，不影响 cooldown 自动恢复流程

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check ✓
npm run build ✓
go vet ./... ✓
go test ./internal/httpapi ./internal/http/... ./internal/store ✓（含 cooldown handler 测试）
authFiles 测试套件 137 例全过（含 6 个 quotaCooldown 专项用例）
eslint ✓
```

## Screenshots / Recordings

徽标为派生 UI，需账号实际进入 CPAMP 冷却状态才可见；本地环境无该状态，未附截图。徽标复用既有 `cardBadgeRow`（flex-wrap）布局，不引入新布局风险。

## Docs

- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

Refs #132
