### PR TITLE
docs(release): add v1.7.0 notes

### DIFF
--- a/docs/release-notes/v1.7.0-en.md
+++ b/docs/release-notes/v1.7.0-en.md
@@ -1,0 +1,63 @@
+# CPA Manager Plus v1.7.0
+
+> 72 commits · 103 files changed · +23372 / -1083
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.7.0/docs/release-notes/v1.7.0-zh.md)
+
+## Overview
+
+This release focuses on monitoring and usage analytics: CPA Manager Plus gains a full Usage Analytics workspace that brings model, API key, credential, heatmap, and anomaly drilldowns into one analysis surface. The backend expands monitoring aggregates, filters, timezone handling, and execution context data, while Codex inspection, account-processing policy, and dashboard statistics receive accuracy and usability fixes.
+
+## Highlights
+
+### Features
+
+- Add the Usage Analytics workspace with overview, trend, model, API key, credential, and heatmap drilldowns (`web/usage-analytics`).
+- Persist usage analytics filters, active tab, and drilldown state across refreshes (`web/usage-analytics`).
+- Add shared ECharts rendering for richer monitoring and analytics charts (`web/charts`).
+- Expand monitoring analytics with summary comparisons, heatmap contributors, filters, timezone alignment, and client key execution contexts (`manager-server/monitoring`).
+- Enrich Codex inspection result lists with status, quota, and context details, plus re-login handling for invalid authentication (`web/codex`, `manager-server/codex`).
+- Add runtime account-processing policy settings and a read-only settings page for clearer automation state (`web/settings`, `manager-server/settings`).
+
+### Fixes
+
+- Unify cache hit-rate semantics across frontend and backend analytics (`web/dashboard`, `manager-server/monitoring`).
+- Correct dashboard token mix buckets so token types are grouped accurately (`manager-server/dashboard`).
+- Simplify account policy controls and share service state consistently between UI and runtime (`web/settings`, `manager-server/settings`).
+- Restore the back link on the auth issues page (`web/auth`).
+- Preserve shared source labels in monitoring provider/source displays (`monitoring`).
+- Serialize PATCH saves and split frontend error states to avoid post-save state overwrites (`web/settings`).
+
+### Refactor
+
+- Rework the credential analytics tab into a more focused layout with detail cards (`web/usage-analytics`).
+- Rename automation concepts to account-processing-policy and harden settings loading (`manager-server/settings`).
+- Move automation status into Manager configuration so runtime state has one source (`manager-server/config`).
+
+### Build
+
+- Add the ECharts frontend dependency (`web`).
+
+### Docs
+
+- Add the usage analytics implementation phase document (`docs`).
+
+### Tests
+
+- Cover usage analytics model, presentation, UI state, and wiring behavior (`web/usage-analytics`).
+- Align monitoring analytics, timezone, scope, and adapter tests (`web/monitoring`, `manager-server/monitoring`).
+
+## Upgrade Notes
+
+- Usage analytics now depends on ECharts, so the frontend bundle grows with the new charting capability.
+- Monitoring analytics responses include more dimensions and context fields; custom integrations should treat optional fields as absent-safe.
+- Automation-related naming has been consolidated under account-processing-policy, so external scripts that rely on older labels or config paths should be reviewed.
+
+## Acknowledgements
+
+- @MuziIsabel - Contributed runtime account-processing policy settings, the read-only settings page, the auth issues back link, and save-flow fixes.
+- @bc19sam-afk - Fixed shared source label display in monitoring.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.6.0...v1.7.0

--- a/docs/release-notes/v1.7.0-zh.md
+++ b/docs/release-notes/v1.7.0-zh.md
@@ -1,0 +1,63 @@
+# CPA Manager Plus v1.7.0
+
+> 72 commits · 103 files changed · +23372 / -1083
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.7.0/docs/release-notes/v1.7.0-en.md)
+
+## Overview
+
+本次发布围绕监控与用量分析展开:新增完整的 Usage Analytics 工作区,将模型、API Key、凭证、热力图与异常明细统一到可钻取的分析视图中;后端同步扩展监控聚合、筛选、时区与执行上下文能力。Codex 检查、账号处理策略与仪表盘统计也获得了多项可用性和准确性修复。
+
+## Highlights
+
+### Features
+
+- 新增用量分析工作区,支持概览、趋势、模型、API Key、凭证与热力图钻取(`web/usage-analytics`)。
+- 用量分析筛选器、当前 tab 与 drilldown 状态可持久化,跨刷新保留分析上下文(`web/usage-analytics`)。
+- 引入共享 ECharts 渲染层,为监控与用量分析提供更丰富的图表呈现(`web/charts`)。
+- 监控分析接口扩展汇总对比、热力图贡献者、筛选条件、时区对齐与客户端 Key 执行上下文(`manager-server/monitoring`)。
+- Codex 检查结果列表展示更多状态、额度与上下文信息,并支持失效认证的重新登录处理(`web/codex`, `manager-server/codex`)。
+- 新增账号处理策略运行时设置与只读设置页,让自动处理状态更清晰(`web/settings`, `manager-server/settings`)。
+
+### Fixes
+
+- 统一缓存命中率口径,修正前端与后端分析中的 cache hit-rate 计算(`web/dashboard`, `manager-server/monitoring`)。
+- 修正仪表盘 token mix 分桶,避免不同 token 类型统计错位(`manager-server/dashboard`)。
+- 账号策略控件与服务状态共享逻辑收敛,避免界面与运行时状态不一致(`web/settings`, `manager-server/settings`)。
+- 认证问题页恢复返回链接,改善异常处理路径的导航体验(`web/auth`)。
+- 共享来源标签在监控中保持稳定,避免 provider/source 显示丢失(`monitoring`)。
+- PATCH 保存流程串行化并拆分前端错误状态,避免保存后重读导致的状态覆盖(`web/settings`)。
+
+### Refactor
+
+- 凭证分析页重构为更聚焦的布局与明细卡片,减少信息层级噪声(`web/usage-analytics`)。
+- 账号自动化命名收敛为 account-processing-policy,并加固设置加载流程(`manager-server/settings`)。
+- 自动处理状态迁移到 Manager 配置模型中,统一运行时状态来源(`manager-server/config`)。
+
+### Build
+
+- 增加 ECharts 前端依赖(`web`)。
+
+### Docs
+
+- 新增用量分析实现阶段文档(`docs`)。
+
+### Tests
+
+- 补充用量分析模型、表现层、UI 状态与 wiring 测试(`web/usage-analytics`)。
+- 同步监控分析、时区、作用域与数据适配测试(`web/monitoring`, `manager-server/monitoring`)。
+
+## Upgrade Notes
+
+- 新增用量分析依赖 ECharts,前端包体会随图表能力增加。
+- 监控分析响应包含更多维度和上下文字段,自定义集成应按字段缺省安全处理。
+- 账号自动化相关命名已收敛为 account-processing-policy,依赖旧文案或配置路径的外部脚本需要核对。
+
+## Acknowledgements
+
+- @MuziIsabel - 贡献账号处理策略运行时设置、只读设置页、认证问题返回链接与保存流程修复。
+- @bc19sam-afk - 修复监控共享来源标签显示问题。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.6.0...v1.7.0


### PR DESCRIPTION
## Summary
Add curated release notes for CPA Manager Plus v1.7.0.

## Changes
- Add Chinese release notes at docs/release-notes/v1.7.0-zh.md.
- Add English release notes at docs/release-notes/v1.7.0-en.md.
- Use tag-pinned language switch links for GitHub Release rendering.

## Testing
- git diff --cached --check
- Verified release note language links are tag-pinned.

## Release
After this PR is merged into main, create and push tag v1.7.0 from the merged main commit to trigger the release workflow.