### PR TITLE
fix: 修复 xAI 认证文件额度刷新误走 Gemini CLI

### DIFF
--- a/apps/web/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -6,7 +6,8 @@ import {
   CLAUDE_CONFIG,
   CODEX_CONFIG,
   GEMINI_CLI_CONFIG,
-  KIMI_CONFIG
+  KIMI_CONFIG,
+  XAI_CONFIG
 } from '@/components/quota';
 import { useNotificationStore, useQuotaStore } from '@/stores';
 import type { AuthFileItem } from '@/types';
@@ -26,6 +27,7 @@ const getQuotaConfig = (type: QuotaProviderType) => {
   if (type === 'claude') return CLAUDE_CONFIG;
   if (type === 'codex') return CODEX_CONFIG;
   if (type === 'kimi') return KIMI_CONFIG;
+  if (type === 'xai') return XAI_CONFIG;
   return GEMINI_CLI_CONFIG;
 };
 
@@ -45,6 +47,7 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     if (quotaType === 'claude') return state.claudeQuota[file.name] as QuotaState;
     if (quotaType === 'codex') return state.codexQuota[file.name] as QuotaState;
     if (quotaType === 'kimi') return state.kimiQuota[file.name] as QuotaState;
+    if (quotaType === 'xai') return state.xaiQuota[file.name] as QuotaState;
     return state.geminiCliQuota[file.name] as QuotaState;
   });
 
@@ -53,6 +56,7 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     if (quotaType === 'claude') return state.setClaudeQuota as unknown as (updater: unknown) => void;
     if (quotaType === 'codex') return state.setCodexQuota as unknown as (updater: unknown) => void;
     if (quotaType === 'kimi') return state.setKimiQuota as unknown as (updater: unknown) => void;
+    if (quotaType === 'xai') return state.setXaiQuota as unknown as (updater: unknown) => void;
     return state.setGeminiCliQuota as unknown as (updater: unknown) => void;
   });
 


### PR DESCRIPTION
问题

  xAI OAuth 登录后，在认证文件卡片里点「刷新额度」会报：Gemini CLI 凭证缺少 Project ID。

  原因

  AuthFileQuotaSection 没接 xai 分支，quotaType 为 xai 时仍走默认的 GEMINI_CLI_CONFIG，去查 Gemini CLI 的
  project_id。CLIProxyAPI 存的凭证是 type: xai，问题出在 Plus版本的 前端。

  改动

  AuthFileQuotaSection.tsx：补上 XAI_CONFIG，以及 xaiQuota / setXaiQuota 的读写。

  验证

  apps/web 下 npm run type-check 已通过。