### PR TITLE
fix(web): constrain realtime monitor model names

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -1231,6 +1231,11 @@
 
 @include summaryTable.styles;
 @include accountOverview.styles;
+.realtimeTable {
+  --realtime-col-source: 18%;
+  --realtime-col-model: 15%;
+}
+
 .realtimeTable .logTypeCell .primaryCell > span {
   display: inline-block;
   max-width: min(240px, 100%);
@@ -1243,6 +1248,18 @@
   white-space: normal;
   word-break: break-word;
   line-height: 1.45;
+}
+
+.realtimeModelCell {
+  max-width: 100%;
+}
+
+.realtimeModelText {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap !important;
 }
 
 .realtimeApiKeyLine {

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -250,6 +250,17 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).not.toContain('>Executor: codex<');
   });
 
+  it('keeps long realtime model names constrained with a full title', () => {
+    const longModel =
+      'claude-opus-4-6-thinking-with-a-very-long-provider-routing-suffix-for-realtime-monitoring';
+    const markup = renderPanel(baseRow({ model: longModel, resolvedModel: longModel }));
+
+    expect(markup).toContain(`title="${longModel}"`);
+    expect(markup).toContain(longModel);
+    expect(markup).toMatch(/class="[^"]*realtimeModelCell[^"]*"/);
+    expect(markup).toMatch(/class="[^"]*realtimeModelText[^"]*"/);
+  });
+
   it('switches realtime source labels between masked and full display', () => {
     const row = baseRow({
       source: 'very-long-user@example.com',

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -463,10 +463,19 @@ export function RealtimeEventsPanel({
                     </div>
                   </td>
                   <td>
-                    <div className={styles.primaryCell}>
-                      <span className={styles.monoCell}>{row.model}</span>
+                    <div
+                      className={`${styles.primaryCell} ${styles.realtimeModelCell}`}
+                      title={[row.model, showResolvedModel ? row.resolvedModel : '']
+                        .filter(Boolean)
+                        .join('\n')}
+                    >
+                      <span className={`${styles.monoCell} ${styles.realtimeModelText}`}>
+                        {row.model}
+                      </span>
                       {showResolvedModel ? (
-                        <small className={styles.monoCell}>{row.resolvedModel}</small>
+                        <small className={`${styles.monoCell} ${styles.realtimeModelText}`}>
+                          {row.resolvedModel}
+                        </small>
                       ) : null}
                     </div>
                   </td>


### PR DESCRIPTION
## Summary
Fix realtime monitoring table overflow when model names are long.

## Cause
The realtime model column used the generic primary cell styling, so long model names could exceed the column and visually collide with neighboring columns.

## Solution
- Give the model column more width by reducing Source / API Key from 21% to 18% and increasing Model from 12% to 15%.
- Add dedicated model text truncation with a full hover title.
- Add a render test covering long realtime model names.

## Testing
- [x] npm --workspace apps/web run test -- src/features/monitoring/components/RealtimeEventsPanel.test.tsx