### PR TITLE
ci(pr): require project PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+## Summary
+<!-- What changed and why. Keep it short, 2-4 lines. -->
+
+## Scope
+<!-- Check all areas touched by this PR. -->
+- [ ] Frontend panel
+- [ ] Manager Server
+- [ ] CPA panel mode
+- [ ] Full Docker mode
+- [ ] Native packages / release
+- [ ] Docs / Wiki
+- [ ] CI / build / tooling
+
+## Changes
+<!-- List concrete changes, not implementation trivia. -->
+-
+-
+-
+
+## User Impact
+<!-- What users will notice. Use "No user-facing behavior change" if applicable. -->
+
+
+## Compatibility / Runtime Notes
+<!-- Mention mode-specific behavior, config changes, queue behavior, or N/A. -->
+- CPA panel mode:
+- Manager Server mode:
+- Full Docker / native packages:
+
+## Data / Security Notes
+<!-- Required for SQLite, admin key, CPA Management Key, auth files, logs, raw usage data, or plugins. Use N/A if not relevant. -->
+
+
+## Risk / Rollback
+Risk level: Low / Medium / High
+
+Rollback notes:
+-
+
+## Verification
+<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->
+- [ ] Type check
+- [ ] Lint
+- [ ] Tests
+- [ ] Build
+- [ ] Manual UI check
+- [ ] Docs/link check
+- [ ] Not applicable, docs-only
+
+Commands / evidence:
+```text
+```
+
+## Screenshots / Recordings
+<!-- Required for visible UI changes. Use N/A for backend/docs-only changes. -->
+
+
+## Docs
+- [ ] README updated
+- [ ] Wiki updated
+- [ ] Release notes needed
+- [ ] Not needed
+
+## Related
+<!-- Closes #123 / Fixes #123 / Refs #123 / N/A -->

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,6 +16,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-template:
+    name: PR Template
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          body="${PR_BODY:-}"
+          required_headers=(
+            "## Summary"
+            "## Scope"
+            "## Changes"
+            "## User Impact"
+            "## Compatibility / Runtime Notes"
+            "## Data / Security Notes"
+            "## Risk / Rollback"
+            "## Verification"
+            "## Screenshots / Recordings"
+            "## Docs"
+            "## Related"
+          )
+
+          missing_headers=()
+          for header in "${required_headers[@]}"; do
+            if ! grep -Fq "$header" <<< "$body"; then
+              missing_headers+=("$header")
+            fi
+          done
+
+          if (( ${#missing_headers[@]} > 0 )); then
+            echo "PR body is missing required template sections:"
+            printf ' - %s\n' "${missing_headers[@]}"
+            exit 1
+          fi
+
+          if ! grep -Eq '^- \[[xX]\] (Frontend panel|Manager Server|CPA panel mode|Full Docker mode|Native packages / release|Docs / Wiki|CI / build / tooling)$' <<< "$body"; then
+            echo "PR body must check at least one item in the Scope section."
+            exit 1
+          fi
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Add a project-specific pull request template and enforce basic template usage through the existing PR Check workflow.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes
- Add a default PR template tailored to CPA Manager Plus review boundaries.
- Require PR bodies to include the core template sections.
- Require contributors to check at least one Scope item.
- Keep the existing frontend, Manager Server, and Docker build jobs unchanged.

## User Impact
Contributors get a structured PR form, and reviewers get consistent scope, verification, data/security, and compatibility notes.

## Compatibility / Runtime Notes
- CPA panel mode: No runtime behavior change.
- Manager Server mode: No runtime behavior change.
- Full Docker / native packages: No runtime behavior change.

## Data / Security Notes
N/A. This only changes GitHub PR metadata and CI validation. No SQLite, admin key, CPA Management Key, auth-file, log, usage queue, or plugin runtime behavior changed.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert `.github/pull_request_template.md` and the `pr-template` job in `.github/workflows/pr-check.yml` if the template check is too strict.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
git diff --check -- .github/pull_request_template.md .github/workflows/pr-check.yml
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-check.yml"); puts "yaml ok"'
```

Local template-check simulation passed after marking one Scope item as checked.

## Screenshots / Recordings
N/A. GitHub PR body and workflow-only change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A