### PR TITLE
fix(usage-analytics): resolve API key aliases by hash

### DIFF
--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -51,6 +51,7 @@ import {
   hasUsageData,
   maskApiKeyHash,
   parseDateTimeLocalValue,
+  resolveUsageApiKeyLabel,
   USAGE_ANALYTICS_TABS,
   USAGE_HEATMAP_METRICS,
   USAGE_HEATMAP_SCALE_MODES,
@@ -435,6 +436,19 @@ const stableOptionCachesEqual = (left: StableUsageOptionCache, right: StableUsag
   left.authFiles.join('\n') === right.authFiles.join('\n') &&
   left.apiKeys.map((option) => `${option.value}:${option.label}`).join('\n') ===
     right.apiKeys.map((option) => `${option.value}:${option.label}`).join('\n');
+
+const getApiKeyRowDisplayLabel = (
+  row: Pick<UsageRankRow, 'apiKeyHash' | 'id' | 'label'>
+) => {
+  const hash = row.apiKeyHash || row.id || '';
+  const label = row.label?.trim();
+  return label && label.toLowerCase() !== hash.toLowerCase() ? label : maskApiKeyHash(hash);
+};
+
+const getApiKeyContributorDisplayLabel = (row: UsageHeatmapContributor) => {
+  const label = row.label?.trim();
+  return label && label.toLowerCase() !== row.key.toLowerCase() ? label : maskApiKeyHash(row.key);
+};
 
 const metricValue = (point: UsageTimelinePoint, key: UsageMetricKey) => point[key];
 
@@ -1360,7 +1374,8 @@ function HeatmapContributorGroup({
         <span className={styles.shortcutEmpty}>{emptyLabel}</span>
       ) : (
         rows.map((row) => {
-          const label = kind === 'apiKey' ? maskApiKeyHash(row.key) : row.label || row.key;
+          const label =
+            kind === 'apiKey' ? getApiKeyContributorDisplayLabel(row) : row.label || row.key;
           return (
             <div key={`${kind}-${row.key}`} className={styles.heatmapContributorRow}>
               <div className={styles.heatmapContributorMain}>
@@ -2049,7 +2064,7 @@ function KeyAnomalyTable({
             rows.slice(0, 8).map((row) => (
               <tr key={row.id}>
                 <td>
-                  {type === 'credential' ? row.label : maskApiKeyHash(row.row.apiKeyHash || row.id)}
+                  {type === 'credential' ? row.label : getApiKeyRowDisplayLabel(row.row)}
                 </td>
                 <td>{t(row.reasonKey)}</td>
                 <td>
@@ -2274,7 +2289,10 @@ function UsageAnalyticsPageInner() {
     const apiKeys = mergeSelectOptions([
       ...(usage.filterOptions?.api_key_stats ?? []).map((row) => {
         const hash = row.api_key_hash || row.id;
-        return { value: hash, label: maskApiKeyHash(hash) };
+        return {
+          value: hash,
+          label: resolveUsageApiKeyLabel(hash, usage.apiKeyDisplayMap),
+        };
       }),
       ...usage.apiKeyRows.map((row) => {
         const hash = row.apiKeyHash || row.id;
@@ -2300,6 +2318,7 @@ function UsageAnalyticsPageInner() {
       apiKeys,
     };
   }, [
+    usage.apiKeyDisplayMap,
     usage.apiKeyRows,
     usage.credentialRows,
     usage.filterOptions?.api_key_stats,
@@ -2384,13 +2403,21 @@ function UsageAnalyticsPageInner() {
           usage.filters.apiKeyHash !== 'all'
             ? {
                 value: usage.filters.apiKeyHash,
-                label: maskApiKeyHash(usage.filters.apiKeyHash),
+                label: resolveUsageApiKeyLabel(
+                  usage.filters.apiKeyHash,
+                  usage.apiKeyDisplayMap
+                ),
               }
             : null,
         ].filter((option): option is SelectOption => Boolean(option?.value))
       ),
     ],
-    [allApiKeyOptionLabel, displayOptionCache.apiKeys, usage.filters.apiKeyHash]
+    [
+      allApiKeyOptionLabel,
+      displayOptionCache.apiKeys,
+      usage.apiKeyDisplayMap,
+      usage.filters.apiKeyHash,
+    ]
   );
   const providerOptions = useMemo<SelectOption[]>(
     () =>
@@ -3531,7 +3558,7 @@ function DrilldownPreviewPanel({ rows, locale }: { rows: UsageDrilldownEvent[]; 
                   <td>{formatLocalDateTime(row.timestampMs, locale)}</td>
                   <td className={styles.monoCell}>{row.requestId || row.eventHash.slice(0, 10)}</td>
                   <td>{row.model}</td>
-                  <td>{maskApiKeyHash(row.apiKeyHash)}</td>
+                  <td>{row.apiKeyLabel || maskApiKeyHash(row.apiKeyHash)}</td>
                   <td>{compactNumber(row.totalTokens)}</td>
                   <td>{formatUsageDurationMs(row.latencyMs)}</td>
                   <td>
@@ -3618,7 +3645,7 @@ function RankTable({
                     ) : (
                       <IconModelCluster size={16} />
                     )}
-                    {type === 'apiKey' ? maskApiKeyHash(row.apiKeyHash) : row.label}
+                    {type === 'apiKey' ? getApiKeyRowDisplayLabel(row) : row.label}
                     {type === 'apiKey' ? <IconCopy size={13} /> : null}
                   </span>
                 </td>

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -552,6 +552,132 @@ describe('usage analytics adapters', () => {
     expect(maskApiKeyHash('sk-live-raw-secret-value')).toBe('sk-****alue');
   });
 
+  it('resolves API key aliases by hash across analytics views', () => {
+    const displayMap = new Map([
+      ['abcdef1234567890', { label: 'Team Alpha Key', masked: 'sk-****7890' }],
+    ]);
+    const apiKeyRows = buildApiKeyRows(
+      [
+        {
+          id: 'hash-a',
+          api_key_hash: 'ABCDEF1234567890',
+          account_snapshot: 'team-alpha',
+          calls: 10,
+          success_calls: 9,
+          failure_calls: 1,
+          success_rate: 0.9,
+          input_tokens: 100,
+          output_tokens: 20,
+          cached_tokens: 5,
+          cache_read_tokens: 3,
+          cache_creation_tokens: 2,
+          total_tokens: 120,
+          cost: 1.25,
+          average_latency_ms: null,
+          last_seen_ms: NOW_MS,
+          models: [
+            {
+              model: 'gpt-4o',
+              calls: 10,
+              success_calls: 9,
+              failure_calls: 1,
+              success_rate: 0.9,
+              input_tokens: 100,
+              output_tokens: 20,
+              cached_tokens: 5,
+              cache_read_tokens: 3,
+              cache_creation_tokens: 2,
+              total_tokens: 120,
+              cost: 1.25,
+              last_seen_ms: NOW_MS,
+            },
+          ],
+        },
+      ],
+      undefined,
+      'team alpha key',
+      displayMap
+    );
+
+    expect(apiKeyRows[0]).toMatchObject({
+      apiKeyHash: 'abcdef1234567890',
+      label: 'Team Alpha Key',
+    });
+    expect(
+      buildUsageMatrix({
+        apiKeyRows,
+        credentialRows: [],
+        dimension: 'apiKeyModel',
+        metric: 'requestCount',
+      }).rowLabels
+    ).toEqual(['Team Alpha Key']);
+
+    const heatmapRows = buildUsageHeatmap(
+      [
+        {
+          weekday: 1,
+          hour: 9,
+          calls: 10,
+          success: 9,
+          failure: 1,
+          tokens: 120,
+          cost: 1.25,
+          failure_rate: 0.1,
+          api_key_contributors: [
+            {
+              key: 'ABCDEF1234567890',
+              label: 'ABCDEF1234567890',
+              calls: 10,
+              success: 9,
+              failure: 1,
+              tokens: 120,
+              cost: 1.25,
+              failure_rate: 0.1,
+              share: 1,
+            },
+          ],
+        },
+      ],
+      displayMap
+    );
+    expect(heatmapRows[0].apiKeyContributors?.[0].label).toBe('Team Alpha Key');
+
+    const drilldownRows = buildDrilldownPreview(
+      [
+        {
+          event_hash: 'event-a',
+          timestamp_ms: NOW_MS,
+          model: 'gpt-4o',
+          endpoint: '/v1/chat/completions',
+          method: 'POST',
+          path: '/v1/chat/completions',
+          auth_index: '0',
+          source: 'codex',
+          source_hash: 'source-a',
+          api_key_hash: 'ABCDEF1234567890',
+          account_snapshot: 'team-alpha',
+          auth_label_snapshot: 'prod',
+          auth_provider_snapshot: 'openai',
+          input_tokens: 60,
+          output_tokens: 40,
+          cached_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          reasoning_tokens: 0,
+          total_tokens: 100,
+          latency_ms: 250,
+          failed: false,
+        },
+      ],
+      [],
+      displayMap
+    );
+    expect(drilldownRows[0]).toMatchObject({
+      apiKeyHash: 'abcdef1234567890',
+      apiKeyLabel: 'Team Alpha Key',
+    });
+  });
+
   it('builds API key/model matrices and key anomaly rows from ranked usage rows', () => {
     const apiKeyRows = buildApiKeyRows(
       [

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -15,6 +15,10 @@ import type {
   MonitoringAnalyticsSummaryComparison,
   MonitoringAnalyticsTimelinePoint,
 } from '@/services/api/usageService';
+import {
+  sanitizeApiKeyDisplayText,
+  type ApiKeyDisplayInfo,
+} from '@/features/monitoring/model/apiKeys';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 
 export type UsageAnalyticsTab =
@@ -381,6 +385,7 @@ export type UsageDrilldownEvent = {
   timestampMs: number;
   model: string;
   apiKeyHash: string;
+  apiKeyLabel: string;
   source: string;
   authIndex: string;
   endpoint: string;
@@ -1124,6 +1129,39 @@ export const maskApiKeyHash = (hash: string | null | undefined) => {
   return `sk-****${value.slice(-4)}`;
 };
 
+export type UsageApiKeyDisplayMap = ReadonlyMap<string, ApiKeyDisplayInfo>;
+
+const normalizeApiKeyHash = (value: string | null | undefined) =>
+  String(value ?? '').trim().toLowerCase();
+
+const isSameApiKeyIdentity = (label: string, hash: string) =>
+  Boolean(label) && Boolean(hash) && label.trim().toLowerCase() === hash;
+
+export const resolveUsageApiKeyLabel = (
+  apiKeyHash: string | null | undefined,
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap,
+  fallbackLabel?: string | null
+) => {
+  const hash = normalizeApiKeyHash(apiKeyHash);
+  const fallback = sanitizeApiKeyDisplayText(String(fallbackLabel ?? ''));
+
+  if (!hash) {
+    return fallback || '-';
+  }
+
+  const display = apiKeyDisplayMap?.get(hash);
+  const displayLabel = sanitizeApiKeyDisplayText(display?.label || display?.masked || '');
+  if (displayLabel && !isSameApiKeyIdentity(displayLabel, hash)) {
+    return displayLabel;
+  }
+
+  if (fallback && !isSameApiKeyIdentity(fallback, hash)) {
+    return fallback;
+  }
+
+  return maskApiKeyHash(hash);
+};
+
 const buildModelSpendRows = (
   rows:
     | NonNullable<MonitoringAnalyticsApiKeyStatRow['models']>
@@ -1177,7 +1215,8 @@ const buildApiKeyContextRows = (
 export const buildApiKeyRows = (
   rows: MonitoringAnalyticsApiKeyStatRow[] = [],
   summary?: UsageSummaryMetrics,
-  keyword = ''
+  keyword = '',
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap
 ): UsageRankRow[] => {
   const normalizedKeyword = keyword.trim().toLowerCase();
   const totalCost = summary?.estimatedCost ?? rows.reduce((sum, row) => sum + rowTotalCost(row), 0);
@@ -1185,17 +1224,19 @@ export const buildApiKeyRows = (
     summary?.totalTokens ?? rows.reduce((sum, row) => sum + toNumber(row.total_tokens), 0);
   return rows
     .filter((row) => {
+      const hash = normalizeApiKeyHash(row.api_key_hash || row.id || '');
+      const label = resolveUsageApiKeyLabel(hash, apiKeyDisplayMap);
       if (!normalizedKeyword) return true;
-      const haystack = [row.api_key_hash, row.account_snapshot, row.auth_label_snapshot]
+      const haystack = [hash, label, row.account_snapshot, row.auth_label_snapshot]
         .join(' ')
         .toLowerCase();
       return haystack.includes(normalizedKeyword);
     })
     .map((row) => {
-      const hash = row.api_key_hash || row.id || '';
+      const hash = normalizeApiKeyHash(row.api_key_hash || row.id || '');
       return {
         id: hash || row.id || '-',
-        label: maskApiKeyHash(hash),
+        label: resolveUsageApiKeyLabel(hash, apiKeyDisplayMap),
         apiKeyHash: hash,
         provider: row.auth_provider_snapshot,
         authIndex: row.auth_indices?.[0],
@@ -1519,7 +1560,11 @@ export const buildUsageMatrix = ({
   const cells = buildMatrixCellsFromEntityRows(
     sourceRows,
     (row) => {
-      if (dimension === 'apiKeyModel') return maskApiKeyHash(row.apiKeyHash || row.id);
+      if (dimension === 'apiKeyModel') {
+        return normalizeMatrixLabel(
+          resolveUsageApiKeyLabel(row.apiKeyHash || row.id, undefined, row.label)
+        );
+      }
       if (dimension === 'authFileModel') return normalizeMatrixLabel(row.authFile || row.label);
       return normalizeProviderLabel(row.provider);
     },
@@ -1839,22 +1884,29 @@ export const buildUsageInsights = ({
 };
 
 const buildUsageHeatmapContributors = (
-  contributors: MonitoringAnalyticsHeatmapContributor[] = []
+  contributors: MonitoringAnalyticsHeatmapContributor[] = [],
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap
 ): UsageHeatmapContributor[] =>
-  contributors.map((contributor) => ({
-    key: contributor.key || '',
-    label: contributor.label || contributor.key || '',
-    requestCount: toNumber(contributor.calls),
-    successCount: toNumber(contributor.success),
-    failureCount: toNumber(contributor.failure),
-    totalTokens: toNumber(contributor.tokens),
-    estimatedCost: toNumber(contributor.cost),
-    failureRate: toNumber(contributor.failure_rate),
-    share: toNumber(contributor.share),
-  }));
+  contributors.map((contributor) => {
+    const key = normalizeApiKeyHash(contributor.key || contributor.label || '');
+    return {
+      key: contributor.key || key,
+      label: apiKeyDisplayMap
+        ? resolveUsageApiKeyLabel(key, apiKeyDisplayMap, contributor.label)
+        : contributor.label || contributor.key || '',
+      requestCount: toNumber(contributor.calls),
+      successCount: toNumber(contributor.success),
+      failureCount: toNumber(contributor.failure),
+      totalTokens: toNumber(contributor.tokens),
+      estimatedCost: toNumber(contributor.cost),
+      failureRate: toNumber(contributor.failure_rate),
+      share: toNumber(contributor.share),
+    };
+  });
 
 export const buildUsageHeatmap = (
-  points: MonitoringAnalyticsHeatmapPoint[] = []
+  points: MonitoringAnalyticsHeatmapPoint[] = [],
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap
 ): UsageHeatmapPoint[] =>
   points.map((point) => ({
     weekday: toNumber(point.weekday),
@@ -1866,7 +1918,10 @@ export const buildUsageHeatmap = (
     estimatedCost: toNumber(point.cost),
     failureRate: toNumber(point.failure_rate),
     modelContributors: buildUsageHeatmapContributors(point.model_contributors),
-    apiKeyContributors: buildUsageHeatmapContributors(point.api_key_contributors),
+    apiKeyContributors: buildUsageHeatmapContributors(
+      point.api_key_contributors,
+      apiKeyDisplayMap
+    ),
     providerContributors: buildUsageHeatmapContributors(point.provider_contributors),
   }));
 
@@ -2017,7 +2072,8 @@ export const summarizeAnomalies = (
 
 export const buildDrilldownPreview = (
   rows: MonitoringAnalyticsEventRow[] = [],
-  modelRows: UsageRankRow[] = []
+  modelRows: UsageRankRow[] = [],
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap
 ): UsageDrilldownEvent[] => {
   const modelCostPerToken = new Map(
     modelRows.map((row) => [
@@ -2034,7 +2090,8 @@ export const buildDrilldownPreview = (
       eventHash: row.event_hash,
       timestampMs: toNumber(row.timestamp_ms),
       model,
-      apiKeyHash: row.api_key_hash || '',
+      apiKeyHash: normalizeApiKeyHash(row.api_key_hash || ''),
+      apiKeyLabel: resolveUsageApiKeyLabel(row.api_key_hash || '', apiKeyDisplayMap),
       source: row.source || '',
       authIndex: row.auth_index || '',
       endpoint: row.endpoint || row.path || '',
@@ -2052,7 +2109,8 @@ export const buildDrilldownPreview = (
 export const adaptUsageAnalyticsData = (
   data: MonitoringAnalyticsResponse | null | undefined,
   granularity: UsageAnalyticsResolvedGranularity,
-  keyword = ''
+  keyword = '',
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap
 ) => {
   const summary = buildUsageSummary(data?.summary);
   const timeline = buildUsageTimeline(data?.timeline ?? [], granularity);
@@ -2061,7 +2119,7 @@ export const adaptUsageAnalyticsData = (
     granularity
   );
   const modelRows = buildModelRows(data?.model_stats ?? [], summary);
-  const apiKeyRows = buildApiKeyRows(data?.api_key_stats ?? [], summary, keyword);
+  const apiKeyRows = buildApiKeyRows(data?.api_key_stats ?? [], summary, keyword, apiKeyDisplayMap);
   const credentialRows = buildCredentialRows(data?.credential_stats ?? [], summary);
   const providerRows = buildProviderRows(
     data?.channel_share ?? [],
@@ -2078,9 +2136,13 @@ export const adaptUsageAnalyticsData = (
     apiKeyRows,
     credentialRows,
     providerRows,
-    heatmap: buildUsageHeatmap(data?.heatmap ?? []),
+    heatmap: buildUsageHeatmap(data?.heatmap ?? [], apiKeyDisplayMap),
     anomalyPoints: buildServerAnomalyPoints(data?.anomaly_points ?? []),
-    drilldownPreview: buildDrilldownPreview(data?.drilldown_preview?.items ?? [], modelRows),
+    drilldownPreview: buildDrilldownPreview(
+      data?.drilldown_preview?.items ?? [],
+      modelRows,
+      apiKeyDisplayMap
+    ),
     filterOptions: data?.filter_options,
   };
 };

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useMonitoringAnalytics } from '@/features/monitoring/hooks/useMonitoringAnalytics';
+import { useUsageData } from '@/features/monitoring/hooks/useUsageData';
+import { buildApiKeyDisplayMap } from '@/features/monitoring/model/apiKeys';
+import { useConfigStore } from '@/stores';
 import {
   adaptUsageAnalyticsData,
   analyzeUsageBucket,
@@ -64,6 +67,8 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
 }
 
 export function useUsageAnalytics() {
+  const config = useConfigStore((state) => state.config);
+  const { apiKeyAliases, loadApiKeyAliases } = useUsageData({ loadUsageEvents: false });
   const [searchParams, setSearchParams] = useSearchParams();
   const [initialUiState] = useState<UsageAnalyticsUiState>(() =>
     buildUsageAnalyticsUiStateFromSearchParams(
@@ -92,6 +97,10 @@ export function useUsageAnalytics() {
     null
   );
   const browserTimeZone = useMemo(() => getBrowserTimeZone(), []);
+  const apiKeyDisplayMap = useMemo(
+    () => buildApiKeyDisplayMap(config?.apiKeys || [], apiKeyAliases || []),
+    [apiKeyAliases, config?.apiKeys]
+  );
   const setActiveTab = useCallback((tab: UsageAnalyticsTab) => {
     setActiveTabState(tab);
     writeUsageAnalyticsUiState({ activeTab: tab });
@@ -205,13 +214,19 @@ export function useUsageAnalytics() {
 
   const analyticsData = analytics.dataStale ? null : analytics.data;
   const adapted = useMemo(
-    () => adaptUsageAnalyticsData(analyticsData, resolvedGranularity, filters.apiKeyKeyword),
-    [analyticsData, filters.apiKeyKeyword, resolvedGranularity]
+    () =>
+      adaptUsageAnalyticsData(
+        analyticsData,
+        resolvedGranularity,
+        filters.apiKeyKeyword,
+        apiKeyDisplayMap
+      ),
+    [analyticsData, apiKeyDisplayMap, filters.apiKeyKeyword, resolvedGranularity]
   );
   const heatmapDateData = heatmapDateAnalytics.dataStale ? null : heatmapDateAnalytics.data;
   const heatmapDateRows = useMemo(
-    () => buildUsageHeatmap(heatmapDateData?.heatmap ?? []),
-    [heatmapDateData]
+    () => buildUsageHeatmap(heatmapDateData?.heatmap ?? [], apiKeyDisplayMap),
+    [apiKeyDisplayMap, heatmapDateData]
   );
   const heatmapDetailSource = selectedHeatmapDate ? heatmapDateRows : adapted.heatmap;
   const heatmapDateRefreshing = Boolean(
@@ -414,6 +429,7 @@ export function useUsageAnalytics() {
 
   const refresh = useCallback(() => {
     setNowMs(Date.now());
+    void loadApiKeyAliases();
     void analytics.refresh({ force: true });
     if (selectedApiKeyTimelineAnalytics.enabled) {
       void selectedApiKeyTimelineAnalytics.refresh({ force: true });
@@ -421,7 +437,13 @@ export function useUsageAnalytics() {
     if (selectedHeatmapDate) {
       void heatmapDateAnalytics.refresh({ force: true });
     }
-  }, [analytics, heatmapDateAnalytics, selectedApiKeyTimelineAnalytics, selectedHeatmapDate]);
+  }, [
+    analytics,
+    heatmapDateAnalytics,
+    loadApiKeyAliases,
+    selectedApiKeyTimelineAnalytics,
+    selectedHeatmapDate,
+  ]);
 
   return {
     filters,
@@ -435,6 +457,7 @@ export function useUsageAnalytics() {
     loading: analytics.loading,
     error: analytics.error,
     enabled: analytics.enabled,
+    apiKeyDisplayMap,
     unavailableReason: analytics.unavailableReason,
     lastRefreshedAt: analytics.lastRefreshedAt,
     refresh,


### PR DESCRIPTION
## Summary
Resolve API key aliases in usage analytics with the same hash-based display map used by request monitoring.
This keeps filters and links keyed by `api_key_hash` while showing configured aliases in user-facing analytics views.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Reuse the monitoring API key display map in usage analytics.
- Resolve API key labels in stats, filter options, matrices, heatmap contributors, anomaly rows, and drilldown previews.
- Add focused coverage for hash-based alias matching across analytics adapters.

## User Impact
Users will see configured client Key aliases in usage analytics instead of hash-only labels when the alias can be matched by `api_key_hash`.

## Compatibility / Runtime Notes
- CPA panel mode: No behavior change; analytics still requires the request monitoring service.
- Manager Server mode: Uses existing API key alias data and keeps backend filters hash-based.
- Full Docker / native packages: No packaging impact.

## Data / Security Notes
No new secret exposure. Display labels are sanitized through the existing API key display helpers, and filters continue to use hashed key values.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR to return usage analytics to hash-only labels.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/features/usage-analytics
npm run type-check
npm run lint
git diff --check
```

## Screenshots / Recordings
N/A; no layout change, only label resolution behavior.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Refs #208