### PR TITLE
fix(usage-analytics): resolve credential labels from monitoring metadata

### DIFF
--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { MonitoringAnalyticsResponse } from '@/services/api/usageService';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import type { UsageRankRow } from './usageAnalyticsModel';
 import {
   analyzeUsageBucket,
   buildApiKeyRows,
+  buildCredentialRows,
   buildSelectedApiKeyTrendSeries,
   buildSelectedCredentialTrendSeries,
   buildDrilldownPreview,
@@ -392,6 +394,82 @@ describe('usage analytics adapters', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('credential-a');
     expect(result[0].points.map((point) => point.value)).toEqual([3, 5]);
+  });
+
+  it('resolves credential labels from the same source metadata as request monitoring', () => {
+    const credentialDisplayContext = {
+      authMetaMap: new Map(),
+      authFileMap: new Map(),
+      sourceInfoMap: buildSourceInfoMap({
+        codexApiKeys: [{ apiKey: 'sk-Key-secret-e9GW', prefix: 'Codex Team Key' }],
+      }),
+      channelByAuthIndex: new Map(),
+    };
+
+    const credentialRows = buildCredentialRows(
+      [
+        {
+          id: 'source-hash-a',
+          source: 'm:sk-K...e9GW',
+          source_hash: 'source-hash-a',
+          auth_index: '',
+          auth_file_snapshot: '',
+          account_snapshot: '',
+          auth_label_snapshot: '',
+          auth_provider_snapshot: 'codex',
+          calls: 3,
+          success_calls: 3,
+          failure_calls: 0,
+          success_rate: 1,
+          input_tokens: 100,
+          output_tokens: 20,
+          cached_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          total_tokens: 120,
+          cost: 0.12,
+          average_latency_ms: null,
+          last_seen_ms: NOW_MS,
+        },
+      ],
+      undefined,
+      credentialDisplayContext
+    );
+    const credentialTimeline = buildUsageCredentialTimeline(
+      [
+        {
+          id: 'source-hash-a',
+          source: 'm:sk-K...e9GW',
+          source_hash: 'source-hash-a',
+          auth_index: '',
+          auth_file_snapshot: '',
+          account_snapshot: '',
+          auth_label_snapshot: '',
+          auth_provider_snapshot: 'codex',
+          bucket_ms: NOW_MS,
+          bucket_label: '06/04',
+          calls: 3,
+          tokens: 120,
+          success: 3,
+          failure: 0,
+          total_tokens: 120,
+          cost: 0.12,
+        },
+      ],
+      'hour',
+      credentialDisplayContext
+    );
+
+    expect(credentialRows[0]).toMatchObject({
+      id: 'source-hash-a',
+      label: 'Codex Team Key',
+      provider: 'codex',
+    });
+    expect(credentialRows[0].label).not.toContain('m:sk-K');
+    expect(credentialTimeline[0]).toMatchObject({
+      id: 'source-hash-a',
+      label: 'Codex Team Key',
+    });
   });
 
   it('does not estimate selected credential trend when backend timeline is missing', () => {

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -19,6 +19,10 @@ import {
   sanitizeApiKeyDisplayText,
   type ApiKeyDisplayInfo,
 } from '@/features/monitoring/model/apiKeys';
+import { buildMonitoringSourceDisplay } from '@/features/monitoring/model/sourceDisplay';
+import type { MonitoringAuthMeta, MonitoringChannelMeta } from '@/features/monitoring/model/types';
+import type { CredentialInfo } from '@/types/sourceInfo';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 
 export type UsageAnalyticsTab =
@@ -806,21 +810,15 @@ export const buildUsageTimeline = (
 
 export const buildUsageCredentialTimeline = (
   timeline: MonitoringAnalyticsCredentialTimelinePoint[] = [],
-  granularity: UsageAnalyticsResolvedGranularity
+  granularity: UsageAnalyticsResolvedGranularity,
+  credentialDisplayContext?: UsageCredentialDisplayContext
 ): UsageCredentialTimelinePoint[] =>
   timeline.map((point) => {
     const bucketMs = toNumber(point.bucket_ms);
+    const display = resolveUsageCredentialDisplay(point, credentialDisplayContext);
     return {
       id: point.id || point.auth_file_snapshot || point.auth_index || point.source_hash || '-',
-      label:
-        point.label ||
-        point.auth_label_snapshot ||
-        point.account_snapshot ||
-        point.auth_file_snapshot ||
-        point.source ||
-        point.auth_index ||
-        point.id ||
-        '-',
+      label: display.label,
       bucketMs,
       bucketLabel: point.bucket_label || formatLocalBucketLabel(bucketMs, granularity),
       requestCount: toNumber(point.calls),
@@ -1131,6 +1129,13 @@ export const maskApiKeyHash = (hash: string | null | undefined) => {
 
 export type UsageApiKeyDisplayMap = ReadonlyMap<string, ApiKeyDisplayInfo>;
 
+export type UsageCredentialDisplayContext = {
+  authMetaMap: Map<string, MonitoringAuthMeta>;
+  authFileMap: Map<string, CredentialInfo>;
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>;
+  channelByAuthIndex: Map<string, MonitoringChannelMeta>;
+};
+
 const normalizeApiKeyHash = (value: string | null | undefined) =>
   String(value ?? '').trim().toLowerCase();
 
@@ -1160,6 +1165,71 @@ export const resolveUsageApiKeyLabel = (
   }
 
   return maskApiKeyHash(hash);
+};
+
+type UsageCredentialDisplayInput = {
+  id?: string;
+  label?: string;
+  auth_file_snapshot?: string;
+  auth_index?: string;
+  source?: string;
+  source_hash?: string;
+  account_snapshot?: string;
+  auth_label_snapshot?: string;
+  auth_provider_snapshot?: string;
+};
+
+const isReadableCredentialLabel = (value: string | null | undefined) => {
+  const trimmed = String(value ?? '').trim();
+  return Boolean(trimmed) && trimmed !== '-';
+};
+
+const firstReadableCredentialLabel = (...values: Array<string | null | undefined>) =>
+  values.find(isReadableCredentialLabel)?.trim() || '';
+
+const resolveUsageCredentialDisplay = (
+  row: UsageCredentialDisplayInput,
+  context?: UsageCredentialDisplayContext
+) => {
+  const fallbackLabel =
+    firstReadableCredentialLabel(
+      row.label,
+      row.auth_label_snapshot,
+      row.account_snapshot,
+      row.auth_file_snapshot,
+      row.source,
+      row.auth_index,
+      row.id
+    ) || '-';
+
+  if (!context) {
+    return {
+      label: fallbackLabel,
+      account: firstReadableCredentialLabel(row.account_snapshot, row.auth_label_snapshot),
+      provider: row.auth_provider_snapshot,
+    };
+  }
+
+  const display = buildMonitoringSourceDisplay(
+    {
+      source: row.source,
+      sourceHash: row.source_hash,
+      authIndex: row.auth_index,
+      accountSnapshot: row.account_snapshot,
+      authLabelSnapshot: row.auth_label_snapshot,
+      authProviderSnapshot: row.auth_provider_snapshot,
+    },
+    context
+  );
+
+  const label =
+    firstReadableCredentialLabel(display.sourceLabel, display.primary, fallbackLabel) || '-';
+
+  return {
+    label,
+    account: firstReadableCredentialLabel(display.account, row.account_snapshot, label),
+    provider: firstReadableCredentialLabel(display.provider, row.auth_provider_snapshot),
+  };
 };
 
 const buildModelSpendRows = (
@@ -1276,30 +1346,25 @@ export const buildApiKeyRows = (
 
 export const buildCredentialRows = (
   rows: MonitoringAnalyticsCredentialStatRow[] = [],
-  summary?: UsageSummaryMetrics
+  summary?: UsageSummaryMetrics,
+  credentialDisplayContext?: UsageCredentialDisplayContext
 ): UsageRankRow[] => {
   const totalCost = summary?.estimatedCost ?? rows.reduce((sum, row) => sum + rowTotalCost(row), 0);
   const totalTokens =
     summary?.totalTokens ?? rows.reduce((sum, row) => sum + toNumber(row.total_tokens), 0);
   return rows
     .map((row) => {
-      const label =
-        row.auth_label_snapshot ||
-        row.account_snapshot ||
-        row.auth_file_snapshot ||
-        row.source ||
-        row.auth_index ||
-        row.id ||
-        '-';
+      const display = resolveUsageCredentialDisplay(row, credentialDisplayContext);
+      const label = display.label;
       return {
         id: row.id || label,
         label,
-        provider: row.auth_provider_snapshot,
+        provider: display.provider || row.auth_provider_snapshot,
         authFile: row.auth_file_snapshot,
         authIndex: row.auth_index,
         source: row.source,
         sourceHash: row.source_hash,
-        account: row.account_snapshot || row.auth_label_snapshot,
+        account: display.account || row.account_snapshot || row.auth_label_snapshot,
         projectId: row.auth_project_id_snapshot,
         requestCount: toNumber(row.calls),
         successCount: toNumber(row.success_calls),
@@ -2110,17 +2175,23 @@ export const adaptUsageAnalyticsData = (
   data: MonitoringAnalyticsResponse | null | undefined,
   granularity: UsageAnalyticsResolvedGranularity,
   keyword = '',
-  apiKeyDisplayMap?: UsageApiKeyDisplayMap
+  apiKeyDisplayMap?: UsageApiKeyDisplayMap,
+  credentialDisplayContext?: UsageCredentialDisplayContext
 ) => {
   const summary = buildUsageSummary(data?.summary);
   const timeline = buildUsageTimeline(data?.timeline ?? [], granularity);
   const credentialTimeline = buildUsageCredentialTimeline(
     data?.credential_timeline ?? [],
-    granularity
+    granularity,
+    credentialDisplayContext
   );
   const modelRows = buildModelRows(data?.model_stats ?? [], summary);
   const apiKeyRows = buildApiKeyRows(data?.api_key_stats ?? [], summary, keyword, apiKeyDisplayMap);
-  const credentialRows = buildCredentialRows(data?.credential_stats ?? [], summary);
+  const credentialRows = buildCredentialRows(
+    data?.credential_stats ?? [],
+    summary,
+    credentialDisplayContext
+  );
   const providerRows = buildProviderRows(
     data?.channel_share ?? [],
     apiKeyRows,

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -3,7 +3,15 @@ import { useSearchParams } from 'react-router-dom';
 import { useMonitoringAnalytics } from '@/features/monitoring/hooks/useMonitoringAnalytics';
 import { useUsageData } from '@/features/monitoring/hooks/useUsageData';
 import { buildApiKeyDisplayMap } from '@/features/monitoring/model/apiKeys';
+import { buildMonitoringAuthMetaMap } from '@/features/monitoring/model/authMeta';
+import { readString } from '@/features/monitoring/model/base';
+import type { MonitoringChannelMeta } from '@/features/monitoring/model/types';
+import { loadMonitoringMetaPayload } from '@/features/monitoring/services/monitoringMetaService';
 import { useConfigStore } from '@/stores';
+import type { AuthFileItem } from '@/types/authFile';
+import type { CredentialInfo } from '@/types/sourceInfo';
+import { buildSourceInfoMap } from '@/utils/sourceResolver';
+import { normalizeAuthIndex } from '@/utils/usage';
 import {
   adaptUsageAnalyticsData,
   analyzeUsageBucket,
@@ -38,6 +46,7 @@ import {
   type UsageHeatmapMetricKey,
   type UsageHeatmapScaleMode,
   type UsageTimelinePoint,
+  type UsageCredentialDisplayContext,
 } from './usageAnalyticsModel';
 import {
   buildUsageAnalyticsSearchParams,
@@ -49,6 +58,16 @@ import {
 
 const USAGE_SEARCH_DEBOUNCE_MS = 350;
 const USAGE_HEATMAP_ALL_DATES_KEY = 'all';
+
+type UsageAnalyticsMonitoringMeta = {
+  authFiles: AuthFileItem[];
+  channels: MonitoringChannelMeta[];
+};
+
+const EMPTY_USAGE_ANALYTICS_MONITORING_META: UsageAnalyticsMonitoringMeta = {
+  authFiles: [],
+  channels: [],
+};
 
 const getBrowserTimeZone = () => {
   if (typeof Intl === 'undefined') return 'UTC';
@@ -69,6 +88,9 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
 export function useUsageAnalytics() {
   const config = useConfigStore((state) => state.config);
   const { apiKeyAliases, loadApiKeyAliases } = useUsageData({ loadUsageEvents: false });
+  const [monitoringMeta, setMonitoringMeta] = useState<UsageAnalyticsMonitoringMeta>(
+    EMPTY_USAGE_ANALYTICS_MONITORING_META
+  );
   const [searchParams, setSearchParams] = useSearchParams();
   const [initialUiState] = useState<UsageAnalyticsUiState>(() =>
     buildUsageAnalyticsUiStateFromSearchParams(
@@ -100,6 +122,82 @@ export function useUsageAnalytics() {
   const apiKeyDisplayMap = useMemo(
     () => buildApiKeyDisplayMap(config?.apiKeys || [], apiKeyAliases || []),
     [apiKeyAliases, config?.apiKeys]
+  );
+  const loadMonitoringMeta = useCallback(async () => {
+    const payload = await loadMonitoringMetaPayload(config);
+    setMonitoringMeta({
+      authFiles: payload.authFiles,
+      channels: payload.channels,
+    });
+  }, [config]);
+  useEffect(() => {
+    let cancelled = false;
+    loadMonitoringMetaPayload(config)
+      .then((payload) => {
+        if (cancelled) return;
+        setMonitoringMeta({
+          authFiles: payload.authFiles,
+          channels: payload.channels,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMonitoringMeta(EMPTY_USAGE_ANALYTICS_MONITORING_META);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config]);
+  const authMetaMap = useMemo(
+    () => buildMonitoringAuthMetaMap(monitoringMeta.authFiles),
+    [monitoringMeta.authFiles]
+  );
+  const authFileMap = useMemo(() => {
+    const map = new Map<string, CredentialInfo>();
+    monitoringMeta.authFiles.forEach((entry) => {
+      const authIndex = normalizeAuthIndex(entry['auth_index'] ?? entry.authIndex);
+      if (!authIndex) return;
+      map.set(authIndex, {
+        name:
+          readString(entry.label) ||
+          readString(entry.name) ||
+          readString(entry.email) ||
+          readString(entry.account) ||
+          authIndex,
+        type: readString(entry.provider) || readString(entry.type),
+      });
+    });
+    return map;
+  }, [monitoringMeta.authFiles]);
+  const sourceInfoMap = useMemo(
+    () =>
+      buildSourceInfoMap({
+        geminiApiKeys: config?.geminiApiKeys || [],
+        claudeApiKeys: config?.claudeApiKeys || [],
+        codexApiKeys: config?.codexApiKeys || [],
+        vertexApiKeys: config?.vertexApiKeys || [],
+        openaiCompatibility: config?.openaiCompatibility || [],
+      }),
+    [config]
+  );
+  const channelByAuthIndex = useMemo(() => {
+    const map = new Map<string, MonitoringChannelMeta>();
+    monitoringMeta.channels.forEach((channel) => {
+      channel.authIndices.forEach((authIndex) => {
+        map.set(authIndex, channel);
+      });
+    });
+    return map;
+  }, [monitoringMeta.channels]);
+  const credentialDisplayContext = useMemo<UsageCredentialDisplayContext>(
+    () => ({
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex,
+    }),
+    [authFileMap, authMetaMap, channelByAuthIndex, sourceInfoMap]
   );
   const setActiveTab = useCallback((tab: UsageAnalyticsTab) => {
     setActiveTabState(tab);
@@ -219,9 +317,16 @@ export function useUsageAnalytics() {
         analyticsData,
         resolvedGranularity,
         filters.apiKeyKeyword,
-        apiKeyDisplayMap
+        apiKeyDisplayMap,
+        credentialDisplayContext
       ),
-    [analyticsData, apiKeyDisplayMap, filters.apiKeyKeyword, resolvedGranularity]
+    [
+      analyticsData,
+      apiKeyDisplayMap,
+      credentialDisplayContext,
+      filters.apiKeyKeyword,
+      resolvedGranularity,
+    ]
   );
   const heatmapDateData = heatmapDateAnalytics.dataStale ? null : heatmapDateAnalytics.data;
   const heatmapDateRows = useMemo(
@@ -430,6 +535,7 @@ export function useUsageAnalytics() {
   const refresh = useCallback(() => {
     setNowMs(Date.now());
     void loadApiKeyAliases();
+    void loadMonitoringMeta();
     void analytics.refresh({ force: true });
     if (selectedApiKeyTimelineAnalytics.enabled) {
       void selectedApiKeyTimelineAnalytics.refresh({ force: true });
@@ -441,6 +547,7 @@ export function useUsageAnalytics() {
     analytics,
     heatmapDateAnalytics,
     loadApiKeyAliases,
+    loadMonitoringMeta,
     selectedApiKeyTimelineAnalytics,
     selectedHeatmapDate,
   ]);


### PR DESCRIPTION
## Summary
Resolve usage analytics credential labels through the same monitoring metadata used by request monitoring.
This prevents masked source identifiers such as `m:sk-...` from appearing in credential rankings and timelines when a readable provider or auth label can be matched.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Load request monitoring metadata for usage analytics credential display resolution.
- Resolve credential ranking and timeline labels from source/auth-index metadata while preserving stable grouping IDs.
- Add regression coverage for masked source identifiers resolving to readable credential labels.

## User Impact
Users will see readable credential names in usage analytics instead of masked source identifiers when metadata is available.

## Compatibility / Runtime Notes
- CPA panel mode: No behavior change beyond improved display when monitoring metadata is available.
- Manager Server mode: Uses existing metadata and keeps filters/links based on stable identifiers.
- Full Docker / native packages: No packaging impact.

## Data / Security Notes
No new secret exposure. Masked source identifiers are replaced with existing sanitized display metadata when available.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR to return credential labels to the backend snapshot fallback order.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/features/usage-analytics
npm run type-check
npm run lint
git diff --check
```

## Screenshots / Recordings
N/A; display-label resolution change only.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed
