### PR TITLE
fix(dashboard): restore four-part token mix display

### DIFF
--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -447,14 +447,32 @@ func requestHealthTone(calls int64, failureRate float64, future bool) string {
 }
 
 func buildTokenMix(today TodaySummary) []TokenMixSegment {
-	inputTokens := max(today.InputTokens, today.CachedTokens) +
+	inputTokens := max(today.InputTokens, int64(0))
+	cachedTokens := max(today.CachedTokens, int64(0)) +
 		max(today.CacheReadTokens, int64(0)) +
 		max(today.CacheCreationTokens, int64(0))
-	outputTokens := max(today.OutputTokens, today.ReasoningTokens)
-	total := inputTokens + outputTokens
+	outputTokens := max(today.OutputTokens, int64(0))
+	reasoningTokens := max(today.ReasoningTokens, int64(0))
+
+	if today.TotalTokens > 0 {
+		overflow := inputTokens + cachedTokens + outputTokens + reasoningTokens - today.TotalTokens
+		if overflow > 0 {
+			inputDeduction := min(inputTokens, overflow)
+			inputTokens -= inputDeduction
+			overflow -= inputDeduction
+		}
+		if overflow > 0 {
+			outputDeduction := min(outputTokens, overflow)
+			outputTokens -= outputDeduction
+		}
+	}
+
+	total := inputTokens + cachedTokens + outputTokens + reasoningTokens
 	return []TokenMixSegment{
 		{Key: "input", Tokens: inputTokens, Share: rate(inputTokens, total)},
+		{Key: "cached", Tokens: cachedTokens, Share: rate(cachedTokens, total)},
 		{Key: "output", Tokens: outputTokens, Share: rate(outputTokens, total)},
+		{Key: "reasoning", Tokens: reasoningTokens, Share: rate(reasoningTokens, total)},
 	}
 }
 

--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -119,14 +119,22 @@ func TestSummaryAggregatesCostsAndWindows(t *testing.T) {
 		resp.RequestHealth.Points[7].Tone != "future" {
 		t.Fatalf("request health timeline points = %#v", resp.RequestHealth.Points[:8])
 	}
-	if len(resp.TokenMix) != 2 || resp.TokenMix[0].Key != "input" ||
+	if len(resp.TokenMix) != 4 || resp.TokenMix[0].Key != "input" ||
 		resp.TokenMix[0].Tokens != 1_000_000 ||
-		math.Abs(resp.TokenMix[0].Share-(1000000.0/1500100.0)) > 0.000001 {
+		math.Abs(resp.TokenMix[0].Share-(1000000.0/1750100.0)) > 0.000001 {
 		t.Fatalf("token mix = %#v", resp.TokenMix)
 	}
-	if resp.TokenMix[1].Key != "output" || resp.TokenMix[1].Tokens != 500_100 ||
-		math.Abs(resp.TokenMix[1].Share-(500100.0/1500100.0)) > 0.000001 {
+	if resp.TokenMix[1].Key != "cached" || resp.TokenMix[1].Tokens != 250_000 ||
+		math.Abs(resp.TokenMix[1].Share-(250000.0/1750100.0)) > 0.000001 {
+		t.Fatalf("token mix cached = %#v", resp.TokenMix)
+	}
+	if resp.TokenMix[2].Key != "output" || resp.TokenMix[2].Tokens != 500_100 ||
+		math.Abs(resp.TokenMix[2].Share-(500100.0/1750100.0)) > 0.000001 {
 		t.Fatalf("token mix output = %#v", resp.TokenMix)
+	}
+	if resp.TokenMix[3].Key != "reasoning" || resp.TokenMix[3].Tokens != 0 ||
+		resp.TokenMix[3].Share != 0 {
+		t.Fatalf("token mix reasoning = %#v", resp.TokenMix)
 	}
 	if len(resp.ModelCostRank) != 1 || resp.ModelCostRank[0].Model != "gpt-a" ||
 		resp.ModelCostRank[0].CostShare != 1 {
@@ -150,7 +158,7 @@ func TestSummaryAggregatesCostsAndWindows(t *testing.T) {
 	}
 }
 
-func TestBuildTokenMixUsesTopLevelInputAndOutputBuckets(t *testing.T) {
+func TestBuildTokenMixRestoresFourVisibleBuckets(t *testing.T) {
 	mix := buildTokenMix(TodaySummary{
 		InputTokens:         1_000,
 		OutputTokens:        200,
@@ -158,18 +166,53 @@ func TestBuildTokenMixUsesTopLevelInputAndOutputBuckets(t *testing.T) {
 		CacheReadTokens:     400,
 		CacheCreationTokens: 100,
 		ReasoningTokens:     150,
+		TotalTokens:         2_150,
 	})
 
-	if len(mix) != 2 {
-		t.Fatalf("token mix length = %d, want 2: %#v", len(mix), mix)
+	if len(mix) != 4 {
+		t.Fatalf("token mix length = %d, want 4: %#v", len(mix), mix)
 	}
-	if mix[0].Key != "input" || mix[0].Tokens != 1_500 ||
-		math.Abs(mix[0].Share-(1500.0/1700.0)) > 0.000001 {
+	if mix[0].Key != "input" || mix[0].Tokens != 1_000 ||
+		math.Abs(mix[0].Share-(1000.0/2150.0)) > 0.000001 {
 		t.Fatalf("input mix = %#v", mix[0])
 	}
-	if mix[1].Key != "output" || mix[1].Tokens != 200 ||
-		math.Abs(mix[1].Share-(200.0/1700.0)) > 0.000001 {
-		t.Fatalf("output mix = %#v", mix[1])
+	if mix[1].Key != "cached" || mix[1].Tokens != 800 ||
+		math.Abs(mix[1].Share-(800.0/2150.0)) > 0.000001 {
+		t.Fatalf("cached mix = %#v", mix[1])
+	}
+	if mix[2].Key != "output" || mix[2].Tokens != 200 ||
+		math.Abs(mix[2].Share-(200.0/2150.0)) > 0.000001 {
+		t.Fatalf("output mix = %#v", mix[2])
+	}
+	if mix[3].Key != "reasoning" || mix[3].Tokens != 150 ||
+		math.Abs(mix[3].Share-(150.0/2150.0)) > 0.000001 {
+		t.Fatalf("reasoning mix = %#v", mix[3])
+	}
+}
+
+func TestBuildTokenMixDeduplicatesNestedCacheAndReasoning(t *testing.T) {
+	mix := buildTokenMix(TodaySummary{
+		InputTokens:     20_700,
+		OutputTokens:    245,
+		CachedTokens:    18_300,
+		ReasoningTokens: 90,
+		TotalTokens:     20_945,
+	})
+
+	if len(mix) != 4 {
+		t.Fatalf("token mix length = %d, want 4: %#v", len(mix), mix)
+	}
+	if mix[0].Key != "input" || mix[0].Tokens != 2_310 {
+		t.Fatalf("input mix = %#v", mix[0])
+	}
+	if mix[1].Key != "cached" || mix[1].Tokens != 18_300 {
+		t.Fatalf("cached mix = %#v", mix[1])
+	}
+	if mix[2].Key != "output" || mix[2].Tokens != 245 {
+		t.Fatalf("output mix = %#v", mix[2])
+	}
+	if mix[3].Key != "reasoning" || mix[3].Tokens != 90 {
+		t.Fatalf("reasoning mix = %#v", mix[3])
 	}
 }
 

--- a/apps/web/src/features/dashboard/components/TrafficOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/TrafficOverviewCard.tsx
@@ -49,15 +49,19 @@ const formatHour = (bucketMs: number, locale: string) =>
 
 const tokenLabelMap: Record<string, string> = {
   input: 'dashboard.token_mix_input',
+  cached: 'dashboard.token_mix_cached',
   output: 'dashboard.token_mix_output',
+  reasoning: 'dashboard.token_mix_reasoning',
 };
 
 const tokenColorMap: Record<string, string> = {
   input: '#3b82f6',
+  cached: '#f59e0b',
   output: '#10b981',
+  reasoning: '#8b5cf6',
 };
 
-const visibleTokenMixKeys = new Set(['input', 'output']);
+const visibleTokenMixKeys = new Set(['input', 'cached', 'output', 'reasoning']);
 
 const healthToneClassMap: Record<string, string> = {
   future: 'healthFuture',


### PR DESCRIPTION
## Summary
Restore the dashboard Token Mix card to show input, cached, output, and reasoning tokens.

This keeps the four-part visual breakdown users expect while preserving the corrected percentage accounting.

## Scope
- [x] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Return four dashboard token mix buckets from Manager Server: input, cached, output, and reasoning.
- Deduplicate nested cache/reasoning values against `total_tokens` to avoid inflated percentages.
- Restore cached and reasoning rows in the web dashboard token composition card.
- Add focused backend coverage for separated and nested token accounting.

## User Impact
Users will again see the dashboard Token Mix card broken down into input, cached, output, and reasoning rows.

Percentages remain bounded by the corrected token total instead of double-counting nested cache or reasoning tokens.

## Compatibility / Runtime Notes
- CPA panel mode: Dashboard display changes apply when the panel consumes Manager Server dashboard summaries.
- Manager Server mode: Dashboard `token_mix` response now returns four visible buckets instead of two.
- Full Docker / native packages: No config, packaging, or deployment changes.

## Data / Security Notes
No secrets, admin keys, CPA Management Keys, auth files, raw usage payloads, or SQLite schema changes.

The change only adjusts dashboard summary aggregation output and frontend presentation.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the two commits in this PR to restore the two-bucket dashboard token mix behavior.

## Verification
- [x] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
go test -run 'TestSummaryAggregatesCostsAndWindows|TestBuildTokenMix' ./internal/service/dashboard
```

## Screenshots / Recordings
Not captured. The change restores the existing ranked bar card to include the cached and reasoning rows.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
