### PR TITLE
docs(release): prepare v1.8.0

### DIFF
--- a/docs/release-notes/v1.8.0-en.md
+++ b/docs/release-notes/v1.8.0-en.md
@@ -1,0 +1,53 @@
+# CPA Manager Plus v1.8.0
+
+> 28 commits · 81 files changed · +3497 / -2335
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.8.0/docs/release-notes/v1.8.0-zh.md)
+
+## Overview
+
+This release focuses on quota and authentication-file status visibility: CPA Manager Plus now derives CPAMP quota cooldown badges, expands quota provider and Antigravity-related surfaces, and fixes accuracy issues across xAI quota refreshes, Usage Analytics labels, dashboard token mix data, and plugin state updates. The project entry docs, monitoring UI, and plugin pages also receive usability improvements.
+
+## Highlights
+
+### Features
+
+- Add derived CPAMP quota cooldown badges to authentication files so server-side cooldown state is visible in the auth file list (`web/authFiles`, `manager-server/quota-cooldown`).
+- Update quota provider display and configuration surfaces, including Antigravity subscription polling and related quota config parsing (`web/quota`, `web/authFiles`).
+
+### Fixes
+
+- Fix xAI authentication-file quota refreshes being routed through Gemini CLI by mistake (`web/quota`).
+- Wait for post-mutation plugin state so plugin pages do not show stale data after changes (`web/plugins`).
+- Clear auth file quota cooldown races across context changes, service base resets, and stale requests (`web/authFiles`).
+- Restore Usage Analytics credential labels from monitoring metadata (`web/usage-analytics`).
+- Resolve Usage Analytics API key aliases by hash (`web/usage-analytics`).
+- Restore dashboard cache and reasoning token mix display, and fix backend token mix buckets (`web/dashboard`, `manager-server/dashboard`).
+- Constrain realtime monitoring model names so long names do not break the layout (`web/monitoring`).
+- Improve responsive layouts for the plugin store and plugin management pages (`web/plugins`).
+
+### Docs
+
+- Refresh README, Chinese README, and home screenshots so the project entry points match the current management panel (`docs`, `img`).
+
+### CI
+
+- Add the project PR template and require template content in PR checks (`ci/pr`).
+
+### Tests
+
+- Add coverage for auth file quota cooldown, Antigravity subscriptions, quota builders, and dashboard token mix behavior (`web`, `manager-server`).
+
+## Upgrade Notes
+
+- Manager Server now exposes a quota cooldown lookup path; CPA Panel and Full Docker modes should keep treating the derived badge data as optional for absent-safe behavior with older servers.
+- Quota provider and Antigravity config parsing now covers more surfaces, so custom configs should verify provider names and model aliases still map as intended.
+
+## Acknowledgements
+
+- @MuziIsabel - Contributed derived CPAMP quota cooldown auth file badges and context-change race fixes.
+- @Ruelya - Fixed xAI authentication-file quota refreshes being routed through Gemini CLI.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.7.0...v1.8.0

--- a/docs/release-notes/v1.8.0-zh.md
+++ b/docs/release-notes/v1.8.0-zh.md
@@ -1,0 +1,53 @@
+# CPA Manager Plus v1.8.0
+
+> 28 commits · 81 files changed · +3497 / -2335
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.8.0/docs/release-notes/v1.8.0-en.md)
+
+## Overview
+
+本次发布聚焦 quota 与认证文件状态展示:新增 CPAMP quota cooldown 派生徽标,扩展 quota provider 与 Antigravity 相关能力,并修复 xAI、Usage Analytics、仪表盘 token mix 和插件状态刷新中的多项准确性问题。文档入口、监控界面与插件页也获得了可用性改善。
+
+## Highlights
+
+### Features
+
+- 新增 CPAMP quota cooldown 派生认证文件徽标,让认证文件列表直接展示服务端冷却状态(`web/authFiles`, `manager-server/quota-cooldown`)。
+- 更新 quota provider 展示与配置能力,补充 Antigravity 订阅轮询和相关 quota 配置解析(`web/quota`, `web/authFiles`)。
+
+### Fixes
+
+- 修复 xAI 认证文件额度刷新误走 Gemini CLI 的问题(`web/quota`)。
+- 修复插件变更后状态刷新时序,避免 mutation 后显示旧状态(`web/plugins`)。
+- 清理认证文件 quota cooldown 的上下文切换竞态,避免 service base 变化或请求过期后残留错误徽标(`web/authFiles`)。
+- 修复 Usage Analytics 凭证标签解析,从监控元数据中恢复 credential label 显示(`web/usage-analytics`)。
+- 修复 Usage Analytics API Key alias 解析,支持按 hash 匹配别名(`web/usage-analytics`)。
+- 恢复仪表盘 cache 与 reasoning token mix 展示,并修复后端 token mix 分桶(`web/dashboard`, `manager-server/dashboard`)。
+- 约束实时监控模型名显示,避免长模型名挤压布局(`web/monitoring`)。
+- 改善插件市场与插件管理页响应式布局(`web/plugins`)。
+
+### Docs
+
+- 刷新 README、中文 README 与首页截图,让项目入口更贴近当前管理面板(`docs`, `img`)。
+
+### CI
+
+- 增加项目 PR 模板并在 PR 检查中强制校验模板内容(`ci/pr`)。
+
+### Tests
+
+- 补充 auth file quota cooldown、Antigravity subscription、quota builders 与仪表盘 token mix 测试(`web`, `manager-server`)。
+
+## Upgrade Notes
+
+- 新增 Manager Server quota cooldown 查询路径,CPA Panel 与 Full Docker 模式都应保持缺省安全处理;旧版本 Manager Server 不会提供该派生徽标数据。
+- Quota provider 与 Antigravity 相关配置解析范围扩大,自定义配置应确认 provider 名称和 model alias 仍按预期映射。
+
+## Acknowledgements
+
+- @MuziIsabel - 贡献 CPAMP quota cooldown 派生认证文件徽标及上下文切换竞态修复。
+- @Ruelya - 修复 xAI 认证文件额度刷新误走 Gemini CLI 的问题。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.7.0...v1.8.0


### PR DESCRIPTION
## Summary
Prepare curated release notes for CPA Manager Plus v1.8.0.
This PR adds the Chinese source notes and English mirror notes required before pushing the v1.8.0 release tag.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add Chinese release notes at docs/release-notes/v1.8.0-zh.md.
- Add English release notes at docs/release-notes/v1.8.0-en.md.
- Use tag-pinned GitHub blob links for language switching in GitHub Releases.

## User Impact
No runtime behavior change. Users will see curated v1.8.0 release notes after the release tag is pushed.

## Compatibility / Runtime Notes
- CPA panel mode: N/A, documentation-only release note preparation.
- Manager Server mode: N/A, documentation-only release note preparation.
- Full Docker / native packages: Release workflow will use these notes after the v1.8.0 tag is pushed.

## Data / Security Notes
N/A. No SQLite data, admin keys, CPA Management Keys, auth files, logs, raw usage data, or plugin runtime data are changed.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the release note commit before tagging if the notes need to be replaced.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
rg -n '\]\(\./|blob/.*/docs/release-notes|Full Changelog|28 commits' docs/release-notes/v1.8.0-zh.md docs/release-notes/v1.8.0-en.md
git diff --cached --check
```

## Screenshots / Recordings
N/A. Documentation-only release note PR.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
N/A
