### PR TITLE
fix(ci): rerun PR template checks on body edits

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,52 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-template:
-    name: PR Template
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check PR body
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          body="${PR_BODY:-}"
-          required_headers=(
-            "## Summary"
-            "## Scope"
-            "## Changes"
-            "## User Impact"
-            "## Compatibility / Runtime Notes"
-            "## Data / Security Notes"
-            "## Risk / Rollback"
-            "## Verification"
-            "## Screenshots / Recordings"
-            "## Docs"
-            "## Related"
-          )
-
-          missing_headers=()
-          for header in "${required_headers[@]}"; do
-            if ! grep -Fq "$header" <<< "$body"; then
-              missing_headers+=("$header")
-            fi
-          done
-
-          if (( ${#missing_headers[@]} > 0 )); then
-            echo "PR body is missing required template sections:"
-            printf ' - %s\n' "${missing_headers[@]}"
-            exit 1
-          fi
-
-          if ! grep -Eq '^- \[[xX]\] (Frontend panel|Manager Server|CPA panel mode|Full Docker mode|Native packages / release|Docs / Wiki|CI / build / tooling)$' <<< "$body"; then
-            echo "PR body must check at least one item in the Scope section."
-            exit 1
-          fi
-
   frontend:
     name: Frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -1,0 +1,65 @@
+name: PR Template
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-template:
+    name: PR Template
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          body="${PR_BODY:-}"
+          required_headers=(
+            "## Summary"
+            "## Scope"
+            "## Changes"
+            "## User Impact"
+            "## Compatibility / Runtime Notes"
+            "## Data / Security Notes"
+            "## Risk / Rollback"
+            "## Verification"
+            "## Screenshots / Recordings"
+            "## Docs"
+            "## Related"
+          )
+
+          missing_headers=()
+          for header in "${required_headers[@]}"; do
+            if ! grep -Fq "$header" <<< "$body"; then
+              missing_headers+=("$header")
+            fi
+          done
+
+          if (( ${#missing_headers[@]} > 0 )); then
+            echo "PR body is missing required template sections:"
+            printf ' - %s\n' "${missing_headers[@]}"
+            exit 1
+          fi
+
+          if ! grep -Eq '^- \[[xX]\] (Frontend panel|Manager Server|CPA panel mode|Full Docker mode|Native packages / release|Docs / Wiki|CI / build / tooling)$' <<< "$body"; then
+            echo "PR body must check at least one item in the Scope section."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
Split PR template validation into a dedicated workflow so PR body edits rerun the template gate.
Keep the heavier frontend, backend, and Docker checks in the existing PR Check workflow.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes
- Add a dedicated PR Template workflow that listens to opened, edited, reopened, synchronize, and ready_for_review pull request events.
- Move the existing PR body validation script out of the full PR Check workflow.
- Leave frontend, manager-server, and Docker build checks unchanged so editing PR text does not rerun full CI.

## User Impact
No runtime behavior change. Contributors get fresh PR template validation after correcting a PR description.

## Compatibility / Runtime Notes
- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: N/A.

## Data / Security Notes
N/A. This only changes GitHub Actions workflow routing for PR validation.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the workflow split to restore the previous single PR Check workflow behavior.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
git diff --cached --check
local equivalent PR body validation: valid body passed; unchecked Scope body failed
actionlint unavailable locally
```

## Screenshots / Recordings
N/A. Workflow-only change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
