### PR TITLE
fix(auth-files): make Antigravity plan lookup manual

### DIFF
--- a/apps/web/src/features/authFiles/AuthFilesPage.module.scss
+++ b/apps/web/src/features/authFiles/AuthFilesPage.module.scss
@@ -979,6 +979,7 @@
 .subscriptionBadge {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   min-width: 0;
   max-width: 100%;
   padding: 3px 8px;
@@ -988,6 +989,39 @@
   line-height: 1;
   white-space: nowrap;
   letter-spacing: 0;
+}
+
+.subscriptionBadgeSpinner {
+  flex: 0 0 auto;
+}
+
+.subscriptionRefreshButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  max-width: 100%;
+  height: 18px;
+  padding: 0 8px;
+  border-radius: 6px;
+  border: 1px solid var(--info-border, #93c5fd);
+  color: var(--info-text, #1e40af);
+  background: var(--info-bg, #dbeafe);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+.subscriptionRefreshButton:hover:not(:disabled) {
+  filter: brightness(0.97);
+}
+
+.subscriptionRefreshButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .subscriptionBadgePaid {
@@ -1013,28 +1047,6 @@
   color: var(--danger-color);
   background: color-mix(in srgb, var(--danger-color) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--danger-color) 35%, transparent);
-}
-
-.subscriptionSubtitle {
-  font-size: 12px;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  display: flex;
-  gap: 6px;
-  align-items: flex-start;
-  min-width: 0;
-}
-
-.subscriptionSubtitleLabel {
-  flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-weight: 600;
-}
-
-.subscriptionSubtitleValue {
-  @include text-ellipsis-multiline(2);
-  min-width: 0;
-  word-break: break-word;
 }
 
 .subscriptionError {

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -763,11 +763,8 @@ export function AuthFilesPage() {
   const currentPage = Math.min(page, totalPages);
   const start = (currentPage - 1) * pageSize;
   const pageItems = useMemo(() => sorted.slice(start, start + pageSize), [pageSize, sorted, start]);
-  const antigravitySubscriptionItems = useMemo(
-    () => (normalizedFilter === 'antigravity' ? pageItems : []),
-    [normalizedFilter, pageItems]
-  );
-  const antigravitySubscriptions = useAntigravitySubscriptions(antigravitySubscriptionItems);
+  const { subscriptions: antigravitySubscriptions, refreshSubscription } =
+    useAntigravitySubscriptions();
   const pageHasInlineQuotaCards = !compactMode && pageItems.some(hasInlineQuotaLayout);
   const selectablePageItems = useMemo(
     () => pageItems.filter((file) => !isRuntimeOnlyAuthFile(file)),
@@ -1319,6 +1316,7 @@ export function AuthFilesPage() {
                       codexStatusBadges={codexStatus?.badges ?? []}
                       codexNeedsReauth={codexStatus?.needsReauth ?? false}
                       antigravitySubscription={antigravitySubscriptions[file.name]}
+                      onRefreshAntigravitySubscription={refreshSubscription}
                       quotaCooldown={quotaCooldowns.get(file.name)}
                       onShowModels={showModels}
                       onReauth={(targetFile) =>

--- a/apps/web/src/features/authFiles/components/AuthFileCard.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileCard.tsx
@@ -54,6 +54,7 @@ export type AuthFileCardProps = {
   codexStatusBadges?: AuthFileCodexStatusBadge[];
   codexNeedsReauth?: boolean;
   antigravitySubscription?: AntigravitySubscriptionState;
+  onRefreshAntigravitySubscription?: (file: AuthFileItem) => void;
   quotaCooldown?: QuotaCooldownInfo;
   onShowModels: (file: AuthFileItem) => void;
   onReauth?: (file: AuthFileItem) => void;
@@ -90,6 +91,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
     codexStatusBadges = [],
     codexNeedsReauth = false,
     antigravitySubscription,
+    onRefreshAntigravitySubscription,
     quotaCooldown,
     onShowModels,
     onReauth,
@@ -143,6 +145,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
   const subscription =
     isAntigravity && !isRuntimeOnly ? antigravitySubscription : undefined;
   const subscriptionData = subscription?.status === 'success' ? subscription.data : undefined;
+  const isSubscriptionLoading = subscription?.status === 'loading';
   const subscriptionPlanLabel =
     subscriptionData?.plan === 'free'
       ? t('antigravity_subscription.plan_free')
@@ -158,7 +161,9 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 t('antigravity_subscription.plan_unknown')
               : '';
   const subscriptionBadgeLabel =
-    subscription?.status === 'error'
+    isSubscriptionLoading
+      ? t('antigravity_subscription.loading_short')
+      : subscription?.status === 'error'
       ? t('antigravity_subscription.error_badge')
       : subscriptionData
         ? t('antigravity_subscription.plan_badge', {
@@ -172,7 +177,9 @@ export function AuthFileCard(props: AuthFileCardProps) {
         ? `${subscriptionData.tierName} (${subscriptionData.tierId})`
         : subscriptionData?.tierName || subscriptionData?.tierId || subscriptionBadgeLabel;
   const subscriptionBadgeClass =
-    subscription?.status === 'error'
+    isSubscriptionLoading
+      ? styles.subscriptionBadgeLoading
+      : subscription?.status === 'error'
       ? styles.subscriptionBadgeError
       : subscriptionData?.plan === 'free'
         ? styles.subscriptionBadgeFree
@@ -183,6 +190,11 @@ export function AuthFileCard(props: AuthFileCardProps) {
     subscription?.status === 'error'
       ? subscription.error || t('common.unknown_error')
       : '';
+  const showSubscriptionRefreshButton =
+    isAntigravity &&
+    !isRuntimeOnly &&
+    !subscriptionBadgeLabel &&
+    Boolean(onRefreshAntigravitySubscription);
   const stateLabel = isRuntimeOnly
     ? t('auth_files.type_virtual') || '虚拟认证文件'
     : file.disabled
@@ -241,8 +253,22 @@ export function AuthFileCard(props: AuthFileCardProps) {
                     className={`${styles.subscriptionBadge} ${subscriptionBadgeClass}`}
                     title={subscriptionTitle}
                   >
+                    {isSubscriptionLoading && (
+                      <LoadingSpinner size={10} className={styles.subscriptionBadgeSpinner} />
+                    )}
                     {subscriptionBadgeLabel}
                   </span>
+                )}
+                {showSubscriptionRefreshButton && (
+                  <button
+                    type="button"
+                    className={styles.subscriptionRefreshButton}
+                    title={t('antigravity_subscription.refresh_button')}
+                    onClick={() => onRefreshAntigravitySubscription?.(file)}
+                    disabled={disableControls}
+                  >
+                    {t('antigravity_subscription.refresh_short')}
+                  </button>
                 )}
                 {codexStatusBadges.map((badge) => {
                   const label = t(badge.labelKey, {
@@ -290,16 +316,6 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 <div className={styles.noteText} title={noteValue}>
                   <span className={styles.noteLabel}>{t('auth_files.note_display')}</span>
                   <span className={styles.noteValue}>{noteValue}</span>
-                </div>
-              )}
-              {!compact && subscriptionData?.tierName && (
-                <div className={styles.subscriptionSubtitle} title={subscriptionTitle}>
-                  <span className={styles.subscriptionSubtitleLabel}>
-                    {t('antigravity_subscription.subscription_label')}
-                  </span>
-                  <span className={styles.subscriptionSubtitleValue}>
-                    {subscriptionData.tierName}
-                  </span>
                 </div>
               )}
             </div>

--- a/apps/web/src/features/authFiles/hooks/useAntigravitySubscriptions.ts
+++ b/apps/web/src/features/authFiles/hooks/useAntigravitySubscriptions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   antigravitySubscriptionApi,
@@ -24,21 +24,6 @@ type SubscriptionTarget = {
   authIndex: string | null;
   cacheKey: string;
 };
-
-type SubscriptionResult =
-  | {
-      name: string;
-      cacheKey: string;
-      status: 'success';
-      data: AntigravitySubscriptionSummary;
-    }
-  | {
-      name: string;
-      cacheKey: string;
-      status: 'error';
-      error: string;
-      errorStatus?: number;
-    };
 
 const successfulSubscriptionCache = new Map<string, AntigravitySubscriptionSummary>();
 const inFlightSubscriptionRequests = new Map<
@@ -78,129 +63,81 @@ const requestAntigravitySubscription = (authIndex: string, cacheKey: string) => 
   return request;
 };
 
-export function useAntigravitySubscriptions(files: AuthFileItem[]) {
+const buildSubscriptionTarget = (file: AuthFileItem): SubscriptionTarget | null => {
+  if (!isAntigravityFile(file) || isRuntimeOnlyAuthFile(file)) return null;
+  const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
+  return {
+    file,
+    authIndex,
+    cacheKey: buildCacheKey(authIndex),
+  };
+};
+
+export function useAntigravitySubscriptions() {
   const { t } = useTranslation();
   const [subscriptions, setSubscriptions] = useState<Record<string, AntigravitySubscriptionState>>(
     {}
   );
-  const targets = useMemo(
-    () =>
-      files.reduce<SubscriptionTarget[]>((result, file) => {
-        if (!isAntigravityFile(file) || isRuntimeOnlyAuthFile(file)) return result;
-        const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
-        result.push({
-          file,
-          authIndex,
-          cacheKey: buildCacheKey(authIndex),
-        });
-        return result;
-      }, []),
-    [files]
-  );
 
-  useEffect(() => {
-    const targetsToLoad = targets.filter((target) => {
-      if (!target.authIndex) return true;
-      return !successfulSubscriptionCache.has(target.cacheKey);
-    });
-    if (targetsToLoad.length === 0) return;
+  const refreshSubscription = useCallback(
+    async (file: AuthFileItem) => {
+      const target = buildSubscriptionTarget(file);
+      if (!target) return;
 
-    let cancelled = false;
-    const requestTargets = targetsToLoad.filter((target) => target.authIndex);
-
-    void (async () => {
-      if (cancelled) return;
-
-      setSubscriptions((prev) => {
-        const next = { ...prev };
-        targetsToLoad.forEach((target) => {
-          const cached = getCachedSubscriptionState(target.cacheKey);
-          if (cached) {
-            next[target.file.name] = cached;
-          } else if (target.authIndex) {
-            next[target.file.name] = { status: 'loading' };
-          } else {
-            next[target.file.name] = {
-              status: 'error',
-              error: t('antigravity_subscription.missing_auth_index'),
-            };
-          }
-        });
-        return next;
-      });
-
-      if (requestTargets.length === 0) return;
-
-      const results = await Promise.all(
-        requestTargets.map(async (target): Promise<SubscriptionResult> => {
-          try {
-            const data = await requestAntigravitySubscription(
-              target.authIndex as string,
-              target.cacheKey
-            );
-            if (!data) {
-              return {
-                name: target.file.name,
-                cacheKey: target.cacheKey,
-                status: 'error',
-                error: t('antigravity_subscription.empty_data'),
-              };
-            }
-            return {
-              name: target.file.name,
-              cacheKey: target.cacheKey,
-              status: 'success',
-              data,
-            };
-          } catch (err: unknown) {
-            return {
-              name: target.file.name,
-              cacheKey: target.cacheKey,
-              status: 'error',
-              error: err instanceof Error ? err.message : t('common.unknown_error'),
-              errorStatus: getStatusFromError(err),
-            };
-          }
-        })
-      );
-
-      if (cancelled) return;
-
-      setSubscriptions((prev) => {
-        const next = { ...prev };
-        results.forEach((result) => {
-          if (result.status === 'success') {
-            next[result.name] = { status: 'success', data: result.data };
-          } else {
-            next[result.name] = {
-              status: 'error',
-              error: result.error,
-              errorStatus: result.errorStatus,
-            };
-          }
-        });
-        return next;
-      });
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [t, targets]);
-
-  return useMemo(() => {
-    const current: Record<string, AntigravitySubscriptionState> = {};
-    targets.forEach((target) => {
       const cached = getCachedSubscriptionState(target.cacheKey);
       if (cached) {
-        current[target.file.name] = cached;
+        setSubscriptions((prev) => ({
+          ...prev,
+          [target.file.name]: cached,
+        }));
         return;
       }
-      const existing = subscriptions[target.file.name];
-      if (existing) {
-        current[target.file.name] = existing;
+
+      if (!target.authIndex) {
+        setSubscriptions((prev) => ({
+          ...prev,
+          [target.file.name]: {
+            status: 'error',
+            error: t('antigravity_subscription.missing_auth_index'),
+          },
+        }));
+        return;
       }
+
+      setSubscriptions((prev) => ({
+        ...prev,
+        [target.file.name]: { status: 'loading' },
+      }));
+
+      try {
+        const data = await requestAntigravitySubscription(target.authIndex, target.cacheKey);
+        setSubscriptions((prev) => ({
+          ...prev,
+          [target.file.name]: data
+            ? { status: 'success', data }
+            : { status: 'error', error: t('antigravity_subscription.empty_data') },
+        }));
+      } catch (err: unknown) {
+        setSubscriptions((prev) => ({
+          ...prev,
+          [target.file.name]: {
+            status: 'error',
+            error: err instanceof Error ? err.message : t('common.unknown_error'),
+            errorStatus: getStatusFromError(err),
+          },
+        }));
+      }
+    },
+    [t]
+  );
+
+  const current = useMemo(() => {
+    const next: Record<string, AntigravitySubscriptionState> = {};
+    Object.entries(subscriptions).forEach(([fileName, state]) => {
+      next[fileName] = state;
     });
-    return current;
-  }, [subscriptions, targets]);
+    return next;
+  }, [subscriptions]);
+
+  return { subscriptions: current, refreshSubscription };
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -942,6 +942,8 @@
   "antigravity_subscription": {
     "subscription_label": "Subscription",
     "loading_short": "Loading plan",
+    "refresh_short": "Check plan",
+    "refresh_button": "Check Antigravity plan",
     "error_badge": "Plan unavailable",
     "load_failed": "Subscription failed: {{message}}",
     "missing_auth_index": "Auth file missing auth_index",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -938,6 +938,8 @@
   "antigravity_subscription": {
     "subscription_label": "Подписка",
     "loading_short": "Загрузка плана",
+    "refresh_short": "Проверить план",
+    "refresh_button": "Проверить план Antigravity",
     "error_badge": "План недоступен",
     "load_failed": "Не удалось получить подписку: {{message}}",
     "missing_auth_index": "В файле авторизации отсутствует auth_index",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -931,6 +931,8 @@
   "antigravity_subscription": {
     "subscription_label": "订阅",
     "loading_short": "加载套餐",
+    "refresh_short": "查询套餐",
+    "refresh_button": "查询 Antigravity 套餐",
     "error_badge": "套餐不可用",
     "load_failed": "订阅获取失败：{{message}}",
     "missing_auth_index": "认证文件缺少 auth_index",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -930,6 +930,8 @@
   "antigravity_subscription": {
     "subscription_label": "訂閱",
     "loading_short": "載入方案",
+    "refresh_short": "查詢方案",
+    "refresh_button": "查詢 Antigravity 方案",
     "error_badge": "方案不可用",
     "load_failed": "訂閱取得失敗：{{message}}",
     "missing_auth_index": "驗證檔案缺少 auth_index",


### PR DESCRIPTION
## Summary
Make Antigravity plan lookup an explicit per-file action instead of an automatic page-load request.
This avoids concurrent subscription requests when many Antigravity auth files are listed.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Replace automatic Antigravity subscription loading with a manual per-card "Check plan" action.
- Remove the inline subscription subtitle from auth file cards.
- Add localized button labels for supported locales.

## User Impact
Users now click "Check plan" before Antigravity plan badges are fetched. Opening the auth files page no longer triggers automatic plan requests.

## Compatibility / Runtime Notes
- CPA panel mode: avoids automatic Antigravity plan requests on page entry.
- Manager Server mode: frontend behavior only; no backend API changes.
- Full Docker / native packages: same frontend behavior change.

## Data / Security Notes
No auth file format or stored data changes. This reduces unnecessary credential-backed external requests.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the frontend commit to restore automatic plan loading.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run test
npm run lint
```

## Screenshots / Recordings
Not captured in this session; visible change is limited to the auth file card plan button/badge area.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A