### PR TITLE
feat(monitoring): show reasoning tokens in realtime usage

### DIFF
--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -202,7 +202,7 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('Elapsed');
     expect(markup).toContain('1.5 s');
     expect(markup).toContain('20');
-    expect(markup).toContain('I 10 · O 20 · C 5 · Create 1 · Read 4');
+    expect(markup).toContain('I 10 · O 20 · R 3 · C 5 · Create 1 · Read 4');
     expect(markup).toContain('role="tooltip"');
     expect(markup).toContain('aria-describedby=');
     expect(markup).toContain('aria-label="HTTP 429 · rate limit exceeded"');
@@ -212,7 +212,7 @@ describe('RealtimeEventsPanel', () => {
   });
 
   it('renders safe defaults when optional usage fields are missing', () => {
-    const markup = renderPanel(baseRow());
+    const markup = renderPanel(baseRow({ reasoningTokens: 0 }));
 
     expect(markup).toContain('<colgroup>');
     expect(markup.match(/<col\b/g)).toHaveLength(12);
@@ -224,6 +224,7 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain(expectedDate);
     expect(markup).toContain(expectedTime);
     expect(markup).toContain('I 10 · O 20 · C 5');
+    expect(markup).not.toContain('R 0');
     expect(markup).not.toContain('Read 0');
     expect(markup).not.toContain('Create 0');
     expect(markup).not.toContain('role="tooltip"');

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -221,8 +221,11 @@ const buildRealtimeTokenSummary = (row: MonitoringEventRow, t: TFunction) => {
   const parts = [
     `I ${formatCompactNumber(row.inputTokens)}`,
     `O ${formatCompactNumber(row.outputTokens)}`,
-    `C ${formatCompactNumber(row.cachedTokens)}`,
   ];
+  if (row.reasoningTokens > 0) {
+    parts.push(`R ${formatCompactNumber(row.reasoningTokens)}`);
+  }
+  parts.push(`C ${formatCompactNumber(row.cachedTokens)}`);
   if (row.cacheCreationTokens > 0) {
     parts.push(
       `${shortLabel(t, 'monitoring.cache_creation_tokens_short', 'monitoring.cache_creation_tokens', 'Create')} ${formatCompactNumber(row.cacheCreationTokens)}`


### PR DESCRIPTION
## Summary
Add compact reasoning token visibility to realtime request usage rows.
The usage breakdown now shows a short R segment only when reasoning tokens are non-zero, keeping ordinary rows compact.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Show non-zero reasoning tokens in realtime request usage summaries as `R {value}`.
- Keep zero reasoning token rows unchanged by omitting `R 0`.
- Update realtime events component coverage for the new compact token summary.

## User Impact
Users can see per-request reasoning token usage directly in the monitoring realtime list without opening another view.
Rows without reasoning usage keep the previous compact layout.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend display only; no runtime contract change.
- Manager Server mode: Uses existing `reasoning_tokens` data already returned by monitoring APIs.
- Full Docker / native packages: No packaging or configuration change.

## Data / Security Notes
N/A. This only displays an existing sanitized aggregate field and does not expose secrets or raw payloads.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the frontend component and test changes to remove the `R` segment from realtime usage rows.

## Verification
- [x] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/features/monitoring/components/RealtimeEventsPanel.test.tsx
npm run type-check
```

## Screenshots / Recordings
Not captured in this run. The change is a compact text addition covered by component markup tests.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A