### PR TITLE
fix(web): preserve omitted provider metadata fields

### DIFF
--- a/apps/web/src/services/api/providers.test.ts
+++ b/apps/web/src/services/api/providers.test.ts
@@ -217,4 +217,226 @@ describe('providersApi v1.16 provider fields', () => {
       },
     ]);
   });
+
+  it('preserves raw provider fields when section payloads omit them', async () => {
+    mocks.put.mockResolvedValue({});
+
+    mocks.get.mockResolvedValueOnce({
+      'gemini-api-key': [
+        {
+          'api-key': 'gemini-key',
+          'disable-cooling': true,
+          models: [{ name: 'gemini-model', image: true, thinking: { mode: 'auto' } }],
+        },
+      ],
+    });
+
+    await providersApi.saveGeminiKeys([
+      {
+        apiKey: 'gemini-key',
+        models: [{ name: 'gemini-model', alias: 'gemini-alias' }],
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenLastCalledWith('/gemini-api-key', [
+      {
+        'api-key': 'gemini-key',
+        'disable-cooling': true,
+        models: [
+          {
+            name: 'gemini-model',
+            alias: 'gemini-alias',
+            image: true,
+            thinking: { mode: 'auto' },
+          },
+        ],
+      },
+    ]);
+
+    mocks.get.mockResolvedValueOnce({
+      'codex-api-key': [
+        {
+          'auth-index': 'codex-auth',
+          'disable-cooling': true,
+          models: [{ name: 'codex-model', image: true, thinking: { budget_tokens: 2048 } }],
+        },
+      ],
+    });
+
+    await providersApi.saveCodexConfigs([
+      {
+        apiKey: '',
+        authIndex: 'codex-auth',
+        models: [{ name: 'codex-model', alias: 'codex-alias' }],
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenLastCalledWith('/codex-api-key', [
+      {
+        'auth-index': 'codex-auth',
+        'disable-cooling': true,
+        models: [
+          {
+            name: 'codex-model',
+            alias: 'codex-alias',
+            image: true,
+            thinking: { budget_tokens: 2048 },
+          },
+        ],
+      },
+    ]);
+
+    mocks.get.mockResolvedValueOnce({
+      'claude-api-key': [
+        {
+          'auth-index': 'claude-auth',
+          'disable-cooling': true,
+          'experimental-cch-signing': true,
+          cloak: { mode: 'auto', 'cache-user-id': true },
+          models: [{ name: 'claude-model', image: true, thinking: { enabled: true } }],
+        },
+      ],
+    });
+
+    await providersApi.saveClaudeConfigs([
+      {
+        apiKey: '',
+        authIndex: 'claude-auth',
+        cloak: { mode: 'always' },
+        models: [{ name: 'claude-model', alias: 'claude-alias' }],
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenLastCalledWith('/claude-api-key', [
+      {
+        'auth-index': 'claude-auth',
+        'disable-cooling': true,
+        'experimental-cch-signing': true,
+        cloak: { mode: 'always', 'cache-user-id': true },
+        models: [
+          {
+            name: 'claude-model',
+            alias: 'claude-alias',
+            image: true,
+            thinking: { enabled: true },
+          },
+        ],
+      },
+    ]);
+
+    mocks.get.mockResolvedValueOnce({
+      'openai-compatibility': [
+        {
+          name: 'openai-compatible',
+          'base-url': 'https://api.example.com/v1',
+          'api-key-entries': [],
+          'disable-cooling': true,
+          models: [{ name: 'openai-model', image: true, thinking: { effort: 'medium' } }],
+        },
+      ],
+    });
+
+    await providersApi.saveOpenAIProviders([
+      {
+        name: 'openai-compatible',
+        baseUrl: 'https://api.example.com/v1',
+        apiKeyEntries: [],
+        models: [{ name: 'openai-model', alias: 'openai-alias' }],
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenLastCalledWith('/openai-compatibility', [
+      {
+        name: 'openai-compatible',
+        'base-url': 'https://api.example.com/v1',
+        'api-key-entries': [],
+        'disable-cooling': true,
+        models: [
+          {
+            name: 'openai-model',
+            alias: 'openai-alias',
+            image: true,
+            thinking: { effort: 'medium' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('lets explicit false values override preserved raw booleans', async () => {
+    mocks.get.mockResolvedValueOnce({
+      'openai-compatibility': [
+        {
+          name: 'openai-compatible',
+          'base-url': 'https://api.example.com/v1',
+          'api-key-entries': [],
+          'disable-cooling': true,
+        },
+      ],
+    });
+    mocks.put.mockResolvedValue({});
+
+    await providersApi.saveOpenAIProviders([
+      {
+        name: 'openai-compatible',
+        baseUrl: 'https://api.example.com/v1',
+        apiKeyEntries: [],
+        disableCooling: false,
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenLastCalledWith('/openai-compatibility', [
+      {
+        name: 'openai-compatible',
+        'base-url': 'https://api.example.com/v1',
+        'api-key-entries': [],
+        'disable-cooling': false,
+      },
+    ]);
+  });
+
+  it('preserves model metadata by index when model names change', async () => {
+    mocks.get.mockResolvedValueOnce({
+      'openai-compatibility': [
+        {
+          name: 'openai-compatible',
+          'base-url': 'https://api.example.com/v1',
+          'api-key-entries': [],
+          models: [
+            {
+              name: 'old-model',
+              image: true,
+              thinking: { effort: 'high' },
+            },
+          ],
+        },
+      ],
+    });
+    mocks.put.mockResolvedValue({});
+
+    await providersApi.saveOpenAIProviders([
+      {
+        name: 'openai-compatible',
+        baseUrl: 'https://api.example.com/v1',
+        apiKeyEntries: [],
+        models: [{ name: 'new-model', alias: 'new-alias' }],
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenLastCalledWith('/openai-compatibility', [
+      {
+        name: 'openai-compatible',
+        'base-url': 'https://api.example.com/v1',
+        'api-key-entries': [],
+        models: [
+          {
+            name: 'new-model',
+            alias: 'new-alias',
+            image: true,
+            thinking: { effort: 'high' },
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/apps/web/src/services/api/providers.ts
+++ b/apps/web/src/services/api/providers.ts
@@ -185,6 +185,22 @@ const mergeKnownFields = (
   return next;
 };
 
+const hasDefinedField = (record: Record<string, unknown>, fields: readonly string[]) =>
+  fields.some((field) => record[field] !== undefined);
+
+const preserveOmittedRawField = (
+  raw: unknown,
+  payload: Record<string, unknown>,
+  next: Record<string, unknown>,
+  fields: readonly string[]
+) => {
+  if (!isRecord(raw) || hasDefinedField(payload, fields)) return;
+  const rawField = fields.find((field) => raw[field] !== undefined);
+  if (rawField) {
+    next[rawField] = raw[rawField];
+  }
+};
+
 const findRawRecord = (
   rawRecords: Array<Record<string, unknown> | undefined>,
   usedIndexes: Set<number>,
@@ -242,12 +258,22 @@ const getRawSectionList = (rawConfig: unknown, section: string) => {
 
 const mergeModelPayloads = (raw: unknown, models: unknown) =>
   Array.isArray(models)
-    ? mergeKnownRecordList(
-        isRecord(raw) ? raw.models : undefined,
-        models.filter(isRecord),
-        MODEL_ALIAS_FIELDS,
-        modelIdentity
-      )
+    ? (() => {
+        const payloadItems = models.filter(isRecord);
+        const rawItems = isRecord(raw) ? raw.models : undefined;
+        const rawRecords = Array.isArray(rawItems)
+          ? rawItems.map((item) => (isRecord(item) ? item : undefined))
+          : [];
+        const usedIndexes = new Set<number>();
+
+        return payloadItems.map((payload, index) => {
+          const rawModel = findRawRecord(rawRecords, usedIndexes, payload, index, modelIdentity);
+          const next = mergeKnownFields(rawModel, payload, MODEL_ALIAS_FIELDS);
+          preserveOmittedRawField(rawModel, payload, next, ['image']);
+          preserveOmittedRawField(rawModel, payload, next, ['thinking']);
+          return next;
+        });
+      })()
     : undefined;
 
 const mergeProviderKeyPayload = (
@@ -256,20 +282,30 @@ const mergeProviderKeyPayload = (
   knownFields: readonly string[]
 ) => {
   const next = mergeKnownFields(raw, payload, knownFields);
+  preserveOmittedRawField(raw, payload, next, DISABLE_COOLING_FIELDS);
+  preserveOmittedRawField(raw, payload, next, [
+    'experimental-cch-signing',
+    'experimentalCchSigning',
+    'experimental_cch_signing',
+  ]);
   const models = mergeModelPayloads(raw, payload.models);
   if (models) next.models = models;
   if (isRecord(payload.cloak)) {
-    next.cloak = mergeKnownFields(
-      isRecord(raw) ? raw.cloak : undefined,
-      payload.cloak,
-      CLOAK_FIELDS
-    );
+    const rawCloak = isRecord(raw) ? raw.cloak : undefined;
+    const cloak = mergeKnownFields(rawCloak, payload.cloak, CLOAK_FIELDS);
+    preserveOmittedRawField(rawCloak, payload.cloak, cloak, [
+      'cache-user-id',
+      'cacheUserId',
+      'cache_user_id',
+    ]);
+    next.cloak = cloak;
   }
   return next;
 };
 
 const mergeOpenAIProviderPayload = (raw: unknown, payload: Record<string, unknown>) => {
   const next = mergeKnownFields(raw, payload, OPENAI_PROVIDER_FIELDS);
+  preserveOmittedRawField(raw, payload, next, DISABLE_COOLING_FIELDS);
   const rawApiKeyEntries = isRecord(raw)
     ? (raw['api-key-entries'] ?? raw.apiKeyEntries)
     : undefined;


### PR DESCRIPTION
## Summary
Fix provider list saves so metadata omitted by section APIs is preserved from the raw config.
This prevents editing or batch-saving providers from removing hidden CPA provider fields.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Preserve omitted raw provider metadata for `disable-cooling`, Claude CCH signing, and cloak cache user IDs.
- Preserve model `image` and `thinking` metadata during provider list saves, including same-row model renames.
- Add regression tests for omitted metadata preservation and explicit false overrides.

## User Impact
Users can safely edit provider lists without losing hidden CPA metadata returned only by the raw config endpoint.

## Compatibility / Runtime Notes
- CPA panel mode: Preserves raw provider metadata when the CPA section endpoints omit fields.
- Manager Server mode: N/A, no Manager Server code changed.
- Full Docker / native packages: Same frontend behavior applies when using the embedded panel.

## Data / Security Notes
N/A. No secrets, SQLite data, auth files, logs, raw usage data, or plugin behavior changed.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this frontend commit to restore the previous provider serialization behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- providers.test.ts
npm run type-check
npm run lint
```

## Screenshots / Recordings
N/A. No visible UI change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #197
