### PR TITLE
fix(ai-providers): keep OpenAI key test status aligned

### DIFF
--- a/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.tsx
@@ -16,6 +16,10 @@ import { normalizeAuthIndex } from '@/utils/authIndex';
 import { areKeyValueEntriesEqual, areModelEntriesEqual } from '@/utils/compare';
 import { entriesToModels, modelsToEntries } from '@/components/ui/modelInputListUtils';
 import { buildApiKeyEntry, buildOpenAIChatCompletionsEndpoint } from '@/components/providers/utils';
+import {
+  appendIdleKeyTestStatus,
+  removeKeyTestStatusAtIndex,
+} from '@/features/aiProviders/model/keyTestStatuses';
 import type { ModelInfo } from '@/utils/models';
 import type { OpenAIFormState } from '@/components/providers';
 import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
@@ -689,9 +693,11 @@ export function OpenAIEditDrawer({
     const removeEntry = (idx: number) => {
       const next = list.filter((_, i) => i !== idx);
       setForm((prev) => ({ ...prev, apiKeyEntries: next.length ? next : [buildApiKeyEntry()] }));
+      setKeyTestStatuses((prev) => removeKeyTestStatusAtIndex(prev, idx, list.length));
     };
     const addEntry = () => {
       setForm((prev) => ({ ...prev, apiKeyEntries: [...list, buildApiKeyEntry()] }));
+      setKeyTestStatuses((prev) => appendIdleKeyTestStatus(prev, list.length));
     };
 
     return (

--- a/apps/web/src/features/aiProviders/AiProvidersOpenAIEditLayout.tsx
+++ b/apps/web/src/features/aiProviders/AiProvidersOpenAIEditLayout.tsx
@@ -44,6 +44,7 @@ export type OpenAIEditOutletContext = {
   setTestMessage: Dispatch<SetStateAction<string>>;
   keyTestStatuses: KeyTestStatus[];
   setDraftKeyTestStatus: (keyIndex: number, status: KeyTestStatus) => void;
+  setDraftKeyTestStatuses: (statuses: KeyTestStatus[]) => void;
   resetDraftKeyTestStatuses: (count: number) => void;
   availableModels: string[];
   handleBack: () => void;
@@ -185,6 +186,7 @@ export function AiProvidersOpenAIEditLayout() {
   const setDraftTestStatus = useOpenAIEditDraftStore((state) => state.setDraftTestStatus);
   const setDraftTestMessage = useOpenAIEditDraftStore((state) => state.setDraftTestMessage);
   const setDraftKeyTestStatus = useOpenAIEditDraftStore((state) => state.setDraftKeyTestStatus);
+  const setDraftKeyTestStatuses = useOpenAIEditDraftStore((state) => state.setDraftKeyTestStatuses);
   const resetDraftKeyTestStatuses = useOpenAIEditDraftStore(
     (state) => state.resetDraftKeyTestStatuses
   );
@@ -229,6 +231,13 @@ export function AiProvidersOpenAIEditLayout() {
       setDraftKeyTestStatus(draftKey, keyIndex, status);
     },
     [draftKey, setDraftKeyTestStatus]
+  );
+
+  const handleSetDraftKeyTestStatuses = useCallback(
+    (statuses: KeyTestStatus[]) => {
+      setDraftKeyTestStatuses(draftKey, statuses);
+    },
+    [draftKey, setDraftKeyTestStatuses]
   );
 
   const handleResetDraftKeyTestStatuses = useCallback(
@@ -571,6 +580,7 @@ export function AiProvidersOpenAIEditLayout() {
           setTestMessage,
           keyTestStatuses,
           setDraftKeyTestStatus: handleSetDraftKeyTestStatus,
+          setDraftKeyTestStatuses: handleSetDraftKeyTestStatuses,
           resetDraftKeyTestStatuses: handleResetDraftKeyTestStatuses,
           availableModels,
           handleBack,

--- a/apps/web/src/features/aiProviders/AiProvidersOpenAIEditPage.tsx
+++ b/apps/web/src/features/aiProviders/AiProvidersOpenAIEditPage.tsx
@@ -15,6 +15,10 @@ import type { ApiKeyEntry } from '@/types';
 import { normalizeAuthIndex } from '@/utils/authIndex';
 import { buildHeaderObject, hasHeader } from '@/utils/headers';
 import { buildApiKeyEntry, buildOpenAIChatCompletionsEndpoint } from '@/components/providers/utils';
+import {
+  appendIdleKeyTestStatus,
+  removeKeyTestStatusAtIndex,
+} from '@/features/aiProviders/model/keyTestStatuses';
 import type { OpenAIEditOutletContext } from './AiProvidersOpenAIEditLayout';
 import type { KeyTestStatus } from '@/stores/useOpenAIEditDraftStore';
 import styles from './AiProvidersPage.module.scss';
@@ -115,6 +119,7 @@ export function AiProvidersOpenAIEditPage() {
     setTestMessage,
     keyTestStatuses,
     setDraftKeyTestStatus,
+    setDraftKeyTestStatuses,
     resetDraftKeyTestStatuses,
     availableModels,
     handleBack,
@@ -385,19 +390,18 @@ export function AiProvidersOpenAIEditPage() {
 
     const removeEntry = (idx: number) => {
       const next = list.filter((_, i) => i !== idx);
-      const nextLength = next.length ? next.length : 1;
       setForm((prev) => ({
         ...prev,
         apiKeyEntries: next.length ? next : [buildApiKeyEntry()],
       }));
-      resetDraftKeyTestStatuses(nextLength);
+      setDraftKeyTestStatuses(removeKeyTestStatusAtIndex(keyTestStatuses, idx, list.length));
       setTestStatus('idle');
       setTestMessage('');
     };
 
     const addEntry = () => {
       setForm((prev) => ({ ...prev, apiKeyEntries: [...list, buildApiKeyEntry()] }));
-      resetDraftKeyTestStatuses(list.length + 1);
+      setDraftKeyTestStatuses(appendIdleKeyTestStatus(keyTestStatuses, list.length));
       setTestStatus('idle');
       setTestMessage('');
     };

--- a/apps/web/src/features/aiProviders/model/keyTestStatuses.test.ts
+++ b/apps/web/src/features/aiProviders/model/keyTestStatuses.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { appendIdleKeyTestStatus, removeKeyTestStatusAtIndex } from './keyTestStatuses';
+
+describe('OpenAI API key test statuses', () => {
+  it('keeps statuses attached to remaining keys after deletion', () => {
+    const statuses = [
+      { status: 'success', message: '' },
+      { status: 'error', message: 'invalid key' },
+      { status: 'success', message: 'still valid' },
+    ];
+
+    expect(removeKeyTestStatusAtIndex(statuses, 1, 3)).toEqual([
+      { status: 'success', message: '' },
+      { status: 'success', message: 'still valid' },
+    ]);
+  });
+
+  it('adds only an idle status for a new key', () => {
+    const statuses = [{ status: 'success', message: '' }];
+
+    expect(appendIdleKeyTestStatus(statuses, 1)).toEqual([
+      { status: 'success', message: '' },
+      { status: 'idle', message: '' },
+    ]);
+  });
+
+  it('fills missing statuses before aligning the list', () => {
+    expect(removeKeyTestStatusAtIndex([{ status: 'error', message: 'failed' }], 0, 3)).toEqual([
+      { status: 'idle', message: '' },
+      { status: 'idle', message: '' },
+    ]);
+  });
+});

--- a/apps/web/src/features/aiProviders/model/keyTestStatuses.ts
+++ b/apps/web/src/features/aiProviders/model/keyTestStatuses.ts
@@ -1,0 +1,27 @@
+export type ApiKeyTestStatus = {
+  status: string;
+  message: string;
+};
+
+const buildIdleStatus = <T extends ApiKeyTestStatus>(): T => ({ status: 'idle', message: '' }) as T;
+
+const normalizeStatusList = <T extends ApiKeyTestStatus>(
+  statuses: readonly T[],
+  count: number
+): T[] =>
+  Array.from({ length: Math.max(0, count) }, (_, index) => statuses[index] ?? buildIdleStatus<T>());
+
+export const removeKeyTestStatusAtIndex = <T extends ApiKeyTestStatus>(
+  statuses: readonly T[],
+  removedIndex: number,
+  sourceCount: number
+): T[] => {
+  const normalized = normalizeStatusList(statuses, sourceCount);
+  const next = normalized.filter((_, index) => index !== removedIndex);
+  return next.length ? next : [buildIdleStatus<T>()];
+};
+
+export const appendIdleKeyTestStatus = <T extends ApiKeyTestStatus>(
+  statuses: readonly T[],
+  sourceCount: number
+): T[] => [...normalizeStatusList(statuses, sourceCount), buildIdleStatus<T>()];

--- a/apps/web/src/stores/useOpenAIEditDraftStore.ts
+++ b/apps/web/src/stores/useOpenAIEditDraftStore.ts
@@ -59,6 +59,7 @@ interface OpenAIEditDraftState {
   setDraftTestStatus: (key: string, action: SetStateAction<OpenAITestStatus>) => void;
   setDraftTestMessage: (key: string, action: SetStateAction<string>) => void;
   setDraftKeyTestStatus: (draftKey: string, keyIndex: number, status: KeyTestStatus) => void;
+  setDraftKeyTestStatuses: (draftKey: string, statuses: KeyTestStatus[]) => void;
   resetDraftKeyTestStatuses: (draftKey: string, count: number) => void;
   clearDraft: (key: string) => void;
 }
@@ -218,6 +219,19 @@ export const useOpenAIEditDraftStore = create<OpenAIEditDraftState>((set, get) =
         drafts: {
           ...state.drafts,
           [draftKey]: { ...existing, initialized: true, keyTestStatuses: nextStatuses },
+        },
+      };
+    });
+  },
+
+  setDraftKeyTestStatuses: (draftKey, statuses) => {
+    if (!draftKey) return;
+    set((state) => {
+      const existing = state.drafts[draftKey] ?? buildEmptyDraft();
+      return {
+        drafts: {
+          ...state.drafts,
+          [draftKey]: { ...existing, initialized: true, keyTestStatuses: statuses },
         },
       };
     });


### PR DESCRIPTION
## Summary
Fix OpenAI compatibility API key test status alignment after adding or deleting key entries.
Statuses now stay attached to the same remaining key in both the route editor and legacy drawer editor.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add shared helpers for preserving and realigning per-key test statuses.
- Apply status realignment in route-based and drawer-based OpenAI provider editors.
- Add focused unit tests for deletion, insertion, and missing status normalization.

## User Impact
Users can delete unusable OpenAI-compatible API keys after batch checks without status icons shifting to the wrong remaining key.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only fix for OpenAI provider editing state.
- Manager Server mode: No backend behavior change.
- Full Docker / native packages: No packaging or runtime config change.

## Data / Security Notes
N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore previous per-key status reset behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run type-check
npm --workspace apps/web run lint
npm --workspace apps/web run test
```

## Screenshots / Recordings
N/A - status icon behavior only; no layout change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #220