### PR TITLE
feat: Add quota mask

### DIFF
--- a/apps/web/src/components/quota/QuotaCard.tsx
+++ b/apps/web/src/components/quota/QuotaCard.tsx
@@ -6,8 +6,13 @@ import { useTranslation } from 'react-i18next';
 import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
+import {
+  DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
+  type QuotaAccountDisplayMode,
+} from '@/features/quota/quotaPageUiState';
 import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
 import { TYPE_COLORS } from '@/utils/quota';
+import { resolveQuotaAccountDisplayText } from './quotaDisplay';
 import styles from '@/features/quota/QuotaPage.module.scss';
 
 type QuotaStatus = 'idle' | 'loading' | 'success' | 'error';
@@ -64,6 +69,7 @@ interface QuotaCardProps<TState extends QuotaStatusState> {
   cardIdleMessageKey?: string;
   cardClassName: string;
   defaultType: string;
+  accountDisplayMode?: QuotaAccountDisplayMode;
   canRefresh?: boolean;
   onRefresh?: () => void;
   canReset?: boolean;
@@ -82,6 +88,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   cardIdleMessageKey,
   cardClassName,
   defaultType,
+  accountDisplayMode = DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
   canRefresh = false,
   onRefresh,
   canReset = false,
@@ -110,6 +117,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   const idleMessageKey = onRefresh
     ? `${i18nPrefix}.idle`
     : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
+  const accountDisplay = resolveQuotaAccountDisplayText(item, accountDisplayMode);
 
   const getTypeLabel = (type: string): string => {
     const key = `auth_files.filter_${type}`;
@@ -174,7 +182,9 @@ export function QuotaCard<TState extends QuotaStatusState>({
         >
           {getTypeLabel(displayType)}
         </span>
-        <span className={styles.fileName}>{item.name}</span>
+        <span className={styles.fileName} title={accountDisplay.title}>
+          {accountDisplay.primary}
+        </span>
       </div>
 
       <div className={styles.quotaSection}>

--- a/apps/web/src/components/quota/QuotaSection.test.tsx
+++ b/apps/web/src/components/quota/QuotaSection.test.tsx
@@ -1,0 +1,221 @@
+import { act } from 'react';
+import { create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthFileItem } from '@/types';
+import type { QuotaConfig } from './quotaConfigs';
+import { QuotaSection } from './QuotaSection';
+
+type TestQuotaState = {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  windows: unknown[];
+  error?: string;
+  errorStatus?: number;
+  rateLimitResetCreditsAvailableCount?: number | null;
+};
+
+type TestQuotaData = {
+  resetCredits: number;
+};
+
+const { mocks } = vi.hoisted(() => {
+  const quotaStoreState: Record<string, unknown> = {
+    codexQuota: {},
+  };
+
+  quotaStoreState.setCodexQuota = vi.fn((updater: unknown) => {
+    const current = quotaStoreState.codexQuota as Record<string, unknown>;
+    quotaStoreState.codexQuota =
+      typeof updater === 'function' ? (updater as (prev: typeof current) => typeof current)(current) : updater;
+  });
+
+  return {
+    mocks: {
+      fetchQuota: vi.fn(),
+      quotaStoreState,
+      resetQuota: vi.fn(),
+      showConfirmation: vi.fn(),
+      showNotification: vi.fn(),
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key}:${JSON.stringify(options)}` : key,
+  }),
+}));
+
+vi.mock('@/hooks/useHeaderRefresh', () => ({
+  triggerHeaderRefresh: vi.fn(),
+}));
+
+vi.mock('@/stores', () => ({
+  useNotificationStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      showConfirmation: mocks.showConfirmation,
+      showNotification: mocks.showNotification,
+    }),
+  useQuotaStore: (selector: (state: unknown) => unknown) => selector(mocks.quotaStoreState),
+  useThemeStore: (selector: (state: unknown) => unknown) => selector({ resolvedTheme: 'light' }),
+}));
+
+const FULL_FILE_NAME = 'very-long-account-name@example.com.json';
+const MASKED_FILE_NAME = 'ver***@example.com.json';
+
+const testFile: AuthFileItem = {
+  name: FULL_FILE_NAME,
+  type: 'codex',
+};
+
+const successQuota: TestQuotaState = {
+  status: 'success',
+  windows: [],
+  rateLimitResetCreditsAvailableCount: 2,
+};
+
+const testConfig: QuotaConfig<TestQuotaState, TestQuotaData> = {
+  type: 'codex',
+  i18nPrefix: 'codex_quota',
+  filterFn: () => true,
+  fetchQuota: (file, t) => mocks.fetchQuota(file, t) as Promise<TestQuotaData>,
+  storeSelector: (state) => state.codexQuota,
+  storeSetter: 'setCodexQuota',
+  buildLoadingState: () => ({ status: 'loading', windows: [] }),
+  buildSuccessState: (data) => ({
+    status: 'success',
+    windows: [],
+    rateLimitResetCreditsAvailableCount: data.resetCredits,
+  }),
+  buildErrorState: (message, status) => ({
+    status: 'error',
+    windows: [],
+    error: message,
+    errorStatus: status,
+  }),
+  cardClassName: 'codex-card',
+  controlsClassName: 'codex-controls',
+  controlClassName: 'codex-control',
+  gridClassName: 'codex-grid',
+  resetQuota: (file, t) => mocks.resetQuota(file, t) as Promise<TestQuotaData>,
+  canResetQuota: (_file, quota) =>
+    quota?.status === 'success' && (quota.rateLimitResetCreditsAvailableCount ?? 0) > 0,
+  renderQuotaItems: () => <div>quota loaded</div>,
+};
+
+const getText = (node: ReactTestInstance): string =>
+  node.children
+    .map((child) => {
+      if (typeof child === 'string' || typeof child === 'number') return String(child);
+      return getText(child);
+    })
+    .join('');
+
+const renderSection = () => {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <QuotaSection
+        config={testConfig}
+        files={[testFile]}
+        loading={false}
+        disabled={false}
+        accountDisplayMode="masked"
+      />
+    );
+  });
+  return renderer;
+};
+
+const findButtonByText = (renderer: ReactTestRenderer, text: string) => {
+  const button = renderer.root.findAllByType('button').find((node) => getText(node).includes(text));
+  if (!button) throw new Error(`Button not found: ${text}`);
+  return button;
+};
+
+describe('QuotaSection account display mode', () => {
+  beforeEach(() => {
+    mocks.fetchQuota.mockReset();
+    mocks.resetQuota.mockReset();
+    mocks.showConfirmation.mockReset();
+    mocks.showNotification.mockReset();
+    mocks.quotaStoreState.codexQuota = {
+      [FULL_FILE_NAME]: successQuota,
+    };
+    (mocks.quotaStoreState.setCodexQuota as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('uses masked names in single quota refresh notifications', async () => {
+    mocks.fetchQuota.mockResolvedValue({ resetCredits: 1 });
+    const renderer = renderSection();
+
+    await act(async () => {
+      findButtonByText(renderer, 'codex_quota.refresh_button').props.onClick();
+      await Promise.resolve();
+    });
+
+    const message = String(mocks.showNotification.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain(MASKED_FILE_NAME);
+    expect(message).not.toContain(FULL_FILE_NAME);
+  });
+
+  it('uses masked names in failed single quota refresh notifications', async () => {
+    mocks.fetchQuota.mockRejectedValue(new Error('network failed'));
+    const renderer = renderSection();
+
+    await act(async () => {
+      findButtonByText(renderer, 'codex_quota.refresh_button').props.onClick();
+      await Promise.resolve();
+    });
+
+    const message = String(mocks.showNotification.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain(MASKED_FILE_NAME);
+    expect(message).not.toContain(FULL_FILE_NAME);
+  });
+
+  it('uses masked names in quota reset confirmation and success notification', async () => {
+    mocks.resetQuota.mockResolvedValue({ resetCredits: 1 });
+    const renderer = renderSection();
+
+    act(() => {
+      findButtonByText(renderer, 'codex_quota.reset_action_button').props.onClick();
+    });
+
+    const confirmation = mocks.showConfirmation.mock.calls[0]?.[0] as {
+      message: string;
+      onConfirm: () => Promise<void>;
+    };
+    expect(confirmation.message).toContain(MASKED_FILE_NAME);
+    expect(confirmation.message).not.toContain(FULL_FILE_NAME);
+
+    await act(async () => {
+      await confirmation.onConfirm();
+    });
+
+    const message = String(mocks.showNotification.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain(MASKED_FILE_NAME);
+    expect(message).not.toContain(FULL_FILE_NAME);
+  });
+
+  it('uses masked names in failed quota reset notifications', async () => {
+    mocks.resetQuota.mockRejectedValue(new Error('reset failed'));
+    const renderer = renderSection();
+
+    act(() => {
+      findButtonByText(renderer, 'codex_quota.reset_action_button').props.onClick();
+    });
+
+    const confirmation = mocks.showConfirmation.mock.calls[0]?.[0] as {
+      onConfirm: () => Promise<void>;
+    };
+
+    await act(async () => {
+      await confirmation.onConfirm();
+    });
+
+    const message = String(mocks.showNotification.mock.calls[0]?.[0] ?? '');
+    expect(message).toContain(MASKED_FILE_NAME);
+    expect(message).not.toContain(FULL_FILE_NAME);
+  });
+});

--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -15,6 +15,7 @@ import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
 import type { QuotaConfig, QuotaSortMode } from './quotaConfigs';
+import { resolveQuotaAccountDisplayText } from './quotaDisplay';
 import {
   DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
   type QuotaAccountDisplayMode,
@@ -168,6 +169,11 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     },
     [onAccountDisplayModeChange]
   );
+  const getAccountDisplayName = useCallback(
+    (file: AuthFileItem) =>
+      resolveQuotaAccountDisplayText(file, resolvedAccountDisplayMode).primary,
+    [resolvedAccountDisplayMode]
+  );
 
   const filteredFiles = useMemo(
     () => files.filter((file) => config.filterFn(file)),
@@ -316,6 +322,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     async (file: AuthFileItem) => {
       if (disabled || file.disabled) return;
       if (quota[file.name]?.status === 'loading') return;
+      const displayName = getAccountDisplayName(file);
 
       setQuota((prev) => ({
         ...prev,
@@ -328,7 +335,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
           ...prev,
           [file.name]: config.buildSuccessState(data),
         }));
-        showNotification(t('auth_files.quota_refresh_success', { name: file.name }), 'success');
+        showNotification(t('auth_files.quota_refresh_success', { name: displayName }), 'success');
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : t('common.unknown_error');
         const status = getStatusFromError(err);
@@ -337,12 +344,12 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
           [file.name]: config.buildErrorState(message, status),
         }));
         showNotification(
-          t('auth_files.quota_refresh_failed', { name: file.name, message }),
+          t('auth_files.quota_refresh_failed', { name: displayName, message }),
           'error'
         );
       }
     },
-    [config, disabled, quota, setQuota, showNotification, t]
+    [config, disabled, getAccountDisplayName, quota, setQuota, showNotification, t]
   );
 
   const resetQuotaForFile = useCallback(
@@ -356,11 +363,12 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
       const resetCount =
         (fileQuota as { rateLimitResetCreditsAvailableCount?: number | null } | undefined)
           ?.rateLimitResetCreditsAvailableCount ?? 0;
+      const displayName = getAccountDisplayName(file);
 
       showConfirmation({
         title: t(`${config.i18nPrefix}.reset_confirm_title`),
         message: t(`${config.i18nPrefix}.reset_confirm_message`, {
-          name: file.name,
+          name: displayName,
           count: resetCount,
         }),
         confirmText: t(`${config.i18nPrefix}.reset_button`, { count: resetCount }),
@@ -382,7 +390,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
               [file.name]: config.buildSuccessState(data),
             }));
             showNotification(
-              t(`${config.i18nPrefix}.reset_success`, { name: file.name }),
+              t(`${config.i18nPrefix}.reset_success`, { name: displayName }),
               'success'
             );
           } catch (err: unknown) {
@@ -393,14 +401,14 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
               [file.name]: config.buildErrorState(message, status),
             }));
             showNotification(
-              t(`${config.i18nPrefix}.reset_failed`, { name: file.name, message }),
+              t(`${config.i18nPrefix}.reset_failed`, { name: displayName, message }),
               'error'
             );
           }
         },
       });
     },
-    [config, disabled, quota, setQuota, showConfirmation, showNotification, t]
+    [config, disabled, getAccountDisplayName, quota, setQuota, showConfirmation, showNotification, t]
   );
 
   const titleNode = (

--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -15,9 +15,13 @@ import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
 import type { QuotaConfig, QuotaSortMode } from './quotaConfigs';
-import type { QuotaSectionViewMode } from '@/features/quota/quotaPageUiState';
+import {
+  DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
+  type QuotaAccountDisplayMode,
+  type QuotaSectionViewMode,
+} from '@/features/quota/quotaPageUiState';
 import { useGridColumns } from './useGridColumns';
-import { IconRefreshCw } from '@/components/ui/icons';
+import { IconEye, IconEyeOff, IconRefreshCw } from '@/components/ui/icons';
 import styles from '@/features/quota/QuotaPage.module.scss';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
@@ -111,6 +115,8 @@ interface QuotaSectionProps<TState extends QuotaStatusState, TData> {
   viewMode?: QuotaSectionViewMode;
   onViewModeChange?: (viewMode: QuotaSectionViewMode) => void;
   onReauthAccount?: (item: AuthFileItem) => void;
+  accountDisplayMode?: QuotaAccountDisplayMode;
+  onAccountDisplayModeChange?: (mode: QuotaAccountDisplayMode) => void;
 }
 
 export function QuotaSection<TState extends QuotaStatusState, TData>({
@@ -123,6 +129,8 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   viewMode,
   onViewModeChange,
   onReauthAccount,
+  accountDisplayMode,
+  onAccountDisplayModeChange,
 }: QuotaSectionProps<TState, TData>) {
   const { t } = useTranslation();
   const resolvedTheme: ResolvedTheme = useThemeStore((state) => state.resolvedTheme);
@@ -135,8 +143,11 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   /* Removed useRef */
   const [columns, gridRef] = useGridColumns(380); // Min card width 380px matches SCSS
   const [internalViewMode, setInternalViewMode] = useState<QuotaSectionViewMode>('paged');
+  const [internalAccountDisplayMode, setInternalAccountDisplayMode] =
+    useState<QuotaAccountDisplayMode>(DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE);
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
   const resolvedViewMode = viewMode ?? internalViewMode;
+  const resolvedAccountDisplayMode = accountDisplayMode ?? internalAccountDisplayMode;
   const setViewMode = useCallback(
     (nextViewMode: QuotaSectionViewMode) => {
       if (onViewModeChange) {
@@ -146,6 +157,16 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
       }
     },
     [onViewModeChange]
+  );
+  const setAccountDisplayMode = useCallback(
+    (nextMode: QuotaAccountDisplayMode) => {
+      if (onAccountDisplayModeChange) {
+        onAccountDisplayModeChange(nextMode);
+      } else {
+        setInternalAccountDisplayMode(nextMode);
+      }
+    },
+    [onAccountDisplayModeChange]
   );
 
   const filteredFiles = useMemo(
@@ -394,12 +415,41 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   );
 
   const isRefreshing = sectionLoading || loading;
+  const nextAccountDisplayMode: QuotaAccountDisplayMode =
+    resolvedAccountDisplayMode === 'masked' ? 'full' : 'masked';
+  const AccountDisplayIcon = resolvedAccountDisplayMode === 'masked' ? IconEyeOff : IconEye;
+  const accountDisplayHint = t(
+    resolvedAccountDisplayMode === 'masked'
+      ? 'quota_management.show_full_credentials_hint'
+      : 'quota_management.show_masked_credentials_hint'
+  );
 
   return (
     <Card
       title={titleNode}
       extra={
         <div className={styles.headerActions}>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className={[
+              styles.accountDisplayModeButton,
+              resolvedAccountDisplayMode === 'full' ? styles.accountDisplayModeButtonActive : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            onClick={() => setAccountDisplayMode(nextAccountDisplayMode)}
+            title={accountDisplayHint}
+            aria-label={accountDisplayHint}
+          >
+            <AccountDisplayIcon size={15} aria-hidden="true" />
+            {t(
+              resolvedAccountDisplayMode === 'masked'
+                ? 'quota_management.account_display_masked'
+                : 'quota_management.account_display_full'
+            )}
+          </Button>
           <div className={styles.viewModeToggle}>
             <Button
               variant="secondary"
@@ -486,6 +536,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                   cardIdleMessageKey={config.cardIdleMessageKey}
                   cardClassName={config.cardClassName}
                   defaultType={config.type}
+                  accountDisplayMode={resolvedAccountDisplayMode}
                   canRefresh={!disabled && !item.disabled}
                   onRefresh={() => void refreshQuotaForFile(item)}
                   canReset={canReset}

--- a/apps/web/src/components/quota/quotaDisplay.test.ts
+++ b/apps/web/src/components/quota/quotaDisplay.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { maskQuotaAccountText, resolveQuotaAccountDisplayText } from './quotaDisplay';
+
+describe('quotaDisplay', () => {
+  it('masks email-like credential names while preserving full titles', () => {
+    const display = resolveQuotaAccountDisplayText(
+      { name: 'very-long-account-name@example.com.json' },
+      'masked'
+    );
+
+    expect(display.primary).toBe('ver***@example.com.json');
+    expect(display.title).toBe('very-long-account-name@example.com.json');
+  });
+
+  it('shows full credential names when full display mode is selected', () => {
+    const display = resolveQuotaAccountDisplayText(
+      { name: 'very-long-account-name@example.com.json' },
+      'full'
+    );
+
+    expect(display.primary).toBe('very-long-account-name@example.com.json');
+    expect(display.title).toBe('very-long-account-name@example.com.json');
+  });
+
+  it('masks key-like credential names before applying generic filename masking', () => {
+    const masked = maskQuotaAccountText('sk-proj-secret-value-1234567890.json');
+
+    expect(masked).not.toContain('secret-value');
+    expect(masked).toMatch(/^sk\*+/);
+  });
+
+  it('falls back to compact masking for long non-email credential names', () => {
+    expect(maskQuotaAccountText('personal-codex-account.json')).toBe('per***ount.json');
+  });
+});

--- a/apps/web/src/components/quota/quotaDisplay.test.ts
+++ b/apps/web/src/components/quota/quotaDisplay.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { maskQuotaAccountText, resolveQuotaAccountDisplayText } from './quotaDisplay';
 
 describe('quotaDisplay', () => {
-  it('masks email-like credential names while preserving full titles', () => {
+  it('masks email-like credential names and title text in masked mode', () => {
     const display = resolveQuotaAccountDisplayText(
       { name: 'very-long-account-name@example.com.json' },
       'masked'
     );
 
     expect(display.primary).toBe('ver***@example.com.json');
-    expect(display.title).toBe('very-long-account-name@example.com.json');
+    expect(display.title).toBe('ver***@example.com.json');
+    expect(display.title).not.toContain('very-long-account-name');
   });
 
   it('shows full credential names when full display mode is selected', () => {

--- a/apps/web/src/components/quota/quotaDisplay.ts
+++ b/apps/web/src/components/quota/quotaDisplay.ts
@@ -1,0 +1,61 @@
+import type { QuotaAccountDisplayMode } from '@/features/quota/quotaPageUiState';
+import type { AuthFileItem } from '@/types';
+import { maskSensitiveText } from '@/utils/format';
+
+const EMAIL_TOKEN_REGEX = /[^\s/\\()[\]{}<>:;"',]+@[^\s/\\()[\]{}<>:;"',]+/g;
+
+const maskEmailLike = (value: string) => {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^([^@\s]{1,3})[^@\s]*@(.+)$/);
+  if (!match) return trimmed;
+  return `${match[1]}***@${match[2]}`;
+};
+
+const splitFileExtension = (value: string) => {
+  const slashIndex = Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
+  const dotIndex = value.lastIndexOf('.');
+
+  if (dotIndex <= slashIndex + 1 || dotIndex >= value.length - 1) {
+    return { base: value, suffix: '' };
+  }
+
+  return {
+    base: value.slice(0, dotIndex),
+    suffix: value.slice(dotIndex),
+  };
+};
+
+export const maskQuotaAccountText = (value: string) => {
+  const trimmed = String(value || '').trim();
+  if (!trimmed || trimmed === '-') return trimmed;
+
+  const maskedSensitiveText = maskSensitiveText(trimmed);
+  const maskedEmailText = maskedSensitiveText.replace(EMAIL_TOKEN_REGEX, (match) =>
+    maskEmailLike(match)
+  );
+
+  if (maskedEmailText !== trimmed) {
+    return maskedEmailText;
+  }
+
+  const { base, suffix } = splitFileExtension(maskedEmailText);
+  if (base.length <= 8) {
+    return maskedEmailText;
+  }
+
+  return `${base.slice(0, 3)}***${base.slice(-4)}${suffix}`;
+};
+
+export const resolveQuotaAccountDisplayText = (
+  item: Pick<AuthFileItem, 'name'>,
+  displayMode: QuotaAccountDisplayMode
+) => {
+  const full = String(item.name || '').trim();
+  const primary = displayMode === 'full' ? full : maskQuotaAccountText(full);
+
+  return {
+    primary: primary || full || '-',
+    full: full || '-',
+    title: full || primary || '-',
+  };
+};

--- a/apps/web/src/components/quota/quotaDisplay.ts
+++ b/apps/web/src/components/quota/quotaDisplay.ts
@@ -56,6 +56,6 @@ export const resolveQuotaAccountDisplayText = (
   return {
     primary: primary || full || '-',
     full: full || '-',
-    title: full || primary || '-',
+    title: displayMode === 'full' ? full || primary || '-' : primary || '-',
   };
 };

--- a/apps/web/src/features/quota/QuotaPage.module.scss
+++ b/apps/web/src/features/quota/QuotaPage.module.scss
@@ -276,11 +276,63 @@
   }
 }
 
+.accountDisplayModeButton:global(.btn.btn-sm) {
+  height: 34px;
+  min-height: 34px;
+  padding-inline: 12px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-primary) 82%, var(--surface-subtle));
+  border-color: color-mix(in srgb, var(--border-color) 86%, transparent);
+  color: color-mix(in srgb, var(--text-secondary) 84%, var(--text-primary));
+  box-shadow: none;
+
+  > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    white-space: nowrap;
+  }
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--primary-color) 8%, var(--surface-subtle));
+    border-color: color-mix(in srgb, var(--primary-color) 20%, var(--border-color));
+    color: var(--text-primary);
+  }
+
+  @include mobile {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
+.accountDisplayModeButtonActive:global(.btn.btn-sm) {
+  background: color-mix(in srgb, var(--primary-color) 12%, var(--bg-primary));
+  border-color: color-mix(in srgb, var(--primary-color) 26%, var(--border-color));
+  color: var(--primary-active);
+  font-weight: 800;
+
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--primary-color) 14%, var(--bg-primary));
+    border-color: color-mix(in srgb, var(--primary-color) 30%, var(--border-color));
+    color: var(--primary-active);
+  }
+}
+
 :global([data-theme='dark']) .viewModeToggle {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 :global([data-theme='dark']) .refreshAllButton:global(.btn.btn-sm) {
+  background: color-mix(in srgb, var(--primary-color) 18%, var(--surface-subtle));
+  border-color: color-mix(in srgb, var(--primary-color) 32%, var(--border-color));
+}
+
+:global([data-theme='dark']) .accountDisplayModeButton:global(.btn.btn-sm) {
+  background: color-mix(in srgb, var(--surface-subtle) 88%, transparent);
+  border-color: color-mix(in srgb, var(--border-color) 90%, transparent);
+}
+
+:global([data-theme='dark']) .accountDisplayModeButtonActive:global(.btn.btn-sm) {
   background: color-mix(in srgb, var(--primary-color) 18%, var(--surface-subtle));
   border-color: color-mix(in srgb, var(--primary-color) 32%, var(--border-color));
 }
@@ -749,10 +801,13 @@
 }
 
 .fileName {
+  min-width: 0;
   font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
-  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   line-height: 1.4;
 }
 

--- a/apps/web/src/features/quota/QuotaPage.tsx
+++ b/apps/web/src/features/quota/QuotaPage.tsx
@@ -26,10 +26,12 @@ import {
 import type { QuotaSortMode } from '@/components/quota/quotaConfigs';
 import type { AuthFileItem } from '@/types';
 import {
+  DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
   readQuotaPageUiState,
   writeQuotaPageUiState,
   type QuotaSectionType,
   type QuotaSectionViewMode,
+  type QuotaAccountDisplayMode,
 } from './quotaPageUiState';
 import styles from './QuotaPage.module.scss';
 
@@ -47,6 +49,9 @@ export function QuotaPage() {
     ...initialUiState.current.sectionViewModes,
   }));
   const [codexReauthTarget, setCodexReauthTarget] = useState<CodexReauthTarget | null>(null);
+  const [accountDisplayModes, setAccountDisplayModes] = useState(() => ({
+    ...initialUiState.current.accountDisplayModes,
+  }));
 
   const disableControls = connectionStatus !== 'connected';
   const sortOptions = useMemo(
@@ -98,8 +103,9 @@ export function QuotaPage() {
       searchQuery,
       sortMode,
       sectionViewModes,
+      accountDisplayModes,
     });
-  }, [searchQuery, sectionViewModes, sortMode]);
+  }, [accountDisplayModes, searchQuery, sectionViewModes, sortMode]);
 
   const getSectionViewMode = useCallback(
     (sectionType: QuotaSectionType): QuotaSectionViewMode =>
@@ -120,6 +126,22 @@ export function QuotaPage() {
   const handleCodexReauthSuccess = useCallback(async () => {
     await loadFiles();
   }, [loadFiles]);
+
+  const getAccountDisplayMode = useCallback(
+    (sectionType: QuotaSectionType): QuotaAccountDisplayMode =>
+      accountDisplayModes[sectionType] ?? DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
+    [accountDisplayModes]
+  );
+
+  const setAccountDisplayMode = useCallback(
+    (sectionType: QuotaSectionType, mode: QuotaAccountDisplayMode) => {
+      setAccountDisplayModes((current) => ({
+        ...current,
+        [sectionType]: mode,
+      }));
+    },
+    []
+  );
 
   return (
     <div className={styles.container}>
@@ -161,6 +183,8 @@ export function QuotaPage() {
         viewMode={getSectionViewMode(CODEX_CONFIG.type)}
         onViewModeChange={(viewMode) => setSectionViewMode(CODEX_CONFIG.type, viewMode)}
         onReauthAccount={(file) => setCodexReauthTarget(createCodexReauthTargetFromAuthFile(file))}
+        accountDisplayMode={getAccountDisplayMode(CODEX_CONFIG.type)}
+        onAccountDisplayModeChange={(mode) => setAccountDisplayMode(CODEX_CONFIG.type, mode)}
       />
       <QuotaSection
         config={CLAUDE_CONFIG}
@@ -171,6 +195,8 @@ export function QuotaPage() {
         sortMode={sortMode}
         viewMode={getSectionViewMode(CLAUDE_CONFIG.type)}
         onViewModeChange={(viewMode) => setSectionViewMode(CLAUDE_CONFIG.type, viewMode)}
+        accountDisplayMode={getAccountDisplayMode(CLAUDE_CONFIG.type)}
+        onAccountDisplayModeChange={(mode) => setAccountDisplayMode(CLAUDE_CONFIG.type, mode)}
       />
       <QuotaSection
         config={ANTIGRAVITY_CONFIG}
@@ -181,6 +207,10 @@ export function QuotaPage() {
         sortMode={sortMode}
         viewMode={getSectionViewMode(ANTIGRAVITY_CONFIG.type)}
         onViewModeChange={(viewMode) => setSectionViewMode(ANTIGRAVITY_CONFIG.type, viewMode)}
+        accountDisplayMode={getAccountDisplayMode(ANTIGRAVITY_CONFIG.type)}
+        onAccountDisplayModeChange={(mode) =>
+          setAccountDisplayMode(ANTIGRAVITY_CONFIG.type, mode)
+        }
       />
       <QuotaSection
         config={KIMI_CONFIG}
@@ -191,6 +221,8 @@ export function QuotaPage() {
         sortMode={sortMode}
         viewMode={getSectionViewMode(KIMI_CONFIG.type)}
         onViewModeChange={(viewMode) => setSectionViewMode(KIMI_CONFIG.type, viewMode)}
+        accountDisplayMode={getAccountDisplayMode(KIMI_CONFIG.type)}
+        onAccountDisplayModeChange={(mode) => setAccountDisplayMode(KIMI_CONFIG.type, mode)}
       />
       <QuotaSection
         config={XAI_CONFIG}
@@ -201,6 +233,8 @@ export function QuotaPage() {
         sortMode={sortMode}
         viewMode={getSectionViewMode(XAI_CONFIG.type)}
         onViewModeChange={(viewMode) => setSectionViewMode(XAI_CONFIG.type, viewMode)}
+        accountDisplayMode={getAccountDisplayMode(XAI_CONFIG.type)}
+        onAccountDisplayModeChange={(mode) => setAccountDisplayMode(XAI_CONFIG.type, mode)}
       />
 
       <CodexReauthDialog

--- a/apps/web/src/features/quota/quotaPageUiState.test.ts
+++ b/apps/web/src/features/quota/quotaPageUiState.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   QUOTA_PAGE_UI_STATE_STORAGE_KEY,
   getDefaultQuotaPageUiState,
+  normalizeQuotaAccountDisplayMode,
   normalizeQuotaPageUiState,
   normalizeQuotaSectionType,
   normalizeQuotaSectionViewMode,
@@ -56,6 +57,8 @@ describe('quotaPageUiState', () => {
     expect(normalizeQuotaSortMode('unknown')).toBe('default');
     expect(normalizeQuotaSectionViewMode('all')).toBe('all');
     expect(normalizeQuotaSectionViewMode('bad')).toBe('paged');
+    expect(normalizeQuotaAccountDisplayMode('full')).toBe('full');
+    expect(normalizeQuotaAccountDisplayMode('visible')).toBe('full');
     expect(normalizeQuotaSectionType('xai')).toBe('xai');
     expect(normalizeQuotaSectionType('bad')).toBeNull();
   });
@@ -71,6 +74,11 @@ describe('quotaPageUiState', () => {
           claude: 'bad',
           unknown: 'all',
         },
+        accountDisplayModes: {
+          codex: 'full',
+          claude: 'bad',
+          unknown: 'full',
+        },
       })
     ).toEqual({
       searchQuery: 'pro',
@@ -78,6 +86,10 @@ describe('quotaPageUiState', () => {
       sectionViewModes: {
         codex: 'all',
         claude: 'paged',
+      },
+      accountDisplayModes: {
+        codex: 'full',
+        claude: 'full',
       },
     });
   });
@@ -90,6 +102,10 @@ describe('quotaPageUiState', () => {
         codex: 'all',
         kimi: 'paged',
       },
+      accountDisplayModes: {
+        codex: 'full',
+        kimi: 'masked',
+      },
     });
 
     expect(JSON.parse(storage.getItem(QUOTA_PAGE_UI_STATE_STORAGE_KEY) ?? '{}')).toEqual({
@@ -99,6 +115,10 @@ describe('quotaPageUiState', () => {
         codex: 'all',
         kimi: 'paged',
       },
+      accountDisplayModes: {
+        codex: 'full',
+        kimi: 'masked',
+      },
     });
     expect(readQuotaPageUiState()).toEqual({
       searchQuery: 'plus',
@@ -106,6 +126,10 @@ describe('quotaPageUiState', () => {
       sectionViewModes: {
         codex: 'all',
         kimi: 'paged',
+      },
+      accountDisplayModes: {
+        codex: 'full',
+        kimi: 'masked',
       },
     });
   });

--- a/apps/web/src/features/quota/quotaPageUiState.ts
+++ b/apps/web/src/features/quota/quotaPageUiState.ts
@@ -7,14 +7,17 @@ export type QuotaSectionType =
   | 'kimi'
   | 'xai';
 export type QuotaSectionViewMode = 'paged' | 'all';
+export type QuotaAccountDisplayMode = 'masked' | 'full';
 
 export type QuotaPageUiState = {
   searchQuery: string;
   sortMode: QuotaSortMode;
   sectionViewModes: Partial<Record<QuotaSectionType, QuotaSectionViewMode>>;
+  accountDisplayModes: Partial<Record<QuotaSectionType, QuotaAccountDisplayMode>>;
 };
 
 export const QUOTA_PAGE_UI_STATE_STORAGE_KEY = 'quotaPage.uiState';
+export const DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE: QuotaAccountDisplayMode = 'full';
 
 const QUOTA_SORT_MODE_SET = new Set<QuotaSortMode>([
   'default',
@@ -29,11 +32,13 @@ const QUOTA_SECTION_TYPE_SET = new Set<QuotaSectionType>([
   'kimi',
   'xai',
 ]);
+const QUOTA_ACCOUNT_DISPLAY_MODE_SET = new Set<QuotaAccountDisplayMode>(['masked', 'full']);
 
 export const getDefaultQuotaPageUiState = (): QuotaPageUiState => ({
   searchQuery: '',
   sortMode: 'default',
   sectionViewModes: {},
+  accountDisplayModes: {},
 });
 
 export const normalizeQuotaSortMode = (value: unknown): QuotaSortMode =>
@@ -43,6 +48,12 @@ export const normalizeQuotaSortMode = (value: unknown): QuotaSortMode =>
 
 export const normalizeQuotaSectionViewMode = (value: unknown): QuotaSectionViewMode =>
   value === 'all' ? 'all' : 'paged';
+
+export const normalizeQuotaAccountDisplayMode = (value: unknown): QuotaAccountDisplayMode =>
+  typeof value === 'string' &&
+  QUOTA_ACCOUNT_DISPLAY_MODE_SET.has(value as QuotaAccountDisplayMode)
+    ? (value as QuotaAccountDisplayMode)
+    : DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE;
 
 export const normalizeQuotaSectionType = (value: unknown): QuotaSectionType | null =>
   typeof value === 'string' && QUOTA_SECTION_TYPE_SET.has(value as QuotaSectionType)
@@ -63,6 +74,20 @@ const normalizeSectionViewModes = (
   return result;
 };
 
+const normalizeAccountDisplayModes = (
+  value: unknown
+): Partial<Record<QuotaSectionType, QuotaAccountDisplayMode>> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  const result: Partial<Record<QuotaSectionType, QuotaAccountDisplayMode>> = {};
+  Object.entries(value as Record<string, unknown>).forEach(([key, mode]) => {
+    const sectionType = normalizeQuotaSectionType(key);
+    if (!sectionType) return;
+    result[sectionType] = normalizeQuotaAccountDisplayMode(mode);
+  });
+  return result;
+};
+
 export const normalizeQuotaPageUiState = (value: unknown): QuotaPageUiState => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return getDefaultQuotaPageUiState();
@@ -73,6 +98,7 @@ export const normalizeQuotaPageUiState = (value: unknown): QuotaPageUiState => {
     searchQuery: typeof record.searchQuery === 'string' ? record.searchQuery : '',
     sortMode: normalizeQuotaSortMode(record.sortMode),
     sectionViewModes: normalizeSectionViewModes(record.sectionViewModes),
+    accountDisplayModes: normalizeAccountDisplayModes(record.accountDisplayModes),
   };
 };
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2876,7 +2876,11 @@
     "sort_default": "Default order",
     "sort_name_asc": "Name A-Z",
     "sort_plan_desc": "Plan high to low",
-    "sort_plan_asc": "Plan low to high"
+    "sort_plan_asc": "Plan low to high",
+    "account_display_masked": "Masked",
+    "account_display_full": "Full",
+    "show_full_credentials_hint": "Show full credential identifiers",
+    "show_masked_credentials_hint": "Show masked credential identifiers"
   },
   "codex_reauth": {
     "title": "Codex Re-login",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -2872,7 +2872,11 @@
     "sort_default": "По умолчанию",
     "sort_name_asc": "Имя A-Z",
     "sort_plan_desc": "План от высокого",
-    "sort_plan_asc": "План от низкого"
+    "sort_plan_asc": "План от низкого",
+    "account_display_masked": "Скрыто",
+    "account_display_full": "Полностью",
+    "show_full_credentials_hint": "Показать полные идентификаторы учётных данных",
+    "show_masked_credentials_hint": "Показать скрытые идентификаторы учётных данных"
   },
   "codex_reauth": {
     "title": "Повторный вход Codex",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -2822,7 +2822,11 @@
     "sort_default": "默认顺序",
     "sort_name_asc": "名称 A-Z",
     "sort_plan_desc": "套餐高到低",
-    "sort_plan_asc": "套餐低到高"
+    "sort_plan_asc": "套餐低到高",
+    "account_display_masked": "脱敏",
+    "account_display_full": "完整",
+    "show_full_credentials_hint": "显示完整凭证标识",
+    "show_masked_credentials_hint": "显示脱敏凭证标识"
   },
   "codex_reauth": {
     "title": "Codex 重新登录",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -2847,7 +2847,11 @@
     "sort_default": "預設順序",
     "sort_name_asc": "名稱 A-Z",
     "sort_plan_desc": "方案高到低",
-    "sort_plan_asc": "方案低到高"
+    "sort_plan_asc": "方案低到高",
+    "account_display_masked": "脫敏",
+    "account_display_full": "完整",
+    "show_full_credentials_hint": "顯示完整憑證標識",
+    "show_masked_credentials_hint": "顯示脫敏憑證標識"
   },
   "codex_reauth": {
     "title": "Codex 重新登入",


### PR DESCRIPTION
## Summary
为 配额管理 界面添加脱敏按钮

## Scope
<!-- Check all areas touched by this PR. -->
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
<!-- List concrete changes, not implementation trivia. -->
- 开启额度脱敏后，所有邮箱采用请求监控中一致的逻辑被脱敏
- 开启额度脱敏后，刷新额度与重置额度时的提示消息也会被脱敏
-

## User Impact

用户可自由选择是否对信息脱敏，方便分享


## Compatibility / Runtime Notes
<!-- Mention mode-specific behavior, config changes, queue behavior, or N/A. -->
N/A

## Data / Security Notes
<!-- Required for SQLite, admin key, CPA Management Key, auth files, logs, raw usage data, or plugins. Use N/A if not relevant. -->
N/A

## Risk / Rollback
Risk level: Low / Medium / High
Low

Rollback notes:
-

## Verification
<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

## Screenshots / Recordings
<!-- Required for visible UI changes. Use N/A for backend/docs-only changes. -->

<img width="381" height="114" alt="image" src="https://github.com/user-attachments/assets/0203dfa0-e57f-45cd-8c4a-e9677a199741" />

<img width="236" height="140" alt="image" src="https://github.com/user-attachments/assets/72875b05-1103-4fcc-aa07-437c9d31504d" />


## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

#191 #193
