### PR TITLE
fix(monitoring): prevent realtime failure tooltip overflow

### DIFF
--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next';
 import { describe, expect, it, vi } from 'vitest';
 import type { AccountDisplayMode } from '@/features/monitoring/accountOverviewState';
 import type { MonitoringEventRow } from '@/features/monitoring/hooks/useMonitoringData';
+import styles from '../MonitoringCenterPage.module.scss';
 import { RealtimeEventsPanel } from './RealtimeEventsPanel';
 
 const t = ((key: string, options?: Record<string, unknown>) => {
@@ -204,6 +205,8 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('20');
     expect(markup).toContain('I 10 · O 20 · R 3 · C 5 · Create 1 · Read 4');
     expect(markup).toContain('role="tooltip"');
+    expect(markup).toContain(styles.realtimeFailureTooltip);
+    expect(markup).toContain(styles.realtimeFailureTooltipBelow);
     expect(markup).toContain('aria-describedby=');
     expect(markup).toContain('aria-label="HTTP 429 · rate limit exceeded"');
     expect(markup).toContain('aria-label="Copy"');

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -1,4 +1,15 @@
-import { useId, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FocusEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { createPortal } from 'react-dom';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
 import { IconCopy, IconEye, IconEyeOff, IconFilter } from '@/components/ui/icons';
@@ -67,6 +78,18 @@ export type RealtimeEventsPanelActionsProps = {
 };
 
 const REALTIME_PAGE_SIZE_OPTIONS = [10, 50, 100, 150, 300] as const;
+const FAILURE_TOOLTIP_VIEWPORT_MARGIN = 12;
+const FAILURE_TOOLTIP_OFFSET = 8;
+const FAILURE_TOOLTIP_MAX_WIDTH = 420;
+const FAILURE_TOOLTIP_MAX_HEIGHT = 240;
+const FAILURE_TOOLTIP_CLOSE_DELAY_MS = 120;
+
+type FailureTooltipPlacement = 'above' | 'below';
+
+type FailureTooltipPosition = {
+  placement: FailureTooltipPlacement;
+  style: CSSProperties;
+};
 
 const formatOptionalText = (value: string | null | undefined) => {
   const trimmed = String(value || '').trim();
@@ -92,6 +115,60 @@ const shortLabel = (
 const formatShortHash = (value: string | null | undefined) => {
   const trimmed = formatReadableText(value);
   return trimmed ? `#${trimmed.slice(0, 8)}` : '';
+};
+
+const clampNumber = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const resolveFailureTooltipPosition = (anchor: HTMLElement): FailureTooltipPosition | null => {
+  if (typeof window === 'undefined') return null;
+
+  const rect = anchor.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const maxWidth = Math.max(
+    220,
+    Math.min(
+      FAILURE_TOOLTIP_MAX_WIDTH,
+      Math.max(0, viewportWidth - FAILURE_TOOLTIP_VIEWPORT_MARGIN * 2)
+    )
+  );
+  const left = clampNumber(
+    rect.left,
+    FAILURE_TOOLTIP_VIEWPORT_MARGIN,
+    Math.max(
+      FAILURE_TOOLTIP_VIEWPORT_MARGIN,
+      viewportWidth - maxWidth - FAILURE_TOOLTIP_VIEWPORT_MARGIN
+    )
+  );
+  const spaceBelow =
+    viewportHeight - rect.bottom - FAILURE_TOOLTIP_VIEWPORT_MARGIN - FAILURE_TOOLTIP_OFFSET;
+  const spaceAbove = rect.top - FAILURE_TOOLTIP_VIEWPORT_MARGIN - FAILURE_TOOLTIP_OFFSET;
+  const placement: FailureTooltipPlacement =
+    spaceBelow >= FAILURE_TOOLTIP_MAX_HEIGHT || spaceBelow >= spaceAbove ? 'below' : 'above';
+  const availableHeight = Math.max(0, placement === 'below' ? spaceBelow : spaceAbove);
+  const maxHeight = Math.min(FAILURE_TOOLTIP_MAX_HEIGHT, availableHeight);
+  const baseStyle: CSSProperties = {
+    left,
+    maxHeight,
+    maxWidth,
+  };
+
+  return placement === 'below'
+    ? {
+        placement,
+        style: {
+          ...baseStyle,
+          top: rect.bottom + FAILURE_TOOLTIP_OFFSET,
+        },
+      }
+    : {
+        placement,
+        style: {
+          ...baseStyle,
+          bottom: viewportHeight - rect.top + FAILURE_TOOLTIP_OFFSET,
+        },
+      };
 };
 
 const buildRealtimeApiKeyDisplay = (row: MonitoringEventRow, t: TFunction) => {
@@ -216,6 +293,179 @@ const buildFailureDetails = (row: MonitoringEventRow, t: TFunction) => {
     copyText: [statusText, summary].filter(Boolean).join('\n'),
   };
 };
+
+type RealtimeFailureDetails = NonNullable<ReturnType<typeof buildFailureDetails>>;
+
+type RealtimeFailureStatusProps = {
+  details: RealtimeFailureDetails;
+  tooltipId: string;
+  t: TFunction;
+  onCopy: (text: string) => void;
+};
+
+const isNodeInside = (element: HTMLElement | null, target: EventTarget | null) => {
+  if (!element || typeof Node === 'undefined' || !(target instanceof Node)) return false;
+  return element.contains(target);
+};
+
+function RealtimeFailureStatus({ details, tooltipId, t, onCopy }: RealtimeFailureStatusProps) {
+  const triggerRef = useRef<HTMLSpanElement | null>(null);
+  const tooltipRef = useRef<HTMLSpanElement | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const [open, setOpen] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState<FailureTooltipPosition | null>(null);
+  const isBrowser = typeof document !== 'undefined';
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current === null || typeof window === 'undefined') return;
+    window.clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = null;
+  }, []);
+
+  const updateTooltipPosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const nextPosition = resolveFailureTooltipPosition(triggerRef.current);
+    if (nextPosition) {
+      setTooltipPosition(nextPosition);
+    }
+  }, []);
+
+  const scheduleTooltipPositionUpdate = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (rafRef.current !== null) {
+      window.cancelAnimationFrame(rafRef.current);
+    }
+    rafRef.current = window.requestAnimationFrame(() => {
+      rafRef.current = null;
+      updateTooltipPosition();
+    });
+  }, [updateTooltipPosition]);
+
+  const showTooltip = useCallback(() => {
+    clearCloseTimer();
+    updateTooltipPosition();
+    setOpen(true);
+  }, [clearCloseTimer, updateTooltipPosition]);
+
+  const requestHideTooltip = useCallback(() => {
+    clearCloseTimer();
+    if (typeof window === 'undefined') {
+      setOpen(false);
+      return;
+    }
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null;
+      setOpen(false);
+    }, FAILURE_TOOLTIP_CLOSE_DELAY_MS);
+  }, [clearCloseTimer]);
+
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (
+        isNodeInside(triggerRef.current, nextTarget) ||
+        isNodeInside(tooltipRef.current, nextTarget)
+      ) {
+        return;
+      }
+      requestHideTooltip();
+    },
+    [requestHideTooltip]
+  );
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearCloseTimer();
+      if (rafRef.current !== null && typeof window !== 'undefined') {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [clearCloseTimer]);
+
+  useEffect(() => {
+    if (!open || typeof window === 'undefined') return undefined;
+
+    scheduleTooltipPositionUpdate();
+    window.addEventListener('resize', scheduleTooltipPositionUpdate);
+    window.addEventListener('scroll', scheduleTooltipPositionUpdate, true);
+
+    return () => {
+      window.removeEventListener('resize', scheduleTooltipPositionUpdate);
+      window.removeEventListener('scroll', scheduleTooltipPositionUpdate, true);
+    };
+  }, [open, scheduleTooltipPositionUpdate]);
+
+  const placement = tooltipPosition?.placement ?? 'below';
+  const tooltipClassName = [
+    styles.realtimeFailureTooltip,
+    placement === 'above' ? styles.realtimeFailureTooltipAbove : styles.realtimeFailureTooltipBelow,
+    open ? styles.realtimeFailureTooltipOpen : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const tooltip = (
+    <span
+      id={tooltipId}
+      ref={tooltipRef}
+      role="tooltip"
+      className={tooltipClassName}
+      style={isBrowser ? tooltipPosition?.style : undefined}
+      onMouseEnter={clearCloseTimer}
+      onMouseLeave={requestHideTooltip}
+      onFocus={showTooltip}
+      onBlur={handleBlur}
+    >
+      <button
+        type="button"
+        className={styles.realtimeFailureCopyButton}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onCopy(details.copyText);
+        }}
+        title={t('common.copy')}
+        aria-label={t('common.copy')}
+      >
+        <IconCopy size={13} />
+      </button>
+      {details.statusCode ? (
+        <span className={styles.realtimeFailureTooltipStatus}>{details.statusText}</span>
+      ) : null}
+      {details.summary ? (
+        <span className={styles.realtimeFailureTooltipBody}>{details.summary}</span>
+      ) : null}
+    </span>
+  );
+
+  return (
+    <span
+      ref={triggerRef}
+      className={styles.realtimeFailureStatus}
+      tabIndex={0}
+      aria-describedby={tooltipId}
+      aria-label={details.label}
+      onMouseEnter={showTooltip}
+      onMouseLeave={requestHideTooltip}
+      onFocus={showTooltip}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+    >
+      <span className={`${styles.realtimeRequestStatus} ${styles.realtimeRequestStatusBad}`}>
+        {t('monitoring.result_failed')}
+      </span>
+      {!isBrowser ? tooltip : null}
+      {isBrowser && open ? createPortal(tooltip, document.body) : null}
+    </span>
+  );
+}
 
 const buildRealtimeTokenSummary = (row: MonitoringEventRow, t: TFunction) => {
   const parts = [
@@ -502,47 +752,12 @@ export function RealtimeEventsPanel({
                   <td>
                     <div className={styles.primaryCell}>
                       {failureDetails ? (
-                        <span
-                          className={styles.realtimeFailureStatus}
-                          tabIndex={0}
-                          aria-describedby={failureTooltipId}
-                          aria-label={failureDetails.label}
-                        >
-                          <span
-                            className={`${styles.realtimeRequestStatus} ${styles.realtimeRequestStatusBad}`}
-                          >
-                            {t('monitoring.result_failed')}
-                          </span>
-                          <span
-                            id={failureTooltipId}
-                            role="tooltip"
-                            className={styles.realtimeFailureTooltip}
-                          >
-                            <button
-                              type="button"
-                              className={styles.realtimeFailureCopyButton}
-                              onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                void handleCopyFailureDetails(failureDetails.copyText);
-                              }}
-                              title={t('common.copy')}
-                              aria-label={t('common.copy')}
-                            >
-                              <IconCopy size={13} />
-                            </button>
-                            {failureDetails.statusCode ? (
-                              <span className={styles.realtimeFailureTooltipStatus}>
-                                {failureDetails.statusText}
-                              </span>
-                            ) : null}
-                            {failureDetails.summary ? (
-                              <span className={styles.realtimeFailureTooltipBody}>
-                                {failureDetails.summary}
-                              </span>
-                            ) : null}
-                          </span>
-                        </span>
+                        <RealtimeFailureStatus
+                          details={failureDetails}
+                          tooltipId={failureTooltipId ?? `${tooltipIdPrefix}-failure-tooltip`}
+                          t={t}
+                          onCopy={handleCopyFailureDetails}
+                        />
                       ) : (
                         <span
                           className={[

--- a/apps/web/src/features/monitoring/styles/_monitoring-summary-table.scss
+++ b/apps/web/src/features/monitoring/styles/_monitoring-summary-table.scss
@@ -1101,16 +1101,6 @@
     outline: none;
   }
 
-  .realtimeFailureStatus::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 100%;
-    z-index: 19;
-    width: min(420px, calc(100vw - 48px));
-    height: 10px;
-  }
-
   .realtimeFailureStatus:focus-visible .realtimeRequestStatus {
     text-decoration: underline;
     text-underline-offset: 3px;
@@ -1145,10 +1135,18 @@
   }
 
   .realtimeFailureTooltip {
-    position: absolute;
-    left: 0;
-    top: calc(100% + 4px);
-    z-index: 20;
+    --monitor-surface: var(--bg-primary);
+    --monitor-surface-elevated: color-mix(in srgb, var(--bg-primary) 82%, var(--surface-subtle));
+    --monitor-surface-hover: color-mix(in srgb, var(--surface-subtle-hover) 74%, var(--bg-primary));
+    --monitor-ink: var(--text-primary);
+    --monitor-muted: var(--text-secondary);
+    --monitor-line: var(--border-color);
+    --monitor-accent: var(--primary-color);
+    --monitor-accent-strong: var(--primary-active);
+    --monitor-red: var(--error-color);
+
+    position: fixed;
+    z-index: 2030;
     display: grid;
     gap: 8px;
     width: max-content;
@@ -1171,6 +1169,7 @@
     transition:
       opacity 0.12s ease,
       transform 0.12s ease;
+    visibility: hidden;
     white-space: normal;
     user-select: text;
   }
@@ -1182,18 +1181,29 @@
     top: -5px;
     width: 8px;
     height: 8px;
-    border-left: 1px solid color-mix(in srgb, var(--monitor-red) 26%, var(--monitor-line));
-    border-top: 1px solid color-mix(in srgb, var(--monitor-red) 26%, var(--monitor-line));
     background: var(--monitor-surface-elevated);
     transform: rotate(45deg);
   }
 
-  .realtimeFailureStatus:hover .realtimeFailureTooltip,
-  .realtimeFailureStatus:focus-visible .realtimeFailureTooltip,
-  .realtimeFailureStatus:focus-within .realtimeFailureTooltip {
+  .realtimeFailureTooltipBelow::before {
+    top: -5px;
+    bottom: auto;
+    border-left: 1px solid color-mix(in srgb, var(--monitor-red) 26%, var(--monitor-line));
+    border-top: 1px solid color-mix(in srgb, var(--monitor-red) 26%, var(--monitor-line));
+  }
+
+  .realtimeFailureTooltipAbove::before {
+    top: auto;
+    bottom: -5px;
+    border-right: 1px solid color-mix(in srgb, var(--monitor-red) 26%, var(--monitor-line));
+    border-bottom: 1px solid color-mix(in srgb, var(--monitor-red) 26%, var(--monitor-line));
+  }
+
+  .realtimeFailureTooltipOpen {
     opacity: 1;
     pointer-events: auto;
     transform: translateY(0);
+    visibility: visible;
   }
 
   .realtimeFailureCopyButton {


### PR DESCRIPTION
## Summary
Fix the realtime monitoring failure detail tooltip so it no longer gets clipped by the horizontally scrollable table.
The tooltip now renders through a body-level portal and positions against viewport bounds.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Render realtime failure details through a body-level portal.
- Position the failure tooltip against the viewport and flip it when needed.
- Cover the tooltip class structure in the realtime panel test.

## User Impact
Users viewing one or a few failed realtime monitoring rows no longer see clipped failure details or an internal table scrollbar.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only display change; no runtime contract changes.
- Manager Server mode: Frontend-only display change; monitoring API data is unchanged.
- Full Docker / native packages: Frontend-only display change; packaging/runtime behavior is unchanged.

## Data / Security Notes
N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore the previous inline tooltip behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/features/monitoring/components/RealtimeEventsPanel.test.tsx
npm run type-check
npm run lint
```

## Screenshots / Recordings
N/A - no local browser screenshot was captured in this session.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A