### PR TITLE
ci(github): handle CRLF PR template bodies

### DIFF
--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -32,6 +32,7 @@ jobs:
           set -euo pipefail
 
           body="${PR_BODY:-}"
+          body="${body//$'\r'/}"
           required_headers=(
             "## Summary"
             "## Scope"


### PR DESCRIPTION
## Summary
Normalize PR body line endings before validating the pull request template.
This fixes false PR Template failures when GitHub event payloads contain CRLF line endings.

## Scope
<!-- Check all areas touched by this PR. -->
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes
<!-- List concrete changes, not implementation trivia. -->
- Remove carriage-return characters from `PR_BODY` before header and Scope checks.
- Keep the existing required-section and checked-Scope validation unchanged.
- Fix CRLF PR descriptions that already contain a valid checked Scope item.

## User Impact
<!-- What users will notice. Use "No user-facing behavior change" if applicable. -->
No user-facing behavior change.

## Compatibility / Runtime Notes
<!-- Mention mode-specific behavior, config changes, queue behavior, or N/A. -->
- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: N/A

## Data / Security Notes
<!-- Required for SQLite, admin key, CPA Management Key, auth files, logs, raw usage data, or plugins. Use N/A if not relevant. -->
N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this workflow-only change to restore the previous PR body validation behavior.

## Verification
<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
CRLF PR body fixture passes the same Scope checkbox grep after normalization.
```

## Screenshots / Recordings
<!-- Required for visible UI changes. Use N/A for backend/docs-only changes. -->
N/A

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
<!-- Closes #123 / Fixes #123 / Refs #123 / N/A -->
Refs #225
