### PR TITLE
Release v1.8.1

### DIFF
--- a/docs/release-notes/v1.8.1-en.md
+++ b/docs/release-notes/v1.8.1-en.md
@@ -1,0 +1,51 @@
+# CPA Manager Plus v1.8.1
+
+> 12 commits · 38 files changed · +1651 / -336
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.8.1/docs/release-notes/v1.8.1-zh.md)
+
+## Overview
+
+This release improves quota, realtime monitoring, and authentication-file workflows: quota account and notification masking make sensitive account data safer for screenshots and sharing; realtime monitoring now shows reasoning tokens and keeps long failure tooltips inside the layout; OpenAI provider editing, Antigravity subscriptions, and reauth inspection results also receive more stable state handling.
+
+## Highlights
+
+### Features
+
+- Add quota account masking and page-level mask state controls so account identifiers can be hidden during screenshots or demos (`web/quota`).
+- Add quota notification masking so quota-section notifications follow the current privacy display mode (`web/quota`).
+- Add explicit deletion for reauth inspection results so stale inspection records can be cleared from the monitoring view (`web/monitoring`).
+- Show reasoning tokens in realtime monitoring events to complete the token and cost breakdown for model calls (`web/monitoring`).
+
+### Fixes
+
+- Prevent long realtime monitoring failure tooltips from overflowing the interface (`web/monitoring`).
+- Fix quota tooltips leaking masked content (`web/quota`).
+- Keep OpenAI key test status aligned with the edit draft state (`web/ai-providers`).
+- Preserve omitted provider metadata fields when updating provider payloads (`web/providers`).
+- Make Antigravity plan lookup manual to avoid unnecessary automatic requests from the auth files page (`web/authFiles`).
+
+### Docs
+
+- Align README and Chinese README preview screenshot captions, and refresh the home screenshots (`docs`, `img`).
+
+### CI
+
+- Split the PR template check workflow so PR body edits rerun validation and CRLF template bodies are handled correctly (`ci/github`).
+
+### Tests
+
+- Add coverage for quota masking, provider metadata preservation, OpenAI key test status, reauth inspection results, and realtime monitoring tooltip layout (`web`).
+
+## Upgrade Notes
+
+- This release is primarily frontend experience and state-handling work; no database or configuration migration is required.
+- The new quota masking controls can change how quota pages appear in privacy mode; verify mask state before using screenshots for docs or support.
+
+## Acknowledgements
+
+- [@Zxis233](https://github.com/Zxis233) - Contributed quota account masking, notification masking, and the tooltip leakage fix.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.8.0...v1.8.1

--- a/docs/release-notes/v1.8.1-zh.md
+++ b/docs/release-notes/v1.8.1-zh.md
@@ -1,0 +1,51 @@
+# CPA Manager Plus v1.8.1
+
+> 12 commits · 38 files changed · +1651 / -336
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.8.1/docs/release-notes/v1.8.1-en.md)
+
+## Overview
+
+本次发布改善 quota、实时监控与认证文件体验:新增 quota 账号与通知遮罩,让敏感账号信息更适合截图和共享;实时监控补充 reasoning token 展示并修复失败提示溢出;OpenAI provider、Antigravity 订阅和 reauth 检查结果也获得了更稳定的状态处理。
+
+## Highlights
+
+### Features
+
+- 新增 quota 账号遮罩,并在 quota 页面提供遮罩状态控制,降低截图或展示时暴露账号信息的风险(`web/quota`)。
+- 新增 quota 通知遮罩,让 quota 区块中的通知信息也能按当前隐私设置隐藏(`web/quota`)。
+- 为 reauth 检查结果增加显式删除入口,便于清理不再需要的检查记录(`web/monitoring`)。
+- 实时监控事件中展示 reasoning tokens,补齐模型调用成本与 token 构成视图(`web/monitoring`)。
+
+### Fixes
+
+- 修复实时监控失败提示内容过长时溢出界面的问题(`web/monitoring`)。
+- 修复 quota tooltip 泄漏遮罩内容的问题(`web/quota`)。
+- 修复 OpenAI key 测试状态与编辑草稿不同步的问题(`web/ai-providers`)。
+- 修复 provider 元数据更新时遗漏字段被意外覆盖的问题(`web/providers`)。
+- 将 Antigravity plan 查询改为手动触发,避免认证文件页面产生不必要的自动请求(`web/authFiles`)。
+
+### Docs
+
+- 对齐 README 与中文 README 的预览截图说明,并刷新首页截图(`docs`, `img`)。
+
+### CI
+
+- 拆分 PR 模板检查 workflow,支持 PR body 编辑后重新校验,并兼容 CRLF 模板内容(`ci/github`)。
+
+### Tests
+
+- 补充 quota 遮罩、provider 元数据、OpenAI key 测试状态、reauth 检查结果和实时监控提示布局相关测试(`web`)。
+
+## Upgrade Notes
+
+- 本版本主要是前端体验与状态处理更新,不需要数据库迁移或配置迁移。
+- 新增的 quota 遮罩会改变部分页面在隐私模式下的展示方式;用于文档或支持排查的截图应确认遮罩状态符合预期。
+
+## Acknowledgements
+
+- [@Zxis233](https://github.com/Zxis233) - 贡献 quota 账号遮罩、通知遮罩与 tooltip 泄漏修复。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.8.0...v1.8.1


### PR DESCRIPTION
## Summary

Prepare CPA Manager Plus v1.8.1 release notes in Chinese and English. The notes cover quota masking, realtime monitoring fixes, provider metadata preservation, and CI template check improvements.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add docs/release-notes/v1.8.1-zh.md.
- Add docs/release-notes/v1.8.1-en.md.
- Use tag-pinned language switch links for GitHub Release rendering.

## User Impact

No runtime behavior change from this PR. Users will see curated v1.8.1 release notes after the release tag is pushed.

## Compatibility / Runtime Notes
- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: Release notes only; release assets are built by the tag workflow.

## Data / Security Notes

N/A.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the release notes commit before tagging if the release should be cancelled.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
git status --porcelain
git rev-list --left-right --count main...origin/main
git ls-remote --heads origin release/v1.8.1
git ls-remote --tags origin v1.8.1
rg -n "\./v1\.8\.1|blob/v1\.8\.1/docs/release-notes/v1\.8\.1" docs/release-notes/v1.8.1-zh.md docs/release-notes/v1.8.1-en.md
```

## Screenshots / Recordings

N/A.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related

N/A