### PR TITLE
fix(web): show provider state in monitoring account summary

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -110,6 +110,7 @@ import type { StatusBarData } from '@/utils/recentRequests';
 import { downloadBlob } from '@/utils/download';
 import { sha256Hex } from '@/utils/apiKeyHash';
 import { formatCompactNumber } from '@/utils/usage';
+import { buildSourceInfoMap, buildSourceProviderStateMap } from '@/utils/sourceResolver';
 import styles from './MonitoringCenterPage.module.scss';
 
 export { AccountExpandedDetails, AccountOverviewCard };
@@ -514,6 +515,19 @@ export function MonitoringCenterPage() {
   const statusOptions = useMemo(() => buildStatusOptions(t), [t]);
 
   const authFilesByAuthIndex = useMemo(() => buildAuthFilesByAuthIndex(authFiles), [authFiles]);
+  const accountSourceProviderStateBySourceKey = useMemo(
+    () =>
+      buildSourceProviderStateMap(
+        buildSourceInfoMap({
+          geminiApiKeys: config?.geminiApiKeys || [],
+          claudeApiKeys: config?.claudeApiKeys || [],
+          codexApiKeys: config?.codexApiKeys || [],
+          vertexApiKeys: config?.vertexApiKeys || [],
+          openaiCompatibility: config?.openaiCompatibility || [],
+        })
+      ),
+    [config]
+  );
 
   const scopedRows = filteredRows;
   const scopedStatsRows = useMemo(
@@ -542,8 +556,13 @@ export function MonitoringCenterPage() {
     return resolvedBounds ? buildEmptyMonitoringStatusData(resolvedBounds) : EMPTY_STATUS_BAR_DATA;
   }, [accountStatusBounds, scopedRows]);
   const accountAuthStateByRowId = useMemo(
-    () => buildMonitoringAccountAuthStateMap(accountRows, authFilesByAuthIndex),
-    [accountRows, authFilesByAuthIndex]
+    () =>
+      buildMonitoringAccountAuthStateMap(
+        accountRows,
+        authFilesByAuthIndex,
+        accountSourceProviderStateBySourceKey
+      ),
+    [accountRows, accountSourceProviderStateBySourceKey, authFilesByAuthIndex]
   );
   const sortedAccountRows = useMemo(
     () => sortAccountRows(accountRows, accountSort),

--- a/apps/web/src/features/monitoring/accountOverviewState.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.test.ts
@@ -27,6 +27,7 @@ const createAccountRow = (overrides: Partial<MonitoringAccountRow> = {}): Monito
   accountMasked: overrides.accountMasked ?? 'acc***@example.com',
   authLabels: overrides.authLabels ?? [],
   authIndices: overrides.authIndices ?? [],
+  sourceKeys: overrides.sourceKeys ?? [],
   channels: overrides.channels ?? [],
   totalCalls: overrides.totalCalls ?? 0,
   successCalls: overrides.successCalls ?? 0,
@@ -337,6 +338,74 @@ describe('accountOverviewState', () => {
     const result = buildMonitoringAccountAuthState(['1'], authFilesByIndex);
 
     expect(result.enabledState).toBe('disabled');
+  });
+
+  it('uses enabled OpenAI provider state for provider-only account rows', () => {
+    const result = buildMonitoringAccountAuthState(
+      [],
+      new Map(),
+      ['openai:0'],
+      new Map([['openai:0', 'enabled']])
+    );
+
+    expect(result.files).toHaveLength(0);
+    expect(result.enabledState).toBe('enabled');
+  });
+
+  it('uses disabled OpenAI provider state for provider-only account rows', () => {
+    const result = buildMonitoringAccountAuthState(
+      [],
+      new Map(),
+      ['openai:0'],
+      new Map([['openai:0', 'disabled']])
+    );
+
+    expect(result.enabledState).toBe('disabled');
+  });
+
+  it('uses disabled non-OpenAI provider state for provider-only account rows', () => {
+    const result = buildMonitoringAccountAuthState(
+      [],
+      new Map(),
+      ['codex:0'],
+      new Map([['codex:0', 'disabled']])
+    );
+
+    expect(result.enabledState).toBe('disabled');
+  });
+
+  it('merges auth-file and provider states as mixed when they differ', () => {
+    const authFilesByIndex = new Map<string, AuthFileItem>([
+      [
+        '1',
+        {
+          name: 'alpha.json',
+          authIndex: '1',
+          disabled: false,
+        },
+      ],
+    ]);
+
+    const result = buildMonitoringAccountAuthState(
+      ['1'],
+      authFilesByIndex,
+      ['openai:0'],
+      new Map([['openai:0', 'disabled']])
+    );
+
+    expect(result.files.map((file) => file.name)).toEqual(['alpha.json']);
+    expect(result.enabledState).toBe('mixed');
+  });
+
+  it('keeps account auth state unavailable when no source can be toggled', () => {
+    const result = buildMonitoringAccountAuthState(
+      [],
+      new Map(),
+      ['source:unknown'],
+      new Map([['openai:0', 'enabled']])
+    );
+
+    expect(result.enabledState).toBe('unavailable');
   });
 
   it('only includes auth files matching the row auth indices', () => {

--- a/apps/web/src/features/monitoring/accountOverviewState.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.ts
@@ -1,4 +1,5 @@
 import type { AuthFileItem } from '@/types';
+import type { SourceProviderEnabledState } from '@/types/sourceInfo';
 import { isDisabledAuthFile } from '@/utils/quota';
 import { normalizeRecentRequestAuthIndex, type StatusBarData } from '@/utils/recentRequests';
 import type {
@@ -556,18 +557,29 @@ export const buildMonitoringAccountStatusDataMap = (
 
 export const buildMonitoringAccountAuthStateMap = (
   rows: MonitoringAccountRow[],
-  authFilesByAuthIndex: Map<string, AuthFileItem>
+  authFilesByAuthIndex: Map<string, AuthFileItem>,
+  sourceProviderStateBySourceKey: Map<string, SourceProviderEnabledState> = new Map()
 ) =>
   new Map(
     rows.map(
       (row) =>
-        [row.id, buildMonitoringAccountAuthState(row.authIndices, authFilesByAuthIndex)] as const
+        [
+          row.id,
+          buildMonitoringAccountAuthState(
+            row.authIndices,
+            authFilesByAuthIndex,
+            row.sourceKeys ?? [],
+            sourceProviderStateBySourceKey
+          ),
+        ] as const
     )
   );
 
 export const buildMonitoringAccountAuthState = (
   authIndices: string[],
-  authFilesByAuthIndex: Map<string, AuthFileItem>
+  authFilesByAuthIndex: Map<string, AuthFileItem>,
+  sourceKeys: string[] = [],
+  sourceProviderStateBySourceKey: Map<string, SourceProviderEnabledState> = new Map()
 ): MonitoringAccountAuthState => {
   const files = Array.from(
     authIndices.reduce<Map<string, AuthFileItem>>((map, authIndex) => {
@@ -585,14 +597,20 @@ export const buildMonitoringAccountAuthState = (
     .sort((left, right) => left.name.localeCompare(right.name));
 
   const toggleableFiles = files.filter((file) => !isRuntimeOnlyAuthFile(file));
-  const disabledCount = toggleableFiles.filter((file) => isDisabledAuthFile(file)).length;
+  const enabledStates: SourceProviderEnabledState[] = [
+    ...toggleableFiles.map((file) => (isDisabledAuthFile(file) ? 'disabled' : 'enabled')),
+    ...sourceKeys.flatMap((sourceKey) => {
+      const providerState = sourceProviderStateBySourceKey.get(sourceKey);
+      return providerState ? [providerState] : [];
+    }),
+  ];
   const enabledState: MonitoringAccountEnabledState =
-    toggleableFiles.length === 0
+    enabledStates.length === 0
       ? 'unavailable'
-      : disabledCount === toggleableFiles.length
-        ? 'disabled'
-        : disabledCount === 0
-          ? 'enabled'
+      : enabledStates.every((state) => state === 'enabled')
+        ? 'enabled'
+        : enabledStates.every((state) => state === 'disabled')
+          ? 'disabled'
           : 'mixed';
 
   return {

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -245,11 +245,13 @@ describe('buildAccountRows', () => {
         timestampMs: Date.parse('2026-05-09T02:12:43.000Z'),
         authIndex: 'auth-999999',
         authIndexMasked: 'auth...9999',
+        sourceKey: 'source:beta',
       }),
     ]);
 
     expect(rows).toHaveLength(1);
     expect(rows[0].authIndices).toEqual(['auth-123456', 'auth-999999']);
+    expect(rows[0].sourceKeys).toEqual(['source:alpha', 'source:beta']);
   });
 });
 

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
@@ -498,6 +498,7 @@ describe('buildFilterOptionsFromAnalytics', () => {
       'auth:openai-auth',
       'source:source-b',
     ]);
+    expect(options.accountRows[0].sourceKeys).toContain('openai:0:0');
   });
 });
 

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -15,7 +15,11 @@ import type {
   MonitoringAnalyticsTimelinePoint,
 } from '@/services/api/usageService';
 import type { CredentialInfo } from '@/types/sourceInfo';
-import { buildSourceInfoMap, resolveSourceDisplay } from '@/utils/sourceResolver';
+import {
+  buildSourceInfoMap,
+  resolveSourceDisplay,
+  resolveSourceIdentityKey,
+} from '@/utils/sourceResolver';
 import { normalizeAuthIndex, type UsageDetailWithEndpoint } from '@/utils/usage';
 import { formatApiKeyHashLabel, joinUnique, maskAuthIndex, maskEmailLike, readString } from './base';
 import { sanitizeApiKeyDisplayText, type ApiKeyDisplayInfo } from './apiKeys';
@@ -53,6 +57,34 @@ const uniqueReadableValues = (values: Array<string | null | undefined> = []) =>
 
 const firstReadableValue = (...values: Array<string | null | undefined>) =>
   values.map(readString).find((value) => value && value !== '-') || '';
+
+const buildSourceKeysFromAnalyticsIdentity = (
+  authIndices: Array<string | null | undefined> | undefined,
+  sources: Array<string | null | undefined> | undefined,
+  sourceInfoMap: ReturnType<typeof buildSourceInfoMap>,
+  authFileMap: Map<string, CredentialInfo>
+) => {
+  const keys = new Set<string>();
+  const normalizedAuthIndices = uniqueReadableValues(authIndices);
+  const normalizedSources = uniqueReadableValues(sources);
+
+  normalizedAuthIndices.forEach((authIndex) => {
+    const key = resolveSourceIdentityKey('', authIndex, sourceInfoMap, authFileMap);
+    if (key) keys.add(key);
+  });
+
+  normalizedSources.forEach((source) => {
+    const sourceOnlyKey = resolveSourceIdentityKey(source, '', sourceInfoMap, authFileMap);
+    if (sourceOnlyKey) keys.add(sourceOnlyKey);
+
+    normalizedAuthIndices.forEach((authIndex) => {
+      const key = resolveSourceIdentityKey(source, authIndex, sourceInfoMap, authFileMap);
+      if (key) keys.add(key);
+    });
+  });
+
+  return Array.from(keys).filter((key) => key && key !== 'source:-').sort();
+};
 
 const normalizeFilterText = (value: string | null | undefined) =>
   readString(value).trim().toLowerCase();
@@ -565,6 +597,12 @@ export const buildAccountRowsFromAnalytics = (
         display.sourceLabel,
       ]);
       const channels = uniqueReadableValues([...channelNames, display.channel]);
+      const sourceKeys = buildSourceKeysFromAnalyticsIdentity(
+        row.auth_indices,
+        row.sources,
+        sourceInfoMap,
+        authFileMap
+      );
 
       return {
         id: account || row.id,
@@ -573,6 +611,7 @@ export const buildAccountRowsFromAnalytics = (
         accountMasked: display.accountMasked || maskEmailLike(account),
         authLabels,
         authIndices: uniqueReadableValues(row.auth_indices),
+        sourceKeys,
         channels,
         totalCalls: row.calls,
         successCalls: row.success_calls,

--- a/apps/web/src/features/monitoring/model/eventRows.test.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.test.ts
@@ -29,7 +29,7 @@ const buildRows = (overrides: Partial<UsageDetailWithEndpoint> = {}) =>
     ],
     new Map(),
     new Map(),
-    { byAuthIndex: new Map(), bySource: new Map() },
+    { byAuthIndex: new Map(), bySource: new Map(), byIdentityKey: new Map() },
     new Map(),
     {},
     new Map()

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -289,6 +289,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       accountMasked: string;
       authLabels: Set<string>;
       authIndices: Set<string>;
+      sourceKeys: Set<string>;
       apiKeyHashes: Set<string>;
       channels: Set<string>;
       modelMap: Map<
@@ -333,6 +334,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       accountMasked: row.accountMasked,
       authLabels: new Set<string>(),
       authIndices: new Set<string>(),
+      sourceKeys: new Set<string>(),
       apiKeyHashes: new Set<string>(),
       channels: new Set<string>(),
       modelMap: new Map(),
@@ -355,6 +357,9 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     existing.rows.push(row);
     existing.authLabels.add(row.authLabel);
     existing.authIndices.add(row.authIndex);
+    if (row.sourceKey) {
+      existing.sourceKeys.add(row.sourceKey);
+    }
     existing.apiKeyHashes.add(row.apiKeyHash);
     existing.channels.add(row.channel);
     existing.totalCalls += 1;
@@ -409,6 +414,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     .map((item) => {
       const channels = Array.from(item.channels).sort();
       const authIndices = Array.from(item.authIndices).sort();
+      const sourceKeys = Array.from(item.sourceKeys).sort();
       const apiKeyHashes = Array.from(item.apiKeyHashes).sort();
       return {
         id: item.id,
@@ -423,6 +429,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
         accountMasked: item.accountMasked,
         authLabels: Array.from(item.authLabels).sort(),
         authIndices,
+        sourceKeys,
         channels,
         totalCalls: item.totalCalls,
         successCalls: item.successCalls,

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -238,6 +238,7 @@ export type MonitoringAccountRow = {
   accountMasked: string;
   authLabels: string[];
   authIndices: string[];
+  sourceKeys?: string[];
   channels: string[];
   totalCalls: number;
   successCalls: number;

--- a/apps/web/src/types/sourceInfo.ts
+++ b/apps/web/src/types/sourceInfo.ts
@@ -1,7 +1,10 @@
+export type SourceProviderEnabledState = 'enabled' | 'disabled' | 'mixed';
+
 export type SourceInfo = {
   displayName: string;
   type: string;
   identityKey?: string;
+  providerEnabledState?: SourceProviderEnabledState;
 };
 
 export type CredentialInfo = {

--- a/apps/web/src/utils/sourceResolver.test.ts
+++ b/apps/web/src/utils/sourceResolver.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSourceInfoMap, resolveSourceDisplay } from './sourceResolver';
+import {
+  buildSourceInfoMap,
+  buildSourceProviderStateMap,
+  resolveSourceDisplay,
+} from './sourceResolver';
 
 describe('source resolver', () => {
   it('resolves CPA masked Codex API key sources to readable base URL hosts', () => {
@@ -190,5 +194,71 @@ describe('source resolver', () => {
 
     expect(resolved.displayName).toBe('m:sk-x...zzzz');
     expect(resolved.identityKey).toBe('source:m:sk-x...zzzz');
+  });
+
+  it('exposes enabled and disabled OpenAI compatible provider states', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      openaiCompatibility: [
+        {
+          name: 'Enabled Relay',
+          baseUrl: 'https://enabled.example/v1',
+          authIndex: 'enabled-openai',
+          apiKeyEntries: [],
+        },
+        {
+          name: 'Disabled Relay',
+          baseUrl: 'https://disabled.example/v1',
+          authIndex: 'disabled-openai',
+          apiKeyEntries: [],
+          disabled: true,
+        },
+      ],
+    });
+
+    const stateMap = buildSourceProviderStateMap(sourceInfoMap);
+
+    expect(stateMap.get('openai:0')).toBe('enabled');
+    expect(stateMap.get('openai:1')).toBe('disabled');
+  });
+
+  it('exposes disabled non-OpenAI provider state from disable-all excluded models', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: 'sk-disabled-codex',
+          excludedModels: ['*'],
+        },
+      ],
+    });
+
+    const stateMap = buildSourceProviderStateMap(sourceInfoMap);
+
+    expect(stateMap.get('codex:0')).toBe('disabled');
+  });
+
+  it('marks shared provider identities as mixed when matched providers differ', () => {
+    const sharedKey = 'sk-shared-provider-state';
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: sharedKey,
+          prefix: 'Shared Relay',
+        },
+      ],
+      claudeApiKeys: [
+        {
+          apiKey: sharedKey,
+          prefix: 'Shared Relay',
+          excludedModels: ['*'],
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('m:sk-s...tate', '', sourceInfoMap, new Map());
+    const stateMap = buildSourceProviderStateMap(sourceInfoMap);
+    const identityKey = resolved.identityKey || '';
+
+    expect(identityKey).toBe('shared:m:sk-s...tate');
+    expect(stateMap.get(identityKey)).toBe('mixed');
   });
 });

--- a/apps/web/src/utils/sourceResolver.ts
+++ b/apps/web/src/utils/sourceResolver.ts
@@ -1,5 +1,5 @@
 import type { GeminiKeyConfig, OpenAIProviderConfig, ProviderKeyConfig } from '@/types';
-import type { CredentialInfo, SourceInfo } from '@/types/sourceInfo';
+import type { CredentialInfo, SourceInfo, SourceProviderEnabledState } from '@/types/sourceInfo';
 import { buildCandidateUsageSourceIds, normalizeAuthIndex, normalizeUsageSourceId } from '@/utils/usage';
 
 export interface SourceInfoMapInput {
@@ -10,14 +10,31 @@ export interface SourceInfoMapInput {
   openaiCompatibility?: OpenAIProviderConfig[];
 }
 
-type SourceInfoEntry = Required<Pick<SourceInfo, 'displayName' | 'type' | 'identityKey'>>;
+type SourceInfoEntry = Required<Pick<SourceInfo, 'displayName' | 'type' | 'identityKey'>> &
+  Pick<SourceInfo, 'providerEnabledState'>;
 
 export interface SourceInfoMap {
   byAuthIndex: Map<string, SourceInfoEntry | null>;
   bySource: Map<string, SourceInfoEntry | null>;
+  byIdentityKey: Map<string, SourceInfoEntry>;
 }
 
 const buildProviderIdentityKey = (type: string, index: number | string) => `${type}:${index}`;
+
+const hasDisableAllModelsRule = (models?: string[]) =>
+  Array.isArray(models) && models.some((model) => String(model ?? '').trim() === '*');
+
+const buildProviderEnabledState = (enabled: boolean): SourceProviderEnabledState =>
+  enabled ? 'enabled' : 'disabled';
+
+const mergeProviderEnabledState = (
+  left?: SourceProviderEnabledState,
+  right?: SourceProviderEnabledState
+): SourceProviderEnabledState | undefined => {
+  if (!left) return right;
+  if (!right || left === right) return left;
+  return 'mixed';
+};
 
 const registerIdentity = (
   map: Map<string, SourceInfoEntry | null>,
@@ -38,6 +55,10 @@ const registerIdentity = (
       displayName: existing.displayName,
       type: existing.type === entry.type ? existing.type : '',
       identityKey: `shared:${key}`,
+      providerEnabledState: mergeProviderEnabledState(
+        existing.providerEnabledState,
+        entry.providerEnabledState
+      ),
     });
     return;
   }
@@ -130,6 +151,7 @@ const buildOpenAIKeyDisplayNameMap = (providers: OpenAIProviderConfig[]) => {
 export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
   const byAuthIndex = new Map<string, SourceInfoEntry | null>();
   const bySource = new Map<string, SourceInfoEntry | null>();
+  const byIdentityKey = new Map<string, SourceInfoEntry>();
 
   const registerProvider = (
     entry: SourceInfoEntry,
@@ -146,7 +168,7 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
   };
 
   const providers: Array<{
-    items: Array<{ apiKey?: string; prefix?: string; authIndex?: string }>;
+    items: Array<{ apiKey?: string; prefix?: string; authIndex?: string; excludedModels?: string[] }>;
     type: string;
     label: string;
   }> = [
@@ -164,6 +186,9 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
           displayName: displayNames[index] || `${label} #${index + 1}`,
           type,
           identityKey: buildProviderIdentityKey(type, index),
+          providerEnabledState: buildProviderEnabledState(
+            !hasDisableAllModelsRule(item.excludedModels)
+          ),
         },
         [item.authIndex],
         buildCandidateUsageSourceIds({ apiKey: item.apiKey, prefix: item.prefix })
@@ -186,6 +211,7 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
       displayName: openaiProviderDisplayNames[providerIndex] || `OpenAI #${providerIndex + 1}`,
       type: 'openai',
       identityKey: buildProviderIdentityKey('openai', providerIndex),
+      providerEnabledState: buildProviderEnabledState(provider.disabled !== true),
     };
 
     registerProvider(
@@ -202,6 +228,7 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
             providerEntry.displayName,
           type: 'openai',
           identityKey: buildProviderIdentityKey('openai', `${providerIndex}:${entryIndex}`),
+          providerEnabledState: providerEntry.providerEnabledState,
         },
         [entry.authIndex],
         buildCandidateUsageSourceIds({ apiKey: entry.apiKey })
@@ -209,8 +236,26 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
     });
   });
 
-  return { byAuthIndex, bySource };
+  [byAuthIndex, bySource].forEach((map) => {
+    map.forEach((entry) => {
+      if (entry) {
+        byIdentityKey.set(entry.identityKey, entry);
+      }
+    });
+  });
+
+  return { byAuthIndex, bySource, byIdentityKey };
 }
+
+export const buildSourceProviderStateMap = (sourceInfoMap: SourceInfoMap) => {
+  const map = new Map<string, SourceProviderEnabledState>();
+  sourceInfoMap.byIdentityKey.forEach((entry, identityKey) => {
+    if (entry.providerEnabledState) {
+      map.set(identityKey, entry.providerEnabledState);
+    }
+  });
+  return map;
+};
 
 export function resolveSourceDisplay(
   sourceRaw: string,
@@ -259,4 +304,13 @@ export function resolveSourceDisplay(
     type: '',
     identityKey: 'source:-',
   };
+}
+
+export function resolveSourceIdentityKey(
+  sourceRaw: string,
+  authIndex: unknown,
+  sourceInfoMap: SourceInfoMap,
+  authFileMap: Map<string, CredentialInfo>
+): string {
+  return resolveSourceDisplay(sourceRaw, authIndex, sourceInfoMap, authFileMap).identityKey || '';
 }


### PR DESCRIPTION
## Summary
Fix monitoring account summary status for rows backed only by AI provider configuration.
Provider-only account rows now show the current provider state instead of falling back to unavailable.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Track provider enabled state in source resolution metadata.
- Preserve provider source identity keys through realtime and analytics account rows.
- Merge auth-file and provider states when building monitoring account summary status.

## User Impact
Monitoring account summary status now shows enabled, disabled, or mixed for AI provider-only rows instead of "No status".

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only behavior change in the monitoring account summary.
- Manager Server mode: No backend API or storage changes.
- Full Docker / native packages: Same embedded frontend behavior after build/package.

## Data / Security Notes
N/A. No SQLite, admin key, CPA Management Key, auth file content, log, raw usage data, or plugin changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this commit to restore the previous auth-file-only status calculation.

## Verification
- [x] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/features/monitoring/accountOverviewState.test.ts
npm --workspace apps/web run test -- src/features/monitoring/hooks/useMonitoringData.test.ts
npm --workspace apps/web run test -- src/features/monitoring/model/analyticsAdapters.test.ts
npm --workspace apps/web run test -- src/utils/sourceResolver.test.ts
npm --workspace apps/web run test -- src/features/monitoring/model/eventRows.test.ts
npm run type-check
```

Skipped:
```text
npm run lint
npm run build
Manual UI check
```

## Screenshots / Recordings
N/A. This changes table status resolution logic and is covered by model/unit tests; no layout changes.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
