### PR TITLE
docs(release): add v1.9.0 release notes

### DIFF
--- a/docs/release-notes/v1.9.0-en.md
+++ b/docs/release-notes/v1.9.0-en.md
@@ -1,0 +1,38 @@
+# CPA Manager Plus v1.9.0
+
+> 11 commits · 81 files changed · +6622 / -580
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.9.0/docs/release-notes/v1.9.0-zh.md)
+
+## Overview
+
+This release focuses on Codex usage response-header observability: Manager Server now parses, persists, and backfills quota, error, trace, and routing metadata from response headers; the monitoring and account quota views can show quota windows and diagnostics observed from real request headers. It also adds a visual effects performance mode and fixes provider state display in monitoring account summaries.
+
+## Highlights
+
+### Features
+
+- Persist usage response-header metadata and automatically backfill parseable header information from historical `raw_json` records (`manager-server/usage`).
+- Derive current windows, usage percentage, recovery time, plan type, and rate-limit window source from Codex quota headers so quota state better reflects real request results (`manager-server/usage`, `web/quota`).
+- Show header error, trace, quota, routing, provider, and response-shape diagnostics in realtime monitoring failure details to make auth, rate-limit, and proxy-path issues easier to investigate (`web/monitoring`).
+- Show observed Codex quota in monitoring account quota cards, giving a useful fallback from recent usage headers even when the CPA quota API is unavailable (`web/monitoring`).
+- Add a visual effects performance mode that reduces background, transparency, and motion rendering cost for performance-sensitive devices or remote desktop sessions (`web/layout`).
+
+### Fixes
+
+- Fix provider-only accounts in monitoring summaries not showing the correct enabled or disabled provider state (`web/monitoring`).
+
+### Tests
+
+- Add coverage for usage response-header parsing, automatic backfill, account action candidates, quota header snapshots, realtime monitoring, and account overview state (`manager-server`, `web`).
+
+## Upgrade Notes
+
+- This version automatically migrates the SQLite `usage_events` table with response-header metadata columns and indexes; no manual database migration is required.
+- Manager Server starts a background batch backfill for historical usage `raw_json` records that already contain response headers. Large instances may log one `usage response metadata backfill` pass on first startup, and completed records are not processed again.
+- Response-header metadata filters sensitive cookie, token, secret, and authorization headers; GitHub Releases and exports should still follow the existing rule of not exposing local runtime data.
+- Recommended screenshots for this release: realtime event header diagnostics, account quota observed headers, and the visual effects performance-mode menu.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.8.1...v1.9.0

--- a/docs/release-notes/v1.9.0-zh.md
+++ b/docs/release-notes/v1.9.0-zh.md
@@ -1,0 +1,38 @@
+# CPA Manager Plus v1.9.0
+
+> 11 commits · 81 files changed · +6622 / -580
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.9.0/docs/release-notes/v1.9.0-en.md)
+
+## Overview
+
+本次发布围绕 Codex usage 响应头可观测性展开:Manager Server 会解析、持久化并回填 response headers 中的 quota、错误、trace 与路由信息;前端监控和账号 quota 视图可以直接展示从真实请求头观察到的 quota 窗口与诊断线索。同时新增视觉效果性能模式,并修复监控账号汇总中的 provider 状态展示。
+
+## Highlights
+
+### Features
+
+- 持久化 usage response headers 元数据,并从历史 `raw_json` 中自动回填可解析的响应头信息(`manager-server/usage`)。
+- 从 Codex quota headers 推导当前窗口、使用率、恢复时间、plan 类型和限流窗口来源,让 quota 状态更接近真实请求结果(`manager-server/usage`, `web/quota`)。
+- 在实时监控失败提示中展示 header error、trace、quota、routing、provider 与 response shape 诊断,便于定位认证、限流和代理链路问题(`web/monitoring`)。
+- 在监控账号 quota 区域展示 observed Codex quota,即使 CPA quota 接口不可用也能基于最近 usage headers 提供参考(`web/monitoring`)。
+- 新增视觉效果性能模式,可降低背景、透明和动效渲染开销,适合性能敏感设备或远程桌面环境(`web/layout`)。
+
+### Fixes
+
+- 修复监控账号汇总中 provider-only 账号未正确展示启用/禁用状态的问题(`web/monitoring`)。
+
+### Tests
+
+- 补充 usage response header 解析、自动回填、账号动作候选、quota header 快照、实时监控和账号汇总状态相关测试(`manager-server`, `web`)。
+
+## Upgrade Notes
+
+- 本版本会自动迁移 SQLite `usage_events` 表,新增 response header metadata 相关列和索引;不需要手工执行数据库迁移。
+- Manager Server 启动后会后台分批回填历史 usage `raw_json` 中已有的 response headers。大数据量实例首次启动时可能看到一次 `usage response metadata backfill` 日志,回填完成后不会重复处理已补齐记录。
+- response header metadata 会过滤 cookie、token、secret 和 authorization 等敏感头;GitHub Release 与导出内容仍应按既有安全规则避免暴露本地运行数据。
+- 建议为本版本补充截图:实时事件 header 诊断、账号 quota observed headers、视觉效果性能模式菜单。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.8.1...v1.9.0


### PR DESCRIPTION
## Summary
Add curated Chinese and English release notes for v1.9.0.
This prepares the release branch before tagging v1.9.0.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add docs/release-notes/v1.9.0-zh.md.
- Add docs/release-notes/v1.9.0-en.md.
- Document automatic usage response-header metadata migration and backfill notes.

## User Impact
No user-facing behavior change from this PR. The release notes describe the v1.9.0 runtime changes already present on main.

## Compatibility / Runtime Notes
- CPA panel mode: No change from this PR.
- Manager Server mode: Release notes document the v1.9.0 automatic SQLite migration and backfill behavior.
- Full Docker / native packages: No package behavior change from this PR.

## Data / Security Notes
Release notes mention response-header metadata filtering for sensitive cookie, token, secret, and authorization headers. This PR does not include runtime data or secrets.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the release notes commit before tagging if the release needs to be postponed.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
Local release preflight passed: clean worktree, main matches origin/main, v1.9.0 branch/tag/release did not exist before execution.

## Screenshots / Recordings
N/A, docs-only PR.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
N/A