### PR TITLE
Fix manual Codex quota refresh persistence

### DIFF
--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -18,7 +18,7 @@ import {
 import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
-import type { QuotaConfig, QuotaSortMode } from './quotaConfigs';
+import { resolveQuotaDisplayState, type QuotaConfig, type QuotaSortMode } from './quotaConfigs';
 import { resolveQuotaAccountDisplayText } from './quotaDisplay';
 import {
   DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
@@ -192,21 +192,12 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const getDisplayQuota = useCallback(
     (file: AuthFileItem): TState | undefined => {
       const activeQuota = quota[file.name];
-      if (activeQuota && activeQuota.status !== 'idle' && activeQuota.status !== 'error') {
-        return activeQuota;
-      }
-      if (
-        activeQuota?.status === 'error' &&
-        (activeQuota as { errorStatus?: number | null }).errorStatus === 401
-      ) {
-        return activeQuota;
-      }
       const observedQuota = config.buildObservedState?.(
         file,
         getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, file),
         t
       );
-      return observedQuota ?? activeQuota;
+      return resolveQuotaDisplayState(activeQuota, observedQuota);
     },
     [config, headerSnapshotLookup, quota, t]
   );

--- a/apps/web/src/components/quota/index.ts
+++ b/apps/web/src/components/quota/index.ts
@@ -12,5 +12,6 @@ export {
   KIMI_CONFIG,
   XAI_CONFIG,
   buildObservedCodexQuotaState,
+  resolveQuotaDisplayState,
 } from './quotaConfigs';
 export type { QuotaConfig } from './quotaConfigs';

--- a/apps/web/src/components/quota/quotaConfigs.test.ts
+++ b/apps/web/src/components/quota/quotaConfigs.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveQuotaDisplayState } from './quotaConfigs';
+
+type TestQuotaState = {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  errorStatus?: number;
+  fetchedAtMs?: number;
+  observedAtMs?: number;
+  observedFromUsageHeaders?: boolean;
+  windows?: unknown[];
+};
+
+describe('resolveQuotaDisplayState', () => {
+  it('keeps a newer manual quota refresh over an older header snapshot', () => {
+    const activeQuota: TestQuotaState = {
+      status: 'success',
+      fetchedAtMs: 2_000,
+      windows: [],
+    };
+    const observedQuota: TestQuotaState = {
+      status: 'success',
+      observedAtMs: 1_000,
+      observedFromUsageHeaders: true,
+      windows: [],
+    };
+
+    expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(activeQuota);
+  });
+
+  it('uses a newer header snapshot when it is fresher than the manual quota refresh', () => {
+    const activeQuota: TestQuotaState = {
+      status: 'success',
+      fetchedAtMs: 1_000,
+      windows: [],
+    };
+    const observedQuota: TestQuotaState = {
+      status: 'success',
+      observedAtMs: 2_000,
+      observedFromUsageHeaders: true,
+      windows: [],
+    };
+
+    expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(observedQuota);
+  });
+
+  it('keeps 401 quota errors so reauth controls stay visible', () => {
+    const activeQuota: TestQuotaState = {
+      status: 'error',
+      errorStatus: 401,
+    };
+    const observedQuota: TestQuotaState = {
+      status: 'success',
+      observedAtMs: 2_000,
+    };
+
+    expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(activeQuota);
+  });
+});

--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -230,6 +230,38 @@ const getCodexSearchText = (
   ];
 };
 
+type DisplayQuotaState = {
+  status?: 'idle' | 'loading' | 'success' | 'error';
+  errorStatus?: number | null;
+  fetchedAtMs?: number;
+  observedAtMs?: number;
+};
+
+const readFiniteTimestamp = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+export const resolveQuotaDisplayState = <TState extends DisplayQuotaState>(
+  activeQuota: TState | undefined,
+  observedQuota: TState | undefined
+): TState | undefined => {
+  if (activeQuota && activeQuota.status !== 'idle' && activeQuota.status !== 'error') {
+    if (activeQuota.status === 'success' && observedQuota?.status === 'success') {
+      const fetchedAtMs = readFiniteTimestamp(activeQuota.fetchedAtMs);
+      const observedAtMs = readFiniteTimestamp(observedQuota.observedAtMs);
+      if (fetchedAtMs !== null && observedAtMs !== null && observedAtMs > fetchedAtMs) {
+        return observedQuota;
+      }
+    }
+    return activeQuota;
+  }
+
+  if (activeQuota?.status === 'error' && activeQuota.errorStatus === 401) {
+    return activeQuota;
+  }
+
+  return observedQuota ?? activeQuota;
+};
+
 export const buildObservedCodexQuotaState = (
   file: AuthFileItem,
   snapshot: UsageHeaderSnapshot | undefined,

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -24,7 +24,7 @@ import { Select } from '@/components/ui/Select';
 import { IconFilterAll, IconSearch } from '@/components/ui/icons';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
-import { buildObservedCodexQuotaState } from '@/components/quota';
+import { buildObservedCodexQuotaState, resolveQuotaDisplayState } from '@/components/quota';
 import { copyToClipboard } from '@/utils/clipboard';
 import { resolveAuthProvider } from '@/utils/quota';
 import {
@@ -645,18 +645,12 @@ export function AuthFilesPage() {
     (file: AuthFileItem): CodexQuotaState | undefined => {
       if (resolveAuthProvider(file) !== 'codex') return undefined;
       const activeQuota = codexQuota[file.name];
-      if (activeQuota && activeQuota.status !== 'idle' && activeQuota.status !== 'error') {
-        return activeQuota;
-      }
-      if (activeQuota?.status === 'error' && activeQuota.errorStatus === 401) {
-        return activeQuota;
-      }
       const observedQuota = buildObservedCodexQuotaState(
         file,
         getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, file),
         t
       );
-      return observedQuota ?? activeQuota;
+      return resolveQuotaDisplayState(activeQuota, observedQuota);
     },
     [codexQuota, headerSnapshotLookup, t]
   );

--- a/apps/web/src/features/system/SystemPage.tsx
+++ b/apps/web/src/features/system/SystemPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/stores';
 import { apiKeysApi } from '@/services/api/apiKeys';
 import { classifyModels } from '@/utils/models';
-import { STORAGE_KEY_AUTH } from '@/utils/constants';
+import { STORAGE_KEY_AUTH, STORAGE_KEY_QUOTA_CACHE } from '@/utils/constants';
 import iconGemini from '@/assets/icons/gemini.svg';
 import iconClaude from '@/assets/icons/claude.svg';
 import iconOpenaiLight from '@/assets/icons/openai-light.svg';
@@ -167,7 +167,14 @@ export function SystemPage() {
       onConfirm: () => {
         auth.logout();
         if (typeof localStorage === 'undefined') return;
-        const keysToRemove = [STORAGE_KEY_AUTH, 'isLoggedIn', 'apiBase', 'apiUrl', 'managementKey'];
+        const keysToRemove = [
+          STORAGE_KEY_AUTH,
+          STORAGE_KEY_QUOTA_CACHE,
+          'isLoggedIn',
+          'apiBase',
+          'apiUrl',
+          'managementKey',
+        ];
         keysToRemove.forEach((key) => localStorage.removeItem(key));
         showNotification(t('notification.login_storage_cleared'), 'success');
       },

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -19,6 +19,7 @@ import { apiClient } from '@/services/api/client';
 import { usageServiceApi } from '@/services/api/usageService';
 import { useConfigStore } from './useConfigStore';
 import { useModelsStore } from './useModelsStore';
+import { useQuotaStore } from './useQuotaStore';
 import { useUsageServiceStore } from './useUsageServiceStore';
 import { detectApiBaseFromLocation, normalizeApiBase } from '@/utils/connection';
 
@@ -162,8 +163,16 @@ export const useAuthStore = create<AuthStoreState>()(
         const rememberPassword = credentials.rememberPassword ?? get().rememberPassword ?? false;
         const sessionMode = credentials.sessionMode ?? get().sessionMode;
         const sessionPanelBase = normalizeApiBase(credentials.sessionPanelBase || get().sessionPanelBase);
+        const previousApiBase = get().apiBase;
+        const previousManagementKey = get().managementKey;
+        const shouldClearQuotaCache =
+          Boolean(previousApiBase || previousManagementKey) &&
+          (previousApiBase !== apiBase || previousManagementKey !== managementKey);
 
         const markAuthenticated = (result: LoginResult = {}) => {
+          if (shouldClearQuotaCache) {
+            useQuotaStore.getState().clearQuotaCache();
+          }
           apiClient.setConfig({ apiBase, managementKey });
           set({
             isAuthenticated: true,
@@ -238,6 +247,7 @@ export const useAuthStore = create<AuthStoreState>()(
         restoreSessionPromise = null;
         useConfigStore.getState().clearCache();
         useModelsStore.getState().clearCache();
+        useQuotaStore.getState().clearQuotaCache();
         useUsageServiceStore.getState().clearUsageServiceConfig();
         apiClient.setConfig({ apiBase: '', managementKey: '' });
         set({

--- a/apps/web/src/stores/useQuotaStore.test.ts
+++ b/apps/web/src/stores/useQuotaStore.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CodexQuotaState } from '@/types';
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+const createMemoryStorage = (): StorageLike => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => (store.has(key) ? (store.get(key) as string) : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+};
+
+const readPersistedCodexQuota = async () => {
+  const { STORAGE_KEY_QUOTA_CACHE } = await import('@/utils/constants');
+  const { obfuscatedStorage } = await import('@/services/storage/secureStorage');
+  const persisted = obfuscatedStorage.getItem<{
+    state?: { codexQuota?: Record<string, CodexQuotaState> };
+  }>(STORAGE_KEY_QUOTA_CACHE);
+  return persisted?.state?.codexQuota ?? {};
+};
+
+describe('useQuotaStore persistence', () => {
+  let storage: StorageLike;
+
+  beforeEach(() => {
+    vi.resetModules();
+    storage = createMemoryStorage();
+    vi.stubGlobal('localStorage', storage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('persists only manually fetched Codex success states', async () => {
+    const { useQuotaStore } = await import('./useQuotaStore');
+
+    useQuotaStore.getState().setCodexQuota({
+      manual: {
+        status: 'success',
+        windows: [],
+        fetchedAtMs: 2_000,
+      },
+      observed: {
+        status: 'success',
+        windows: [],
+        observedFromUsageHeaders: true,
+        observedAtMs: 1_000,
+      },
+      failed: {
+        status: 'error',
+        windows: [],
+        error: 'failed',
+      },
+    });
+
+    expect(Object.keys(await readPersistedCodexQuota())).toEqual(['manual']);
+  });
+
+  it('clears quota state and persisted quota cache together', async () => {
+    const { useQuotaStore } = await import('./useQuotaStore');
+
+    useQuotaStore.getState().setCodexQuota({
+      manual: {
+        status: 'success',
+        windows: [],
+        fetchedAtMs: 2_000,
+      },
+    });
+
+    useQuotaStore.getState().clearQuotaCache();
+
+    expect(useQuotaStore.getState().codexQuota).toEqual({});
+    expect(await readPersistedCodexQuota()).toEqual({});
+  });
+});

--- a/apps/web/src/stores/useQuotaStore.ts
+++ b/apps/web/src/stores/useQuotaStore.ts
@@ -3,6 +3,7 @@
  */
 
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 import type {
   AntigravityQuotaState,
   ClaudeQuotaState,
@@ -10,6 +11,8 @@ import type {
   KimiQuotaState,
   XaiQuotaState,
 } from '@/types';
+import { obfuscatedStorage } from '@/services/storage/secureStorage';
+import { STORAGE_KEY_QUOTA_CACHE } from '@/utils/constants';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
 
@@ -34,38 +37,79 @@ const resolveUpdater = <T,>(updater: QuotaUpdater<T>, prev: T): T => {
   return updater;
 };
 
-export const useQuotaStore = create<QuotaStoreState>((set) => ({
+const emptyQuotaState = {
   antigravityQuota: {},
   claudeQuota: {},
   codexQuota: {},
   kimiQuota: {},
   xaiQuota: {},
-  setAntigravityQuota: (updater) =>
-    set((state) => ({
-      antigravityQuota: resolveUpdater(updater, state.antigravityQuota)
-    })),
-  setClaudeQuota: (updater) =>
-    set((state) => ({
-      claudeQuota: resolveUpdater(updater, state.claudeQuota)
-    })),
-  setCodexQuota: (updater) =>
-    set((state) => ({
-      codexQuota: resolveUpdater(updater, state.codexQuota)
-    })),
-  setKimiQuota: (updater) =>
-    set((state) => ({
-      kimiQuota: resolveUpdater(updater, state.kimiQuota)
-    })),
-  setXaiQuota: (updater) =>
-    set((state) => ({
-      xaiQuota: resolveUpdater(updater, state.xaiQuota)
-    })),
-  clearQuotaCache: () =>
-    set({
-      antigravityQuota: {},
-      claudeQuota: {},
-      codexQuota: {},
-      kimiQuota: {},
-      xaiQuota: {}
+};
+
+const filterPersistableCodexQuota = (
+  quota: Record<string, CodexQuotaState> | undefined
+): Record<string, CodexQuotaState> => {
+  if (!quota) return {};
+
+  return Object.fromEntries(
+    Object.entries(quota).filter(([, item]) => {
+      return item?.status === 'success' && item.observedFromUsageHeaders !== true;
     })
-}));
+  );
+};
+
+export const useQuotaStore = create<QuotaStoreState>()(
+  persist(
+    (set) => ({
+      ...emptyQuotaState,
+      setAntigravityQuota: (updater) =>
+        set((state) => ({
+          antigravityQuota: resolveUpdater(updater, state.antigravityQuota),
+        })),
+      setClaudeQuota: (updater) =>
+        set((state) => ({
+          claudeQuota: resolveUpdater(updater, state.claudeQuota),
+        })),
+      setCodexQuota: (updater) =>
+        set((state) => ({
+          codexQuota: resolveUpdater(updater, state.codexQuota),
+        })),
+      setKimiQuota: (updater) =>
+        set((state) => ({
+          kimiQuota: resolveUpdater(updater, state.kimiQuota),
+        })),
+      setXaiQuota: (updater) =>
+        set((state) => ({
+          xaiQuota: resolveUpdater(updater, state.xaiQuota),
+        })),
+      clearQuotaCache: () => set(emptyQuotaState),
+    }),
+    {
+      name: STORAGE_KEY_QUOTA_CACHE,
+      storage: createJSONStorage(() => ({
+        getItem: (name) => {
+          if (typeof localStorage === 'undefined') return null;
+          const data = obfuscatedStorage.getItem<Partial<QuotaStoreState>>(name);
+          return data ? JSON.stringify(data) : null;
+        },
+        setItem: (name, value) => {
+          if (typeof localStorage === 'undefined') return;
+          obfuscatedStorage.setItem(name, JSON.parse(value));
+        },
+        removeItem: (name) => {
+          if (typeof localStorage === 'undefined') return;
+          obfuscatedStorage.removeItem(name);
+        },
+      })),
+      partialize: (state) => ({
+        codexQuota: filterPersistableCodexQuota(state.codexQuota),
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<QuotaStoreState> | undefined;
+        return {
+          ...currentState,
+          codexQuota: filterPersistableCodexQuota(persisted?.codexQuota),
+        };
+      },
+    }
+  )
+);

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -40,6 +40,7 @@ export const STORAGE_KEY_VISUAL_EFFECTS = 'cli-proxy-visual-effects';
 export const STORAGE_KEY_LANGUAGE = 'cli-proxy-language';
 export const STORAGE_KEY_SIDEBAR = 'cli-proxy-sidebar-collapsed';
 export const STORAGE_KEY_AUTH_FILES_PAGE_SIZE = 'cli-proxy-auth-files-page-size';
+export const STORAGE_KEY_QUOTA_CACHE = 'cli-proxy-quota-cache';
 
 // 语言配置
 export const LANGUAGE_ORDER = defineLanguageOrder(['zh-CN', 'zh-TW', 'en', 'ru'] as const);


### PR DESCRIPTION
## Summary
Persist manual Codex quota refresh results so they survive a full page reload.
Resolve Codex quota display state by freshness, preventing older usage-header snapshots from overriding newer manual refresh data.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Persist successful manual Codex quota refresh states while excluding usage-header snapshots and errors.
- Share quota display resolution between quota management and auth files, with 401 errors preserved for reauth controls.
- Clear persisted quota cache on auth identity changes, logout, and login storage cleanup.
- Add unit coverage for display freshness resolution and persisted quota filtering/cleanup.

## User Impact
Codex quota cards continue to show the latest manual refresh result after a full page reload instead of falling back to stale header-derived quota data.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only cache behavior applies in the browser.
- Manager Server mode: No backend API or storage schema changes.
- Full Docker / native packages: Management panel behavior is updated after rebuild/package.

## Data / Security Notes
Persists only successful manual Codex quota response state in existing obfuscated local storage and clears it on auth identity changes/logout.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore prior in-memory quota-only behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/components/quota/quotaConfigs.test.ts src/stores/useQuotaStore.test.ts
npm run type-check
npm run lint
npm run test
```

## Screenshots / Recordings
N/A. No visual layout change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A