### PR TITLE
fix(auth-files): prevent stale Codex quota status

### DIFF
--- a/apps/web/src/components/quota/QuotaSection.test.tsx
+++ b/apps/web/src/components/quota/QuotaSection.test.tsx
@@ -1,9 +1,10 @@
-import { act } from 'react';
+import { act, useEffect } from 'react';
 import { create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthFileItem } from '@/types';
 import type { QuotaConfig } from './quotaConfigs';
 import { QuotaSection } from './QuotaSection';
+import { useQuotaLoader } from './useQuotaLoader';
 
 type TestQuotaState = {
   status: 'idle' | 'loading' | 'success' | 'error';
@@ -11,6 +12,7 @@ type TestQuotaState = {
   error?: string;
   errorStatus?: number;
   rateLimitResetCreditsAvailableCount?: number | null;
+  authFileKey?: string;
 };
 
 type TestQuotaData = {
@@ -75,6 +77,13 @@ const successQuota: TestQuotaState = {
   rateLimitResetCreditsAvailableCount: 2,
 };
 
+const authScopedSuccessQuota: TestQuotaState & { authFileKey: string } = {
+  ...successQuota,
+  authFileKey: `${FULL_FILE_NAME}::0`,
+};
+
+const getTestAuthFileKey = (file: AuthFileItem): string => `${file.name}::${file.authIndex ?? '-'}`;
+
 const testConfig: QuotaConfig<TestQuotaState, TestQuotaData> = {
   type: 'codex',
   i18nPrefix: 'codex_quota',
@@ -104,6 +113,34 @@ const testConfig: QuotaConfig<TestQuotaState, TestQuotaData> = {
   renderQuotaItems: () => <div>quota loaded</div>,
 };
 
+const createScopedTestConfig = (): QuotaConfig<TestQuotaState, TestQuotaData> => ({
+  ...testConfig,
+  getStoreKey: getTestAuthFileKey,
+  buildLoadingState: (file) => ({
+    status: 'loading',
+    windows: [],
+    authFileKey: file ? getTestAuthFileKey(file) : undefined,
+  }),
+  buildSuccessState: (data, file) => ({
+    status: 'success',
+    windows: [],
+    rateLimitResetCreditsAvailableCount: data.resetCredits,
+    authFileKey: file ? getTestAuthFileKey(file) : undefined,
+  }),
+  buildErrorState: (message, status, file) => ({
+    status: 'error',
+    windows: [],
+    error: message,
+    errorStatus: status,
+    authFileKey: file ? getTestAuthFileKey(file) : undefined,
+  }),
+  scopeState: (file, quota) => {
+    if (!quota) return undefined;
+    if (!quota.authFileKey) return quota;
+    return quota.authFileKey === getTestAuthFileKey(file) ? quota : undefined;
+  },
+});
+
 const getText = (node: ReactTestInstance): string =>
   node.children
     .map((child) => {
@@ -112,13 +149,18 @@ const getText = (node: ReactTestInstance): string =>
     })
     .join('');
 
-const renderSection = () => {
+const renderSection = (
+  options: {
+    config?: QuotaConfig<TestQuotaState, TestQuotaData>;
+    files?: AuthFileItem[];
+  } = {}
+) => {
   let renderer!: ReactTestRenderer;
   act(() => {
     renderer = create(
       <QuotaSection
-        config={testConfig}
-        files={[testFile]}
+        config={options.config ?? testConfig}
+        files={options.files ?? [testFile]}
         loading={false}
         disabled={false}
         accountDisplayMode="masked"
@@ -133,6 +175,28 @@ const findButtonByText = (renderer: ReactTestRenderer, text: string) => {
   if (!button) throw new Error(`Button not found: ${text}`);
   return button;
 };
+
+const findButtonsByText = (renderer: ReactTestRenderer, text: string) =>
+  renderer.root.findAllByType('button').filter((node) => getText(node).includes(text));
+
+let runLoadQuota:
+  | ((targets: AuthFileItem[], setLoading?: (loading: boolean) => void) => Promise<void>)
+  | undefined;
+
+function QuotaLoaderHarness({
+  config,
+  onLoadQuota,
+}: {
+  config: QuotaConfig<TestQuotaState, TestQuotaData>;
+  onLoadQuota: (loadQuota: typeof runLoadQuota) => void;
+}) {
+  const { loadQuota } = useQuotaLoader(config);
+  useEffect(() => {
+    onLoadQuota((targets, setLoading = vi.fn()) => loadQuota(targets, 'all', setLoading));
+    return () => onLoadQuota(undefined);
+  }, [loadQuota, onLoadQuota]);
+  return null;
+}
 
 describe('QuotaSection account display mode', () => {
   beforeEach(() => {
@@ -217,5 +281,72 @@ describe('QuotaSection account display mode', () => {
     const message = String(mocks.showNotification.mock.calls[0]?.[0] ?? '');
     expect(message).toContain(MASKED_FILE_NAME);
     expect(message).not.toContain(FULL_FILE_NAME);
+  });
+
+  it('scopes same-name quota cache by auth file identity', () => {
+    const scopedConfig = createScopedTestConfig();
+    const files: AuthFileItem[] = [
+      { ...testFile, authIndex: 0 },
+      { ...testFile, authIndex: 1 },
+    ];
+    mocks.quotaStoreState.codexQuota = {
+      [getTestAuthFileKey(files[0])]: authScopedSuccessQuota,
+    };
+
+    const renderer = renderSection({ config: scopedConfig, files });
+
+    const quotaItems = renderer.root
+      .findAllByType('div')
+      .filter((node) => getText(node) === 'quota loaded');
+    expect(quotaItems).toHaveLength(1);
+    expect(findButtonsByText(renderer, 'codex_quota.reset_action_button')).toHaveLength(1);
+  });
+
+  it('stores bulk same-name quota results by auth file identity', async () => {
+    const scopedConfig = createScopedTestConfig();
+    const files: AuthFileItem[] = [
+      { ...testFile, authIndex: 0 },
+      { ...testFile, authIndex: 1 },
+    ];
+    mocks.quotaStoreState.codexQuota = {};
+    mocks.fetchQuota.mockImplementation(async (file: AuthFileItem) => ({
+      resetCredits: file.authIndex === 0 ? 1 : 2,
+    }));
+
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <QuotaLoaderHarness
+          config={scopedConfig}
+          onLoadQuota={(nextLoadQuota) => {
+            runLoadQuota = nextLoadQuota;
+          }}
+        />
+      );
+    });
+
+    await act(async () => {
+      await runLoadQuota?.(files);
+    });
+
+    expect(mocks.quotaStoreState.codexQuota).toMatchObject({
+      [getTestAuthFileKey(files[0])]: {
+        status: 'success',
+        rateLimitResetCreditsAvailableCount: 1,
+        authFileKey: getTestAuthFileKey(files[0]),
+      },
+      [getTestAuthFileKey(files[1])]: {
+        status: 'success',
+        rateLimitResetCreditsAvailableCount: 2,
+        authFileKey: getTestAuthFileKey(files[1]),
+      },
+    });
+    expect(
+      (mocks.quotaStoreState.codexQuota as Record<string, unknown>)[FULL_FILE_NAME]
+    ).toBeUndefined();
+
+    act(() => {
+      renderer.unmount();
+    });
   });
 });

--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -18,7 +18,12 @@ import {
 import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
-import { resolveQuotaDisplayState, type QuotaConfig, type QuotaSortMode } from './quotaConfigs';
+import {
+  getQuotaStoreKey,
+  resolveQuotaDisplayState,
+  type QuotaConfig,
+  type QuotaSortMode,
+} from './quotaConfigs';
 import { resolveQuotaAccountDisplayText } from './quotaDisplay';
 import {
   DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
@@ -189,9 +194,21 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
   const { quota, loadQuota } = useQuotaLoader(config);
 
+  const getScopedQuota = useCallback(
+    (file: AuthFileItem): TState | undefined => {
+      const storeKey = getQuotaStoreKey(config, file);
+      const activeQuota = quota[storeKey];
+      const scopedQuota = config.scopeState ? config.scopeState(file, activeQuota) : activeQuota;
+      if (scopedQuota || storeKey === file.name) return scopedQuota;
+      const legacyQuota = quota[file.name];
+      return config.scopeState ? config.scopeState(file, legacyQuota) : legacyQuota;
+    },
+    [config, quota]
+  );
+
   const getDisplayQuota = useCallback(
     (file: AuthFileItem): TState | undefined => {
-      const activeQuota = quota[file.name];
+      const activeQuota = getScopedQuota(file);
       const observedQuota = config.buildObservedState?.(
         file,
         getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, file),
@@ -199,7 +216,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
       );
       return resolveQuotaDisplayState(activeQuota, observedQuota);
     },
-    [config, headerSnapshotLookup, quota, t]
+    [config, getScopedQuota, headerSnapshotLookup, t]
   );
 
   const displayFiles = useMemo(() => {
@@ -328,31 +345,44 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     setQuota((prev) => {
       const nextState: Record<string, TState> = {};
       filteredFiles.forEach((file) => {
-        const cached = prev[file.name];
-        if (cached) {
-          nextState[file.name] = cached;
+        const storeKey = getQuotaStoreKey(config, file);
+        const cached = prev[storeKey];
+        const scoped = config.scopeState && cached ? config.scopeState(file, cached) : cached;
+        if (scoped) {
+          nextState[storeKey] = cached;
+          return;
+        }
+        if (storeKey === file.name) {
+          return;
+        }
+        const legacyCached = prev[file.name];
+        const legacyScoped =
+          config.scopeState && legacyCached ? config.scopeState(file, legacyCached) : legacyCached;
+        if (legacyScoped) {
+          nextState[file.name] = legacyCached;
         }
       });
       return nextState;
     });
-  }, [filteredFiles, loading, setQuota]);
+  }, [config, filteredFiles, loading, setQuota]);
 
   const refreshQuotaForFile = useCallback(
     async (file: AuthFileItem) => {
       if (disabled || file.disabled) return;
-      if (quota[file.name]?.status === 'loading') return;
+      if (getScopedQuota(file)?.status === 'loading') return;
       const displayName = getAccountDisplayName(file);
+      const storeKey = getQuotaStoreKey(config, file);
 
       setQuota((prev) => ({
         ...prev,
-        [file.name]: config.buildLoadingState(),
+        [storeKey]: config.buildLoadingState(file),
       }));
 
       try {
         const data = await config.fetchQuota(file, t);
         setQuota((prev) => ({
           ...prev,
-          [file.name]: config.buildSuccessState(data),
+          [storeKey]: config.buildSuccessState(data, file),
         }));
         showNotification(t('auth_files.quota_refresh_success', { name: displayName }), 'success');
       } catch (err: unknown) {
@@ -360,7 +390,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         const status = getStatusFromError(err);
         setQuota((prev) => ({
           ...prev,
-          [file.name]: config.buildErrorState(message, status),
+          [storeKey]: config.buildErrorState(message, status, file),
         }));
         showNotification(
           t('auth_files.quota_refresh_failed', { name: displayName, message }),
@@ -368,13 +398,13 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         );
       }
     },
-    [config, disabled, getAccountDisplayName, quota, setQuota, showNotification, t]
+    [config, disabled, getAccountDisplayName, getScopedQuota, setQuota, showNotification, t]
   );
 
   const resetQuotaForFile = useCallback(
     (file: AuthFileItem) => {
       if (!config.resetQuota || disabled || file.disabled) return;
-      const fileQuota = quota[file.name];
+      const fileQuota = getScopedQuota(file);
       const canReset =
         config.canResetQuota?.(file, fileQuota) ??
         Boolean(fileQuota && fileQuota.status === 'success');
@@ -383,6 +413,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         (fileQuota as { rateLimitResetCreditsAvailableCount?: number | null } | undefined)
           ?.rateLimitResetCreditsAvailableCount ?? 0;
       const displayName = getAccountDisplayName(file);
+      const storeKey = getQuotaStoreKey(config, file);
 
       showConfirmation({
         title: t(`${config.i18nPrefix}.reset_confirm_title`),
@@ -396,7 +427,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         onConfirm: async () => {
           setQuota((prev) => ({
             ...prev,
-            [file.name]: config.buildLoadingState(),
+            [storeKey]: config.buildLoadingState(file),
           }));
 
           try {
@@ -406,7 +437,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             }
             setQuota((prev) => ({
               ...prev,
-              [file.name]: config.buildSuccessState(data),
+              [storeKey]: config.buildSuccessState(data, file),
             }));
             showNotification(
               t(`${config.i18nPrefix}.reset_success`, { name: displayName }),
@@ -417,7 +448,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             const status = getStatusFromError(err);
             setQuota((prev) => ({
               ...prev,
-              [file.name]: config.buildErrorState(message, status),
+              [storeKey]: config.buildErrorState(message, status, file),
             }));
             showNotification(
               t(`${config.i18nPrefix}.reset_failed`, { name: displayName, message }),
@@ -431,7 +462,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
       config,
       disabled,
       getAccountDisplayName,
-      quota,
+      getScopedQuota,
       setQuota,
       showConfirmation,
       showNotification,
@@ -544,7 +575,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         <>
           <div ref={gridRef} className={config.gridClassName}>
             {pageItems.map((item) => {
-              const itemQuota = quota[item.name];
+              const itemQuota = getScopedQuota(item);
               const displayQuota = getDisplayQuota(item);
               const resetCount =
                 (itemQuota as { rateLimitResetCreditsAvailableCount?: number | null } | undefined)
@@ -565,7 +596,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
               return (
                 <QuotaCard
-                  key={item.name}
+                  key={getQuotaStoreKey(config, item)}
                   item={item}
                   quota={displayQuota}
                   resolvedTheme={resolvedTheme}

--- a/apps/web/src/components/quota/index.ts
+++ b/apps/web/src/components/quota/index.ts
@@ -12,6 +12,7 @@ export {
   KIMI_CONFIG,
   XAI_CONFIG,
   buildObservedCodexQuotaState,
+  getQuotaStoreKey,
   resolveQuotaDisplayState,
 } from './quotaConfigs';
 export type { QuotaConfig } from './quotaConfigs';

--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -51,6 +51,7 @@ import {
   getHeaderSnapshotUsedPercent,
   hasUsageHeaderQuotaSignal,
 } from '@/utils/usageHeaderSnapshots';
+import { normalizeAuthIndex } from '@/utils/authIndex';
 import type { QuotaRenderHelpers } from './QuotaCard';
 import styles from '@/features/quota/QuotaPage.module.scss';
 
@@ -84,9 +85,11 @@ export interface QuotaConfig<TState, TData> {
   fetchQuota: (file: AuthFileItem, t: TFunction) => Promise<TData>;
   storeSelector: (state: QuotaStore) => Record<string, TState>;
   storeSetter: keyof QuotaStore;
-  buildLoadingState: () => TState;
-  buildSuccessState: (data: TData) => TState;
-  buildErrorState: (message: string, status?: number) => TState;
+  getStoreKey?: (file: AuthFileItem) => string;
+  buildLoadingState: (file?: AuthFileItem) => TState;
+  buildSuccessState: (data: TData, file?: AuthFileItem) => TState;
+  buildErrorState: (message: string, status?: number, file?: AuthFileItem) => TState;
+  scopeState?: (file: AuthFileItem, state: TState | undefined) => TState | undefined;
   cardClassName: string;
   controlsClassName: string;
   controlClassName: string;
@@ -102,6 +105,11 @@ export interface QuotaConfig<TState, TData> {
   canResetQuota?: (file: AuthFileItem, quota: TState | undefined) => boolean;
   renderQuotaItems: (quota: TState, t: TFunction, helpers: QuotaRenderHelpers) => ReactNode;
 }
+
+export const getQuotaStoreKey = <TState, TData>(
+  config: Pick<QuotaConfig<TState, TData>, 'getStoreKey'>,
+  file: AuthFileItem
+): string => config.getStoreKey?.(file) ?? file.name;
 
 const renderAntigravityItems = (
   quota: AntigravityQuotaState,
@@ -239,6 +247,29 @@ type DisplayQuotaState = {
 
 const readFiniteTimestamp = (value: unknown): number | null =>
   typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+const buildCodexQuotaAuthIdentity = (file: AuthFileItem | undefined) => {
+  if (!file?.name) return {};
+  const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']);
+  return {
+    authFileKey: `${file.name}::${authIndex ?? '-'}`,
+    authFileName: file.name,
+    authIndex,
+  };
+};
+
+export const getCodexQuotaStoreKey = (file: AuthFileItem): string =>
+  buildCodexQuotaAuthIdentity(file).authFileKey ?? file.name;
+
+const scopeCodexQuotaStateToAuthFile = (
+  file: AuthFileItem,
+  state: CodexQuotaState | undefined
+): CodexQuotaState | undefined => {
+  if (!state) return undefined;
+  const identity = buildCodexQuotaAuthIdentity(file);
+  if (!state.authFileKey) return identity.authIndex === null ? state : undefined;
+  return state.authFileKey === identity.authFileKey ? state : undefined;
+};
 
 export const resolveQuotaDisplayState = <TState extends DisplayQuotaState>(
   activeQuota: TState | undefined,
@@ -712,21 +743,29 @@ export const CODEX_CONFIG: QuotaConfig<
   fetchQuota: fetchCodexQuota,
   storeSelector: (state) => state.codexQuota,
   storeSetter: 'setCodexQuota',
-  buildLoadingState: () => ({ status: 'loading', windows: [] }),
-  buildSuccessState: (data) => ({
+  getStoreKey: getCodexQuotaStoreKey,
+  buildLoadingState: (file) => ({
+    status: 'loading',
+    windows: [],
+    ...buildCodexQuotaAuthIdentity(file),
+  }),
+  buildSuccessState: (data, file) => ({
     status: 'success',
     windows: data.windows,
     planType: data.planType,
     subscriptionActiveUntil: data.subscriptionActiveUntil,
     rateLimitResetCreditsAvailableCount: data.rateLimitResetCreditsAvailableCount,
+    ...buildCodexQuotaAuthIdentity(file),
     fetchedAtMs: Date.now(),
   }),
-  buildErrorState: (message, status) => ({
+  buildErrorState: (message, status, file) => ({
     status: 'error',
     windows: [],
     error: message,
     errorStatus: status,
+    ...buildCodexQuotaAuthIdentity(file),
   }),
+  scopeState: scopeCodexQuotaStateToAuthFile,
   cardClassName: styles.codexCard,
   controlsClassName: styles.codexControls,
   controlClassName: styles.codexControl,

--- a/apps/web/src/components/quota/useQuotaLoader.ts
+++ b/apps/web/src/components/quota/useQuotaLoader.ts
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import type { AuthFileItem } from '@/types';
 import { useQuotaStore } from '@/stores';
 import { getStatusFromError } from '@/utils/quota';
-import type { QuotaConfig } from './quotaConfigs';
+import { getQuotaStoreKey, type QuotaConfig } from './quotaConfigs';
 
 type QuotaScope = 'page' | 'all';
 
@@ -16,7 +16,8 @@ type QuotaUpdater<T> = T | ((prev: T) => T);
 type QuotaSetter<T> = (updater: QuotaUpdater<T>) => void;
 
 interface LoadQuotaResult<TData> {
-  name: string;
+  storeKey: string;
+  file: AuthFileItem;
   status: 'success' | 'error';
   data?: TData;
   error?: string;
@@ -50,20 +51,21 @@ export function useQuotaLoader<TState, TData>(config: QuotaConfig<TState, TData>
         setQuota((prev) => {
           const nextState = { ...prev };
           targets.forEach((file) => {
-            nextState[file.name] = config.buildLoadingState();
+            nextState[getQuotaStoreKey(config, file)] = config.buildLoadingState(file);
           });
           return nextState;
         });
 
         const results = await Promise.all(
           targets.map(async (file): Promise<LoadQuotaResult<TData>> => {
+            const storeKey = getQuotaStoreKey(config, file);
             try {
               const data = await config.fetchQuota(file, t);
-              return { name: file.name, status: 'success', data };
+              return { storeKey, file, status: 'success', data };
             } catch (err: unknown) {
               const message = err instanceof Error ? err.message : t('common.unknown_error');
               const errorStatus = getStatusFromError(err);
-              return { name: file.name, status: 'error', error: message, errorStatus };
+              return { storeKey, file, status: 'error', error: message, errorStatus };
             }
           })
         );
@@ -74,11 +76,15 @@ export function useQuotaLoader<TState, TData>(config: QuotaConfig<TState, TData>
           const nextState = { ...prev };
           results.forEach((result) => {
             if (result.status === 'success') {
-              nextState[result.name] = config.buildSuccessState(result.data as TData);
+              nextState[result.storeKey] = config.buildSuccessState(
+                result.data as TData,
+                result.file
+              );
             } else {
-              nextState[result.name] = config.buildErrorState(
+              nextState[result.storeKey] = config.buildErrorState(
                 result.error || t('common.unknown_error'),
-                result.errorStatus
+                result.errorStatus,
+                result.file
               );
             }
           });

--- a/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
@@ -28,6 +28,7 @@ const { mocks } = vi.hoisted(() => {
       loadModelAlias: vi.fn(async () => undefined),
       listCodexInspectionRuns: vi.fn(),
       getCodexInspectionRun: vi.fn(),
+      getHeaderSnapshots: vi.fn(),
       deleteExcluded: vi.fn(async () => undefined),
       deleteModelAlias: vi.fn(async () => undefined),
       handleMappingUpdate: vi.fn(async () => undefined),
@@ -41,8 +42,11 @@ const { mocks } = vi.hoisted(() => {
       closePrefixProxyEditor: vi.fn(),
       handlePrefixProxyChange: vi.fn(),
       handlePrefixProxySave: vi.fn(async () => undefined),
+      codexQuota: {} as Record<string, unknown>,
       lastCodexInspectionLastRun: null as {
         result: {
+          startedAt?: number;
+          finishedAt?: number;
           results: Array<{
             fileName: string;
             authIndex?: string | number | null;
@@ -112,6 +116,9 @@ vi.mock('@/services/api/usageService', () => ({
     listCodexInspectionRuns: mocks.listCodexInspectionRuns,
     getCodexInspectionRun: mocks.getCodexInspectionRun,
   },
+  monitoringAnalyticsApi: {
+    getHeaderSnapshots: mocks.getHeaderSnapshots,
+  },
 }));
 
 vi.mock('@/stores', () => ({
@@ -141,8 +148,8 @@ vi.mock('@/stores', () => ({
     }),
   useThemeStore: (selector: (state: { resolvedTheme: 'dark' }) => unknown) =>
     selector({ resolvedTheme: 'dark' }),
-  useQuotaStore: (selector: (state: { codexQuota: Record<string, never> }) => unknown) =>
-    selector({ codexQuota: {} }),
+  useQuotaStore: (selector: (state: { codexQuota: Record<string, unknown> }) => unknown) =>
+    selector({ codexQuota: mocks.codexQuota }),
 }));
 
 vi.mock('@/features/authFiles/hooks/useAuthFilesOauth', () => ({
@@ -278,7 +285,9 @@ describe('AuthFilesPage real auth JSON paste flow', () => {
     mocks.loadModelAlias.mockReset();
     mocks.listCodexInspectionRuns.mockReset();
     mocks.getCodexInspectionRun.mockReset();
+    mocks.getHeaderSnapshots.mockReset();
     mocks.connectionStatus = 'connected';
+    mocks.codexQuota = {};
     mocks.panelFeatureAvailability = {
       checking: false,
       managerServiceBase: 'http://manager.local:18317',
@@ -294,6 +303,12 @@ describe('AuthFilesPage real auth JSON paste flow', () => {
     mocks.loadModelAlias.mockResolvedValue(undefined);
     mocks.listCodexInspectionRuns.mockResolvedValue({ items: [] });
     mocks.getCodexInspectionRun.mockResolvedValue({ run: { id: 1 }, results: [], logs: [] });
+    mocks.getHeaderSnapshots.mockResolvedValue({
+      generated_at_ms: 1_700_000_000_000,
+      from_ms: 1_700_000_000_000,
+      to_ms: 1_700_000_000_000,
+      items: [],
+    });
   });
 
   it('keeps Codex inspection status scoped to auth index for rows from the same file', async () => {
@@ -469,6 +484,194 @@ describe('AuthFilesPage real auth JSON paste flow', () => {
 
     expect(mocks.listCodexInspectionRuns).not.toHaveBeenCalled();
     expect(mocks.getCodexInspectionRun).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+  });
+
+  it('suppresses stale server Codex inspection status after a newer same-row quota refresh', async () => {
+    mocks.list.mockResolvedValue({
+      files: [{ name: 'server-stale-codex.json', type: 'codex', authIndex: 0 }],
+    });
+    mocks.codexQuota = {
+      'server-stale-codex.json::0': {
+        status: 'success',
+        windows: [],
+        authFileKey: 'server-stale-codex.json::0',
+        fetchedAtMs: 2_000,
+      },
+    };
+    mocks.listCodexInspectionRuns.mockResolvedValue({ items: [{ id: 10 }] });
+    mocks.getCodexInspectionRun.mockResolvedValue({
+      run: { id: 10, startedAtMs: 900, finishedAtMs: 1_000, updatedAtMs: 1_000 },
+      results: [
+        {
+          fileName: 'server-stale-codex.json',
+          authIndex: '0',
+          statusCode: 401,
+          action: 'reauth',
+          usedPercent: null,
+          isQuota: false,
+        },
+      ],
+      logs: [],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'server-stale-codex.json::0' }).props[
+          'data-codex-badges'
+        ]
+      ).not.toContain('reauth');
+    });
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+  });
+
+  it('suppresses stale usage-header quota status after a newer healthy Codex inspection', async () => {
+    mocks.list.mockResolvedValue({
+      files: [{ name: 'header-stale-codex.json', type: 'codex', authIndex: 0 }],
+    });
+    mocks.listCodexInspectionRuns.mockResolvedValue({ items: [{ id: 11 }] });
+    mocks.getCodexInspectionRun.mockResolvedValue({
+      run: { id: 11, startedAtMs: 1_900, finishedAtMs: 2_000, updatedAtMs: 2_000 },
+      results: [
+        {
+          fileName: 'header-stale-codex.json',
+          authIndex: '0',
+          statusCode: 200,
+          action: 'keep',
+          usedPercent: null,
+          isQuota: false,
+        },
+      ],
+      logs: [],
+    });
+    mocks.getHeaderSnapshots.mockResolvedValue({
+      generated_at_ms: 1_000,
+      from_ms: 1_000,
+      to_ms: 1_000,
+      items: [
+        {
+          event_hash: 'old-weekly-limit',
+          timestamp_ms: 1_000,
+          auth_file_snapshot: 'header-stale-codex.json',
+          auth_index: '0',
+          auth_provider_snapshot: 'codex',
+          response_metadata: {
+            quota: {
+              rate_limit_reached_type: 'secondary',
+              reached_window_kind: 'weekly',
+              secondary: {
+                used_percent: 100,
+                window_minutes: 10_080,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.getCodexInspectionRun).toHaveBeenCalled();
+      expect(mocks.getHeaderSnapshots).toHaveBeenCalled();
+    });
+
+    const badges = renderer!.root.findByProps({
+      'data-auth-card': 'header-stale-codex.json::0',
+    }).props['data-codex-badges'];
+    expect(badges).not.toContain('weekly_limited');
+    expect(badges).not.toContain('observed_quota');
+
+    await act(async () => {
+      renderer!.unmount();
+    });
+  });
+
+  it('does not suppress another auth index row when same-file quota identity differs', async () => {
+    mocks.panelFeatureAvailability = {
+      checking: false,
+      managerServiceBase: '',
+      serverCodexInspectionAvailable: false,
+    };
+    mocks.list.mockResolvedValue({
+      files: [
+        { name: 'shared-stale-codex.json', type: 'codex', authIndex: 0 },
+        { name: 'shared-stale-codex.json', type: 'codex', authIndex: 1 },
+      ],
+    });
+    mocks.codexQuota = {
+      'shared-stale-codex.json::0': {
+        status: 'success',
+        windows: [
+          {
+            id: 'weekly',
+            label: 'Weekly limit',
+            usedPercent: 100,
+            resetLabel: '06/04 12:00',
+            limitWindowSeconds: 604_800,
+          },
+        ],
+        authFileKey: 'shared-stale-codex.json::0',
+        fetchedAtMs: 2_000,
+      },
+    };
+    mocks.lastCodexInspectionLastRun = {
+      result: {
+        startedAt: 900,
+        finishedAt: 1_000,
+        results: [
+          {
+            fileName: 'shared-stale-codex.json',
+            authIndex: 0,
+            statusCode: 401,
+            action: 'reauth',
+            usedPercent: null,
+            isQuota: false,
+          },
+          {
+            fileName: 'shared-stale-codex.json',
+            authIndex: 1,
+            statusCode: 401,
+            action: 'reauth',
+            usedPercent: null,
+            isQuota: false,
+          },
+        ],
+      },
+    };
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      const firstBadges = renderer!.root.findByProps({
+        'data-auth-card': 'shared-stale-codex.json::0',
+      }).props['data-codex-badges'];
+      const secondBadges = renderer!.root.findByProps({
+        'data-auth-card': 'shared-stale-codex.json::1',
+      }).props['data-codex-badges'];
+
+      expect(firstBadges).not.toContain('reauth');
+      expect(firstBadges).toContain('weekly_limited');
+      expect(secondBadges).toContain('reauth');
+      expect(secondBadges).not.toContain('weekly_limited');
+    });
 
     await act(async () => {
       renderer!.unmount();

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -57,7 +57,6 @@ import {
 import {
   monitoringAnalyticsApi,
   usageServiceApi,
-  type CodexInspectionResult,
   type QuotaCooldownInfo,
   type UsageHeaderSnapshot,
 } from '@/services/api/usageService';
@@ -90,9 +89,11 @@ import {
   getAuthFileCodexStatus,
   getAuthFilePatchTarget,
   getAuthFilePlanSortRank,
+  getAuthFileScopedCodexQuota,
   getAuthFileSearchValues,
   getAuthFileSelectionKey,
   getAuthFileNameFromSelectionKey,
+  getFreshAuthFileCodexStatusSources,
   hasPartialSharedAuthFileSelection,
   normalizeAuthFilesCodexPlanFilter,
   normalizeAuthFilesCodexStatusFilter,
@@ -125,8 +126,31 @@ const hasInlineQuotaLayout = (file: AuthFileItem): boolean => {
   return QUOTA_PROVIDER_TYPES.has(provider as QuotaProviderType);
 };
 
+type CodexInspectionSnapshotSource = {
+  fileName: string;
+  authIndex?: string | number | null;
+  statusCode?: number | string | null;
+  action?: string | null;
+  usedPercent?: number | string | null;
+  isQuota?: boolean | null;
+};
+
+const readCodexInspectionRunAtMs = (run: {
+  finishedAtMs?: number;
+  updatedAtMs?: number;
+  startedAtMs?: number;
+}): number | null =>
+  run.finishedAtMs && Number.isFinite(run.finishedAtMs)
+    ? run.finishedAtMs
+    : run.updatedAtMs && Number.isFinite(run.updatedAtMs)
+      ? run.updatedAtMs
+      : run.startedAtMs && Number.isFinite(run.startedAtMs)
+        ? run.startedAtMs
+        : null;
+
 const toAuthFileCodexInspectionSnapshots = (
-  results: CodexInspectionResult[]
+  results: CodexInspectionSnapshotSource[],
+  inspectionAtMs?: number | null
 ): AuthFileCodexInspectionSnapshot[] =>
   results.map((item) => ({
     fileName: item.fileName,
@@ -135,6 +159,7 @@ const toAuthFileCodexInspectionSnapshots = (
     action: item.action ?? null,
     usedPercent: item.usedPercent ?? null,
     isQuota: item.isQuota ?? null,
+    inspectionAtMs: inspectionAtMs ?? null,
   }));
 
 const isStaleCodexReauthSnapshot = (item: AuthFileCodexInspectionSnapshot): boolean => {
@@ -423,7 +448,12 @@ export function AuthFilesPage() {
             managementKey,
             latestRun.id
           );
-          setLastCodexInspectionResults(toAuthFileCodexInspectionSnapshots(detail.results));
+          setLastCodexInspectionResults(
+            toAuthFileCodexInspectionSnapshots(
+              detail.results,
+              readCodexInspectionRunAtMs(detail.run)
+            )
+          );
           return;
         }
       } catch {
@@ -431,7 +461,14 @@ export function AuthFilesPage() {
       }
     }
 
-    setLastCodexInspectionResults(lastRun?.result.results ?? []);
+    setLastCodexInspectionResults(
+      lastRun
+        ? toAuthFileCodexInspectionSnapshots(
+            lastRun.result.results,
+            lastRun.result.finishedAt || lastRun.result.startedAt || null
+          )
+        : []
+    );
   }, [
     connectionFingerprint,
     featureAvailability.checking,
@@ -641,40 +678,74 @@ export function AuthFilesPage() {
     [headerSnapshots]
   );
 
-  const getDisplayCodexQuota = useCallback(
+  const getActiveCodexQuota = useCallback(
     (file: AuthFileItem): CodexQuotaState | undefined => {
       if (resolveAuthProvider(file) !== 'codex') return undefined;
-      const activeQuota = codexQuota[file.name];
-      const observedQuota = buildObservedCodexQuotaState(
+      const storeKey = getAuthFileCodexInspectionKeyForFile(file);
+      return getAuthFileScopedCodexQuota(
         file,
-        getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, file),
-        t
+        codexQuota[storeKey] ?? codexQuota[file.name]
       );
-      return resolveQuotaDisplayState(activeQuota, observedQuota);
     },
-    [codexQuota, headerSnapshotLookup, t]
+    [codexQuota]
   );
 
-  const codexStatusByAuthFileKey = useMemo(() => {
-    const statusMap = new Map<string, ReturnType<typeof getAuthFileCodexStatus>>();
+  const codexStatusSourcesByAuthFileKey = useMemo(() => {
+    const sourcesMap = new Map<
+      string,
+      ReturnType<typeof getFreshAuthFileCodexStatusSources>
+    >();
     files.forEach((file) => {
       const statusKey = getAuthFileCodexInspectionKeyForFile(file);
       const headerSnapshot = getHighConfidenceUsageHeaderSnapshotForAuthFile(
         headerSnapshotLookup,
         file
       );
-      statusMap.set(
+      sourcesMap.set(
         statusKey,
-        getAuthFileCodexStatus(
+        getFreshAuthFileCodexStatusSources(
           file,
-          getDisplayCodexQuota(file),
+          getActiveCodexQuota(file),
           codexInspectionByAuthFile.get(statusKey),
           headerSnapshot
         )
       );
     });
+    return sourcesMap;
+  }, [codexInspectionByAuthFile, files, getActiveCodexQuota, headerSnapshotLookup]);
+
+  const getDisplayCodexQuota = useCallback(
+    (file: AuthFileItem): CodexQuotaState | undefined => {
+      if (resolveAuthProvider(file) !== 'codex') return undefined;
+      const statusKey = getAuthFileCodexInspectionKeyForFile(file);
+      const activeQuota = getActiveCodexQuota(file);
+      const observedQuota = buildObservedCodexQuotaState(
+        file,
+        codexStatusSourcesByAuthFileKey.get(statusKey)?.headerSnapshot,
+        t
+      );
+      return resolveQuotaDisplayState(activeQuota, observedQuota);
+    },
+    [codexStatusSourcesByAuthFileKey, getActiveCodexQuota, t]
+  );
+
+  const codexStatusByAuthFileKey = useMemo(() => {
+    const statusMap = new Map<string, ReturnType<typeof getAuthFileCodexStatus>>();
+    files.forEach((file) => {
+      const statusKey = getAuthFileCodexInspectionKeyForFile(file);
+      const sources = codexStatusSourcesByAuthFileKey.get(statusKey);
+      statusMap.set(
+        statusKey,
+        getAuthFileCodexStatus(
+          file,
+          getDisplayCodexQuota(file),
+          sources?.inspection,
+          sources?.headerSnapshot
+        )
+      );
+    });
     return statusMap;
-  }, [codexInspectionByAuthFile, files, getDisplayCodexQuota, headerSnapshotLookup]);
+  }, [codexStatusSourcesByAuthFileKey, files, getDisplayCodexQuota]);
 
   const filesMatchingStatusFilters = useMemo(
     () =>
@@ -780,6 +851,13 @@ export function AuthFilesPage() {
     return filesMatchingStatusFilters.filter((item) => {
       const type = normalizeProviderKey(String(item.type ?? item.provider ?? ''));
       const matchType = normalizedFilter === 'all' || type === normalizedFilter;
+      const authFileKey = getAuthFileCodexInspectionKeyForFile(item);
+      const planHeaderSnapshot = getHighConfidenceUsageHeaderSnapshotForAuthFile(
+        headerSnapshotLookup,
+        item
+      );
+      const statusHeaderSnapshot =
+        codexStatusSourcesByAuthFileKey.get(authFileKey)?.headerSnapshot;
       const matchSearch =
         !normalizedSearch ||
         stringifySearchValue(
@@ -787,8 +865,9 @@ export function AuthFilesPage() {
             item,
             t,
             getDisplayCodexQuota(item),
-            codexStatusByAuthFileKey.get(getAuthFileCodexInspectionKeyForFile(item)),
-            getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, item)
+            codexStatusByAuthFileKey.get(authFileKey),
+            statusHeaderSnapshot,
+            planHeaderSnapshot
           )
         ).some((value) => {
           const content = value.toString();
@@ -800,6 +879,7 @@ export function AuthFilesPage() {
     });
   }, [
     codexStatusByAuthFileKey,
+    codexStatusSourcesByAuthFileKey,
     filesMatchingStatusFilters,
     getDisplayCodexQuota,
     headerSnapshotLookup,

--- a/apps/web/src/features/authFiles/components/AuthFileCard.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileCard.tsx
@@ -392,7 +392,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 file={file}
                 quotaType={quotaType}
                 disableControls={disableControls}
-                quotaOverride={quotaType === 'codex' ? codexDisplayQuota : undefined}
+                quotaOverride={quotaType === 'codex' ? (codexDisplayQuota ?? null) : undefined}
               />
             )}
           </div>

--- a/apps/web/src/features/authFiles/components/AuthFileQuotaSection.test.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileQuotaSection.test.tsx
@@ -1,0 +1,150 @@
+import { act } from 'react';
+import { create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthFileItem, CodexQuotaState } from '@/types';
+import { AuthFileQuotaSection } from './AuthFileQuotaSection';
+
+const { mocks } = vi.hoisted(() => {
+  const quotaStoreState: Record<string, unknown> = {
+    codexQuota: {},
+  };
+
+  quotaStoreState.setCodexQuota = vi.fn((updater: unknown) => {
+    const current = quotaStoreState.codexQuota as Record<string, unknown>;
+    quotaStoreState.codexQuota =
+      typeof updater === 'function' ? (updater as (prev: typeof current) => typeof current)(current) : updater;
+  });
+
+  return {
+    mocks: {
+      quotaStoreState,
+      showNotification: vi.fn(),
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key}:${JSON.stringify(options)}` : key,
+  }),
+}));
+
+vi.mock('@/stores', () => ({
+  useNotificationStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      showNotification: mocks.showNotification,
+    }),
+  useQuotaStore: (selector: (state: unknown) => unknown) => selector(mocks.quotaStoreState),
+}));
+
+const file: AuthFileItem = {
+  name: 'shared-codex.json',
+  type: 'codex',
+  authIndex: 1,
+};
+
+const matchingQuota: CodexQuotaState = {
+  status: 'success',
+  windows: [],
+  planType: 'pro',
+  subscriptionActiveUntil: null,
+  rateLimitResetCreditsAvailableCount: 2,
+  authFileKey: 'shared-codex.json::1',
+  authFileName: 'shared-codex.json',
+  authIndex: '1',
+};
+
+const mismatchedQuota: CodexQuotaState = {
+  ...matchingQuota,
+  authFileKey: 'shared-codex.json::0',
+  authIndex: '0',
+};
+
+const legacyQuotaWithoutIdentity: CodexQuotaState = {
+  status: 'success',
+  windows: [],
+  planType: 'pro',
+  subscriptionActiveUntil: null,
+  rateLimitResetCreditsAvailableCount: 2,
+};
+
+const getText = (node: ReactTestInstance): string =>
+  node.children
+    .map((child) => {
+      if (typeof child === 'string' || typeof child === 'number') return String(child);
+      return getText(child);
+    })
+    .join('');
+
+const renderSection = (quotaOverride?: CodexQuotaState | null) => {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <AuthFileQuotaSection
+        file={file}
+        quotaType="codex"
+        disableControls={false}
+        quotaOverride={quotaOverride}
+      />
+    );
+  });
+  return renderer;
+};
+
+describe('AuthFileQuotaSection Codex quota scoping', () => {
+  beforeEach(() => {
+    mocks.showNotification.mockReset();
+    mocks.quotaStoreState.codexQuota = {};
+    (mocks.quotaStoreState.setCodexQuota as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('does not fall back to stored Codex quota when override explicitly clears display quota', () => {
+    mocks.quotaStoreState.codexQuota = {
+      [file.name]: matchingQuota,
+    };
+
+    const renderer = renderSection(null);
+    const text = getText(renderer.root);
+
+    expect(text).toContain('codex_quota.idle');
+    expect(text).not.toContain('codex_quota.plan_pro');
+  });
+
+  it('reads matching stored Codex quota by auth file identity key', () => {
+    mocks.quotaStoreState.codexQuota = {
+      [matchingQuota.authFileKey as string]: matchingQuota,
+    };
+
+    const renderer = renderSection();
+    const text = getText(renderer.root);
+
+    expect(text).toContain('codex_quota.plan_pro');
+    expect(text).not.toContain('codex_quota.idle');
+  });
+
+  it('ignores stored Codex quota from another same-name auth file', () => {
+    mocks.quotaStoreState.codexQuota = {
+      [mismatchedQuota.authFileKey as string]: mismatchedQuota,
+    };
+
+    const renderer = renderSection();
+    const text = getText(renderer.root);
+
+    expect(text).toContain('codex_quota.idle');
+    expect(text).not.toContain('codex_quota.plan_pro');
+  });
+
+  it('ignores legacy Codex quota without identity for auth-indexed files', () => {
+    mocks.quotaStoreState.codexQuota = {
+      [file.name]: legacyQuotaWithoutIdentity,
+    };
+
+    const renderer = renderSection();
+    const text = getText(renderer.root);
+
+    expect(text).toContain('codex_quota.idle');
+    expect(text).not.toContain('codex_quota.plan_pro');
+  });
+});

--- a/apps/web/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -5,6 +5,7 @@ import {
   ANTIGRAVITY_CONFIG,
   CLAUDE_CONFIG,
   CODEX_CONFIG,
+  getQuotaStoreKey,
   KIMI_CONFIG,
   XAI_CONFIG
 } from '@/components/quota';
@@ -20,6 +21,16 @@ import { QuotaProgressBar } from '@/features/authFiles/components/QuotaProgressB
 import styles from '@/features/authFiles/AuthFilesPage.module.scss';
 
 type QuotaState = { status?: string; error?: string; errorStatus?: number } | undefined;
+type InlineQuotaConfig = {
+  i18nPrefix: string;
+  getStoreKey?: (file: AuthFileItem) => string;
+  fetchQuota: (file: AuthFileItem, t: TFunction) => Promise<unknown>;
+  buildLoadingState: (file?: AuthFileItem) => unknown;
+  buildSuccessState: (data: unknown, file?: AuthFileItem) => unknown;
+  buildErrorState: (message: string, status?: number, file?: AuthFileItem) => unknown;
+  renderQuotaItems: (quota: unknown, t: TFunction, helpers: unknown) => unknown;
+  scopeState?: (file: AuthFileItem, state: QuotaState) => QuotaState;
+};
 
 const getQuotaConfig = (type: QuotaProviderType) => {
   if (type === 'antigravity') return ANTIGRAVITY_CONFIG;
@@ -33,21 +44,26 @@ export type AuthFileQuotaSectionProps = {
   file: AuthFileItem;
   quotaType: QuotaProviderType;
   disableControls: boolean;
-  quotaOverride?: QuotaState;
+  quotaOverride?: QuotaState | null;
 };
 
 export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
   const { file, quotaType, disableControls, quotaOverride } = props;
   const { t } = useTranslation();
   const showNotification = useNotificationStore((state) => state.showNotification);
+  const config = getQuotaConfig(quotaType) as unknown as InlineQuotaConfig;
+  const storeKey = getQuotaStoreKey(config, file);
 
-  const quota = useQuotaStore((state) => {
-    if (quotaType === 'antigravity') return state.antigravityQuota[file.name] as QuotaState;
-    if (quotaType === 'claude') return state.claudeQuota[file.name] as QuotaState;
-    if (quotaType === 'codex') return state.codexQuota[file.name] as QuotaState;
-    if (quotaType === 'kimi') return state.kimiQuota[file.name] as QuotaState;
-    return state.xaiQuota[file.name] as QuotaState;
+  const storedQuota = useQuotaStore((state) => {
+    if (quotaType === 'antigravity') return state.antigravityQuota[storeKey] as QuotaState;
+    if (quotaType === 'claude') return state.claudeQuota[storeKey] as QuotaState;
+    if (quotaType === 'codex') {
+      return (state.codexQuota[storeKey] ?? state.codexQuota[file.name]) as QuotaState;
+    }
+    if (quotaType === 'kimi') return state.kimiQuota[storeKey] as QuotaState;
+    return state.xaiQuota[storeKey] as QuotaState;
   });
+  const quota = config.scopeState ? config.scopeState(file, storedQuota) : storedQuota;
 
   const updateQuotaState = useQuotaStore((state) => {
     if (quotaType === 'antigravity') return state.setAntigravityQuota as unknown as (updater: unknown) => void;
@@ -63,25 +79,16 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     if (file.disabled) return;
     if (quota?.status === 'loading') return;
 
-    const config = getQuotaConfig(quotaType) as unknown as {
-      i18nPrefix: string;
-      fetchQuota: (file: AuthFileItem, t: TFunction) => Promise<unknown>;
-      buildLoadingState: () => unknown;
-      buildSuccessState: (data: unknown) => unknown;
-      buildErrorState: (message: string, status?: number) => unknown;
-      renderQuotaItems: (quota: unknown, t: TFunction, helpers: unknown) => unknown;
-    };
-
     updateQuotaState((prev: Record<string, unknown>) => ({
       ...prev,
-      [file.name]: config.buildLoadingState()
+      [storeKey]: config.buildLoadingState(file)
     }));
 
     try {
       const data = await config.fetchQuota(file, t);
       updateQuotaState((prev: Record<string, unknown>) => ({
         ...prev,
-        [file.name]: config.buildSuccessState(data)
+        [storeKey]: config.buildSuccessState(data, file)
       }));
       showNotification(t('auth_files.quota_refresh_success', { name: file.name }), 'success');
     } catch (err: unknown) {
@@ -89,18 +96,13 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
       const status = getStatusFromError(err);
       updateQuotaState((prev: Record<string, unknown>) => ({
         ...prev,
-        [file.name]: config.buildErrorState(message, status)
+        [storeKey]: config.buildErrorState(message, status, file)
       }));
       showNotification(t('auth_files.quota_refresh_failed', { name: file.name, message }), 'error');
     }
-  }, [disableControls, file, quota?.status, quotaType, showNotification, t, updateQuotaState]);
+  }, [config, disableControls, file, quota?.status, showNotification, storeKey, t, updateQuotaState]);
 
-  const config = getQuotaConfig(quotaType) as unknown as {
-    i18nPrefix: string;
-    renderQuotaItems: (quota: unknown, t: TFunction, helpers: unknown) => unknown;
-  };
-
-  const displayQuota = quotaOverride ?? quota;
+  const displayQuota = quotaOverride === undefined ? quota : (quotaOverride ?? undefined);
   const quotaStatus = displayQuota?.status ?? 'idle';
   const canRefreshQuota = !disableControls && !file.disabled;
   const quotaErrorMessage = resolveQuotaErrorMessage(

--- a/apps/web/src/features/authFiles/model/authFilesPageModel.test.ts
+++ b/apps/web/src/features/authFiles/model/authFilesPageModel.test.ts
@@ -9,8 +9,10 @@ import {
   getAuthFileCodexStatus,
   getAuthFileNameFromSelectionKey,
   getAuthFilePatchTarget,
+  getAuthFileScopedCodexQuota,
   getAuthFileSearchValues,
   getAuthFileSelectionKey,
+  getFreshAuthFileCodexStatusSources,
   hasPartialSharedAuthFileSelection,
   normalizeAuthFilesCodexStatusFilter,
   stringifySearchValue,
@@ -328,6 +330,129 @@ describe('auth file Codex status helpers', () => {
     expect(authFileMatchesCodexStatusFilter(status, 'weekly_limited')).toBe(true);
   });
 
+  it('does not mark observed five-hour quota as limited when the reached window is under 100%', () => {
+    const usageLimitSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'usage-limit-five-hour-under-limit',
+      timestamp_ms: 1_700_000_000_000,
+      response_metadata: {
+        quota: {
+          rate_limit_reached_type: 'primary',
+          reached_window_kind: 'five_hour',
+          reached_window_source: 'primary',
+          primary: {
+            used_percent: 99,
+            window_minutes: 300,
+          },
+        },
+        errors: {
+          kind: 'rate_limit',
+          code: 'usage_limit_reached',
+        },
+      },
+    };
+
+    const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, usageLimitSnapshot);
+
+    expect(status.isQuotaLimited).toBe(false);
+    expect(status.isFiveHourLimited).toBe(false);
+    expect(status.isUnknownQuotaLimited).toBe(false);
+    expect(authFileMatchesCodexStatusFilter(status, 'quota_limited')).toBe(false);
+    expect(authFileMatchesCodexStatusFilter(status, 'five_hour_limited')).toBe(false);
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_quota');
+  });
+
+  it('does not mark observed weekly quota as limited when the reached window is under 100%', () => {
+    const usageLimitSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'usage-limit-weekly-under-limit',
+      timestamp_ms: 1_700_000_000_000,
+      response_metadata: {
+        quota: {
+          rate_limit_reached_type: 'secondary',
+          reached_window_kind: 'weekly',
+          reached_window_source: 'secondary',
+          secondary: {
+            used_percent: 98,
+            window_minutes: 10_080,
+          },
+        },
+        errors: {
+          kind: 'rate_limit',
+          code: 'usage_limit_reached',
+        },
+      },
+    };
+
+    const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, usageLimitSnapshot);
+
+    expect(status.isQuotaLimited).toBe(false);
+    expect(status.isWeeklyLimited).toBe(false);
+    expect(status.isUnknownQuotaLimited).toBe(false);
+    expect(authFileMatchesCodexStatusFilter(status, 'quota_limited')).toBe(false);
+    expect(authFileMatchesCodexStatusFilter(status, 'weekly_limited')).toBe(false);
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_quota');
+  });
+
+  it('does not mark observed monthly quota as limited when the reached window is under 100%', () => {
+    const usageLimitSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'usage-limit-monthly-under-limit',
+      timestamp_ms: 1_700_000_000_000,
+      response_metadata: {
+        quota: {
+          rate_limit_reached_type: 'secondary',
+          reached_window_kind: 'monthly',
+          reached_window_source: 'secondary',
+          secondary: {
+            used_percent: 99,
+            window_minutes: 43_200,
+          },
+        },
+        errors: {
+          kind: 'rate_limit',
+          code: 'usage_limit_reached',
+        },
+      },
+    };
+
+    const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, usageLimitSnapshot);
+
+    expect(status.isQuotaLimited).toBe(false);
+    expect(status.isMonthlyLimited).toBe(false);
+    expect(status.isUnknownQuotaLimited).toBe(false);
+    expect(authFileMatchesCodexStatusFilter(status, 'quota_limited')).toBe(false);
+    expect(authFileMatchesCodexStatusFilter(status, 'monthly_limited')).toBe(false);
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_quota');
+  });
+
+  it('keeps observed quota limited when the reached window is at 100%', () => {
+    const usageLimitSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'usage-limit-five-hour-full',
+      timestamp_ms: 1_700_000_000_000,
+      response_metadata: {
+        quota: {
+          rate_limit_reached_type: 'primary',
+          reached_window_kind: 'five_hour',
+          reached_window_source: 'primary',
+          primary: {
+            used_percent: 100,
+            window_minutes: 300,
+          },
+        },
+        errors: {
+          kind: 'rate_limit',
+          code: 'usage_limit_reached',
+        },
+      },
+    };
+
+    const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, usageLimitSnapshot);
+
+    expect(status.isQuotaLimited).toBe(true);
+    expect(status.isFiveHourLimited).toBe(true);
+    expect(authFileMatchesCodexStatusFilter(status, 'quota_limited')).toBe(true);
+    expect(authFileMatchesCodexStatusFilter(status, 'five_hour_limited')).toBe(true);
+    expect(status.badges.map((badge) => badge.kind)).toContain('observed_quota');
+  });
+
   it('ignores non-Codex files for Codex-only status filters', () => {
     const status = getAuthFileCodexStatus({ name: 'qwen.json', type: 'qwen' }, codexQuota());
 
@@ -351,6 +476,230 @@ describe('auth file Codex status helpers', () => {
     expect(map.get(getAuthFileCodexInspectionKey('codex-main.json', 'codex-main'))).toBe(
       inspection
     );
+  });
+
+  it('suppresses older Codex inspection and header status sources after a same-row quota refresh', () => {
+    const file = codexFile();
+    const quota = codexQuota({
+      authFileKey: getAuthFileCodexInspectionKey(file.name, file.authIndex),
+      fetchedAtMs: 2_000,
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          usedPercent: 10,
+          resetLabel: '06/01 17:00',
+          limitWindowSeconds: 18_000,
+        },
+      ],
+    });
+    const inspection: AuthFileCodexInspectionSnapshot = {
+      fileName: file.name,
+      authIndex: file.authIndex,
+      statusCode: 401,
+      action: 'reauth',
+      usedPercent: null,
+      isQuota: false,
+      inspectionAtMs: 1_000,
+    };
+    const headerSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'old-auth-error',
+      timestamp_ms: 1_000,
+      header_error_kind: 'auth',
+      header_error_code: 'invalid_api_key',
+    };
+
+    const sources = getFreshAuthFileCodexStatusSources(file, quota, inspection, headerSnapshot);
+    const status = getAuthFileCodexStatus(
+      file,
+      quota,
+      sources.inspection,
+      sources.headerSnapshot
+    );
+
+    expect(sources.inspection).toBeUndefined();
+    expect(sources.headerSnapshot).toBeUndefined();
+    expect(status.needsReauth).toBe(false);
+    expect(status.badges).toHaveLength(0);
+  });
+
+  it('keeps newer Codex inspection and header status sources after an older quota refresh', () => {
+    const file = codexFile();
+    const quota = codexQuota({
+      authFileKey: getAuthFileCodexInspectionKey(file.name, file.authIndex),
+      fetchedAtMs: 1_000,
+      windows: [],
+    });
+    const inspection: AuthFileCodexInspectionSnapshot = {
+      fileName: file.name,
+      authIndex: file.authIndex,
+      statusCode: 401,
+      action: 'reauth',
+      usedPercent: null,
+      isQuota: false,
+      inspectionAtMs: 2_000,
+    };
+    const headerSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'new-auth-error',
+      timestamp_ms: 2_000,
+      header_error_kind: 'auth',
+      header_error_code: 'invalid_api_key',
+    };
+
+    const sources = getFreshAuthFileCodexStatusSources(file, quota, inspection, headerSnapshot);
+    const status = getAuthFileCodexStatus(
+      file,
+      quota,
+      sources.inspection,
+      sources.headerSnapshot
+    );
+
+    expect(sources.inspection).toBe(inspection);
+    expect(sources.headerSnapshot).toBe(headerSnapshot);
+    expect(status.needsReauth).toBe(true);
+    expect(status.badges.map((badge) => badge.kind)).toContain('reauth');
+  });
+
+  it('suppresses older Codex inspection after a newer same-row header snapshot', () => {
+    const file = codexFile();
+    const inspection: AuthFileCodexInspectionSnapshot = {
+      fileName: file.name,
+      authIndex: file.authIndex,
+      statusCode: 401,
+      action: 'reauth',
+      usedPercent: null,
+      isQuota: false,
+      inspectionAtMs: 1_000,
+    };
+    const headerSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'newer-healthy-header',
+      timestamp_ms: 2_000,
+      header_trace_id: 'trace-new',
+    };
+
+    const sources = getFreshAuthFileCodexStatusSources(
+      file,
+      undefined,
+      inspection,
+      headerSnapshot
+    );
+    const status = getAuthFileCodexStatus(
+      file,
+      undefined,
+      sources.inspection,
+      sources.headerSnapshot
+    );
+
+    expect(sources.inspection).toBeUndefined();
+    expect(sources.headerSnapshot).toBe(headerSnapshot);
+    expect(status.needsReauth).toBe(false);
+  });
+
+  it('suppresses older header diagnostics after a newer Codex inspection', () => {
+    const file = codexFile();
+    const inspection: AuthFileCodexInspectionSnapshot = {
+      fileName: file.name,
+      authIndex: file.authIndex,
+      statusCode: 200,
+      action: null,
+      usedPercent: null,
+      isQuota: false,
+      inspectionAtMs: 2_000,
+    };
+    const headerSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'older-auth-header',
+      timestamp_ms: 1_000,
+      header_error_kind: 'auth',
+      header_error_code: 'invalid_api_key',
+    };
+
+    const sources = getFreshAuthFileCodexStatusSources(
+      file,
+      undefined,
+      inspection,
+      headerSnapshot
+    );
+    const status = getAuthFileCodexStatus(
+      file,
+      undefined,
+      sources.inspection,
+      sources.headerSnapshot
+    );
+
+    expect(sources.inspection).toBe(inspection);
+    expect(sources.headerSnapshot).toBeUndefined();
+    expect(status.needsReauth).toBe(false);
+  });
+
+  it('does not suppress older status sources when quota identity is missing', () => {
+    const file = codexFile();
+    const quota = codexQuota({
+      fetchedAtMs: 2_000,
+      windows: [],
+    });
+    const inspection: AuthFileCodexInspectionSnapshot = {
+      fileName: file.name,
+      authIndex: file.authIndex,
+      statusCode: 401,
+      action: 'reauth',
+      usedPercent: null,
+      isQuota: false,
+      inspectionAtMs: 1_000,
+    };
+
+    const sources = getFreshAuthFileCodexStatusSources(file, quota, inspection);
+
+    expect(sources.inspection).toBe(inspection);
+  });
+
+  it('keeps active Codex quota scoped to the matching auth file row', () => {
+    const first = codexFile({ name: 'shared-codex.json', authIndex: 0 });
+    const second = codexFile({ name: 'shared-codex.json', authIndex: 1 });
+    const quota = codexQuota({
+      authFileKey: getAuthFileCodexInspectionKey(first.name, first.authIndex),
+    });
+
+    expect(getAuthFileScopedCodexQuota(first, quota)).toBe(quota);
+    expect(getAuthFileScopedCodexQuota(second, quota)).toBeUndefined();
+  });
+
+  it('keeps legacy Codex quota without identity available for files without auth index', () => {
+    const quota = codexQuota();
+
+    expect(getAuthFileScopedCodexQuota(codexFile({ authIndex: undefined }), quota)).toBe(quota);
+  });
+
+  it('drops legacy Codex quota without identity for auth-indexed files', () => {
+    const quota = codexQuota();
+
+    expect(getAuthFileScopedCodexQuota(codexFile(), quota)).toBeUndefined();
+  });
+
+  it('keeps plan search fallback while dropping stale header diagnostics from search values', () => {
+    const file = codexFile();
+    const quota = codexQuota({
+      authFileKey: getAuthFileCodexInspectionKey(file.name, file.authIndex),
+      fetchedAtMs: 2_000,
+      windows: [],
+    });
+    const headerSnapshot: UsageHeaderSnapshot = {
+      event_hash: 'old-header-diagnostics',
+      timestamp_ms: 1_000,
+      header_quota_plan_type: 'plus',
+      header_error_kind: 'auth',
+      header_error_code: 'invalid_api_key',
+      header_trace_id: 'trace-old',
+    };
+    const sources = getFreshAuthFileCodexStatusSources(file, quota, undefined, headerSnapshot);
+    const status = getAuthFileCodexStatus(file, quota, undefined, sources.headerSnapshot);
+    const searchValues = stringifySearchValue(
+      getAuthFileSearchValues(file, t, quota, status, sources.headerSnapshot, headerSnapshot)
+    );
+
+    expect(searchValues).toContain('plus');
+    expect(searchValues).not.toContain('invalid_api_key');
+    expect(searchValues).not.toContain('trace-old');
+    expect(searchValues).not.toContain('auth_files.codex_status_badge_reauth');
   });
 
   it('adds derived Codex status labels to searchable values', () => {

--- a/apps/web/src/features/authFiles/model/authFilesPageModel.ts
+++ b/apps/web/src/features/authFiles/model/authFilesPageModel.ts
@@ -15,6 +15,7 @@ import {
   getHeaderSnapshotSummaryWindowKind,
   getHeaderSnapshotTraceId,
   getHeaderSnapshotUsedPercent,
+  getHeaderSnapshotWindowUsedPercent,
 } from '@/utils/usageHeaderSnapshots';
 import {
   getTypeLabel,
@@ -115,7 +116,14 @@ export type AuthFileCodexInspectionSnapshot = {
   action?: string | null;
   usedPercent?: number | string | null;
   isQuota?: boolean | null;
+  inspectionAtMs?: number | null;
 };
+
+export type AuthFileCodexStatusSources = {
+  inspection?: AuthFileCodexInspectionSnapshot;
+  headerSnapshot?: UsageHeaderSnapshot;
+};
+
 export type AuthFilePatchTarget = {
   name: string;
   authIndex?: string | number | null;
@@ -166,11 +174,16 @@ const isObservedQuotaLimitError = (kind: string, code: string) => {
   );
 };
 
+const isUnderQuotaLimit = (value: number | null): boolean => value !== null && value < 100;
+
 const normalizeAuthIndexKey = (value: unknown): string => {
   if (value === undefined || value === null) return UNKNOWN_AUTH_INDEX_KEY;
   const normalized = String(value).trim();
   return normalized || UNKNOWN_AUTH_INDEX_KEY;
 };
+
+const readFiniteTimestamp = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
 
 const readAuthFileAuthIndex = (file: AuthFileItem): string | number | null =>
   (file.authIndex ?? file['auth_index'] ?? file['auth-index'] ?? null) as string | number | null;
@@ -295,6 +308,67 @@ export const buildAuthFileCodexInspectionMap = (
   return map;
 };
 
+const activeCodexQuotaMatchesAuthFile = (
+  file: AuthFileItem,
+  quota: CodexQuotaState | undefined
+): boolean => {
+  const quotaAuthFileKey = typeof quota?.authFileKey === 'string' ? quota.authFileKey.trim() : '';
+  if (!quotaAuthFileKey) return false;
+  return quotaAuthFileKey === getAuthFileCodexInspectionKeyForFile(file);
+};
+
+export const getAuthFileScopedCodexQuota = (
+  file: AuthFileItem,
+  quota: CodexQuotaState | undefined
+): CodexQuotaState | undefined => {
+  if (!quota) return undefined;
+  if (!quota.authFileKey) return readAuthFileAuthIndex(file) == null ? quota : undefined;
+  return activeCodexQuotaMatchesAuthFile(file, quota) ? quota : undefined;
+};
+
+const shouldSuppressOlderCodexStatusSource = (
+  file: AuthFileItem,
+  quota: CodexQuotaState | undefined,
+  sourceAtMs: unknown,
+  newerSourceAtMs?: unknown
+): boolean => {
+  const normalizedSourceAtMs = readFiniteTimestamp(sourceAtMs);
+  if (normalizedSourceAtMs === null) return false;
+  const fetchedAtMs =
+    quota?.status === 'success' && activeCodexQuotaMatchesAuthFile(file, quota)
+      ? readFiniteTimestamp(quota.fetchedAtMs)
+      : null;
+  const normalizedNewerSourceAtMs = readFiniteTimestamp(newerSourceAtMs);
+  return (
+    (fetchedAtMs !== null && fetchedAtMs >= normalizedSourceAtMs) ||
+    (normalizedNewerSourceAtMs !== null && normalizedNewerSourceAtMs > normalizedSourceAtMs)
+  );
+};
+
+export const getFreshAuthFileCodexStatusSources = (
+  file: AuthFileItem,
+  quota: CodexQuotaState | undefined,
+  inspection?: AuthFileCodexInspectionSnapshot,
+  headerSnapshot?: UsageHeaderSnapshot
+): AuthFileCodexStatusSources => ({
+  inspection: shouldSuppressOlderCodexStatusSource(
+    file,
+    quota,
+    inspection?.inspectionAtMs,
+    headerSnapshot?.timestamp_ms
+  )
+    ? undefined
+    : inspection,
+  headerSnapshot: shouldSuppressOlderCodexStatusSource(
+    file,
+    quota,
+    headerSnapshot?.timestamp_ms,
+    inspection?.inspectionAtMs
+  )
+    ? undefined
+    : headerSnapshot,
+});
+
 export const getAuthFileCodexStatus = (
   file: AuthFileItem,
   quota?: CodexQuotaState,
@@ -353,12 +427,26 @@ export const getAuthFileCodexStatus = (
     (observedUsedPercent !== null && observedUsedPercent >= 100
       ? observedSummaryWindowKind
       : null);
+  const getObservedWindowUsedPercent = (windowKind: 'five_hour' | 'weekly' | 'monthly') =>
+    getHeaderSnapshotWindowUsedPercent(headerSnapshot, windowKind) ??
+    (observedLimitWindowKind === windowKind ? observedUsedPercent : null);
+  const observedFiveHourUsedPercent = getObservedWindowUsedPercent('five_hour');
+  const observedWeeklyUsedPercent = getObservedWindowUsedPercent('weekly');
+  const observedMonthlyUsedPercent = getObservedWindowUsedPercent('monthly');
+  const observedFiveHourUnderLimit = isUnderQuotaLimit(observedFiveHourUsedPercent);
+  const observedWeeklyUnderLimit = isUnderQuotaLimit(observedWeeklyUsedPercent);
+  const observedMonthlyUnderLimit = isUnderQuotaLimit(observedMonthlyUsedPercent);
+  const observedSpecificLimitSuppressed =
+    (observedLimitWindowKind === 'five_hour' && observedFiveHourUnderLimit) ||
+    (observedLimitWindowKind === 'weekly' && observedWeeklyUnderLimit) ||
+    (observedLimitWindowKind === 'monthly' && observedMonthlyUnderLimit);
   const observedFiveHourLimited =
-    observedQuotaLimited && observedLimitWindowKind === 'five_hour';
+    observedQuotaLimited && observedLimitWindowKind === 'five_hour' && !observedFiveHourUnderLimit;
   const observedWeeklyLimited =
-    observedQuotaLimited && observedLimitWindowKind === 'weekly';
+    observedQuotaLimited && observedLimitWindowKind === 'weekly' && !observedWeeklyUnderLimit;
   const observedMonthlyLimited =
-    observedQuotaLimited && observedLimitWindowKind === 'monthly';
+    observedQuotaLimited && observedLimitWindowKind === 'monthly' && !observedMonthlyUnderLimit;
+  const observedQuotaLimitedStatus = observedQuotaLimited && !observedSpecificLimitSuppressed;
   const monthlyUsedPercent =
     monthlyWindowUsedPercent ?? (monthlyWindow ? inspectionUsedPercent : null);
   const longWindowUsedPercent = weeklyWindowUsedPercent ?? monthlyUsedPercent;
@@ -399,14 +487,17 @@ export const getAuthFileCodexStatus = (
   const isFiveHourLimited =
     (fiveHourUsedPercent !== null && fiveHourUsedPercent >= 100) || observedFiveHourLimited;
   const isUnknownQuotaLimited =
-    observedQuotaLimited && !isFiveHourLimited && !isWeeklyLimited && !isMonthlyLimited;
+    observedQuotaLimitedStatus &&
+    !isFiveHourLimited &&
+    !isWeeklyLimited &&
+    !isMonthlyLimited;
   const isQuotaLimited =
     isFiveHourLimited || isWeeklyLimited || isMonthlyLimited || isUnknownQuotaLimited;
   const recoveryResetLabel =
     (isMonthlyLimited && monthlyResetLabel) ||
     (isWeeklyLimited && weeklyResetLabel) ||
     (isFiveHourLimited && fiveHourResetLabel) ||
-    (observedQuotaLimited && observedRecoverLabel) ||
+    (observedQuotaLimitedStatus && observedRecoverLabel) ||
     null;
   const hasDisabledRecoveryReset = file.disabled === true && recoveryResetLabel !== null;
   const badges: AuthFileCodexStatusBadge[] = [];
@@ -467,7 +558,7 @@ export const getAuthFileCodexStatus = (
     });
   }
 
-  if (observedQuotaLimited) {
+  if (observedQuotaLimitedStatus) {
     badges.push({
       kind: 'observed_quota',
       tone: 'warning',
@@ -688,9 +779,10 @@ export const getAuthFileSearchValues = (
   t: TFunction,
   quota?: CodexQuotaState,
   codexStatus?: AuthFileCodexStatusSummary,
-  headerSnapshot?: UsageHeaderSnapshot
+  headerSnapshot?: UsageHeaderSnapshot,
+  planHeaderSnapshot: UsageHeaderSnapshot | undefined = headerSnapshot
 ) => {
-  const planType = getAuthFilePlanType(file, quota, headerSnapshot);
+  const planType = getAuthFilePlanType(file, quota, planHeaderSnapshot);
   const planLabel = getCodexPlanLabel(planType, t);
   const accountId = resolveCodexChatgptAccountId(file);
   const type = file.type || file.provider;

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -312,6 +312,9 @@ export interface CodexQuotaState {
   primaryOverSecondaryLimitPercent?: number | null;
   subscriptionActiveUntil?: string | null;
   rateLimitResetCreditsAvailableCount?: number | null;
+  authFileKey?: string;
+  authFileName?: string;
+  authIndex?: string | null;
   fetchedAtMs?: number;
   error?: string;
   errorStatus?: number;

--- a/apps/web/src/utils/usageHeaderSnapshots.test.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.test.ts
@@ -8,6 +8,7 @@ import {
   getHeaderSnapshotReachedWindowKind,
   getHeaderSnapshotPlanType,
   getHeaderSnapshotSummaryWindowKind,
+  getHeaderSnapshotWindowUsedPercent,
   getHighConfidenceUsageHeaderSnapshotForAuthFile,
   getUsageHeaderSnapshotForAuthFile,
   hasUsageHeaderDiagnosticSignal,
@@ -128,6 +129,32 @@ describe('buildObservedCodexQuotaFromHeaderSnapshot', () => {
     ]);
   });
 
+  it('reads used percent for the reached quota window', () => {
+    const snapshot: UsageHeaderSnapshot = {
+      event_hash: 'event-reached-window-percent',
+      timestamp_ms: 1_700_000_000_000,
+      response_metadata: {
+        quota: {
+          rate_limit_reached_type: 'secondary',
+          reached_window_kind: 'weekly',
+          reached_window_source: 'secondary',
+          primary: {
+            used_percent: 99,
+            window_minutes: 300,
+          },
+          secondary: {
+            used_percent: 98,
+            window_minutes: 10_080,
+          },
+        },
+      },
+    };
+
+    expect(getHeaderSnapshotWindowUsedPercent(snapshot, 'five_hour')).toBe(99);
+    expect(getHeaderSnapshotWindowUsedPercent(snapshot, 'weekly')).toBe(98);
+    expect(getHeaderSnapshotWindowUsedPercent(snapshot, 'monthly')).toBeNull();
+  });
+
   it('does not treat trace-only metadata as quota evidence', () => {
     const snapshot: UsageHeaderSnapshot = {
       event_hash: 'trace-only',
@@ -189,6 +216,48 @@ describe('buildObservedCodexQuotaFromHeaderSnapshot', () => {
       'auth-index-only'
     );
     expect(getHighConfidenceUsageHeaderSnapshotForAuthFile(lookup, unmatchedFile)).toBeUndefined();
+  });
+
+  it('does not use same-file header snapshots across different auth indexes', () => {
+    const lookup = buildUsageHeaderSnapshotLookup([
+      {
+        event_hash: 'shared-file-index-0',
+        timestamp_ms: 1_700_000_000_200,
+        auth_file_snapshot: 'shared-codex.json',
+        auth_index: '0',
+        response_metadata: {
+          quota: {
+            plan_type: 'plus',
+          },
+        },
+      },
+      {
+        event_hash: 'shared-file-index-1',
+        timestamp_ms: 1_700_000_000_100,
+        auth_file_snapshot: 'shared-codex.json',
+        auth_index: '1',
+        response_metadata: {
+          quota: {
+            plan_type: 'team',
+          },
+        },
+      },
+    ]);
+    const file = {
+      name: 'shared-codex.json',
+      provider: 'codex',
+      authIndex: '1',
+    } as AuthFileItem;
+    const missingIndexFile = {
+      name: 'shared-codex.json',
+      provider: 'codex',
+      authIndex: '2',
+    } as AuthFileItem;
+
+    expect(getHighConfidenceUsageHeaderSnapshotForAuthFile(lookup, file)?.event_hash).toBe(
+      'shared-file-index-1'
+    );
+    expect(getHighConfidenceUsageHeaderSnapshotForAuthFile(lookup, missingIndexFile)).toBeUndefined();
   });
 
   it('does not use active limit as the plan type', () => {

--- a/apps/web/src/utils/usageHeaderSnapshots.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.ts
@@ -80,6 +80,11 @@ const getHeaderQuotaWindowBySource = (
   return undefined;
 };
 
+const normalizeHeaderQuotaWindowSource = (value: unknown): 'primary' | 'secondary' | null => {
+  const source = readString(value).toLowerCase();
+  return source === 'primary' || source === 'secondary' ? source : null;
+};
+
 const newerSnapshot = (
   current: UsageHeaderSnapshot | undefined,
   next: UsageHeaderSnapshot
@@ -164,9 +169,10 @@ export const getUsageHeaderSnapshotMatchForIdentity = (
   const authIndex = normalizeAuthIndex(identity.authIndex);
   const account = readString(identity.account);
   const source = readString(identity.source);
+  const hasAuthIndex = authIndex !== null;
   const candidates = [
     matchOf(lookup.byFileAuthIndex.get(fileAuthKey(fileName, authIndex ?? '')), 'high'),
-    matchOf(lookup.byFileName.get(normalizeKey(fileName)), 'high'),
+    matchOf(hasAuthIndex ? undefined : lookup.byFileName.get(normalizeKey(fileName)), 'high'),
     matchOf(lookup.byAccount.get(normalizeKey(account)), 'high'),
     matchOf(lookup.byAuthIndex.get(normalizeKey(authIndex)), 'low'),
     matchOf(lookup.bySource.get(normalizeKey(source)), 'low'),
@@ -248,6 +254,43 @@ export const getHeaderSnapshotReachedWindowKind = (
       ? readString(quota?.rate_limit_reached_type).toLowerCase()
       : '');
   return classifyHeaderQuotaWindowKind(getHeaderQuotaWindowBySource(quota, source));
+};
+
+export const getHeaderSnapshotWindowUsedPercent = (
+  snapshot: UsageHeaderSnapshot | null | undefined,
+  windowKind: 'five_hour' | 'weekly' | 'monthly' | 'unknown'
+): number | null => {
+  const quota = getHeaderSnapshotQuotaMetadata(snapshot);
+  if (!quota) return null;
+
+  const sourceCandidates: Array<'primary' | 'secondary'> = [];
+  const addSourceCandidate = (value: unknown) => {
+    const source = normalizeHeaderQuotaWindowSource(value);
+    if (source && !sourceCandidates.includes(source)) {
+      sourceCandidates.push(source);
+    }
+  };
+
+  if (getHeaderSnapshotReachedWindowKind(snapshot) === windowKind) {
+    addSourceCandidate(quota.reached_window_source);
+    addSourceCandidate(quota.rate_limit_reached_type);
+  }
+  if (getHeaderSnapshotSummaryWindowKind(snapshot) === windowKind) {
+    addSourceCandidate(quota.summary_window_source);
+  }
+
+  for (const source of sourceCandidates) {
+    const value = readNumber(getHeaderQuotaWindowBySource(quota, source)?.used_percent);
+    if (value !== null) return value;
+  }
+
+  const classifiedValues = [quota.primary, quota.secondary]
+    .filter((window) => classifyHeaderQuotaWindowKind(window) === windowKind)
+    .map((window) => readNumber(window?.used_percent))
+    .filter((value): value is number => value !== null);
+
+  if (classifiedValues.length > 0) return Math.max(...classifiedValues);
+  return null;
 };
 
 export const getHeaderSnapshotUsedPercent = (


### PR DESCRIPTION
## Summary
Fix stale Codex quota status handling in the auth files view.
This prevents older inspection or usage-header signals from continuing to show an account as quota-limited after fresher quota data says it is available.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Scope Codex quota state by auth file identity and auth index to avoid same-file account state reuse.
- Suppress older Codex inspection and usage-header quota sources when fresher quota or header data exists.
- Use reached-window usage percentages to avoid showing 5h, weekly, or monthly quota-limited states when the reported window is below 100%.
- Add regression tests for stale source suppression, same-file auth index isolation, inline quota rendering, and header reached-window percentages.

## User Impact
Users should no longer see fresh, available Codex quota incorrectly displayed as 5h, weekly, monthly, or observed quota-limited because of stale inspection or header data.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only behavior change; no API or config changes.
- Manager Server mode: Existing inspection data is still used, but stale results are suppressed when fresher account-specific quota/header data exists.
- Full Docker / native packages: No packaging or runtime config changes.

## Data / Security Notes
N/A. No SQLite, key storage, auth secret, log, raw usage, or plugin data changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this commit to restore the previous quota status source precedence and store-key behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test
npm run build
```

## Screenshots / Recordings
N/A. Verified with automated frontend checks; no manual UI capture was taken.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
