### PR TITLE
Release v1.9.1

### DIFF
--- a/docs/release-notes/v1.9.1-en.md
+++ b/docs/release-notes/v1.9.1-en.md
@@ -1,0 +1,33 @@
+# CPA Manager Plus v1.9.1
+
+> 2 commits · 21 files changed · +1567 / -140
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.9.1/docs/release-notes/v1.9.1-zh.md)
+
+## Overview
+
+This patch release fixes Codex quota state persistence and isolation across manual refreshes, full page reloads, and multiple auth-file scenarios. The frontend now preserves successful manual quota refresh results and prevents older usage-header or inspection data from overriding newer, more accurate quota state.
+
+## Highlights
+
+### Fixes
+
+- Persist successful manual Codex quota refresh results so the latest valid result can be reused after a full page reload (`web/quota`).
+- Scope Codex quota state by auth file identity and auth index to avoid stale or mismatched quota results for shared filenames or different accounts (`web/auth-files`).
+- Suppress older Codex inspection and usage-header quota signals when newer quota or header data exists, reducing stale quota-limit false positives (`web/auth-files`, `web/quota`).
+- Clear quota cache on auth identity changes, logout, and login storage cleanup to avoid cross-account residue (`web/auth`).
+- Fix usage-header window usage below 100% still being able to surface as a quota reached state (`web/auth-files`).
+
+### Tests
+
+- Add regression coverage for quota store persistence, quota display state resolution, auth-files stale status suppression, auth index isolation, inline quota rendering, and window usage handling (`web`).
+
+## Upgrade Notes
+
+- No database migration or configuration change is required.
+- This version clears local quota cache after auth identity changes; the first quota view after signing back in may need to fetch fresh state again.
+- Recommended screenshots for this release: Codex inline quota state in auth files and quota-cache behavior after clearing login storage from the system page.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.9.0...v1.9.1

--- a/docs/release-notes/v1.9.1-zh.md
+++ b/docs/release-notes/v1.9.1-zh.md
@@ -1,0 +1,33 @@
+# CPA Manager Plus v1.9.1
+
+> 2 commits · 21 files changed · +1567 / -140
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.9.1/docs/release-notes/v1.9.1-en.md)
+
+## Overview
+
+本次补丁发布修复 Codex quota 在手动刷新、页面重载和多 auth file 场景下的状态持久化与隔离问题。前端现在会保留成功的手动 quota 刷新结果,并避免旧的 usage header 或检查结果覆盖更新、更准确的 quota 状态。
+
+## Highlights
+
+### Fixes
+
+- 持久化成功的手动 Codex quota 刷新结果,页面完整刷新后仍可复用最近一次有效结果(`web/quota`)。
+- 按 auth file identity 与 auth index 隔离 Codex quota 状态,避免同名文件或不同账号复用过期、错配的 quota 结果(`web/auth-files`)。
+- 当存在更新的 quota 或 header 数据时,抑制较旧的 Codex inspection 与 usage-header quota 信号,减少过期限额状态误报(`web/auth-files`, `web/quota`)。
+- 登录身份变化、登出和清理登录存储时同步清理 quota cache,避免跨账号残留(`web/auth`)。
+- 修复 usage header 中窗口占用率低于 100% 时仍可能显示 quota reached 状态的问题(`web/auth-files`)。
+
+### Tests
+
+- 补充 quota store 持久化、quota 展示状态解析、auth files 过期状态抑制、auth index 隔离、inline quota 渲染和窗口占用率处理的回归测试(`web`)。
+
+## Upgrade Notes
+
+- 无需数据库迁移或配置变更。
+- 本版本会清理登录身份变化后的本地 quota cache;重新登录后首次查看 quota 时可能需要重新拉取一次最新状态。
+- 建议为本版本补充截图:auth files 中 Codex inline quota 状态、系统页清理登录存储后的 quota cache 行为。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.9.0...v1.9.1


### PR DESCRIPTION
## Summary

Add curated release notes for CPA Manager Plus v1.9.1 before pushing the release tag.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add Chinese and English release note files under docs/release-notes/.
- Use tag-pinned GitHub blob URLs for release-note language switch links.
- Document Codex quota cache persistence and auth-file stale status fixes.

## User Impact

Users get accurate release notes for v1.9.1 before the tag workflow publishes the GitHub Release.

## Compatibility / Runtime Notes

No runtime compatibility change. The release notes state that no database migration or configuration change is required.

## Data / Security Notes

No secrets, runtime data, or local configuration are included.

## Risk / Rollback

Low risk: documentation-only release-note files. Rollback is to revert this PR before tagging.

## Verification

- git diff --check
- Checked release-note language links for tag-pinned GitHub blob URLs

## Screenshots / Recordings

Not applicable for release-note files.

## Docs

- docs/release-notes/v1.9.1-zh.md
- docs/release-notes/v1.9.1-en.md

## Related

Release: v1.9.1