### PR TITLE
feat(web): normalize plugin OAuth provider id

### DIFF
--- a/apps/web/src/features/oauth/OAuthPage.test.tsx
+++ b/apps/web/src/features/oauth/OAuthPage.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePluginOAuthProviderId, shouldShowPluginOAuthProvider } from './oauthProviderHelpers';
+
+const builtInProviderIds = new Set(['codex', 'anthropic', 'antigravity', 'kimi', 'xai']);
+
+describe('plugin OAuth provider helpers', () => {
+  it('uses explicit plugin OAuth provider ids when present', () => {
+    expect(resolvePluginOAuthProviderId({ id: 'legacy-plugin', oauthProvider: 'custom' })).toBe(
+      'custom'
+    );
+    expect(resolvePluginOAuthProviderId({ id: 'legacy-plugin' })).toBe('legacy-plugin');
+  });
+
+  it('hides plugin OAuth entries that resolve to built-in providers', () => {
+    expect(
+      shouldShowPluginOAuthProvider(
+        {
+          id: 'custom-plugin',
+          oauthProvider: 'codex',
+          supportsOAuth: true,
+        },
+        builtInProviderIds
+      )
+    ).toBe(false);
+    expect(
+      shouldShowPluginOAuthProvider(
+        {
+          id: 'custom-plugin',
+          oauthProvider: 'custom-provider',
+          supportsOAuth: true,
+        },
+        builtInProviderIds
+      )
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/features/oauth/OAuthPage.tsx
+++ b/apps/web/src/features/oauth/OAuthPage.tsx
@@ -15,6 +15,10 @@ import { vertexApi, type VertexImportResponse } from '@/services/api/vertex';
 import { copyToClipboard } from '@/utils/clipboard';
 import type { PluginListEntry } from '@/types';
 import { getPluginTitle, resolvePluginAssetURL } from '@/features/plugins/pluginResources';
+import {
+  resolvePluginOAuthProviderId,
+  shouldShowPluginOAuthProvider,
+} from './oauthProviderHelpers';
 import styles from './OAuthPage.module.scss';
 import iconCodex from '@/assets/icons/codex.svg';
 import iconClaude from '@/assets/icons/claude.svg';
@@ -245,12 +249,12 @@ export function OAuthPage() {
     }));
     const pluginProviders = pluginOAuthAvailable
       ? pluginOAuthPlugins
-          .filter((plugin) => plugin.supportsOAuth && !BUILT_IN_PROVIDER_IDS.has(plugin.id))
+          .filter((plugin) => shouldShowPluginOAuthProvider(plugin, BUILT_IN_PROVIDER_IDS))
           .map((plugin) => {
             const title = getPluginTitle(plugin);
             const logo = resolvePluginAssetURL(plugin.logo || plugin.metadata?.logo || '', apiBase);
             return {
-              id: plugin.id,
+              id: resolvePluginOAuthProviderId(plugin),
               title,
               hint: t('auth_login.plugin_oauth_hint', { plugin: title }),
               urlLabel: t('auth_login.plugin_oauth_url_label'),

--- a/apps/web/src/features/oauth/oauthProviderHelpers.ts
+++ b/apps/web/src/features/oauth/oauthProviderHelpers.ts
@@ -1,0 +1,11 @@
+import type { PluginListEntry } from '@/types';
+
+export const resolvePluginOAuthProviderId = (
+  plugin: Pick<PluginListEntry, 'id' | 'oauthProvider'>
+): string => plugin.oauthProvider ?? plugin.id;
+
+export const shouldShowPluginOAuthProvider = (
+  plugin: Pick<PluginListEntry, 'id' | 'oauthProvider' | 'supportsOAuth'>,
+  builtInProviderIds: ReadonlySet<string>
+): boolean =>
+  plugin.supportsOAuth && !builtInProviderIds.has(resolvePluginOAuthProviderId(plugin));

--- a/apps/web/src/services/api/plugins.test.ts
+++ b/apps/web/src/services/api/plugins.test.ts
@@ -76,6 +76,7 @@ describe('plugin API normalizers', () => {
     expect(result.plugins).toHaveLength(1);
     expect(result.plugins[0]).toMatchObject({
       id: 'demo',
+      oauthProvider: 'demo',
       enabled: false,
       effectiveEnabled: true,
       supportsOAuth: true,
@@ -86,6 +87,33 @@ describe('plugin API normalizers', () => {
     });
     expect(result.plugins[0]?.configFields[0]?.enumValues).toEqual(['fast', 'safe']);
     expect(result.plugins[0]?.menus[0]?.path).toBe('/plugins/demo/page');
+  });
+
+  it('normalizes explicit plugin OAuth providers without legacy fallback override', () => {
+    const result = normalizePluginList({
+      plugins: [
+        {
+          id: 'legacy-plugin',
+          supports_oauth: true,
+          oauth_provider: 'custom-oauth-provider',
+        },
+        {
+          id: 'no-provider',
+          supports_oauth: true,
+          oauth_provider: '',
+        },
+      ],
+    });
+
+    expect(result.plugins[0]).toMatchObject({
+      id: 'legacy-plugin',
+      oauthProvider: 'custom-oauth-provider',
+    });
+    expect(result.plugins[1]).toMatchObject({
+      id: 'no-provider',
+      supportsOAuth: true,
+    });
+    expect(result.plugins[1]?.oauthProvider).toBeUndefined();
   });
 
   it('normalizes plugin delete results', () => {

--- a/apps/web/src/services/api/plugins.ts
+++ b/apps/web/src/services/api/plugins.ts
@@ -22,6 +22,14 @@ const asString = (value: unknown): string => {
 
 const asBoolean = (value: unknown): boolean => value === true;
 
+const hasOwn = (source: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(source, key);
+
+const normalizePluginOAuthProvider = (value: unknown): string | undefined => {
+  const provider = asString(value).trim();
+  return provider || undefined;
+};
+
 const normalizeConfigField = (value: unknown): PluginConfigField | null => {
   if (!isRecord(value)) return null;
   const name = asString(value.name).trim();
@@ -94,15 +102,22 @@ const normalizePluginEntry = (value: unknown): PluginListEntry | null => {
 
   const metadata = normalizeMetadata(value.metadata);
   const configFields = normalizeConfigFields(value.config_fields ?? value.configFields);
+  const supportsOAuth = asBoolean(value.supports_oauth ?? value.supportsOAuth);
+  const oauthProvider = normalizePluginOAuthProvider(value.oauth_provider ?? value.oauthProvider);
+  const legacyOAuthProvider =
+    supportsOAuth && !hasOwn(value, 'oauth_provider') && !hasOwn(value, 'oauthProvider')
+      ? normalizePluginOAuthProvider(id)
+      : undefined;
 
   return {
     id,
+    oauthProvider: oauthProvider ?? legacyOAuthProvider,
     path: asString(value.path).trim(),
     configured: asBoolean(value.configured),
     registered: asBoolean(value.registered),
     enabled: value.enabled !== false,
     effectiveEnabled: asBoolean(value.effective_enabled ?? value.effectiveEnabled),
-    supportsOAuth: asBoolean(value.supports_oauth ?? value.supportsOAuth),
+    supportsOAuth,
     logo: asString(value.logo || metadata?.logo).trim(),
     configFields: configFields.length > 0 ? configFields : (metadata?.configFields ?? []),
     menus: normalizeMenus(value.menus),

--- a/apps/web/src/types/plugin.ts
+++ b/apps/web/src/types/plugin.ts
@@ -33,6 +33,7 @@ export interface PluginMenu {
 
 export interface PluginListEntry {
   id: string;
+  oauthProvider?: string;
   path: string;
   configured: boolean;
   registered: boolean;


### PR DESCRIPTION
## Summary
Normalize plugin OAuth provider ids in the web panel so plugins can publish an explicit OAuth provider key without colliding with built-in providers.
Keep legacy behavior for plugins that support OAuth but do not provide an explicit provider id.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add plugin OAuth provider id normalization from `oauth_provider` / `oauthProvider`.
- Use resolved OAuth provider ids when rendering plugin OAuth login entries.
- Hide plugin OAuth entries that resolve to built-in provider ids.
- Add focused tests for plugin list normalization and OAuth provider helper behavior.

## User Impact
Plugins can register custom OAuth provider ids without being forced to use the plugin id in the OAuth login flow.

## Compatibility / Runtime Notes
- CPA panel mode: Plugin OAuth entries continue to load through the existing plugin list API.
- Manager Server mode: No backend behavior change.
- Full Docker / native packages: No packaging behavior change.

## Data / Security Notes
N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR to restore the previous plugin-id-based OAuth provider behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
git diff --check origin/main...HEAD
```

## Screenshots / Recordings
N/A

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
