### PR TITLE
feat(web): surface Codex rate limit reset credits

### DIFF
--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -19,7 +19,7 @@ import type {
   XaiQuotaState,
 } from '@/types';
 import type { UsageHeaderSnapshot } from '@/services/api/usageService';
-import type { AntigravityQuotaData } from '@/utils/quota';
+import type { AntigravityQuotaData, CodexQuotaData } from '@/utils/quota';
 import { IconInfo } from '@/components/ui/icons';
 import { resetCodexQuota } from '@/services/api/codexQuota';
 import {
@@ -729,12 +729,7 @@ export const ANTIGRAVITY_CONFIG: QuotaConfig<AntigravityQuotaState, AntigravityQ
 
 export const CODEX_CONFIG: QuotaConfig<
   CodexQuotaState,
-  {
-    planType: string | null;
-    windows: CodexQuotaWindow[];
-    subscriptionActiveUntil: string | null;
-    rateLimitResetCreditsAvailableCount: number | null;
-  }
+  CodexQuotaData
 > = {
   type: 'codex',
   i18nPrefix: 'codex_quota',
@@ -755,6 +750,8 @@ export const CODEX_CONFIG: QuotaConfig<
     planType: data.planType,
     subscriptionActiveUntil: data.subscriptionActiveUntil,
     rateLimitResetCreditsAvailableCount: data.rateLimitResetCreditsAvailableCount,
+    rateLimitResetCredits: data.rateLimitResetCredits,
+    rateLimitResetCreditsError: data.rateLimitResetCreditsError,
     ...buildCodexQuotaAuthIdentity(file),
     fetchedAtMs: Date.now(),
   }),

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -250,6 +250,8 @@ describe('monitoringCenterPageModel account quota', () => {
       planType: 'free',
       subscriptionActiveUntil: null,
       rateLimitResetCreditsAvailableCount: null,
+      rateLimitResetCredits: [],
+      rateLimitResetCreditsError: null,
       windows: [
         {
           id: 'monthly',

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -173,6 +173,19 @@ export interface CodexRateLimitResetCreditsInfo {
   availableCount?: number | string;
 }
 
+export interface CodexRateLimitResetCredit {
+  id: string;
+  status: string;
+  grantedAt: string;
+  expiresAt: string;
+}
+
+export interface CodexResetCreditsSummary {
+  availableCount: number | null;
+  credits: CodexRateLimitResetCredit[];
+  invalidPayload: boolean;
+}
+
 export interface CodexUsagePayload {
   user_id?: string;
   userId?: string;
@@ -312,6 +325,8 @@ export interface CodexQuotaState {
   primaryOverSecondaryLimitPercent?: number | null;
   subscriptionActiveUntil?: string | null;
   rateLimitResetCreditsAvailableCount?: number | null;
+  rateLimitResetCredits?: CodexRateLimitResetCredit[];
+  rateLimitResetCreditsError?: string | null;
   authFileKey?: string;
   authFileName?: string;
   authIndex?: string | null;

--- a/apps/web/src/utils/quota/constants.ts
+++ b/apps/web/src/utils/quota/constants.ts
@@ -144,6 +144,9 @@ export const CLAUDE_USAGE_WINDOW_KEYS = [
 // Codex API configuration
 export const CODEX_USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
 
+export const CODEX_RATE_LIMIT_RESET_CREDITS_URL =
+  'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits';
+
 export const CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL =
   'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume';
 

--- a/apps/web/src/utils/quota/index.ts
+++ b/apps/web/src/utils/quota/index.ts
@@ -9,4 +9,5 @@ export * from './formatters';
 export * from './validators';
 export * from './builders';
 export * from './codexQuota';
+export * from './resetCredits';
 export * from './providerRequests';

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -1,0 +1,136 @@
+import type { TFunction } from 'i18next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/api/apiCall', () => ({
+  apiCallApi: {
+    request: mocks.request,
+  },
+  getApiCallErrorMessage: (result: { statusCode: number; bodyText?: string }) =>
+    `${result.statusCode} ${result.bodyText ?? ''}`.trim(),
+}));
+
+import {
+  CODEX_RATE_LIMIT_RESET_CREDITS_URL,
+  CODEX_USAGE_URL,
+} from './constants';
+import { fetchCodexQuota } from './providerRequests';
+
+const t = ((key: string) => key) as TFunction;
+
+beforeEach(() => {
+  mocks.request.mockReset();
+});
+
+describe('fetchCodexQuota', () => {
+  it('fetches reset credit details after usage and prefers detail counts', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          plan_type: 'plus',
+          rate_limit_reset_credits: {
+            available_count: 1,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          available_count: 2,
+          credits: [
+            {
+              id: 'credit-1',
+              reset_type: 'codex_rate_limits',
+              status: 'available',
+              granted_at: '2026-06-01T00:00:00Z',
+              expires_at: '2026-06-30T00:00:00Z',
+            },
+          ],
+        },
+      });
+
+    const result = await fetchCodexQuota(
+      {
+        name: 'codex.json',
+        type: 'codex',
+        authIndex: ' auth-1 ',
+        id_token: { account_id: 'acct-1' },
+      },
+      t
+    );
+
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    expect(mocks.request.mock.calls[0][0]).toMatchObject({
+      authIndex: 'auth-1',
+      method: 'GET',
+      url: CODEX_USAGE_URL,
+      header: expect.objectContaining({
+        Authorization: 'Bearer $TOKEN$',
+        'Chatgpt-Account-Id': 'acct-1',
+      }),
+    });
+    expect(mocks.request.mock.calls[1][0]).toMatchObject({
+      authIndex: 'auth-1',
+      method: 'GET',
+      url: CODEX_RATE_LIMIT_RESET_CREDITS_URL,
+      header: expect.objectContaining({
+        Accept: 'application/json',
+        'OpenAI-Beta': 'codex-1',
+        Originator: 'Codex Desktop',
+        'Chatgpt-Account-Id': 'acct-1',
+      }),
+    });
+    expect(mocks.request.mock.calls[1][1]).toMatchObject({ timeout: 8000 });
+    expect(result.rateLimitResetCreditsAvailableCount).toBe(2);
+    expect(result.rateLimitResetCredits).toHaveLength(1);
+    expect(result.rateLimitResetCreditsError).toBeNull();
+  });
+
+  it('keeps usage quota data when reset credit details fail', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          plan_type: 'plus',
+          rate_limit_reset_credits: {
+            available_count: 1,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 502,
+        hasStatusCode: true,
+        header: {},
+        bodyText: 'bad gateway',
+        body: null,
+      });
+
+    const result = await fetchCodexQuota(
+      {
+        name: 'codex.json',
+        type: 'codex',
+        authIndex: 'auth-1',
+      },
+      t
+    );
+
+    expect(result.rateLimitResetCreditsAvailableCount).toBe(1);
+    expect(result.rateLimitResetCredits).toEqual([]);
+    expect(result.rateLimitResetCreditsError).toBe('502 bad gateway');
+  });
+});

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -7,6 +7,7 @@ import type {
   ClaudeProfileResponse,
   ClaudeQuotaWindow,
   ClaudeUsagePayload,
+  CodexRateLimitResetCredit,
   CodexQuotaWindow,
   CodexUsagePayload,
   KimiQuotaRow,
@@ -23,6 +24,7 @@ import {
   CLAUDE_USAGE_URL,
   CLAUDE_USAGE_WINDOW_KEYS,
   CODEX_REQUEST_HEADERS,
+  CODEX_RATE_LIMIT_RESET_CREDITS_URL,
   CODEX_USAGE_URL,
   KIMI_REQUEST_HEADERS,
   KIMI_USAGE_URL,
@@ -44,14 +46,18 @@ import {
 } from './parsers';
 import { resolveCodexChatgptAccountId, resolveCodexPlanType } from './resolvers';
 import { buildCodexQuotaWindowInfos } from './codexQuota';
+import { normalizeCodexResetCreditsPayload } from './resetCredits';
 
 const DEFAULT_ANTIGRAVITY_PROJECT_ID = 'bamboo-precept-lgxtn';
+const CODEX_RESET_CREDITS_REQUEST_TIMEOUT_MS = 8000;
 
 export type CodexQuotaData = {
   planType: string | null;
   windows: CodexQuotaWindow[];
   subscriptionActiveUntil: string | null;
   rateLimitResetCreditsAvailableCount: number | null;
+  rateLimitResetCredits: CodexRateLimitResetCredit[];
+  rateLimitResetCreditsError: string | null;
 };
 
 export type ClaudeQuotaData = {
@@ -233,6 +239,15 @@ const buildCodexUsageRequestHeaders = (accountId?: string | null): Record<string
   return headers;
 };
 
+const buildCodexResetCreditsRequestHeaders = (
+  accountId?: string | null
+): Record<string, string> => ({
+  ...buildCodexUsageRequestHeaders(accountId),
+  Accept: 'application/json',
+  'OpenAI-Beta': 'codex-1',
+  Originator: 'Codex Desktop',
+});
+
 const resolveCodexRateLimitResetCreditsAvailableCount = (
   payload: CodexUsagePayload
 ): number | null => {
@@ -242,6 +257,67 @@ const resolveCodexRateLimitResetCreditsAvailableCount = (
 
 const resolveCodexSubscriptionActiveUntil = (payload: CodexUsagePayload): string | null =>
   normalizeStringValue(payload.subscription_active_until ?? payload.subscriptionActiveUntil);
+
+type CodexResetCreditsData = {
+  availableCount: number | null;
+  credits: CodexRateLimitResetCredit[];
+  error: string | null;
+};
+
+const resolveCodexResetCreditsAvailableCount = (
+  resetCredits: CodexResetCreditsData,
+  usageAvailableCount: number | null
+): number | null => {
+  if (resetCredits.availableCount !== null) return resetCredits.availableCount;
+  if (resetCredits.credits.length > 0) return resetCredits.credits.length;
+  return usageAvailableCount;
+};
+
+const fetchCodexResetCredits = async (
+  authIndex: string,
+  accountId?: string | null
+): Promise<CodexResetCreditsData> => {
+  try {
+    const result = await apiCallApi.request(
+      {
+        authIndex,
+        method: 'GET',
+        url: CODEX_RATE_LIMIT_RESET_CREDITS_URL,
+        header: buildCodexResetCreditsRequestHeaders(accountId),
+      },
+      { timeout: CODEX_RESET_CREDITS_REQUEST_TIMEOUT_MS }
+    );
+
+    if (result.statusCode < 200 || result.statusCode >= 300) {
+      return {
+        availableCount: null,
+        credits: [],
+        error: getApiCallErrorMessage(result),
+      };
+    }
+
+    const payload = normalizeCodexResetCreditsPayload(result.body ?? result.bodyText);
+    if (payload.invalidPayload) {
+      return {
+        availableCount: null,
+        credits: [],
+        error: 'Invalid Codex reset credits payload',
+      };
+    }
+
+    return {
+      availableCount: payload.availableCount,
+      credits: payload.credits,
+      error: null,
+    };
+  } catch (err: unknown) {
+    return {
+      availableCount: null,
+      credits: [],
+      error: err instanceof Error ? err.message : 'Failed to fetch Codex reset credits',
+    };
+  }
+};
 
 export const fetchCodexQuota = async (
   file: AuthFileItem,
@@ -274,11 +350,18 @@ export const fetchCodexQuota = async (
   const planTypeFromUsage = normalizePlanType(payload.plan_type ?? payload.planType);
   const planType = planTypeFromUsage ?? planTypeFromFile;
   const windows = buildCodexQuotaWindows(payload, t, planType);
+  const usageResetCreditsAvailableCount = resolveCodexRateLimitResetCreditsAvailableCount(payload);
+  const resetCredits = await fetchCodexResetCredits(authIndex, accountId);
   return {
     planType,
     windows,
     subscriptionActiveUntil: resolveCodexSubscriptionActiveUntil(payload),
-    rateLimitResetCreditsAvailableCount: resolveCodexRateLimitResetCreditsAvailableCount(payload),
+    rateLimitResetCreditsAvailableCount: resolveCodexResetCreditsAvailableCount(
+      resetCredits,
+      usageResetCreditsAvailableCount
+    ),
+    rateLimitResetCredits: resetCredits.credits,
+    rateLimitResetCreditsError: resetCredits.error,
   };
 };
 

--- a/apps/web/src/utils/quota/resetCredits.test.ts
+++ b/apps/web/src/utils/quota/resetCredits.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCodexResetCreditsPayload } from './resetCredits';
+
+describe('normalizeCodexResetCreditsPayload', () => {
+  it('normalizes available Codex rate limit reset credits', () => {
+    const result = normalizeCodexResetCreditsPayload({
+      available_count: '2',
+      credits: [
+        {
+          id: 123,
+          reset_type: 'codex_rate_limits',
+          status: 'available',
+          granted_at: '2026-06-01T00:00:00Z',
+          expires_at: '2026-06-30T00:00:00Z',
+        },
+        {
+          id: 'used-credit',
+          reset_type: 'codex_rate_limits',
+          status: 'used',
+          expires_at: '2026-06-30T00:00:00Z',
+        },
+        {
+          id: 'other-credit',
+          reset_type: 'other',
+          status: 'available',
+          expires_at: '2026-06-30T00:00:00Z',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      availableCount: 2,
+      invalidPayload: false,
+      credits: [
+        {
+          id: '123',
+          status: 'available',
+          grantedAt: '2026-06-01T00:00:00Z',
+          expiresAt: '2026-06-30T00:00:00Z',
+        },
+      ],
+    });
+  });
+
+  it('parses JSON string payloads and supports camelCase fields', () => {
+    const result = normalizeCodexResetCreditsPayload(
+      JSON.stringify({
+        availableCount: 1,
+        credits: [
+          {
+            id: 'credit-1',
+            resetType: 'codex_rate_limits',
+            status: 'available',
+            grantedAt: '2026-06-01T00:00:00Z',
+            expiresAt: '2026-06-30T00:00:00Z',
+          },
+        ],
+      })
+    );
+
+    expect(result.availableCount).toBe(1);
+    expect(result.credits[0]?.id).toBe('credit-1');
+    expect(result.invalidPayload).toBe(false);
+  });
+
+  it('marks invalid payloads', () => {
+    expect(normalizeCodexResetCreditsPayload('not-json')).toEqual({
+      availableCount: null,
+      credits: [],
+      invalidPayload: true,
+    });
+
+    expect(normalizeCodexResetCreditsPayload({ unknown: true })).toEqual({
+      availableCount: null,
+      credits: [],
+      invalidPayload: true,
+    });
+  });
+});

--- a/apps/web/src/utils/quota/resetCredits.ts
+++ b/apps/web/src/utils/quota/resetCredits.ts
@@ -1,0 +1,60 @@
+import type { CodexRateLimitResetCredit, CodexResetCreditsSummary } from '@/types';
+import { normalizeNumberValue, normalizeStringValue } from './parsers';
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+const normalizeCredit = (value: unknown): CodexRateLimitResetCredit | null => {
+  const record = asRecord(value);
+  if (!record) return null;
+  if (normalizeStringValue(record.reset_type ?? record.resetType) !== 'codex_rate_limits') {
+    return null;
+  }
+  if (normalizeStringValue(record.status) !== 'available') {
+    return null;
+  }
+
+  const expiresAt = normalizeStringValue(record.expires_at ?? record.expiresAt);
+  if (!expiresAt) return null;
+
+  return {
+    id: normalizeStringValue(record.id) ?? '',
+    status: normalizeStringValue(record.status) ?? '',
+    grantedAt: normalizeStringValue(record.granted_at ?? record.grantedAt) ?? '',
+    expiresAt,
+  };
+};
+
+export const normalizeCodexResetCreditsPayload = (
+  payload: unknown
+): CodexResetCreditsSummary => {
+  let parsedPayload = payload;
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    if (!trimmed) return { availableCount: null, credits: [], invalidPayload: true };
+    try {
+      parsedPayload = JSON.parse(trimmed);
+    } catch {
+      return { availableCount: null, credits: [], invalidPayload: true };
+    }
+  }
+
+  const record = asRecord(parsedPayload);
+  if (!record) return { availableCount: null, credits: [], invalidPayload: true };
+
+  const hasExpectedShape =
+    'credits' in record || 'available_count' in record || 'availableCount' in record;
+  const credits = Array.isArray(record.credits)
+    ? record.credits.map(normalizeCredit).filter((credit): credit is CodexRateLimitResetCredit =>
+        Boolean(credit)
+      )
+    : [];
+
+  return {
+    availableCount: normalizeNumberValue(record.available_count ?? record.availableCount),
+    credits,
+    invalidPayload: !hasExpectedShape,
+  };
+};


### PR DESCRIPTION
## Summary
Adds Codex reset credit detail fetching so the quota card can use the dedicated reset-credit endpoint.
Keeps existing usage quota data when the reset-credit detail request fails.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Fetch Codex reset-credit details from the dedicated ChatGPT endpoint after usage data.
- Normalize available reset credits and expose them in Codex quota state.
- Add focused tests for reset-credit parsing and Codex quota request fallback behavior.

## User Impact
Codex quota cards can show a more accurate reset-credit count when reset-credit details are available.

## Compatibility / Runtime Notes
- CPA panel mode: Uses existing frontend quota request flow.
- Manager Server mode: No backend changes.
- Full Docker / native packages: Updated panel behavior after frontend build.

## Data / Security Notes
No schema or persisted data changes. Uses existing token-substitution request flow for Codex quota APIs.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR to restore usage-payload-only reset-credit counts.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
git diff --check origin/main...HEAD
```

## Screenshots / Recordings
N/A

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A