### PR TITLE
chore(github): improve issue triage templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -10,6 +10,25 @@ body:
         感谢反馈。请尽量完整填写下面信息，否则很难判断是 CPA、CPA Manager Plus、网络、Docker 还是配置问题。
 
   - type: dropdown
+    id: problem-type
+    attributes:
+      label: 问题类型
+      description: 请选择最接近的问题类型，便于快速分流。
+      options:
+        - 请求监控为空或数据延迟
+        - 用量 / 成本统计不准确
+        - AI 提供商不可用或测活异常
+        - 认证文件 / 配额 / 巡检异常
+        - 自动禁用 / 自动恢复异常
+        - 登录 / 权限 / Management Key
+        - 配置保存或配置读取异常
+        - 前端显示或交互异常
+        - 部署 / 网络 / 反代异常
+        - 其他
+    validations:
+      required: true
+
+  - type: dropdown
     id: deploy-mode
     attributes:
       label: 部署方式

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -9,6 +9,25 @@ body:
       value: |
         请尽量描述真实使用场景，而不是只写“希望支持 xxx”。
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: 影响页面 / 模块
+      description: 这个需求主要影响哪里？
+      options:
+        - 请求监控
+        - 用量分析 / 成本分析
+        - AI 提供商
+        - 认证文件 / 配额 / 巡检
+        - API Key / 调用方管理
+        - 配置中心
+        - 部署 / Manager Server
+        - 备份 / 维护
+        - README / 文档 / 增长展示
+        - 不确定 / 其他
+    validations:
+      required: true
+
   - type: textarea
     id: scenario
     attributes:
@@ -31,6 +50,34 @@ body:
     attributes:
       label: 期望方案
       description: 你希望 CPA Manager Plus 怎么实现？
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: dimensions
+    attributes:
+      label: 关注的数据维度
+      description: 如果这个需求涉及统计、筛选、展示、额度或导出，请勾选相关维度。
+      options:
+        - label: API Key / 调用方
+        - label: AI 提供商 / Provider
+        - label: 模型
+        - label: 认证文件 / Auth File
+        - label: 账号
+        - label: 项目 / Project
+        - label: 时间范围
+        - label: 成本
+        - label: Token / 用量
+        - label: 配额 / Quota
+        - label: 失败原因 / 错误类型
+        - label: 不涉及这些维度
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 期望验收结果
+      description: 什么情况下你会认为这个需求已经完成？请尽量写成可验证结果。
+      placeholder: 例如：当供应商能返回模型列表但真实请求失败时，测活结果应显示不可用，并提示失败原因。
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/03-deployment-help.yml
+++ b/.github/ISSUE_TEMPLATE/03-deployment-help.yml
@@ -64,6 +64,21 @@ body:
       required: true
 
   - type: textarea
+    id: connectivity
+    attributes:
+      label: 连通性检查结果
+      description: 请粘贴已执行的连通性检查结果。注意浏览器能访问不等于容器之间能访问。
+      render: shell
+      placeholder: |
+        curl <CPA 地址>/status
+        curl <Manager Server 地址>/status
+        docker network ls
+        docker compose ps
+        反代路径 / base path：
+    validations:
+      required: false
+
+  - type: textarea
     id: tried
     attributes:
       label: 已尝试的排查

--- a/.github/ISSUE_TEMPLATE/04-bug-report-en.yml
+++ b/.github/ISSUE_TEMPLATE/04-bug-report-en.yml
@@ -10,6 +10,25 @@ body:
         Thanks for reporting a bug. Please fill in the details below as completely as possible so we can determine whether the issue is caused by CPA, CPA Manager Plus, networking, Docker, or configuration.
 
   - type: dropdown
+    id: problem-type
+    attributes:
+      label: Problem Type
+      description: Choose the closest issue type to help triage.
+      options:
+        - Empty or delayed request monitoring
+        - Incorrect usage / cost statistics
+        - AI provider unavailable or health check failure
+        - Auth file / quota / inspection issue
+        - Auto-disable / auto-recovery issue
+        - Login / permission / Management Key
+        - Configuration save or load issue
+        - Frontend display or interaction issue
+        - Deployment / networking / reverse proxy issue
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
     id: deploy-mode
     attributes:
       label: Deployment Mode

--- a/.github/ISSUE_TEMPLATE/05-feature-request-en.yml
+++ b/.github/ISSUE_TEMPLATE/05-feature-request-en.yml
@@ -9,6 +9,25 @@ body:
       value: |
         Please describe the real use case instead of only saying "please support xxx".
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Page / Module
+      description: Where does this request mainly apply?
+      options:
+        - Request monitoring
+        - Usage analytics / cost analytics
+        - AI providers
+        - Auth files / quota / inspection
+        - API keys / client management
+        - Configuration center
+        - Deployment / Manager Server
+        - Backup / maintenance
+        - README / docs / growth presentation
+        - Not sure / other
+    validations:
+      required: true
+
   - type: textarea
     id: scenario
     attributes:
@@ -34,14 +53,42 @@ body:
     validations:
       required: true
 
+  - type: checkboxes
+    id: dimensions
+    attributes:
+      label: Relevant Data Dimensions
+      description: If this request involves statistics, filters, display, quota, or export, select the related dimensions.
+      options:
+        - label: API Key / client
+        - label: AI provider
+        - label: Model
+        - label: Auth file
+        - label: Account
+        - label: Project
+        - label: Time range
+        - label: Cost
+        - label: Token / usage
+        - label: Quota
+        - label: Failure reason / error type
+        - label: None of these
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Expected Acceptance Result
+      description: What result would make this request complete? Please make it verifiable.
+      placeholder: "Example: If a provider can return a model list but real requests fail, the health check should show it as unavailable and explain the failure reason."
+    validations:
+      required: true
+
   - type: dropdown
     id: priority
     attributes:
       label: Priority
       options:
-        - High: affects the main workflow
-        - Medium: clearly improves usability
-        - Low: nice to have
+        - "High: affects the main workflow"
+        - "Medium: clearly improves usability"
+        - "Low: nice to have"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/06-deployment-help-en.yml
+++ b/.github/ISSUE_TEMPLATE/06-deployment-help-en.yml
@@ -64,6 +64,21 @@ body:
       required: true
 
   - type: textarea
+    id: connectivity
+    attributes:
+      label: Connectivity Check Results
+      description: Paste connectivity checks you have run. Browser access does not always mean containers can reach each other.
+      render: shell
+      placeholder: |
+        curl <CPA URL>/status
+        curl <Manager Server URL>/status
+        docker network ls
+        docker compose ps
+        Reverse proxy path / base path:
+    validations:
+      required: false
+
+  - type: textarea
     id: tried
     attributes:
       label: Troubleshooting Already Tried

--- a/.github/ISSUE_TEMPLATE/07-observability-ops-request.yml
+++ b/.github/ISSUE_TEMPLATE/07-observability-ops-request.yml
@@ -1,0 +1,111 @@
+name: 可观测性 / 运维需求
+description: 请求监控、用量导出、健康检查、备份、成本治理、采集可靠性等需求
+title: "[Ops]: "
+labels: ["enhancement", "needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        这个模板适合请求监控、用量分析、成本治理、健康检查、备份维护、collector 可靠性、导出和诊断报告等运维类需求。
+
+  - type: dropdown
+    id: observability-scenario
+    attributes:
+      label: 可观测性场景
+      description: 这个需求最接近哪类场景？
+      options:
+        - 请求监控 / Request Events
+        - 用量分析 / 成本分析
+        - Provider / 模型健康检查
+        - 认证文件 / 配额 / 账号健康
+        - Usage Collector / 队列可靠性
+        - 导出 / 诊断报告 / 脱敏
+        - 备份 / 维护 / 数据保留
+        - 系统健康检查 / Doctor
+        - 其他
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 当前无法回答的问题
+      description: 你希望通过这个能力看清什么？例如失败原因、成本归因、额度状态、队列积压、备份状态。
+      placeholder: 例如：我无法判断某段时间内失败请求主要来自哪个 Provider 和模型。
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: dimensions
+    attributes:
+      label: 需要支持的筛选 / 聚合维度
+      options:
+        - label: 时间范围
+        - label: API Key / 调用方
+        - label: AI 提供商 / Provider
+        - label: 模型
+        - label: 认证文件 / Auth File
+        - label: 账号
+        - label: 项目 / Project
+        - label: 成本
+        - label: Token / 用量
+        - label: 配额 / Quota
+        - label: 失败原因 / 错误类型
+        - label: Header / 响应元数据
+        - label: 队列 / Collector 状态
+
+  - type: textarea
+    id: data-source
+    attributes:
+      label: 数据来源
+      description: 这些信息来自哪里？可以是请求监控事件、CPA usage queue、Provider API、response headers、SQLite、外部接口等。
+      placeholder: 例如：来自 CPA usage queue 中的 usage events，以及 response header 中的 quota 信息。
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: 期望展示 / 导出结果
+      description: 你希望看到什么页面、字段、图表、导出格式或诊断结论？
+      placeholder: 例如：按当前筛选条件导出 CSV，包含时间、Provider、模型、API Key、失败原因、成本，且不包含 raw_json。
+    validations:
+      required: true
+
+  - type: textarea
+    id: scale
+    attributes:
+      label: 数据规模 / 性能背景
+      description: 如果知道，请提供事件量、时间窗口、刷新频率、数据库大小或导出规模。
+      placeholder: 例如：每天约 10 万条 usage events，希望导出最近 7 天失败请求。
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: 安全与隐私
+      options:
+        - label: 结果中不能包含 CPA Management Key、API Key、token 或账号敏感信息
+          required: true
+        - label: 如果涉及导出或诊断报告，需要明确脱敏字段
+          required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 期望验收结果
+      description: 什么情况下你会认为这个需求已经完成？请尽量写成可验证结果。
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: 检查清单
+      options:
+        - label: 我已经搜索过现有 Issues，没有找到重复需求
+          required: true
+        - label: 我已经确认敏感信息已经脱敏，例如 token、key、账号信息
+          required: true

--- a/.github/ISSUE_TEMPLATE/08-observability-ops-request-en.yml
+++ b/.github/ISSUE_TEMPLATE/08-observability-ops-request-en.yml
@@ -1,0 +1,111 @@
+name: Observability / Operations Request
+description: Request monitoring, usage export, health checks, backup, cost governance, collector reliability, and diagnostics
+title: "[Ops]: "
+labels: ["enhancement", "needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for operational observability requests: request monitoring, usage analytics, cost governance, health checks, backup and maintenance, collector reliability, exports, and diagnostic reports.
+
+  - type: dropdown
+    id: observability-scenario
+    attributes:
+      label: Observability Scenario
+      description: Which scenario is closest to this request?
+      options:
+        - Request monitoring / Request Events
+        - Usage analytics / cost analytics
+        - Provider / model health check
+        - Auth file / quota / account health
+        - Usage Collector / queue reliability
+        - Export / diagnostic report / redaction
+        - Backup / maintenance / data retention
+        - System health check / Doctor
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Question You Cannot Answer Today
+      description: What do you want this capability to make visible? For example failure reasons, cost attribution, quota state, queue backlog, or backup status.
+      placeholder: "Example: I cannot tell which provider and model caused most failures during a time window."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: dimensions
+    attributes:
+      label: Required Filter / Aggregation Dimensions
+      options:
+        - label: Time range
+        - label: API Key / client
+        - label: AI provider
+        - label: Model
+        - label: Auth file
+        - label: Account
+        - label: Project
+        - label: Cost
+        - label: Token / usage
+        - label: Quota
+        - label: Failure reason / error type
+        - label: Header / response metadata
+        - label: Queue / Collector state
+
+  - type: textarea
+    id: data-source
+    attributes:
+      label: Data Source
+      description: Where does the information come from? Examples include request events, CPA usage queue, provider APIs, response headers, SQLite, or external APIs.
+      placeholder: "Example: CPA usage queue events plus quota information from response headers."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected Display / Export Result
+      description: What page, fields, chart, export format, or diagnostic conclusion do you expect?
+      placeholder: "Example: Export the current filtered result as CSV with time, provider, model, API key, failure reason, and cost, without raw_json."
+    validations:
+      required: true
+
+  - type: textarea
+    id: scale
+    attributes:
+      label: Data Scale / Performance Context
+      description: If known, provide event volume, time window, refresh frequency, database size, or export scale.
+      placeholder: "Example: About 100k usage events per day; need to export failed requests from the last 7 days."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Security And Privacy
+      options:
+        - label: Results must not include CPA Management Keys, API keys, tokens, or sensitive account information.
+          required: true
+        - label: If export or diagnostic reports are involved, redacted fields should be explicit.
+          required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Expected Acceptance Result
+      description: What result would make this request complete? Please make it verifiable.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing Issues and did not find a duplicate request.
+          required: true
+        - label: I have removed sensitive information such as tokens, keys, and account details.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: false
 
 contact_links:
   - name: 使用交流 / 非结构化讨论
-    url: https://linux.do/t/topic/2116998
-    about: 如果不是明确 Bug 或功能需求，可以先到 linux.do 讨论。
+    url: https://t.me/cpa_mp
+    about: 如果不是明确 Bug 或功能需求，可以先到 Telegram 群组讨论。

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -24,9 +24,11 @@ jobs:
               "### 部署方式",
               "### 使用场景",
               "### 运行环境",
+              "### 可观测性场景",
               "### Deployment Mode",
               "### Use Case",
-              "### Runtime Environment"
+              "### Runtime Environment",
+              "### Observability Scenario"
             ];
 
             const usesTemplate = requiredMarkers.some((marker) => body.includes(marker));
@@ -99,8 +101,8 @@ jobs:
                 "这个 Issue 看起来没有使用模板，信息不足，暂时无法排查。",
                 "This issue does not appear to use a required template, so it does not contain enough information for triage.",
                 "",
-                "请重新创建 Issue，并选择对应模板：Bug 反馈、功能需求或部署 / 配置求助。",
-                "Please recreate the issue and choose one of the templates: Bug Report, Feature Request, or Deployment / Configuration Help.",
+                "请重新创建 Issue，并选择对应模板：Bug 反馈、功能需求、部署 / 配置求助或可观测性 / 运维需求。",
+                "Please recreate the issue and choose one of the templates: Bug Report, Feature Request, Deployment / Configuration Help, or Observability / Operations Request.",
                 "",
                 "如果是请求监控为空、Manager Server、Docker 网络相关问题，请务必提供版本、部署方式、关键配置和 `/status` 返回内容。",
                 "For empty request monitoring, Manager Server, or Docker networking issues, include versions, deployment mode, key configuration, and the `/status` response."

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ settings.local.json
 *.sw?
 
 TODO.md
+/docs/plan/
 
 /bin/tmp/
 /bin/cpa-manager


### PR DESCRIPTION
## Summary
Improve GitHub issue templates so incoming bugs, feature requests, deployment questions, and observability requests include enough information for triage and planning.

The PR also ignores the local docs/plan workspace and updates the non-structured discussion link to the CPA Manager Plus Telegram group.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes
- Add problem type, affected module, data dimension, acceptance, and connectivity fields to existing issue forms.
- Add Chinese and English observability / operations request templates.
- Update issue-template detection for the new forms.
- Ignore `docs/plan/` as a local planning workspace.

## User Impact
Issue reporters will see more structured templates and a Telegram group link for informal discussion.

## Compatibility / Runtime Notes
- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: N/A

## Data / Security Notes
No runtime data changes. The new templates explicitly ask reporters to redact sensitive keys, tokens, and account data.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the template and workflow changes if the new forms cause submission friction.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
ruby -e "require 'yaml'; Dir['.github/ISSUE_TEMPLATE/*.yml', '.github/workflows/issue-check.yml'].each { |f| YAML.load_file(f); puts \"OK #{f}\" }"
ruby -e "require 'yaml'; ok=true; Dir['.github/ISSUE_TEMPLATE/*.yml'].each do |f| data=YAML.load_file(f); Array(data['body']).each do |item| type=item['type']; next unless ['dropdown','checkboxes'].include?(type); Array(item.dig('attributes','options')).each do |opt| if type=='dropdown' && !opt.is_a?(String); warn \"non-string dropdown option in #{f}##{item['id']}: #{opt.inspect}\"; ok=false; elsif type=='checkboxes' && !opt['label'].is_a?(String); warn \"non-string checkbox label in #{f}##{item['id']}: #{opt.inspect}\"; ok=false; end; end; end; end; exit(ok ? 0 : 1)"
```

## Screenshots / Recordings
N/A

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
