### PR TITLE
build(web): add isolated demo build mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ style.md
 
 node_modules
 dist
+dist-demo
 dist-ssr
 *.local
 skills

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:demo": "vite --mode demo",
     "build": "tsc && vite build",
+    "build:demo": "tsc && vite build --mode demo",
     "preview": "vite preview",
+    "preview:demo": "vite preview --outDir dist-demo",
     "test": "vitest run",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",

--- a/apps/web/src/features/demo/demoFixtures.empty.ts
+++ b/apps/web/src/features/demo/demoFixtures.empty.ts
@@ -1,0 +1,45 @@
+const emptyObject = {};
+const emptyArray: unknown[] = [];
+
+export const getDemoRawConfig = () => emptyObject;
+export const getDemoProviderModels = () => emptyArray;
+export const getDemoAuthFiles = () => ({ files: [] });
+export const getDemoPlugins = () => ({ plugins: [] });
+export const getDemoPluginStore = () => ({ sources: [], plugins: [] });
+export const getDemoManagerConfig = () => emptyObject;
+export const getDemoDashboardSummary = () => emptyObject;
+export const getDemoMonitoringAnalytics = () => emptyObject;
+export const getDemoModelPrices = () => ({ prices: {} });
+export const getDemoUsagePayload = () => emptyObject;
+export const getDemoUsageServiceInfo = () => emptyObject;
+export const getDemoUsageServiceStatus = () => emptyObject;
+export const getDemoAccountProcessingPolicy = () => emptyObject;
+export const getDemoQuotaCooldowns = () => emptyArray;
+export const getDemoHeaderSnapshots = () => emptyObject;
+export const getDemoCodexInspectionRuns = () => ({ items: [] });
+export const getDemoCodexInspectionRun = () => ({ results: [] });
+export const getDemoAccountActionCandidates = () => ({ items: [], pendingCount: 0 });
+export const getDemoApiKeyAliases = () => ({ items: [] });
+export const getDemoLogsResponse = () => ({
+  lines: [],
+  'line-count': 0,
+  'latest-timestamp': Date.now(),
+  latestAfter: Date.now(),
+  nextCursor: '',
+  cursorReset: false,
+});
+export const getDemoErrorLogsResponse = () => ({ files: [] });
+export const getDemoLatestVersion = () => ({
+  latest: '',
+  current: '',
+  buildDate: '',
+  updateAvailable: false,
+});
+export const getDemoManagerLatestRelease = () => ({
+  tag_name: '',
+  name: '',
+  html_url: '',
+  published_at: new Date(0).toISOString(),
+});
+export const getDemoConfigYaml = () => '';
+export const getDemoApiCallResult = () => emptyObject;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __DEMO_SITE__: boolean;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -35,43 +35,64 @@ function getVersion(): string {
   return 'dev';
 }
 
+const isDemoSiteBuild = (mode: string) =>
+  mode === 'demo' || process.env.DEMO_SITE === 'true' || process.env.VITE_DEMO_SITE === 'true';
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    viteSingleFile({
-      removeViteModuleLoader: true
-    })
-  ],
-  define: {
-    __APP_VERSION__: JSON.stringify(getVersion())
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src')
-    }
-  },
-  css: {
-    modules: {
-      localsConvention: 'camelCase',
-      generateScopedName: '[name]__[local]___[hash:base64:5]'
+export default defineConfig(({ mode }) => {
+  const demoSite = isDemoSiteBuild(mode);
+  const useRealDemoFixtures = demoSite || mode === 'test';
+
+  return {
+    plugins: [
+      react(),
+      viteSingleFile({
+        removeViteModuleLoader: true
+      })
+    ],
+    define: {
+      __APP_VERSION__: JSON.stringify(getVersion()),
+      __DEMO_SITE__: JSON.stringify(demoSite || mode === 'test')
     },
-    preprocessorOptions: {
-      scss: {
-        additionalData: `@use "@/styles/variables.scss" as *;`
+    resolve: {
+      alias: [
+        {
+          find: /^@\/features\/demo\/demoFixtures$/,
+          replacement: path.resolve(
+            __dirname,
+            useRealDemoFixtures
+              ? './src/features/demo/demoFixtures.ts'
+              : './src/features/demo/demoFixtures.empty.ts'
+          )
+        },
+        {
+          find: '@',
+          replacement: path.resolve(__dirname, './src')
+        }
+      ]
+    },
+    css: {
+      modules: {
+        localsConvention: 'camelCase',
+        generateScopedName: '[name]__[local]___[hash:base64:5]'
+      },
+      preprocessorOptions: {
+        scss: {
+          additionalData: `@use "@/styles/variables.scss" as *;`
+        }
+      }
+    },
+    build: {
+      target: 'es2020',
+      outDir: demoSite ? 'dist-demo' : 'dist',
+      assetsInlineLimit: 100000000,
+      chunkSizeWarningLimit: 100000000,
+      cssCodeSplit: false,
+      rolldownOptions: {
+        output: {
+          codeSplitting: false
+        }
       }
     }
-  },
-  build: {
-    target: 'es2020',
-    outDir: 'dist',
-    assetsInlineLimit: 100000000,
-    chunkSizeWarningLimit: 100000000,
-    cssCodeSplit: false,
-    rolldownOptions: {
-      output: {
-        codeSplitting: false
-      }
-    }
-  }
+  };
 });

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   ],
   "scripts": {
     "dev": "npm --workspace apps/web run dev",
+    "dev:demo": "npm --workspace apps/web run dev:demo",
     "build": "npm --workspace apps/web run build",
+    "build:demo": "npm --workspace apps/web run build:demo",
     "preview": "npm --workspace apps/web run preview",
+    "preview:demo": "npm --workspace apps/web run preview:demo",
     "test": "npm --workspace apps/web run test -- src ../../tests",
     "lint": "npm --workspace apps/web run lint",
     "format": "npm --workspace apps/web run format",


### PR DESCRIPTION
## Summary
Add an isolated demo build mode for the web panel.
Default production builds continue to output `apps/web/dist/index.html`, while demo builds output `apps/web/dist-demo`.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes
- Add root and workspace `dev:demo`, `build:demo`, and `preview:demo` scripts.
- Add `__DEMO_SITE__` and demo-mode Vite output selection.
- Alias production demo fixtures to an empty stub and ignore `dist-demo` output.

## User Impact
No user-facing behavior change in the default management panel.
Developers can build a separate demo bundle with `npm run build:demo`.

## Compatibility / Runtime Notes
- CPA panel mode: unchanged for the default build.
- Manager Server mode: unchanged for the default build.
- Full Docker / native packages: unchanged because they continue to use `apps/web/dist/index.html`.

## Data / Security Notes
Production builds use an empty demo fixture alias so demo fixture data is not bundled into the default panel.
No real credentials or runtime data are added.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the build-mode script and Vite alias changes.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test
npm run build
npm run check:demo-isolation
npm run build:demo
git diff --check
```

## Screenshots / Recordings
N/A

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A