### PR TITLE
ci(demo): publish demo site and guard release bundles

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -1,0 +1,61 @@
+name: Demo Site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: demo-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Demo Site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build demo site
+        run: npm run build:demo
+        env:
+          VERSION: demo-${{ github.sha }}
+
+      - name: Upload demo artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/web/dist-demo
+
+  deploy:
+    name: Deploy Demo Site
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -39,10 +41,21 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build
         env:
           VERSION: ci
+
+      - name: Check demo isolation
+        run: npm run check:demo-isolation
+
+      - name: Build demo site
+        run: npm run build:demo
+        env:
+          VERSION: ci-demo
 
   manager-server:
     name: Manager Server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
 
+      - name: Check demo isolation
+        run: npm run check:demo-isolation
+
       - name: Build native release packages
         run: bin/release/package-native.sh
         env:

--- a/bin/release/check-web-demo-isolation.mjs
+++ b/bin/release/check-web-demo-isolation.mjs
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const bundlePath = path.resolve(repoRoot, process.argv[2] || 'apps/web/dist/index.html');
+
+const forbiddenMarkers = [
+  '#/demo',
+  '/demo/oauth',
+  'http://demo.local',
+  'demo-management-key',
+  'demo-cpa-management-key',
+  'request-errors-',
+  'hash_openai_primary',
+  'codex-fallback-02',
+  'request-insights',
+  'demo-usage.sqlite',
+  'demo-request-',
+  'demo-event-',
+  'demo-trace-',
+];
+
+if (!existsSync(bundlePath)) {
+  console.error(`Missing web bundle: ${path.relative(repoRoot, bundlePath)}`);
+  process.exit(1);
+}
+
+const bundle = readFileSync(bundlePath, 'utf8');
+const hits = forbiddenMarkers.filter((marker) => bundle.includes(marker));
+
+if (hits.length > 0) {
+  console.error(
+    [
+      `Default web bundle contains demo-only markers: ${path.relative(repoRoot, bundlePath)}`,
+      ...hits.map((marker) => `- ${marker}`),
+    ].join('\n')
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Default web bundle is free of demo fixture markers: ${path.relative(repoRoot, bundlePath)}`
+);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:demo": "npm --workspace apps/web run dev:demo",
     "build": "npm --workspace apps/web run build",
     "build:demo": "npm --workspace apps/web run build:demo",
+    "check:demo-isolation": "node bin/release/check-web-demo-isolation.mjs",
     "preview": "npm --workspace apps/web run preview",
     "preview:demo": "npm --workspace apps/web run preview:demo",
     "test": "npm --workspace apps/web run test -- src ../../tests",


### PR DESCRIPTION
## Summary
Add CI coverage for demo builds and publish the demo bundle through GitHub Pages.
Add a release-time guard that fails if default production bundles contain demo-only fixture markers.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes
- Run tests, default build isolation, and demo build in PR CI.
- Check release bundles before native packaging.
- Add a GitHub Pages workflow that uploads `apps/web/dist-demo`.

## User Impact
No direct runtime behavior change.
Maintainers get automated demo publishing and stronger protection against demo data leaking into release artifacts.

## Compatibility / Runtime Notes
- CPA panel mode: unchanged.
- Manager Server mode: unchanged.
- Full Docker / native packages: release packaging is blocked if demo markers are found in the default bundle.

## Data / Security Notes
The guard searches for high-signal demo fixture markers in `apps/web/dist/index.html`.
The Pages workflow publishes only the demo build output and does not touch release artifacts.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Remove `.github/workflows/demo-pages.yml` and the demo isolation check steps.
- Remove `npm run check:demo-isolation` if the guard must be disabled temporarily.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test
npm run build
npm run check:demo-isolation
npm run build:demo
git diff --check
```

## Screenshots / Recordings
N/A

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Depends on #256