### PR TITLE
docs: update CPA compose deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,23 +91,48 @@ If you don't have CPA running yet, this Compose file starts both:
 services:
   cli-proxy-api:
     image: eceasy/cli-proxy-api:latest
+    container_name: cli-proxy-api
     restart: unless-stopped
     ports:
       - "8317:8317"
     volumes:
-      - cpa-data:/app/data
+      - ./cpa_data/config.yaml:/CLIProxyAPI/config.yaml
+      - ./cpa_data/auths:/root/.cli-proxy-api
+      - ./cpa_data/logs:/CLIProxyAPI/logs
 
   cpa-manager-plus:
     image: seakee/cpa-manager-plus:latest
+    container_name: cpa-manager-plus
     restart: unless-stopped
+    depends_on:
+      - cli-proxy-api
     ports:
       - "18317:18317"
     volumes:
-      - cpa-manager-plus-data:/data
+      - ./cmp_data:/data
+```
 
-volumes:
-  cpa-data:
-  cpa-manager-plus-data:
+Before starting the stack, create the host paths used by the bind mounts:
+
+```bash
+mkdir -p cpa_data/auths cpa_data/logs cmp_data
+touch cpa_data/config.yaml
+```
+
+`cpa_data/config.yaml` must be a file before `docker compose up -d`; otherwise Docker may create it as a directory. At minimum, enable the CPA Management API so CPAMP can reach CPA from the Compose network:
+
+```yaml
+host: ""
+port: 8317
+
+remote-management:
+  allow-remote: true
+  secret-key: "replace-with-your-cpa-management-key"
+
+auth-dir: "~/.cli-proxy-api"
+
+api-keys:
+  - "replace-with-your-client-api-key"
 ```
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -91,23 +91,48 @@ CPA Manager Plus 配合 [CPA / CLIProxyAPI](https://github.com/router-for-me/CLI
 services:
   cli-proxy-api:
     image: eceasy/cli-proxy-api:latest
+    container_name: cli-proxy-api
     restart: unless-stopped
     ports:
       - "8317:8317"
     volumes:
-      - cpa-data:/app/data
+      - ./cpa_data/config.yaml:/CLIProxyAPI/config.yaml
+      - ./cpa_data/auths:/root/.cli-proxy-api
+      - ./cpa_data/logs:/CLIProxyAPI/logs
 
   cpa-manager-plus:
     image: seakee/cpa-manager-plus:latest
+    container_name: cpa-manager-plus
     restart: unless-stopped
+    depends_on:
+      - cli-proxy-api
     ports:
       - "18317:18317"
     volumes:
-      - cpa-manager-plus-data:/data
+      - ./cmp_data:/data
+```
 
-volumes:
-  cpa-data:
-  cpa-manager-plus-data:
+启动前先创建 bind mount 使用的宿主机路径：
+
+```bash
+mkdir -p cpa_data/auths cpa_data/logs cmp_data
+touch cpa_data/config.yaml
+```
+
+`cpa_data/config.yaml` 在执行 `docker compose up -d` 前必须是文件，否则 Docker 可能把它创建成目录。最小配置需要启用 CPA Management API，这样 CPAMP 才能在 Compose 网络里访问 CPA：
+
+```yaml
+host: ""
+port: 8317
+
+remote-management:
+  allow-remote: true
+  secret-key: "replace-with-your-cpa-management-key"
+
+auth-dir: "~/.cli-proxy-api"
+
+api-keys:
+  - "replace-with-your-client-api-key"
 ```
 
 ```bash


### PR DESCRIPTION
Use bind-mounted CPA config, auth, and log paths for the CPA + CPAMP Compose example.

Add setup commands for required host directories and config.yaml, plus a minimal CPA Management API config needed before running docker compose.

If the following configuration is not performed, the following will be obtained:
<img width="2900" height="996" alt="image" src="https://github.com/user-attachments/assets/811075da-4aa3-45f0-9bec-f3746df67480" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker Compose setup guide for deploying CPA and CPAMP together.
  * Added clearer pre-start steps to create required host folders and configuration files before running Compose.
  * Expanded the sample configuration with the minimum settings needed for API access.
  * Reworked the example to use explicit service names and host-mounted paths for easier setup and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->