### PR TITLE
feat(quota): add auth file delete actions

### DIFF
--- a/apps/web/src/components/quota/QuotaCard.tsx
+++ b/apps/web/src/components/quota/QuotaCard.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
+import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
 import {
   DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
   type QuotaAccountDisplayMode,
@@ -72,11 +73,14 @@ interface QuotaCardProps<TState extends QuotaStatusState> {
   accountDisplayMode?: QuotaAccountDisplayMode;
   canRefresh?: boolean;
   onRefresh?: () => void;
+  selected?: boolean;
+  onToggleSelect?: (name: string, selected: boolean) => void;
   canReset?: boolean;
   resetLabel?: string;
   onReset?: () => void;
   canReauth?: boolean;
   onReauth?: () => void;
+  deleteAuthFileAction?: ReactNode;
   renderQuotaItems: (quota: TState, t: TFunction, helpers: QuotaRenderHelpers) => ReactNode;
 }
 
@@ -91,11 +95,14 @@ export function QuotaCard<TState extends QuotaStatusState>({
   accountDisplayMode = DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE,
   canRefresh = false,
   onRefresh,
+  selected = false,
+  onToggleSelect,
   canReset = false,
   resetLabel,
   onReset,
   canReauth = false,
   onReauth,
+  deleteAuthFileAction,
   renderQuotaItems,
 }: QuotaCardProps<TState>) {
   const { t } = useTranslation();
@@ -128,7 +135,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   };
 
   const renderActions = (options?: { includeReauth?: boolean }) =>
-    onRefresh || (onReset && resetLabel) || (options?.includeReauth && onReauth) ? (
+    onRefresh || (onReset && resetLabel) || (options?.includeReauth && onReauth) || deleteAuthFileAction ? (
       <div className={styles.quotaActions}>
         {options?.includeReauth && onReauth ? (
           <Button
@@ -166,12 +173,22 @@ export function QuotaCard<TState extends QuotaStatusState>({
             {t(`${i18nPrefix}.refresh_button`)}
           </Button>
         ) : null}
+        {deleteAuthFileAction}
       </div>
     ) : null;
 
   return (
     <div className={`${styles.fileCard} ${cardClassName}`}>
       <div className={styles.cardHeader}>
+        {onToggleSelect ? (
+          <SelectionCheckbox
+            checked={selected}
+            onChange={(value) => onToggleSelect(item.name, value)}
+            className={styles.quotaCardSelection}
+            ariaLabel={selected ? t('auth_files.batch_deselect') : t('auth_files.batch_select_all')}
+            title={selected ? t('auth_files.batch_deselect') : t('auth_files.batch_select_all')}
+          />
+        ) : null}
         <span
           className={styles.typeBadge}
           style={{

--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -7,7 +7,9 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
+import { authFilesApi } from '@/services/api';
 import { useNotificationStore, useQuotaStore, useThemeStore } from '@/stores';
 import type { AuthFileItem, ResolvedTheme } from '@/types';
 import { getStatusFromError } from '@/utils/quota';
@@ -31,7 +33,7 @@ import {
   type QuotaSectionViewMode,
 } from '@/features/quota/quotaPageUiState';
 import { useGridColumns } from './useGridColumns';
-import { IconEye, IconEyeOff, IconRefreshCw } from '@/components/ui/icons';
+import { IconEye, IconEyeOff, IconRefreshCw, IconTrash2 } from '@/components/ui/icons';
 import styles from '@/features/quota/QuotaPage.module.scss';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
@@ -40,6 +42,7 @@ type QuotaSetter<T> = (updater: QuotaUpdater<T>) => void;
 
 const MAX_ITEMS_PER_PAGE = 25;
 const MAX_SHOW_ALL_THRESHOLD = 30;
+const PAGE_ROWS = 5;
 
 const stringifySearchValue = (value: unknown): string[] => {
   if (value === undefined || value === null) return [];
@@ -84,8 +87,11 @@ const useQuotaPagination = <T,>(items: T[], defaultPageSize = 6): QuotaPaginatio
   }, [items, currentPage, pageSize]);
 
   const setPageSize = useCallback((size: number) => {
-    setPageSizeState(size);
-    setPage(1);
+    setPageSizeState((prev) => {
+      if (prev === size) return prev;
+      setPage(1);
+      return size;
+    });
   }, []);
 
   const goToPrev = useCallback(() => {
@@ -158,6 +164,9 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const [internalAccountDisplayMode, setInternalAccountDisplayMode] =
     useState<QuotaAccountDisplayMode>(DEFAULT_QUOTA_ACCOUNT_DISPLAY_MODE);
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
+  const [deletingFileNames, setDeletingFileNames] = useState<Set<string>>(() => new Set());
+  const [deletedFileNames, setDeletedFileNames] = useState<Set<string>>(() => new Set());
+  const [selectedFileNames, setSelectedFileNames] = useState<Set<string>>(() => new Set());
   const resolvedViewMode = viewMode ?? internalViewMode;
   const resolvedAccountDisplayMode = accountDisplayMode ?? internalAccountDisplayMode;
   const setViewMode = useCallback(
@@ -187,9 +196,10 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   );
 
   const filteredFiles = useMemo(
-    () => files.filter((file) => config.filterFn(file)),
-    [files, config]
+    () => files.filter((file) => config.filterFn(file) && !deletedFileNames.has(file.name)),
+    [files, config, deletedFileNames]
   );
+  const selectedCount = selectedFileNames.size;
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
 
   const { quota, loadQuota } = useQuotaLoader(config);
@@ -308,10 +318,28 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     if (effectiveViewMode === 'all') {
       setPageSize(Math.max(1, displayFiles.length));
     } else {
-      // Paged mode: 3 rows * columns, capped to avoid oversized pages.
-      setPageSize(Math.min(columns * 3, MAX_ITEMS_PER_PAGE));
+      // Paged mode: fixed rows * columns, capped to avoid oversized pages.
+      setPageSize(Math.min(columns * PAGE_ROWS, MAX_ITEMS_PER_PAGE));
     }
   }, [effectiveViewMode, columns, displayFiles.length, setPageSize]);
+
+  useEffect(() => {
+    setDeletedFileNames((prev) => {
+      if (prev.size === 0) return prev;
+      const fileNames = new Set(files.map((file) => file.name));
+      const next = new Set([...prev].filter((name) => fileNames.has(name)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [files]);
+
+  useEffect(() => {
+    setSelectedFileNames((prev) => {
+      if (prev.size === 0) return prev;
+      const displayNames = new Set(displayFiles.map((file) => file.name));
+      const next = new Set([...prev].filter((name) => displayNames.has(name)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [displayFiles]);
 
   const pendingQuotaRefreshRef = useRef(false);
   const prevFilesLoadingRef = useRef(loading);
@@ -470,6 +498,161 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     ]
   );
 
+  const applyDeletedAuthFiles = useCallback(
+    (names: string[]) => {
+      if (names.length === 0) return;
+      const deletedNames = new Set(names);
+      const deletedStoreKeys = new Set(
+        files
+          .filter((file) => deletedNames.has(file.name))
+          .map((file) => getQuotaStoreKey(config, file))
+      );
+
+      setDeletedFileNames((prev) => {
+        const next = new Set(prev);
+        names.forEach((name) => next.add(name));
+        return next;
+      });
+      setSelectedFileNames((prev) => {
+        if (prev.size === 0) return prev;
+        const next = new Set(prev);
+        names.forEach((name) => next.delete(name));
+        return next;
+      });
+      setQuota((prev) => {
+        const next = { ...prev };
+        names.forEach((name) => {
+          delete next[name];
+        });
+        deletedStoreKeys.forEach((key) => {
+          delete next[key];
+        });
+        return next;
+      });
+    },
+    [config, files, setQuota]
+  );
+
+  const deleteAuthFile = useCallback(
+    (file: AuthFileItem) => {
+      if (disabled || deletingFileNames.has(file.name)) return;
+      const displayName = getAccountDisplayName(file);
+
+      showConfirmation({
+        title: t('auth_files.delete_title', { defaultValue: 'Delete File' }),
+        message: `${t('auth_files.delete_confirm')} "${displayName}" ?`,
+        confirmText: t('common.confirm'),
+        cancelText: t('common.cancel'),
+        variant: 'danger',
+        onConfirm: async () => {
+          setDeletingFileNames((prev) => new Set(prev).add(file.name));
+          try {
+            const result = await authFilesApi.deleteFile(file.name);
+            applyDeletedAuthFiles(result.files.length > 0 ? result.files : [file.name]);
+            showNotification(t('auth_files.delete_success'), 'success');
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : t('common.unknown_error');
+            showNotification(`${t('notification.delete_failed')}: ${message}`, 'error');
+          } finally {
+            setDeletingFileNames((prev) => {
+              const next = new Set(prev);
+              next.delete(file.name);
+              return next;
+            });
+          }
+        },
+      });
+    },
+    [
+      applyDeletedAuthFiles,
+      deletingFileNames,
+      disabled,
+      getAccountDisplayName,
+      showConfirmation,
+      showNotification,
+      t,
+    ]
+  );
+
+  const toggleSelectedFile = useCallback((name: string, selected: boolean) => {
+    setSelectedFileNames((prev) => {
+      const next = new Set(prev);
+      if (selected) {
+        next.add(name);
+      } else {
+        next.delete(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const deleteSelectedAuthFiles = useCallback(() => {
+    if (disabled || selectedFileNames.size === 0) return;
+    const names = [...selectedFileNames].filter((name) => !deletingFileNames.has(name));
+    if (names.length === 0) return;
+
+    showConfirmation({
+      title: t('auth_files.batch_delete_title'),
+      message: t('auth_files.batch_delete_confirm', { count: names.length }),
+      confirmText: t('common.confirm'),
+      cancelText: t('common.cancel'),
+      variant: 'danger',
+      onConfirm: async () => {
+        setDeletingFileNames((prev) => {
+          const next = new Set(prev);
+          names.forEach((name) => next.add(name));
+          return next;
+        });
+        try {
+          const result = await authFilesApi.deleteFiles(names);
+          const failedNames = new Set(result.failed.map((item) => item.name));
+          const deletedNames =
+            result.files.length > 0
+              ? result.files
+              : result.failed.length === 0
+                ? names
+                : names.filter((name) => !failedNames.has(name));
+          applyDeletedAuthFiles(deletedNames);
+          if (result.failed.length > 0) {
+            showNotification(
+              t('auth_files.delete_filtered_result_partial', {
+                success: deletedNames.length,
+                failed: result.failed.length,
+              }),
+              'warning'
+            );
+          } else {
+            showNotification(
+              t('auth_files.delete_filtered_result_success', { count: deletedNames.length }),
+              'success'
+            );
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : t('common.unknown_error');
+          showNotification(`${t('notification.delete_failed')}: ${message}`, 'error');
+        } finally {
+          setDeletingFileNames((prev) => {
+            const next = new Set(prev);
+            names.forEach((name) => next.delete(name));
+            return next;
+          });
+        }
+      },
+    });
+  }, [
+    applyDeletedAuthFiles,
+    deletingFileNames,
+    disabled,
+    selectedFileNames,
+    showConfirmation,
+    showNotification,
+    t,
+  ]);
+
+  const clearSelectedFiles = useCallback(() => {
+    setSelectedFileNames(new Set());
+  }, []);
+
   const titleNode = (
     <div className={styles.titleWrapper}>
       <span>{t(`${config.i18nPrefix}.title`)}</span>
@@ -558,6 +741,20 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             {!isRefreshing && <IconRefreshCw size={16} />}
             {t('quota_management.refresh_all_credentials')}
           </Button>
+          {selectedCount > 0 ? (
+            <div className={styles.quotaBatchActions}>
+              <span className={styles.quotaBatchSelected}>
+                {t('auth_files.batch_selected', { count: selectedCount })}
+              </span>
+              <Button variant="danger" size="sm" onClick={deleteSelectedAuthFiles} disabled={disabled}>
+                <IconTrash2 size={16} />
+                {t('auth_files.delete_button')}
+              </Button>
+              <Button variant="secondary" size="sm" onClick={clearSelectedFiles}>
+                {t('auth_files.batch_deselect')}
+              </Button>
+            </div>
+          ) : null}
         </div>
       }
     >
@@ -577,6 +774,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             {pageItems.map((item) => {
               const itemQuota = getScopedQuota(item);
               const displayQuota = getDisplayQuota(item);
+              const isDeletingFile = deletingFileNames.has(item.name);
               const resetCount =
                 (itemQuota as { rateLimitResetCreditsAvailableCount?: number | null } | undefined)
                   ?.rateLimitResetCreditsAvailableCount ?? 0;
@@ -584,6 +782,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                 Boolean(config.resetQuota) &&
                 !disabled &&
                 !item.disabled &&
+                !isDeletingFile &&
                 (config.canResetQuota?.(item, itemQuota) ??
                   Boolean(itemQuota && itemQuota.status === 'success'));
               const canReauth =
@@ -592,7 +791,23 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                 itemQuota.errorStatus === 401 &&
                 !disabled &&
                 !item.disabled &&
+                !isDeletingFile &&
                 Boolean(onReauthAccount);
+              const canDeleteAuthFile = !disabled && !isDeletingFile;
+              const deleteAuthFileAction = (
+                <Button
+                  type="button"
+                  variant="danger"
+                  size="sm"
+                  className={styles.quotaDeleteAuthFileButton}
+                  onClick={() => deleteAuthFile(item)}
+                  disabled={!canDeleteAuthFile}
+                  title={t('auth_files.delete_button')}
+                  aria-label={t('auth_files.delete_button')}
+                >
+                  {isDeletingFile ? <LoadingSpinner size={14} /> : <IconTrash2 size={16} />}
+                </Button>
+              );
 
               return (
                 <QuotaCard
@@ -605,8 +820,10 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                   cardClassName={config.cardClassName}
                   defaultType={config.type}
                   accountDisplayMode={resolvedAccountDisplayMode}
-                  canRefresh={!disabled && !item.disabled}
+                  canRefresh={!disabled && !item.disabled && !isDeletingFile}
                   onRefresh={() => void refreshQuotaForFile(item)}
+                  selected={selectedFileNames.has(item.name)}
+                  onToggleSelect={toggleSelectedFile}
                   canReset={canReset}
                   resetLabel={
                     canReset
@@ -616,6 +833,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                   onReset={canReset ? () => resetQuotaForFile(item) : undefined}
                   canReauth={canReauth}
                   onReauth={canReauth ? () => onReauthAccount?.(item) : undefined}
+                  deleteAuthFileAction={deleteAuthFileAction}
                   renderQuotaItems={config.renderQuotaItems}
                 />
               );

--- a/apps/web/src/features/quota/QuotaPage.module.scss
+++ b/apps/web/src/features/quota/QuotaPage.module.scss
@@ -276,6 +276,36 @@
   }
 }
 
+.quotaBatchActions {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 3px;
+  border: 1px solid color-mix(in srgb, var(--danger-color) 22%, var(--border-color));
+  border-radius: $radius-md;
+  background: color-mix(in srgb, var(--danger-color) 7%, var(--bg-secondary));
+
+  :global(.btn.btn-sm) > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+  }
+
+  @include mobile {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+.quotaBatchSelected {
+  padding-inline: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
 .accountDisplayModeButton:global(.btn.btn-sm) {
   height: 34px;
   min-height: 34px;
@@ -381,6 +411,16 @@
   padding-top: $spacing-sm;
   margin-top: $spacing-xs;
   border-top: 1px dashed var(--border-color);
+}
+
+.quotaCardSelection {
+  flex: 0 0 auto;
+}
+
+.quotaDeleteAuthFileButton:global(.btn.btn-sm) {
+  width: 34px;
+  padding-inline: 0;
+  border-radius: $radius-sm;
 }
 
 .quotaRow {


### PR DESCRIPTION
在配额管理页面添加”删除“和”批量删除“按钮（勾选后删除），便于在认证文件401无效时删除对应认证文件，不用跳到认证文件页面再删除。

## Summary
- add per-card auth file delete action on quota cards
- support selecting quota cards and batch deleting selected auth files
- clear deleted auth files from quota display state and cache after successful deletion

## Test
- bun run build (apps/web)
- git diff --check

单个文件删除：
<img width="2657" height="1601" alt="image" src="https://github.com/user-attachments/assets/33d089d3-8cd2-4f79-a1d1-6db98a8f2148" />

多个文件删除：
<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/ba629bdf-91a8-42a6-a7c4-184eb6f7785f" />


## Notes
Ported from router-for-me/Cli-Proxy-API-Management-Center#334 into the current CPA Manager Plus app structure.