### PR TITLE
fix: preserve quota refresh failure timing for header updates

### DIFF
--- a/apps/web/src/components/quota/QuotaSection.test.tsx
+++ b/apps/web/src/components/quota/QuotaSection.test.tsx
@@ -11,6 +11,7 @@ type TestQuotaState = {
   windows: unknown[];
   error?: string;
   errorStatus?: number;
+  failedAtMs?: number;
   rateLimitResetCreditsAvailableCount?: number | null;
   authFileKey?: string;
 };
@@ -102,6 +103,14 @@ const testConfig: QuotaConfig<TestQuotaState, TestQuotaData> = {
     windows: [],
     error: message,
     errorStatus: status,
+  }),
+  buildFailureState: (message, status, _file, activeState) => ({
+    ...(activeState ?? { windows: [] }),
+    status: 'error',
+    windows: activeState?.windows ?? [],
+    error: message,
+    errorStatus: status,
+    failedAtMs: 1234,
   }),
   cardClassName: 'codex-card',
   controlsClassName: 'codex-controls',
@@ -238,6 +247,33 @@ describe('QuotaSection account display mode', () => {
     expect(message).not.toContain(FULL_FILE_NAME);
   });
 
+  it('keeps previous quota data when a single quota refresh fails', async () => {
+    mocks.fetchQuota.mockRejectedValue(new Error('network failed'));
+    mocks.quotaStoreState.codexQuota = {
+      [FULL_FILE_NAME]: {
+        ...successQuota,
+        windows: ['api-only-window'],
+        rateLimitResetCreditsAvailableCount: 2,
+      },
+    };
+    const renderer = renderSection();
+
+    await act(async () => {
+      findButtonByText(renderer, 'codex_quota.refresh_button').props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(mocks.quotaStoreState.codexQuota).toMatchObject({
+      [FULL_FILE_NAME]: {
+        status: 'error',
+        error: 'network failed',
+        windows: ['api-only-window'],
+        rateLimitResetCreditsAvailableCount: 2,
+        failedAtMs: 1234,
+      },
+    });
+  });
+
   it('uses masked names in quota reset confirmation and success notification', async () => {
     mocks.resetQuota.mockResolvedValue({ resetCredits: 1 });
     const renderer = renderSection();
@@ -281,6 +317,40 @@ describe('QuotaSection account display mode', () => {
     const message = String(mocks.showNotification.mock.calls[0]?.[0] ?? '');
     expect(message).toContain(MASKED_FILE_NAME);
     expect(message).not.toContain(FULL_FILE_NAME);
+  });
+
+  it('keeps previous quota data when quota reset fails', async () => {
+    mocks.resetQuota.mockRejectedValue(new Error('reset failed'));
+    mocks.quotaStoreState.codexQuota = {
+      [FULL_FILE_NAME]: {
+        ...successQuota,
+        windows: ['api-only-window'],
+        rateLimitResetCreditsAvailableCount: 2,
+      },
+    };
+    const renderer = renderSection();
+
+    act(() => {
+      findButtonByText(renderer, 'codex_quota.reset_action_button').props.onClick();
+    });
+
+    const confirmation = mocks.showConfirmation.mock.calls[0]?.[0] as {
+      onConfirm: () => Promise<void>;
+    };
+
+    await act(async () => {
+      await confirmation.onConfirm();
+    });
+
+    expect(mocks.quotaStoreState.codexQuota).toMatchObject({
+      [FULL_FILE_NAME]: {
+        status: 'error',
+        error: 'reset failed',
+        windows: ['api-only-window'],
+        rateLimitResetCreditsAvailableCount: 2,
+        failedAtMs: 1234,
+      },
+    });
   });
 
   it('scopes same-name quota cache by auth file identity', () => {
@@ -344,6 +414,50 @@ describe('QuotaSection account display mode', () => {
     expect(
       (mocks.quotaStoreState.codexQuota as Record<string, unknown>)[FULL_FILE_NAME]
     ).toBeUndefined();
+
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it('keeps previous scoped quota data when bulk quota refresh fails', async () => {
+    const scopedConfig = createScopedTestConfig();
+    const files: AuthFileItem[] = [{ ...testFile, authIndex: 0 }];
+    const storeKey = getTestAuthFileKey(files[0]);
+    mocks.quotaStoreState.codexQuota = {
+      [storeKey]: {
+        ...authScopedSuccessQuota,
+        windows: ['api-only-window'],
+        rateLimitResetCreditsAvailableCount: 2,
+      },
+    };
+    mocks.fetchQuota.mockRejectedValue(new Error('bulk failed'));
+
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <QuotaLoaderHarness
+          config={scopedConfig}
+          onLoadQuota={(nextLoadQuota) => {
+            runLoadQuota = nextLoadQuota;
+          }}
+        />
+      );
+    });
+
+    await act(async () => {
+      await runLoadQuota?.(files);
+    });
+
+    expect(mocks.quotaStoreState.codexQuota).toMatchObject({
+      [storeKey]: {
+        status: 'error',
+        error: 'bulk failed',
+        windows: ['api-only-window'],
+        rateLimitResetCreditsAvailableCount: 2,
+        failedAtMs: 1234,
+      },
+    });
 
     act(() => {
       renderer.unmount();

--- a/apps/web/src/components/quota/QuotaSection.tsx
+++ b/apps/web/src/components/quota/QuotaSection.tsx
@@ -19,7 +19,9 @@ import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
 import {
+  buildQuotaFailureState,
   getQuotaStoreKey,
+  getScopedQuotaState,
   resolveQuotaDisplayState,
   type QuotaConfig,
   type QuotaSortMode,
@@ -196,12 +198,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
   const getScopedQuota = useCallback(
     (file: AuthFileItem): TState | undefined => {
-      const storeKey = getQuotaStoreKey(config, file);
-      const activeQuota = quota[storeKey];
-      const scopedQuota = config.scopeState ? config.scopeState(file, activeQuota) : activeQuota;
-      if (scopedQuota || storeKey === file.name) return scopedQuota;
-      const legacyQuota = quota[file.name];
-      return config.scopeState ? config.scopeState(file, legacyQuota) : legacyQuota;
+      return getScopedQuotaState(config, quota, file);
     },
     [config, quota]
   );
@@ -372,6 +369,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
       if (getScopedQuota(file)?.status === 'loading') return;
       const displayName = getAccountDisplayName(file);
       const storeKey = getQuotaStoreKey(config, file);
+      const previousQuota = getScopedQuota(file);
 
       setQuota((prev) => ({
         ...prev,
@@ -390,7 +388,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         const status = getStatusFromError(err);
         setQuota((prev) => ({
           ...prev,
-          [storeKey]: config.buildErrorState(message, status, file),
+          [storeKey]: buildQuotaFailureState(config, message, status, file, previousQuota),
         }));
         showNotification(
           t('auth_files.quota_refresh_failed', { name: displayName, message }),
@@ -425,6 +423,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         cancelText: t('common.cancel'),
         variant: 'primary',
         onConfirm: async () => {
+          const previousQuota = getScopedQuota(file);
           setQuota((prev) => ({
             ...prev,
             [storeKey]: config.buildLoadingState(file),
@@ -448,7 +447,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             const status = getStatusFromError(err);
             setQuota((prev) => ({
               ...prev,
-              [storeKey]: config.buildErrorState(message, status, file),
+              [storeKey]: buildQuotaFailureState(config, message, status, file, previousQuota),
             }));
             showNotification(
               t(`${config.i18nPrefix}.reset_failed`, { name: displayName, message }),

--- a/apps/web/src/components/quota/quotaConfigs.test.ts
+++ b/apps/web/src/components/quota/quotaConfigs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { CodexQuotaState } from '@/types';
 import { getSortedCodexResetCreditExpiries, resolveQuotaDisplayState } from './quotaConfigs';
 
 type TestQuotaState = {
@@ -67,20 +68,133 @@ describe('resolveQuotaDisplayState', () => {
     expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(activeQuota);
   });
 
-  it('uses a newer header snapshot when it is fresher than the manual quota refresh', () => {
+  it('merges a newer header snapshot into the manual quota refresh', () => {
     const activeQuota: TestQuotaState = {
       status: 'success',
       fetchedAtMs: 1_000,
-      windows: [],
+      windows: [
+        {
+          id: 'manual',
+          label: 'Manual window',
+          usedPercent: 10,
+          resetLabel: '06/30 12:00',
+        },
+      ],
     };
     const observedQuota: TestQuotaState = {
       status: 'success',
       observedAtMs: 2_000,
       observedFromUsageHeaders: true,
-      windows: [],
+      windows: [
+        {
+          id: 'observed',
+          label: 'Observed window',
+          usedPercent: 20,
+          resetLabel: '07/01 12:00',
+        },
+      ],
     };
 
-    expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(observedQuota);
+    const result = resolveQuotaDisplayState(activeQuota, observedQuota);
+
+    expect(result).not.toBe(activeQuota);
+    expect(result).not.toBe(observedQuota);
+    expect(result).toMatchObject({
+      status: 'success',
+      fetchedAtMs: 1_000,
+      observedAtMs: 2_000,
+      windows: [
+        { id: 'manual', usedPercent: 10 },
+        { id: 'observed', usedPercent: 20 },
+      ],
+    });
+  });
+
+  it('keeps API-only Codex quota data when merging newer header snapshots', () => {
+    const activeQuota: CodexQuotaState = {
+      status: 'success',
+      fetchedAtMs: 1_000,
+      planType: 'plus',
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          labelKey: 'codex_quota.primary_window',
+          usedPercent: 10,
+          resetLabel: '06/30 12:00',
+          limitWindowSeconds: 18_000,
+        },
+        {
+          id: 'spark-five-hour-0',
+          label: 'Spark 5-hour limit',
+          labelKey: 'codex_quota.additional_primary_window',
+          labelParams: { name: 'spark' },
+          usedPercent: 30,
+          resetLabel: '07/01 01:00',
+          limitWindowSeconds: 18_000,
+        },
+      ],
+      rateLimitResetCreditsAvailableCount: 2,
+      rateLimitResetCredits: [
+        {
+          id: 'credit-1',
+          status: 'available',
+          grantedAt: '2026-06-29T00:00:00Z',
+          expiresAt: '2026-07-19T00:42:09Z',
+        },
+      ],
+      rateLimitResetCreditsError: null,
+    };
+    const observedQuota: CodexQuotaState = {
+      status: 'success',
+      observedFromUsageHeaders: true,
+      observedResetCreditsUnknown: true,
+      observedAtMs: 2_000,
+      planType: 'free',
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          labelKey: 'codex_quota.primary_window',
+          usedPercent: 80,
+          resetLabel: '07/01 02:00',
+          limitWindowSeconds: null,
+        },
+        {
+          id: 'weekly',
+          label: 'Weekly limit',
+          labelKey: 'codex_quota.secondary_window',
+          usedPercent: 40,
+          resetLabel: '07/07 02:00',
+          limitWindowSeconds: 604_800,
+        },
+      ],
+    };
+
+    const result = resolveQuotaDisplayState(activeQuota, observedQuota) as CodexQuotaState;
+
+    expect(result.planType).toBe('free');
+    expect(result.observedAtMs).toBe(2_000);
+    expect(result.observedFromUsageHeaders).toBe(true);
+    expect(result.observedResetCreditsUnknown).toBeUndefined();
+    expect(result.rateLimitResetCreditsAvailableCount).toBe(2);
+    expect(result.rateLimitResetCredits).toHaveLength(1);
+    expect(result.windows.map((window) => window.id)).toEqual([
+      'five-hour',
+      'spark-five-hour-0',
+      'weekly',
+    ]);
+    expect(result.windows[0]).toMatchObject({
+      id: 'five-hour',
+      usedPercent: 80,
+      resetLabel: '07/01 02:00',
+      limitWindowSeconds: 18_000,
+    });
+    expect(result.windows[1]).toMatchObject({
+      id: 'spark-five-hour-0',
+      usedPercent: 30,
+      resetLabel: '07/01 01:00',
+    });
   });
 
   it('keeps 401 quota errors so reauth controls stay visible', () => {
@@ -94,5 +208,124 @@ describe('resolveQuotaDisplayState', () => {
     };
 
     expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(activeQuota);
+  });
+
+  it('keeps manual refresh failures over older header snapshots', () => {
+    const activeQuota: CodexQuotaState = {
+      status: 'error',
+      error: 'refresh failed',
+      errorStatus: 502,
+      failedAtMs: 2_000,
+      planType: 'plus',
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          usedPercent: 10,
+          resetLabel: '06/30 12:00',
+          limitWindowSeconds: 18_000,
+        },
+      ],
+      rateLimitResetCreditsAvailableCount: 2,
+    };
+    const observedQuota: CodexQuotaState = {
+      status: 'success',
+      observedFromUsageHeaders: true,
+      observedAtMs: 1_000,
+      planType: 'free',
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          usedPercent: 80,
+          resetLabel: '07/01 02:00',
+          limitWindowSeconds: null,
+        },
+      ],
+    };
+
+    expect(resolveQuotaDisplayState(activeQuota, observedQuota)).toBe(activeQuota);
+  });
+
+  it('recovers manual refresh failures with newer header snapshots without dropping API-only fields', () => {
+    const activeQuota: CodexQuotaState = {
+      status: 'error',
+      error: 'refresh failed',
+      errorStatus: 502,
+      failedAtMs: 1_000,
+      fetchedAtMs: 500,
+      planType: 'plus',
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          labelKey: 'codex_quota.primary_window',
+          usedPercent: 10,
+          resetLabel: '06/30 12:00',
+          limitWindowSeconds: 18_000,
+        },
+        {
+          id: 'spark-five-hour-0',
+          label: 'Spark 5-hour limit',
+          labelKey: 'codex_quota.additional_primary_window',
+          labelParams: { name: 'spark' },
+          usedPercent: 30,
+          resetLabel: '07/01 01:00',
+          limitWindowSeconds: 18_000,
+        },
+      ],
+      rateLimitResetCreditsAvailableCount: 2,
+      rateLimitResetCredits: [
+        {
+          id: 'credit-1',
+          status: 'available',
+          grantedAt: '2026-06-29T00:00:00Z',
+          expiresAt: '2026-07-19T00:42:09Z',
+        },
+      ],
+      rateLimitResetCreditsError: null,
+    };
+    const observedQuota: CodexQuotaState = {
+      status: 'success',
+      observedFromUsageHeaders: true,
+      observedResetCreditsUnknown: true,
+      observedAtMs: 2_000,
+      planType: 'free',
+      windows: [
+        {
+          id: 'five-hour',
+          label: '5-hour limit',
+          labelKey: 'codex_quota.primary_window',
+          usedPercent: 80,
+          resetLabel: '07/01 02:00',
+          limitWindowSeconds: null,
+        },
+      ],
+    };
+
+    const result = resolveQuotaDisplayState(activeQuota, observedQuota) as CodexQuotaState;
+
+    expect(result.status).toBe('success');
+    expect(result.error).toBeUndefined();
+    expect(result.errorStatus).toBeUndefined();
+    expect(result.failedAtMs).toBeUndefined();
+    expect(result.observedFromUsageHeaders).toBe(true);
+    expect(result.rateLimitResetCreditsAvailableCount).toBe(2);
+    expect(result.rateLimitResetCredits).toHaveLength(1);
+    expect(result.windows.map((window) => window.id)).toEqual([
+      'five-hour',
+      'spark-five-hour-0',
+    ]);
+    expect(result.windows[0]).toMatchObject({
+      id: 'five-hour',
+      usedPercent: 80,
+      resetLabel: '07/01 02:00',
+      limitWindowSeconds: 18_000,
+    });
+    expect(result.windows[1]).toMatchObject({
+      id: 'spark-five-hour-0',
+      usedPercent: 30,
+      resetLabel: '07/01 01:00',
+    });
   });
 });

--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -90,6 +90,13 @@ export interface QuotaConfig<TState, TData> {
   buildLoadingState: (file?: AuthFileItem) => TState;
   buildSuccessState: (data: TData, file?: AuthFileItem) => TState;
   buildErrorState: (message: string, status?: number, file?: AuthFileItem) => TState;
+  buildFailureState?: (
+    message: string,
+    status: number | undefined,
+    file: AuthFileItem | undefined,
+    activeState: TState | undefined,
+    failedAtMs: number
+  ) => TState;
   scopeState?: (file: AuthFileItem, state: TState | undefined) => TState | undefined;
   cardClassName: string;
   controlsClassName: string;
@@ -111,6 +118,31 @@ export const getQuotaStoreKey = <TState, TData>(
   config: Pick<QuotaConfig<TState, TData>, 'getStoreKey'>,
   file: AuthFileItem
 ): string => config.getStoreKey?.(file) ?? file.name;
+
+export const getScopedQuotaState = <TState, TData>(
+  config: Pick<QuotaConfig<TState, TData>, 'getStoreKey' | 'scopeState'>,
+  states: Record<string, TState>,
+  file: AuthFileItem
+): TState | undefined => {
+  const storeKey = getQuotaStoreKey(config, file);
+  const activeQuota = states[storeKey];
+  const scopedQuota = config.scopeState ? config.scopeState(file, activeQuota) : activeQuota;
+  if (scopedQuota || storeKey === file.name) return scopedQuota;
+  const legacyQuota = states[file.name];
+  return config.scopeState ? config.scopeState(file, legacyQuota) : legacyQuota;
+};
+
+export const buildQuotaFailureState = <TState, TData>(
+  config: Pick<QuotaConfig<TState, TData>, 'buildErrorState' | 'buildFailureState'>,
+  message: string,
+  status: number | undefined,
+  file: AuthFileItem | undefined,
+  activeState: TState | undefined,
+  failedAtMs = Date.now()
+): TState =>
+  config.buildFailureState
+    ? config.buildFailureState(message, status, file, activeState, failedAtMs)
+    : config.buildErrorState(message, status, file);
 
 const renderAntigravityItems = (
   quota: AntigravityQuotaState,
@@ -241,13 +273,139 @@ const getCodexSearchText = (
 
 type DisplayQuotaState = {
   status?: 'idle' | 'loading' | 'success' | 'error';
+  error?: string;
   errorStatus?: number | null;
   fetchedAtMs?: number;
+  failedAtMs?: number;
   observedAtMs?: number;
 };
 
+type CodexQuotaMergeState = DisplayQuotaState & Partial<CodexQuotaState>;
+
 const readFiniteTimestamp = (value: unknown): number | null =>
   typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+const hasHeaderValue = (value: unknown): boolean => {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim() !== '';
+  if (typeof value === 'number') return Number.isFinite(value);
+  return true;
+};
+
+const hasKnownResetLabel = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return trimmed !== '' && trimmed !== '-';
+};
+
+const mergeCodexQuotaWindow = (
+  activeWindow: CodexQuotaWindow,
+  observedWindow: CodexQuotaWindow
+): CodexQuotaWindow => ({
+  ...activeWindow,
+  ...(hasHeaderValue(observedWindow.label) ? { label: observedWindow.label } : {}),
+  ...(hasHeaderValue(observedWindow.labelKey) ? { labelKey: observedWindow.labelKey } : {}),
+  ...(observedWindow.labelParams && Object.keys(observedWindow.labelParams).length > 0
+    ? { labelParams: observedWindow.labelParams }
+    : {}),
+  ...(observedWindow.usedPercent !== null &&
+  observedWindow.usedPercent !== undefined &&
+  Number.isFinite(observedWindow.usedPercent)
+    ? { usedPercent: observedWindow.usedPercent }
+    : {}),
+  ...(hasKnownResetLabel(observedWindow.resetLabel)
+    ? { resetLabel: observedWindow.resetLabel }
+    : {}),
+  ...(observedWindow.limitWindowSeconds !== null &&
+  observedWindow.limitWindowSeconds !== undefined &&
+  observedWindow.limitWindowSeconds > 0
+    ? { limitWindowSeconds: observedWindow.limitWindowSeconds }
+    : {}),
+});
+
+const mergeCodexQuotaWindows = (
+  activeWindows: CodexQuotaWindow[] | undefined,
+  observedWindows: CodexQuotaWindow[] | undefined
+): CodexQuotaWindow[] | undefined => {
+  if (!observedWindows || observedWindows.length === 0) return activeWindows;
+  if (!activeWindows || activeWindows.length === 0) return observedWindows;
+
+  const observedById = new Map(observedWindows.map((window) => [window.id, window]));
+  const mergedWindows = activeWindows.map((window) => {
+    const observedWindow = observedById.get(window.id);
+    if (!observedWindow) return window;
+    observedById.delete(window.id);
+    return mergeCodexQuotaWindow(window, observedWindow);
+  });
+
+  return [...mergedWindows, ...observedById.values()];
+};
+
+const hasKnownResetCreditCount = (quota: CodexQuotaMergeState): boolean => {
+  const value = quota.rateLimitResetCreditsAvailableCount;
+  return typeof value === 'number' && Number.isFinite(value);
+};
+
+const mergeObservedQuotaIntoActive = <TState extends DisplayQuotaState>(
+  activeQuota: TState,
+  observedQuota: TState
+): TState => {
+  const active = activeQuota as CodexQuotaMergeState;
+  const observed = observedQuota as CodexQuotaMergeState;
+  const merged: CodexQuotaMergeState = { ...active };
+
+  const scalarKeys: Array<keyof CodexQuotaMergeState> = [
+    'status',
+    'planType',
+    'activeLimit',
+    'creditsHasCredits',
+    'creditsUnlimited',
+    'creditsBalance',
+    'rateLimitReachedType',
+    'primaryOverSecondaryLimitPercent',
+    'observedAtMs',
+    'observedTraceId',
+    'observedErrorKind',
+    'observedErrorCode',
+  ];
+
+  scalarKeys.forEach((key) => {
+    const value = observed[key];
+    if (hasHeaderValue(value)) {
+      (merged as Record<string, unknown>)[key] = value;
+    }
+  });
+
+  merged.windows = mergeCodexQuotaWindows(active.windows, observed.windows);
+  if (observed.observedFromUsageHeaders === true) {
+    merged.observedFromUsageHeaders = true;
+  }
+  if (observed.observedResetCreditsUnknown === true && !hasKnownResetCreditCount(active)) {
+    merged.observedResetCreditsUnknown = true;
+  }
+
+  return merged as TState;
+};
+
+const clearQuotaFailureForObservedRecovery = <TState extends DisplayQuotaState>(
+  quota: TState
+): TState => {
+  const recovered = { ...quota };
+  delete recovered.error;
+  delete recovered.errorStatus;
+  delete recovered.failedAtMs;
+  return recovered;
+};
+
+const isObservedQuotaNewerThanFailure = <TState extends DisplayQuotaState>(
+  activeQuota: TState,
+  observedQuota: TState | undefined
+): observedQuota is TState => {
+  if (observedQuota?.status !== 'success') return false;
+  const failedAtMs = readFiniteTimestamp(activeQuota.failedAtMs);
+  const observedAtMs = readFiniteTimestamp(observedQuota.observedAtMs);
+  return failedAtMs !== null && observedAtMs !== null && observedAtMs > failedAtMs;
+};
 
 const buildCodexQuotaAuthIdentity = (file: AuthFileItem | undefined) => {
   if (!file?.name) return {};
@@ -272,22 +430,46 @@ const scopeCodexQuotaStateToAuthFile = (
   return state.authFileKey === identity.authFileKey ? state : undefined;
 };
 
+const buildCodexQuotaFailureState = (
+  message: string,
+  status: number | undefined,
+  file: AuthFileItem | undefined,
+  activeState: CodexQuotaState | undefined,
+  failedAtMs: number
+): CodexQuotaState => {
+  const preservedState = activeState ? { ...activeState } : null;
+  return {
+    ...(preservedState ?? { windows: [] }),
+    status: 'error',
+    windows: preservedState?.windows ?? [],
+    error: message,
+    errorStatus: status,
+    failedAtMs,
+    ...buildCodexQuotaAuthIdentity(file),
+  };
+};
+
 export const resolveQuotaDisplayState = <TState extends DisplayQuotaState>(
   activeQuota: TState | undefined,
   observedQuota: TState | undefined
 ): TState | undefined => {
-  if (activeQuota && activeQuota.status !== 'idle' && activeQuota.status !== 'error') {
-    if (activeQuota.status === 'success' && observedQuota?.status === 'success') {
-      const fetchedAtMs = readFiniteTimestamp(activeQuota.fetchedAtMs);
-      const observedAtMs = readFiniteTimestamp(observedQuota.observedAtMs);
-      if (fetchedAtMs !== null && observedAtMs !== null && observedAtMs > fetchedAtMs) {
-        return observedQuota;
-      }
+  if (activeQuota?.status === 'error') {
+    if (isObservedQuotaNewerThanFailure(activeQuota, observedQuota)) {
+      return clearQuotaFailureForObservedRecovery(
+        mergeObservedQuotaIntoActive(activeQuota, observedQuota)
+      );
     }
     return activeQuota;
   }
 
-  if (activeQuota?.status === 'error' && activeQuota.errorStatus === 401) {
+  if (activeQuota && activeQuota.status !== 'idle') {
+    if (activeQuota.status === 'success' && observedQuota?.status === 'success') {
+      const fetchedAtMs = readFiniteTimestamp(activeQuota.fetchedAtMs);
+      const observedAtMs = readFiniteTimestamp(observedQuota.observedAtMs);
+      if (fetchedAtMs !== null && observedAtMs !== null && observedAtMs > fetchedAtMs) {
+        return mergeObservedQuotaIntoActive(activeQuota, observedQuota);
+      }
+    }
     return activeQuota;
   }
 
@@ -854,8 +1036,10 @@ export const CODEX_CONFIG: QuotaConfig<
     windows: [],
     error: message,
     errorStatus: status,
+    failedAtMs: Date.now(),
     ...buildCodexQuotaAuthIdentity(file),
   }),
+  buildFailureState: buildCodexQuotaFailureState,
   scopeState: scopeCodexQuotaStateToAuthFile,
   cardClassName: styles.codexCard,
   controlsClassName: styles.codexControls,

--- a/apps/web/src/components/quota/useQuotaLoader.ts
+++ b/apps/web/src/components/quota/useQuotaLoader.ts
@@ -7,7 +7,12 @@ import { useTranslation } from 'react-i18next';
 import type { AuthFileItem } from '@/types';
 import { useQuotaStore } from '@/stores';
 import { getStatusFromError } from '@/utils/quota';
-import { getQuotaStoreKey, type QuotaConfig } from './quotaConfigs';
+import {
+  buildQuotaFailureState,
+  getQuotaStoreKey,
+  getScopedQuotaState,
+  type QuotaConfig,
+} from './quotaConfigs';
 
 type QuotaScope = 'page' | 'all';
 
@@ -48,10 +53,13 @@ export function useQuotaLoader<TState, TData>(config: QuotaConfig<TState, TData>
       try {
         if (targets.length === 0) return;
 
+        const previousStateByStoreKey = new Map<string, TState | undefined>();
         setQuota((prev) => {
           const nextState = { ...prev };
           targets.forEach((file) => {
-            nextState[getQuotaStoreKey(config, file)] = config.buildLoadingState(file);
+            const storeKey = getQuotaStoreKey(config, file);
+            previousStateByStoreKey.set(storeKey, getScopedQuotaState(config, prev, file));
+            nextState[storeKey] = config.buildLoadingState(file);
           });
           return nextState;
         });
@@ -81,10 +89,12 @@ export function useQuotaLoader<TState, TData>(config: QuotaConfig<TState, TData>
                 result.file
               );
             } else {
-              nextState[result.storeKey] = config.buildErrorState(
+              nextState[result.storeKey] = buildQuotaFailureState(
+                config,
                 result.error || t('common.unknown_error'),
                 result.errorStatus,
-                result.file
+                result.file,
+                previousStateByStoreKey.get(result.storeKey)
               );
             }
           });

--- a/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
@@ -22,6 +22,7 @@ const { mocks } = vi.hoisted(() => {
       getCodexInspectionRun: vi.fn(),
       getActiveQuotaCooldowns: vi.fn(),
       getHeaderSnapshots: vi.fn(),
+      codexQuota: {} as Record<string, unknown>,
       panelFeatureAvailability: {
         checking: false,
         panelHostMode: 'manager_embedded' as const,
@@ -124,8 +125,8 @@ vi.mock('@/stores', () => ({
     }),
   useThemeStore: (selector: (state: { resolvedTheme: 'dark' }) => unknown) =>
     selector({ resolvedTheme: 'dark' }),
-  useQuotaStore: (selector: (state: { codexQuota: Record<string, never> }) => unknown) =>
-    selector({ codexQuota: {} }),
+  useQuotaStore: (selector: (state: { codexQuota: Record<string, unknown> }) => unknown) =>
+    selector({ codexQuota: mocks.codexQuota }),
 }));
 
 vi.mock('@/features/authFiles/hooks/useAuthFilesData', () => ({
@@ -233,7 +234,12 @@ vi.mock('@/features/authFiles/components/AuthFileCard', () => ({
       status?: string;
       planType?: string | null;
       observedFromUsageHeaders?: boolean;
-      windows?: Array<{ usedPercent?: number | null; limitWindowSeconds?: number | null }>;
+      rateLimitResetCreditsAvailableCount?: number | null;
+      windows?: Array<{
+        id?: string;
+        usedPercent?: number | null;
+        limitWindowSeconds?: number | null;
+      }>;
     };
   }) => {
     const cooldown = props.quotaCooldown
@@ -249,6 +255,15 @@ vi.mock('@/features/authFiles/components/AuthFileCard', () => ({
         data-codex-quota-observed={String(
           props.codexDisplayQuota?.observedFromUsageHeaders ?? false
         )}
+        data-codex-quota-reset-count={
+          props.codexDisplayQuota?.rateLimitResetCreditsAvailableCount === undefined ||
+          props.codexDisplayQuota.rateLimitResetCreditsAvailableCount === null
+            ? ''
+            : String(props.codexDisplayQuota.rateLimitResetCreditsAvailableCount)
+        }
+        data-codex-quota-window-ids={
+          props.codexDisplayQuota?.windows?.map((quotaWindow) => quotaWindow.id).join(',') ?? ''
+        }
         data-codex-quota-window-percent={
           window?.usedPercent === undefined || window.usedPercent === null
             ? ''
@@ -330,6 +345,7 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     mocks.listCodexInspectionRuns.mockReset();
     mocks.getCodexInspectionRun.mockReset();
     mocks.getHeaderSnapshots.mockReset();
+    mocks.codexQuota = {};
     mocks.connectionStatus = 'connected';
     mocks.managementKey = 'test-key';
     mocks.pageTransitionStatus = 'current';
@@ -426,6 +442,224 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     expect(card.props['data-codex-quota-observed']).toBe('true');
     expect(card.props['data-codex-quota-window-percent']).toBe('20');
     expect(card.props['data-codex-quota-window-seconds']).toBe('2592000');
+  });
+
+  it('merges observed Codex header quota without clearing stored quota-only fields', async () => {
+    mocks.codexQuota = {
+      'codex-one.json::-': {
+        status: 'success',
+        authFileKey: 'codex-one.json::-',
+        authFileName: 'codex-one.json',
+        authIndex: null,
+        fetchedAtMs: 1_000,
+        planType: 'plus',
+        rateLimitResetCreditsAvailableCount: 2,
+        windows: [
+          {
+            id: 'five-hour',
+            label: '5-hour limit',
+            labelKey: 'codex_quota.primary_window',
+            usedPercent: 10,
+            resetLabel: '06/30 12:00',
+            limitWindowSeconds: 18_000,
+          },
+          {
+            id: 'spark-five-hour-0',
+            label: 'Spark 5-hour limit',
+            labelKey: 'codex_quota.additional_primary_window',
+            labelParams: { name: 'spark' },
+            usedPercent: 30,
+            resetLabel: '07/01 01:00',
+            limitWindowSeconds: 18_000,
+          },
+        ],
+      },
+    };
+    mocks.getHeaderSnapshots.mockResolvedValue({
+      generated_at_ms: 1_700_000_000_000,
+      from_ms: 1_700_000_000_000,
+      to_ms: 1_700_000_000_000,
+      items: [
+        {
+          event_hash: 'event-1',
+          timestamp_ms: 1_700_000_000_000,
+          auth_file_snapshot: 'codex-one.json',
+          auth_provider_snapshot: 'codex',
+          response_metadata: {
+            quota: {
+              plan_type: 'free',
+              primary: {
+                used_percent: 20,
+                reset_at_ms: 1_700_018_000_000,
+                window_minutes: 300,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+          'data-codex-quota-window-percent'
+        ]
+      ).toBe('20');
+    });
+
+    const card = renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' });
+    expect(card.props['data-codex-quota-plan']).toBe('free');
+    expect(card.props['data-codex-quota-observed']).toBe('true');
+    expect(card.props['data-codex-quota-reset-count']).toBe('2');
+    expect(card.props['data-codex-quota-window-ids']).toBe('five-hour,spark-five-hour-0');
+    expect(card.props['data-codex-quota-window-seconds']).toBe('18000');
+  });
+
+  it('keeps manual Codex quota refresh failures over older header snapshots', async () => {
+    mocks.codexQuota = {
+      'codex-one.json::-': {
+        status: 'error',
+        error: 'refresh failed',
+        errorStatus: 502,
+        failedAtMs: 1_700_000_000_500,
+        authFileKey: 'codex-one.json::-',
+        authFileName: 'codex-one.json',
+        authIndex: null,
+        planType: 'plus',
+        rateLimitResetCreditsAvailableCount: 2,
+        windows: [
+          {
+            id: 'five-hour',
+            label: '5-hour limit',
+            usedPercent: 10,
+            resetLabel: '06/30 12:00',
+            limitWindowSeconds: 18_000,
+          },
+        ],
+      },
+    };
+    mocks.getHeaderSnapshots.mockResolvedValue({
+      generated_at_ms: 1_700_000_000_000,
+      from_ms: 1_700_000_000_000,
+      to_ms: 1_700_000_000_000,
+      items: [
+        {
+          event_hash: 'event-1',
+          timestamp_ms: 1_700_000_000_000,
+          auth_file_snapshot: 'codex-one.json',
+          auth_provider_snapshot: 'codex',
+          response_metadata: {
+            quota: {
+              plan_type: 'free',
+              primary: {
+                used_percent: 20,
+                reset_at_ms: 1_700_018_000_000,
+                window_minutes: 300,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+          'data-codex-quota-status'
+        ]
+      ).toBe('error');
+    });
+
+    const card = renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' });
+    expect(card.props['data-codex-quota-plan']).toBe('plus');
+    expect(card.props['data-codex-quota-observed']).toBe('false');
+    expect(card.props['data-codex-quota-reset-count']).toBe('2');
+    expect(card.props['data-codex-quota-window-percent']).toBe('10');
+  });
+
+  it('uses newer header snapshots after manual Codex quota refresh failures', async () => {
+    mocks.codexQuota = {
+      'codex-one.json::-': {
+        status: 'error',
+        error: 'refresh failed',
+        errorStatus: 502,
+        failedAtMs: 1_699_999_999_000,
+        authFileKey: 'codex-one.json::-',
+        authFileName: 'codex-one.json',
+        authIndex: null,
+        planType: 'plus',
+        rateLimitResetCreditsAvailableCount: 2,
+        windows: [
+          {
+            id: 'five-hour',
+            label: '5-hour limit',
+            usedPercent: 10,
+            resetLabel: '06/30 12:00',
+            limitWindowSeconds: 18_000,
+          },
+          {
+            id: 'spark-five-hour-0',
+            label: 'Spark 5-hour limit',
+            usedPercent: 30,
+            resetLabel: '07/01 01:00',
+            limitWindowSeconds: 18_000,
+          },
+        ],
+      },
+    };
+    mocks.getHeaderSnapshots.mockResolvedValue({
+      generated_at_ms: 1_700_000_000_000,
+      from_ms: 1_700_000_000_000,
+      to_ms: 1_700_000_000_000,
+      items: [
+        {
+          event_hash: 'event-1',
+          timestamp_ms: 1_700_000_000_000,
+          auth_file_snapshot: 'codex-one.json',
+          auth_provider_snapshot: 'codex',
+          response_metadata: {
+            quota: {
+              plan_type: 'free',
+              primary: {
+                used_percent: 20,
+                reset_at_ms: 1_700_018_000_000,
+                window_minutes: 300,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+          'data-codex-quota-status'
+        ]
+      ).toBe('success');
+    });
+
+    const card = renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' });
+    expect(card.props['data-codex-quota-plan']).toBe('free');
+    expect(card.props['data-codex-quota-observed']).toBe('true');
+    expect(card.props['data-codex-quota-reset-count']).toBe('2');
+    expect(card.props['data-codex-quota-window-percent']).toBe('20');
+    expect(card.props['data-codex-quota-window-ids']).toBe('five-hour,spark-five-hour-0');
   });
 
   it('clears stale cooldowns when managerServiceBase becomes empty', async () => {

--- a/apps/web/src/features/authFiles/components/AuthFileQuotaSection.test.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileQuotaSection.test.tsx
@@ -17,6 +17,7 @@ const { mocks } = vi.hoisted(() => {
 
   return {
     mocks: {
+      fetchCodexQuota: vi.fn(),
       quotaStoreState,
       showNotification: vi.fn(),
     },
@@ -30,6 +31,14 @@ vi.mock('react-i18next', () => ({
       options ? `${key}:${JSON.stringify(options)}` : key,
   }),
 }));
+
+vi.mock('@/utils/quota', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/quota')>();
+  return {
+    ...actual,
+    fetchCodexQuota: mocks.fetchCodexQuota,
+  };
+});
 
 vi.mock('@/stores', () => ({
   useNotificationStore: (selector: (state: unknown) => unknown) =>
@@ -78,6 +87,12 @@ const getText = (node: ReactTestInstance): string =>
     })
     .join('');
 
+const findButtonByText = (renderer: ReactTestRenderer, text: string) => {
+  const button = renderer.root.findAllByType('button').find((node) => getText(node).includes(text));
+  if (!button) throw new Error(`Button not found: ${text}`);
+  return button;
+};
+
 const renderSection = (quotaOverride?: CodexQuotaState | null) => {
   let renderer!: ReactTestRenderer;
   act(() => {
@@ -95,6 +110,7 @@ const renderSection = (quotaOverride?: CodexQuotaState | null) => {
 
 describe('AuthFileQuotaSection Codex quota scoping', () => {
   beforeEach(() => {
+    mocks.fetchCodexQuota.mockReset();
     mocks.showNotification.mockReset();
     mocks.quotaStoreState.codexQuota = {};
     (mocks.quotaStoreState.setCodexQuota as ReturnType<typeof vi.fn>).mockClear();
@@ -146,5 +162,49 @@ describe('AuthFileQuotaSection Codex quota scoping', () => {
 
     expect(text).toContain('codex_quota.idle');
     expect(text).not.toContain('codex_quota.plan_pro');
+  });
+
+  it('keeps previous Codex quota data when inline refresh fails', async () => {
+    mocks.fetchCodexQuota.mockRejectedValue(new Error('refresh failed'));
+    mocks.quotaStoreState.codexQuota = {
+      [matchingQuota.authFileKey as string]: {
+        ...matchingQuota,
+        windows: [
+          {
+            id: 'spark-five-hour-0',
+            label: 'Spark 5-hour limit',
+            usedPercent: 30,
+            resetLabel: '07/01 01:00',
+            limitWindowSeconds: 18_000,
+          },
+        ],
+      },
+    };
+    const renderer = renderSection(null);
+
+    await act(async () => {
+      findButtonByText(renderer, 'codex_quota.idle').props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(mocks.quotaStoreState.codexQuota).toMatchObject({
+      [matchingQuota.authFileKey as string]: {
+        status: 'error',
+        error: 'refresh failed',
+        windows: [
+          {
+            id: 'spark-five-hour-0',
+            usedPercent: 30,
+            limitWindowSeconds: 18_000,
+          },
+        ],
+        rateLimitResetCreditsAvailableCount: 2,
+      },
+    });
+    expect(
+      (mocks.quotaStoreState.codexQuota as Record<string, CodexQuotaState>)[
+        matchingQuota.authFileKey as string
+      ].failedAtMs
+    ).toEqual(expect.any(Number));
   });
 });

--- a/apps/web/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/apps/web/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -28,6 +28,13 @@ type InlineQuotaConfig = {
   buildLoadingState: (file?: AuthFileItem) => unknown;
   buildSuccessState: (data: unknown, file?: AuthFileItem) => unknown;
   buildErrorState: (message: string, status?: number, file?: AuthFileItem) => unknown;
+  buildFailureState?: (
+    message: string,
+    status: number | undefined,
+    file: AuthFileItem | undefined,
+    activeState: unknown | undefined,
+    failedAtMs: number
+  ) => unknown;
   renderQuotaItems: (quota: unknown, t: TFunction, helpers: unknown) => unknown;
   scopeState?: (file: AuthFileItem, state: QuotaState) => QuotaState;
 };
@@ -78,6 +85,7 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     if (isRuntimeOnlyAuthFile(file)) return;
     if (file.disabled) return;
     if (quota?.status === 'loading') return;
+    const previousQuota = quota;
 
     updateQuotaState((prev: Record<string, unknown>) => ({
       ...prev,
@@ -96,11 +104,13 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
       const status = getStatusFromError(err);
       updateQuotaState((prev: Record<string, unknown>) => ({
         ...prev,
-        [storeKey]: config.buildErrorState(message, status, file)
+        [storeKey]: config.buildFailureState
+          ? config.buildFailureState(message, status, file, previousQuota, Date.now())
+          : config.buildErrorState(message, status, file)
       }));
       showNotification(t('auth_files.quota_refresh_failed', { name: file.name, message }), 'error');
     }
-  }, [config, disableControls, file, quota?.status, showNotification, storeKey, t, updateQuotaState]);
+  }, [config, disableControls, file, quota, showNotification, storeKey, t, updateQuotaState]);
 
   const displayQuota = quotaOverride === undefined ? quota : (quotaOverride ?? undefined);
   const quotaStatus = displayQuota?.status ?? 'idle';

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -75,7 +75,7 @@ import {
   buildApiKeyOptionsFromRows,
   buildApiKeyOverviewColumns,
   buildAuthFilesByAuthIndex,
-  buildAccountQuotaErrorEntry,
+  buildAccountQuotaRefreshFailureEntry,
   buildObservedCodexAccountQuotaEntry,
   buildChannelOptionsFromValues,
   buildMonitoringInitialStateFromQuery,
@@ -90,6 +90,7 @@ import {
   getCurrentInputValue,
   getTodayStartInputValue,
   isUsageImportFile,
+  mergeObservedAccountQuotaState,
   parseDateTimeLocalValue,
   requestAccountQuota,
   type FocusSnapshot,
@@ -693,6 +694,28 @@ export function MonitoringCenterPage() {
     [headerSnapshots]
   );
   const scopedFailureCount = scopedSummary.failureCalls;
+  const accountQuotaStatesWithObservedHeaders = useMemo(() => {
+    let changed = false;
+    const nextStates = Object.fromEntries(
+      Object.entries(accountQuotaStates).map(([account, state]) => {
+        const targets = accountQuotaTargetsByAccount.get(account) ?? [];
+        const observedEntries = targets
+          .map((target) =>
+            buildObservedCodexAccountQuotaEntry(
+              target,
+              getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, target.file),
+              t
+            )
+          )
+          .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+        const nextState =
+          mergeObservedAccountQuotaState(state, targets, observedEntries) ?? state;
+        changed = changed || nextState !== state;
+        return [account, nextState] as const;
+      })
+    );
+    return changed ? nextStates : accountQuotaStates;
+  }, [accountQuotaStates, accountQuotaTargetsByAccount, headerSnapshotLookup, t]);
 
   const hasSearchFilter = Boolean(deferredSearch.trim());
   const hasScopeFilter =
@@ -900,6 +923,10 @@ export function MonitoringCenterPage() {
       const currentState = accountQuotaStatesRef.current[account];
       const targets = accountQuotaTargetsByAccount.get(account) ?? [];
       const targetKey = targets.map((target) => target.key).join('|');
+      const previousEntriesByKey =
+        currentState?.targetKey === targetKey
+          ? new Map(currentState.entries.map((entry) => [entry.key, entry]))
+          : new Map();
       const observedEntries = targets
         .map((target) =>
           buildObservedCodexAccountQuotaEntry(
@@ -953,6 +980,8 @@ export function MonitoringCenterPage() {
       );
       if (accountQuotaRequestIdsRef.current[account] !== requestId) return;
 
+      const hasFailure = settled.some((result) => result.status === 'rejected');
+      const completedAtMs = Date.now();
       const entries = settled.map((result, index) => {
         const fallback = targets[index];
         if (result.status === 'fulfilled') {
@@ -963,24 +992,32 @@ export function MonitoringCenterPage() {
           result.reason instanceof Error
             ? result.reason.message
             : String(result.reason || t('common.unknown_error'));
-        return (
-          buildObservedCodexAccountQuotaEntry(
-            fallback,
-            getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, fallback.file),
-            t
-          ) ?? buildAccountQuotaErrorEntry(fallback, error, t)
+        const observedEntry = buildObservedCodexAccountQuotaEntry(
+          fallback,
+          getHighConfidenceUsageHeaderSnapshotForAuthFile(headerSnapshotLookup, fallback.file),
+          t
+        );
+        return buildAccountQuotaRefreshFailureEntry(
+          fallback,
+          error,
+          t,
+          previousEntriesByKey.get(fallback.key),
+          observedEntry,
+          completedAtMs
         );
       });
 
       const hasSuccess = entries.some((entry) => !entry.error);
+      const firstError = entries.find((entry) => entry.error)?.error;
       setAccountQuotaStates((previous) => ({
         ...previous,
         [account]: {
-          status: hasSuccess ? 'success' : 'error',
+          status: hasFailure ? 'error' : hasSuccess ? 'success' : 'error',
           targetKey,
           entries,
-          error: hasSuccess ? '' : entries[0]?.error || t('common.unknown_error'),
-          lastRefreshedAt: Date.now(),
+          error: hasFailure ? firstError || t('common.unknown_error') : '',
+          failedAtMs: hasFailure ? completedAtMs : undefined,
+          lastRefreshedAt: hasFailure ? previous[account]?.lastRefreshedAt : completedAtMs,
         },
       }));
     },
@@ -1386,7 +1423,7 @@ export function MonitoringCenterPage() {
                 accountAuthStateByRowId={accountAuthStateByRowId}
                 accountStatusDataByRowId={accountStatusDataByRowId}
                 emptyAccountStatusData={emptyAccountStatusData}
-                accountQuotaStates={accountQuotaStates}
+                accountQuotaStates={accountQuotaStatesWithObservedHeaders}
                 accountPageSize={accountPageSize}
                 accountPageSizeOptions={accountPageSizeOptions}
                 accountOverviewScopeText={accountOverviewScopeText}

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -27,6 +27,9 @@ export type AccountQuotaEntry = {
   emptyMessage?: string;
   windows: AccountQuotaWindow[];
   error?: string;
+  failedAtMs?: number;
+  observedAtMs?: number;
+  observedFromUsageHeaders?: boolean;
 };
 
 export type AccountQuotaState = {
@@ -34,6 +37,7 @@ export type AccountQuotaState = {
   targetKey: string;
   entries: AccountQuotaEntry[];
   error?: string;
+  failedAtMs?: number;
   lastRefreshedAt?: number;
 };
 

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -15,9 +15,12 @@ import {
   buildAccountOptions,
   buildApiKeyOptionsFromRows,
   buildChannelOptionsFromValues,
+  buildAccountQuotaRefreshFailureEntry,
   buildMonitoringInitialStateFromQuery,
   buildModelOptionsFromValues,
   buildProviderOptionsFromValues,
+  mergeObservedAccountQuotaEntry,
+  mergeObservedAccountQuotaState,
   requestAccountQuota,
 } from './monitoringCenterPageModel';
 import { getDefaultMonitoringCenterUiState } from '@/features/monitoring/monitoringCenterUiState';
@@ -288,6 +291,509 @@ describe('monitoringCenterPageModel account quota', () => {
         },
       ],
     });
+  });
+
+  it('merges observed Codex account quota without dropping existing API-only windows', () => {
+    const activeEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'free',
+      metaLabels: ['Codex Quota', 'Plan: Free'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 95,
+          resetLabel: '06/30 12:00',
+          usageLabel: '1.5d / 30d used',
+        },
+        {
+          id: 'spark-five-hour-0',
+          label: 'spark 5-hour limit',
+          remainingPercent: 70,
+          resetLabel: '07/01 01:00',
+          usageLabel: '1.5h / 5h used',
+        },
+      ],
+    };
+    const observedEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'plus',
+      metaLabels: ['Codex Quota', 'Plan: Plus', 'Observed from latest usage response headers'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+      ],
+    };
+
+    const merged = mergeObservedAccountQuotaEntry(activeEntry, observedEntry);
+
+    expect(merged).toMatchObject({
+      planType: 'plus',
+      metaLabels: [
+        'Codex Quota',
+        'Plan: Plus',
+        'Observed from latest usage response headers',
+      ],
+      windows: [
+        {
+          id: 'monthly',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+        {
+          id: 'spark-five-hour-0',
+          remainingPercent: 70,
+          resetLabel: '07/01 01:00',
+          usageLabel: '1.5h / 5h used',
+        },
+      ],
+    });
+  });
+
+  it('marks manual quota refresh failures instead of treating cached entries as success', () => {
+    const target = createTarget({
+      provider: 'codex',
+      key: 'codex::2::codex.json',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const activeEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'free',
+      metaLabels: ['Codex Quota', 'Plan: Free'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 95,
+          resetLabel: '06/30 12:00',
+          usageLabel: '1.5d / 30d used',
+        },
+      ],
+    };
+
+    const failedEntry = buildAccountQuotaRefreshFailureEntry(
+      target,
+      '502 bad gateway',
+      t,
+      activeEntry,
+      null
+    );
+
+    expect(failedEntry).toMatchObject({
+      key: 'codex::2::codex.json',
+      error: '502 bad gateway',
+      windows: [
+        {
+          id: 'monthly',
+          remainingPercent: 95,
+        },
+      ],
+    });
+  });
+
+  it('keeps header-updated fields on manual quota refresh failures', () => {
+    const target = createTarget({
+      provider: 'codex',
+      key: 'codex::2::codex.json',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const activeEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'free',
+      metaLabels: ['Codex Quota', 'Plan: Free'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 95,
+          resetLabel: '06/30 12:00',
+          usageLabel: '1.5d / 30d used',
+        },
+        {
+          id: 'spark-five-hour-0',
+          label: 'spark 5-hour limit',
+          remainingPercent: 70,
+          resetLabel: '07/01 01:00',
+          usageLabel: '1.5h / 5h used',
+        },
+      ],
+    };
+    const observedEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'plus',
+      metaLabels: ['Codex Quota', 'Plan: Plus', 'Observed from latest usage response headers'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+      ],
+    };
+
+    const failedEntry = buildAccountQuotaRefreshFailureEntry(
+      target,
+      '502 bad gateway',
+      t,
+      activeEntry,
+      observedEntry
+    );
+
+    expect(failedEntry).toMatchObject({
+      planType: 'plus',
+      error: '502 bad gateway',
+      windows: [
+        {
+          id: 'monthly',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+        },
+        {
+          id: 'spark-five-hour-0',
+          remainingPercent: 70,
+          resetLabel: '07/01 01:00',
+        },
+      ],
+    });
+  });
+
+  it('keeps API-only windows across repeated manual quota refresh failures', () => {
+    const target = createTarget({
+      provider: 'codex',
+      key: 'codex::2::codex.json',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const activeEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'free',
+      metaLabels: ['Codex Quota', 'Plan: Free'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 95,
+          resetLabel: '06/30 12:00',
+          usageLabel: '1.5d / 30d used',
+        },
+        {
+          id: 'spark-five-hour-0',
+          label: 'spark 5-hour limit',
+          remainingPercent: 70,
+          resetLabel: '07/01 01:00',
+          usageLabel: '1.5h / 5h used',
+        },
+      ],
+    };
+    const firstFailedEntry = buildAccountQuotaRefreshFailureEntry(
+      target,
+      '502 bad gateway',
+      t,
+      activeEntry,
+      null
+    );
+    const observedEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'plus',
+      metaLabels: ['Codex Quota', 'Plan: Plus', 'Observed from latest usage response headers'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+      ],
+    };
+
+    const secondFailedEntry = buildAccountQuotaRefreshFailureEntry(
+      target,
+      '504 timeout',
+      t,
+      firstFailedEntry,
+      observedEntry
+    );
+
+    expect(secondFailedEntry.error).toBe('504 timeout');
+    expect(secondFailedEntry.windows.map((window) => window.id)).toEqual([
+      'monthly',
+      'spark-five-hour-0',
+    ]);
+    expect(secondFailedEntry).toMatchObject({
+      planType: 'plus',
+      windows: [
+        {
+          id: 'monthly',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+        },
+        {
+          id: 'spark-five-hour-0',
+          remainingPercent: 70,
+          resetLabel: '07/01 01:00',
+        },
+      ],
+    });
+  });
+
+  it('merges older header entries into failed account quota state without clearing the failure', () => {
+    const target = createTarget({
+      provider: 'codex',
+      key: 'codex::2::codex.json',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const state = {
+      status: 'error' as const,
+      targetKey: 'codex::2::codex.json',
+      error: '502 bad gateway',
+      failedAtMs: 2_000,
+      entries: [
+        {
+          key: 'codex::2::codex.json',
+          provider: 'codex' as const,
+          providerLabel: 'Codex Quota',
+          authLabel: 'Auth',
+          fileName: 'codex.json',
+          planType: 'free',
+          metaLabels: ['Codex Quota', 'Plan: Free'],
+          error: '502 bad gateway',
+          failedAtMs: 2_000,
+          windows: [
+            {
+              id: 'monthly',
+              label: 'Monthly limit',
+              remainingPercent: 95,
+              resetLabel: '06/30 12:00',
+              usageLabel: '1.5d / 30d used',
+            },
+            {
+              id: 'spark-five-hour-0',
+              label: 'spark 5-hour limit',
+              remainingPercent: 70,
+              resetLabel: '07/01 01:00',
+              usageLabel: '1.5h / 5h used',
+            },
+          ],
+        },
+      ],
+    };
+    const observedEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'plus',
+      metaLabels: ['Codex Quota', 'Plan: Plus', 'Observed from latest usage response headers'],
+      observedAtMs: 1_000,
+      observedFromUsageHeaders: true,
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+      ],
+    };
+
+    const merged = mergeObservedAccountQuotaState(state, [target], [observedEntry]);
+
+    expect(merged).not.toBe(state);
+    expect(merged).toMatchObject({
+      status: 'error',
+      error: '502 bad gateway',
+      failedAtMs: 2_000,
+      entries: [
+        {
+          planType: 'plus',
+          error: '502 bad gateway',
+          failedAtMs: 2_000,
+          windows: [
+            {
+              id: 'monthly',
+              remainingPercent: 55,
+              resetLabel: '07/01 02:00',
+            },
+            {
+              id: 'spark-five-hour-0',
+              remainingPercent: 70,
+              resetLabel: '07/01 01:00',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('recovers failed account quota state with newer header entries', () => {
+    const target = createTarget({
+      provider: 'codex',
+      key: 'codex::2::codex.json',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const state = {
+      status: 'error' as const,
+      targetKey: 'codex::2::codex.json',
+      error: '502 bad gateway',
+      failedAtMs: 1_000,
+      entries: [
+        {
+          key: 'codex::2::codex.json',
+          provider: 'codex' as const,
+          providerLabel: 'Codex Quota',
+          authLabel: 'Auth',
+          fileName: 'codex.json',
+          planType: 'free',
+          metaLabels: ['Codex Quota', 'Plan: Free'],
+          error: '502 bad gateway',
+          failedAtMs: 1_000,
+          windows: [
+            {
+              id: 'monthly',
+              label: 'Monthly limit',
+              remainingPercent: 95,
+              resetLabel: '06/30 12:00',
+              usageLabel: '1.5d / 30d used',
+            },
+            {
+              id: 'spark-five-hour-0',
+              label: 'spark 5-hour limit',
+              remainingPercent: 70,
+              resetLabel: '07/01 01:00',
+              usageLabel: '1.5h / 5h used',
+            },
+          ],
+        },
+      ],
+    };
+    const observedEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'plus',
+      metaLabels: ['Codex Quota', 'Plan: Plus', 'Observed from latest usage response headers'],
+      observedAtMs: 2_000,
+      observedFromUsageHeaders: true,
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+      ],
+    };
+
+    const merged = mergeObservedAccountQuotaState(state, [target], [observedEntry]);
+
+    expect(merged).not.toBe(state);
+    expect(merged).toMatchObject({
+      status: 'success',
+      error: '',
+      failedAtMs: undefined,
+      entries: [
+        {
+          planType: 'plus',
+          observedAtMs: 2_000,
+          observedFromUsageHeaders: true,
+          windows: [
+            {
+              id: 'monthly',
+              remainingPercent: 55,
+              resetLabel: '07/01 02:00',
+            },
+            {
+              id: 'spark-five-hour-0',
+              remainingPercent: 70,
+              resetLabel: '07/01 01:00',
+            },
+          ],
+        },
+      ],
+    });
+    expect(merged?.entries[0].error).toBeUndefined();
+    expect(merged?.entries[0].failedAtMs).toBeUndefined();
+  });
+
+  it('does not merge later header entries when the account quota target set changed', () => {
+    const target = createTarget({
+      provider: 'codex',
+      key: 'codex::2::codex.json',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const state = {
+      status: 'error' as const,
+      targetKey: 'codex::1::old.json',
+      error: '502 bad gateway',
+      entries: [],
+    };
+    const observedEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'plus',
+      metaLabels: ['Codex Quota', 'Plan: Plus'],
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/01 02:00',
+          usageLabel: '13.5d / 30d used',
+        },
+      ],
+    };
+
+    expect(mergeObservedAccountQuotaState(state, [target], [observedEntry])).toBe(state);
   });
 
   it('maps Antigravity grouped buckets into account quota entries', async () => {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -22,6 +22,7 @@ import {
 import type { MonitoringCenterUiState } from '@/features/monitoring/monitoringCenterUiState';
 import type {
   AccountQuotaEntry,
+  AccountQuotaState,
   AccountQuotaWindow,
 } from '@/features/monitoring/components/accountOverviewPresentation';
 import {
@@ -792,6 +793,207 @@ const buildCodexAccountQuotaWindows = (
     };
   });
 
+const hasKnownAccountQuotaResetLabel = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return trimmed !== '' && trimmed !== '-';
+};
+
+const readFiniteTimestamp = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+const mergeAccountQuotaWindow = (
+  activeWindow: AccountQuotaWindow,
+  observedWindow: AccountQuotaWindow
+): AccountQuotaWindow => ({
+  ...activeWindow,
+  ...(observedWindow.label.trim() ? { label: observedWindow.label } : {}),
+  ...(observedWindow.remainingPercent !== null &&
+  observedWindow.remainingPercent !== undefined &&
+  Number.isFinite(observedWindow.remainingPercent)
+    ? { remainingPercent: observedWindow.remainingPercent }
+    : {}),
+  ...(hasKnownAccountQuotaResetLabel(observedWindow.resetLabel)
+    ? { resetLabel: observedWindow.resetLabel }
+    : {}),
+  ...(observedWindow.usageLabel && observedWindow.usageLabel.trim()
+    ? { usageLabel: observedWindow.usageLabel }
+    : {}),
+});
+
+const mergeAccountQuotaWindows = (
+  activeWindows: AccountQuotaWindow[],
+  observedWindows: AccountQuotaWindow[]
+): AccountQuotaWindow[] => {
+  if (observedWindows.length === 0) return activeWindows;
+  if (activeWindows.length === 0) return observedWindows;
+
+  const observedById = new Map(observedWindows.map((window) => [window.id, window]));
+  const mergedWindows = activeWindows.map((window) => {
+    const observedWindow = observedById.get(window.id);
+    if (!observedWindow) return window;
+    observedById.delete(window.id);
+    return mergeAccountQuotaWindow(window, observedWindow);
+  });
+
+  return [...mergedWindows, ...observedById.values()];
+};
+
+const mergeAccountQuotaMetaLabels = (
+  activeLabels: string[] | undefined,
+  observedLabels: string[] | undefined
+) => {
+  const labels: string[] = [];
+  [...(activeLabels ?? []), ...(observedLabels ?? [])].forEach((label) => {
+    const trimmed = label.trim();
+    if (!trimmed || labels.includes(trimmed)) return;
+    labels.push(trimmed);
+  });
+  return labels.length > 0 ? labels : undefined;
+};
+
+const mergeAccountQuotaEntryMetaLabels = (
+  activeEntry: AccountQuotaEntry,
+  observedEntry: AccountQuotaEntry
+) => {
+  if (
+    observedEntry.planType &&
+    observedEntry.planType !== activeEntry.planType &&
+    observedEntry.metaLabels &&
+    observedEntry.metaLabels.length > 0
+  ) {
+    return mergeAccountQuotaMetaLabels(undefined, observedEntry.metaLabels);
+  }
+
+  return mergeAccountQuotaMetaLabels(activeEntry.metaLabels, observedEntry.metaLabels);
+};
+
+const getMergeableAccountQuotaEntry = (
+  entry: AccountQuotaEntry | undefined
+): AccountQuotaEntry | undefined => {
+  if (!entry?.error) return entry;
+  const mergeableEntry = { ...entry };
+  delete mergeableEntry.error;
+  return mergeableEntry;
+};
+
+export const mergeObservedAccountQuotaEntry = (
+  activeEntry: AccountQuotaEntry | undefined,
+  observedEntry: AccountQuotaEntry | null
+): AccountQuotaEntry | null => {
+  const mergeableActiveEntry = getMergeableAccountQuotaEntry(activeEntry);
+  if (!mergeableActiveEntry) return observedEntry;
+  if (!observedEntry || observedEntry.error) return mergeableActiveEntry;
+
+  return {
+    ...mergeableActiveEntry,
+    planType: observedEntry.planType ?? mergeableActiveEntry.planType,
+    metaLabels: mergeAccountQuotaEntryMetaLabels(mergeableActiveEntry, observedEntry),
+    windows: mergeAccountQuotaWindows(mergeableActiveEntry.windows, observedEntry.windows),
+    observedAtMs: observedEntry.observedAtMs ?? mergeableActiveEntry.observedAtMs,
+    observedFromUsageHeaders:
+      observedEntry.observedFromUsageHeaders ?? mergeableActiveEntry.observedFromUsageHeaders,
+  };
+};
+
+const isObservedAccountQuotaNewerThanFailure = (
+  failedAtMs: number | undefined,
+  observedEntry: AccountQuotaEntry | null | undefined
+) => {
+  const failureTime = readFiniteTimestamp(failedAtMs);
+  const observedTime = readFiniteTimestamp(observedEntry?.observedAtMs);
+  return failureTime !== null && observedTime !== null && observedTime > failureTime;
+};
+
+const clearAccountQuotaEntryFailure = (entry: AccountQuotaEntry): AccountQuotaEntry => {
+  const recovered = { ...entry };
+  delete recovered.error;
+  delete recovered.failedAtMs;
+  return recovered;
+};
+
+export const buildAccountQuotaRefreshFailureEntry = (
+  target: MonitoringAccountQuotaTarget,
+  error: string,
+  t: TFunction,
+  activeEntry?: AccountQuotaEntry,
+  observedEntry?: AccountQuotaEntry | null,
+  failedAtMs = Date.now()
+): AccountQuotaEntry => {
+  const mergeableActiveEntry = getMergeableAccountQuotaEntry(activeEntry);
+  const mergedEntry =
+    mergeObservedAccountQuotaEntry(mergeableActiveEntry, observedEntry ?? null) ??
+    observedEntry ??
+    mergeableActiveEntry ??
+    null;
+
+  if (!mergedEntry) {
+    return {
+      ...buildAccountQuotaErrorEntry(target, error, t),
+      failedAtMs,
+    };
+  }
+
+  return {
+    ...mergedEntry,
+    error,
+    failedAtMs,
+  };
+};
+
+export const mergeObservedAccountQuotaState = (
+  state: AccountQuotaState | undefined,
+  targets: MonitoringAccountQuotaTarget[],
+  observedEntries: AccountQuotaEntry[]
+): AccountQuotaState | undefined => {
+  if (!state || state.status === 'loading' || observedEntries.length === 0) return state;
+
+  const targetKey = targets.map((target) => target.key).join('|');
+  if (state.targetKey !== targetKey) return state;
+
+  const observedByKey = new Map(observedEntries.map((entry) => [entry.key, entry]));
+  const activeKeys = new Set(state.entries.map((entry) => entry.key));
+  let changed = false;
+
+  const entries = state.entries.map((entry) => {
+    const observedEntry = observedByKey.get(entry.key);
+    if (!observedEntry) return entry;
+
+    const mergedEntry = mergeObservedAccountQuotaEntry(entry, observedEntry) ?? entry;
+    const nextEntry = entry.error
+      ? isObservedAccountQuotaNewerThanFailure(entry.failedAtMs, observedEntry)
+        ? clearAccountQuotaEntryFailure(mergedEntry)
+        : { ...mergedEntry, error: entry.error, failedAtMs: entry.failedAtMs }
+      : mergedEntry;
+    changed = changed || nextEntry !== entry;
+    return nextEntry;
+  });
+
+  const targetKeys = new Set(targets.map((target) => target.key));
+  observedEntries.forEach((observedEntry) => {
+    if (!targetKeys.has(observedEntry.key) || activeKeys.has(observedEntry.key)) return;
+
+    if (state.status === 'error' && !isObservedAccountQuotaNewerThanFailure(state.failedAtMs, observedEntry)) {
+      if (!state.error) return;
+      entries.push({ ...observedEntry, error: state.error, failedAtMs: state.failedAtMs });
+    } else {
+      entries.push(observedEntry);
+    }
+    changed = true;
+  });
+
+  if (!changed) return state;
+
+  const firstError = entries.find((entry) => entry.error)?.error;
+  return {
+    ...state,
+    status: firstError ? 'error' : 'success',
+    entries,
+    error: firstError || '',
+    failedAtMs: firstError ? state.failedAtMs : undefined,
+  };
+};
+
 const buildClaudeAccountQuotaWindows = (
   windows: ClaudeQuotaWindow[],
   t: TFunction
@@ -957,10 +1159,8 @@ export const buildObservedCodexAccountQuotaEntry = (
   const planType = target.planType ?? getHeaderSnapshotPlanType(snapshot) ?? null;
   const observedQuota = buildObservedCodexQuotaFromHeaderSnapshot(snapshot);
   const planLabel = getCodexPlanLabel(planType, t);
-  const observedAt =
-    snapshot?.timestamp_ms && Number.isFinite(snapshot.timestamp_ms)
-      ? new Date(snapshot.timestamp_ms).toLocaleString()
-      : '';
+  const observedAtMs = readFiniteTimestamp(snapshot?.timestamp_ms) ?? undefined;
+  const observedAt = observedAtMs ? new Date(observedAtMs).toLocaleString() : '';
   const usedPercent = getHeaderSnapshotUsedPercent(snapshot);
   const recoverAtMS = getHeaderSnapshotRecoverAtMs(snapshot);
   const errorKind = getHeaderSnapshotErrorKind(snapshot);
@@ -1016,6 +1216,8 @@ export const buildObservedCodexAccountQuotaEntry = (
     ...buildBaseAccountQuotaEntry({ ...target, planType }, t, metaLabels),
     planType,
     windows,
+    observedAtMs,
+    observedFromUsageHeaders: true,
   };
 };
 

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -331,6 +331,7 @@ export interface CodexQuotaState {
   authFileName?: string;
   authIndex?: string | null;
   fetchedAtMs?: number;
+  failedAtMs?: number;
   error?: string;
   errorStatus?: number;
   observedFromUsageHeaders?: boolean;


### PR DESCRIPTION
## Summary
Fix quota display timing so manual refresh failures remain visible until a newer usage-header snapshot arrives.
Preserve API-only Codex quota fields when header snapshots merge into quota management, auth file, and monitoring views.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Track manual quota refresh failure timestamps and compare them with usage-header snapshot timestamps.
- Preserve previous Codex quota windows, reset credits, and window metadata on failed refresh and reset paths.
- Apply the same timing contract to request monitoring account quota entries.

## User Impact
Users see manual quota refresh failures immediately, but continued request traffic can update the display once newer header data exists. Header-derived quota data keeps its source indicator and no longer clears API-only quota details.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only behavior change applies to the CPA-hosted panel.
- Manager Server mode: Embedded management panel uses the same frontend behavior after rebuild.
- Full Docker / native packages: No runtime config changes; packaged panels pick up the frontend fix when rebuilt.

## Data / Security Notes
N/A. No credential, auth file, SQLite, log, or raw usage data storage changes.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Revert the two commits in this PR to restore the previous header snapshot display behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/components/quota/quotaConfigs.test.ts src/components/quota/QuotaSection.test.tsx src/features/authFiles/components/AuthFileQuotaSection.test.tsx src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx src/features/monitoring/model/monitoringCenterPageModel.test.ts
npm run type-check
npm run lint
npm run test
```

## Screenshots / Recordings
N/A. No layout changes; quota state behavior is covered by automated tests.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Closes #268
