### PR TITLE
docs(release): add v1.10.0 release notes

### DIFF
--- a/docs/release-notes/v1.10.0-en.md
+++ b/docs/release-notes/v1.10.0-en.md
@@ -1,0 +1,56 @@
+# CPA Manager Plus v1.10.0
+
+> 33 commits · 167 files changed · +22962 / -2971
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.0/docs/release-notes/v1.10.0-zh.md)
+
+## Overview
+
+This release focuses on deployment readiness, public documentation, and a try-before-deploy experience: a guided CPAMP installer, bilingual documentation site, and isolated demo runtime are now available, alongside plugin store auth improvements, Codex quota reset-credit visibility, and safer quota/monitoring header timing.
+
+## Highlights
+
+### Features
+
+- Add a guided CPAMP deployment script covering Docker full-stack, CPAMP-only Docker, and native package deployments, including generated secrets, dry-run support, rerun behavior, write preflight checks, and startup health checks (`installer`).
+- Add a frontend-only mock demo runtime that reuses real app pages with local fixture data and keeps demo builds constrained to the `/demo` route (`web/demo`).
+- Add plugin store version selection, auth status handling, platform metadata, and `plugins.store-auth` visual config editing; installing older plugin versions now waits for an explicit user selection (`web/plugins`).
+- Show the earliest unexpired Codex reset credit in quota cards, with a tooltip listing reset credits sorted by expiry (`web/quota`).
+- Add a GitHub repository entry to the global header using the existing icon system and localized accessible labels (`web/layout`).
+
+### Fixes
+
+- Standardize newly generated Manager Server admin keys with a `cpamp_` prefix and fixed-length random secret while preserving verification for existing hash-based admin keys (`manager-server/auth`).
+- After manual quota refresh or reset failures, older usage headers no longer clear API-only quota windows or reset-credit data; only newer post-failure snapshots can recover the display (`web/quota`).
+- Realtime monitoring account quotas now follow the same header timing contract as quota cards, reducing confusion from stale header snapshots (`web/monitoring`).
+- Demo page release-date assertions now use local-day boundaries to avoid timezone failures on UTC CI runners (`web/demo`).
+
+### Docs
+
+- Add a bilingual VitePress documentation site covering getting started, gateway runtime, deployment, operations, panel manuals, migration, troubleshooting, and references (`docs/site`).
+- Update English and Chinese README entry points to prioritize the documentation site and online demo, while documenting the installer, generated secrets, CPA-hosted panel compatibility, and backup boundaries (`docs`).
+
+### CI
+
+- Publish both the demo build and documentation site through GitHub Pages; PR checks now build docs, and the release flow guards production bundles against demo markers (`ci/demo-docs`).
+- Add Chinese and English issue triage templates for deployment help, observability, and operations requests (`github`).
+
+### Build
+
+- Add a dedicated VitePress docs workspace and demo Vite mode; the default production build uses an empty fixture alias so demo data stays out of `management.html`, Docker images, and native release packages (`build`).
+
+### Tests
+
+- Add regression coverage for installer injection and write protection, native startup failure reporting, plugin version forwarding, demo isolation, quota header recovery, and monitoring quota timing (`tests`).
+
+## Upgrade Notes
+
+- No database migration is required.
+- Newly generated Manager Server admin keys now use the `cpamp_` prefix; existing admin keys do not need to be regenerated and continue to verify normally.
+- Production release bundles, Docker images, and native packages still use the production build path; demo fixtures remain isolated in the demo build and are guarded by release checks.
+- Documentation and deployment guidance now centers on the new documentation site and guided installer; older wiki-first README guidance has been replaced.
+- Suggested screenshots for this release: installer interaction flow, documentation site homepage, online demo, plugin store version/auth state, and Codex reset-credit tooltip.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.9.2...v1.10.0

--- a/docs/release-notes/v1.10.0-zh.md
+++ b/docs/release-notes/v1.10.0-zh.md
@@ -1,0 +1,56 @@
+# CPA Manager Plus v1.10.0
+
+> 33 commits · 167 files changed · +22962 / -2971
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.0/docs/release-notes/v1.10.0-en.md)
+
+## Overview
+
+本次发布聚焦部署落地、公开文档和可试用体验:新增引导式 CPAMP 部署脚本、双语文档站和隔离 demo runtime,同时补齐插件商店认证能力、Codex quota reset credit 展示以及 quota/监控 header 时序修复。
+
+## Highlights
+
+### Features
+
+- 新增引导式 CPAMP 部署脚本,覆盖 Docker full-stack、CPAMP-only Docker 和 native package 部署,并包含生成密钥、dry-run、重复执行、写入预检和启动健康检查(`installer`)。
+- 新增前端 mock demo runtime,复用真实页面和本地 fixture 数据,并将 demo build 限定在 `/demo` 路由下运行(`web/demo`)。
+- 插件商店支持版本选择、认证状态、平台 metadata 和 `plugins.store-auth` 可视化配置,安装指定旧版本时会等待用户显式选择(`web/plugins`)。
+- 在 Codex quota 卡片展示最早的未过期 reset credit,并提供按过期时间排序的 tooltip 明细(`web/quota`)。
+- 全局 header 新增 GitHub 仓库入口,使用现有图标系统和多语言可访问标签(`web/layout`)。
+
+### Fixes
+
+- 新生成的 Manager Server admin key 统一为 `cpamp_` 前缀和固定长度随机密钥,既有 hash-based admin key 仍可继续验证(`manager-server/auth`)。
+- 手动 quota refresh 或 reset 失败后,旧的 usage header 不再清空 API-only quota 窗口和 reset credit 数据;只有失败后的更新快照才会恢复展示(`web/quota`)。
+- 实时监控账号 quota 采用与 quota 卡片一致的 header 时序,减少旧 header 快照造成的状态混淆(`web/monitoring`)。
+- demo 页面日期断言改为本地日期边界,避免 UTC CI runner 上的跨时区失败(`web/demo`)。
+
+### Docs
+
+- 新增 VitePress 双语文档站,覆盖入门、网关运行模型、部署、运维、面板手册、迁移、故障排查和参考内容(`docs/site`)。
+- README 中英文入口改为优先指向文档站和在线 demo,并补充安装脚本、生成密钥、CPA-hosted panel 兼容性和备份边界说明(`docs`)。
+
+### CI
+
+- GitHub Pages 同时发布 demo build 和文档站,PR 检查会构建文档,release 流程会检查正式 bundle 是否混入 demo 标记(`ci/demo-docs`)。
+- 新增中英文 issue triage 模板,覆盖部署帮助、可观测性和运维请求等场景(`github`)。
+
+### Build
+
+- 新增独立 VitePress docs workspace 和 demo Vite mode,默认 production build 使用空 fixture alias,避免 demo 数据进入 `management.html`、Docker 或 native release 包(`build`)。
+
+### Tests
+
+- 补充安装脚本注入与写入保护、native 启动失败报告、插件版本转发、demo 隔离、quota header 恢复和监控 quota 时序相关回归测试(`tests`)。
+
+## Upgrade Notes
+
+- 无需数据库迁移。
+- 新生成的 Manager Server admin key 将使用 `cpamp_` 前缀;已有 admin key 不需要重新生成,仍可正常验证。
+- 正式 release bundle、Docker 镜像和 native package 仍走 production build 路径;demo fixture 会被隔离在 demo build 中,并由 release 检查防止误打包。
+- 文档与部署建议入口已迁移到新的文档站和引导式安装脚本,README 中的旧 wiki-first 指引已被替换。
+- 建议为本版本补充截图:安装脚本交互流程、文档站首页、在线 demo、插件商店版本/认证状态、Codex reset credit tooltip。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.9.2...v1.10.0


### PR DESCRIPTION
## Summary
Add curated Chinese and English release notes for v1.10.0. The notes cover the installer, documentation site, demo runtime, plugin store, quota, monitoring, CI, and build changes, with tag-pinned language switch links for GitHub Release rendering.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add docs/release-notes/v1.10.0-zh.md.
- Add docs/release-notes/v1.10.0-en.md.
- Include upgrade notes, screenshot suggestions, and the v1.9.2...v1.10.0 changelog link.

## User Impact
Users will see curated v1.10.0 release notes when the release tag workflow creates the GitHub Release.

## Compatibility / Runtime Notes
- CPA panel mode: N/A, release notes only.
- Manager Server mode: N/A, release notes only.
- Full Docker / native packages: The release workflow will use the curated notes after the tag is pushed.

## Data / Security Notes
No data or security behavior changes. The release notes mention the new generated admin key format but do not include secrets.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this release-notes commit before tagging if the content needs correction.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
sed -n 1,240p docs/release-notes/v1.10.0-zh.md
sed -n 1,240p docs/release-notes/v1.10.0-en.md
git diff --cached --name-status
```

## Screenshots / Recordings
N/A, release notes only.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
Refs v1.10.0 release.