### PR TITLE
fix(manager-server): fall back to requested model pricing

### DIFF
--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -694,11 +694,7 @@ func aggregateModelStats(stats []store.ModelStat, prices map[string]store.ModelP
 }
 
 func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -708,11 +704,7 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 }
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,

--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -263,6 +263,51 @@ func TestSummaryUsesResolvedModelPricing(t *testing.T) {
 	}
 }
 
+func TestSummaryFallsBackToRequestedModelPriceWhenResolvedPriceIsMissing(t *testing.T) {
+	db := newDashboardTestStore(t)
+	ctx := context.Background()
+	todayStart := int64(1_778_005_000_000)
+	nowMS := todayStart + 60*60*1000
+
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"GLM-5.2": {Prompt: 3},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	event := dashboardEvent("dashboard-alias-fallback-cost", todayStart+1_000, "GLM-5.2", false, 1_000_000, 0, 0, 0, 0, 1_000_000, nil)
+	event.RequestedModel = "GLM-5.2"
+	event.ResolvedModel = "zai/glm-5.2"
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Summary(ctx, SummaryParams{
+		TodayStartMS:   todayStart,
+		NowMS:          nowMS,
+		TopModels:      5,
+		RecentFailures: 1,
+	})
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+
+	if math.Abs(resp.Today.TotalCost-3) > 0.000001 {
+		t.Fatalf("today cost = %v", resp.Today.TotalCost)
+	}
+	if len(resp.TopModelsToday) != 1 || resp.TopModelsToday[0].Model != "GLM-5.2" ||
+		math.Abs(resp.TopModelsToday[0].Cost-3) > 0.000001 {
+		t.Fatalf("top models = %#v", resp.TopModelsToday)
+	}
+	if len(resp.ModelCostRank) != 1 || resp.ModelCostRank[0].Model != "GLM-5.2" ||
+		math.Abs(resp.ModelCostRank[0].Cost-3) > 0.000001 {
+		t.Fatalf("model cost rank = %#v", resp.ModelCostRank)
+	}
+	if len(resp.ChannelHealth) != 1 || resp.ChannelHealth[0].AuthIndex != "auth-1" ||
+		math.Abs(resp.ChannelHealth[0].Cost-3) > 0.000001 {
+		t.Fatalf("channel health = %#v", resp.ChannelHealth)
+	}
+}
+
 func TestSummaryPricesPriorityAndDefaultServiceTiersSeparately(t *testing.T) {
 	db := newDashboardTestStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -2226,11 +2226,7 @@ func sumCost(stats []store.ModelStat, prices map[string]store.ModelPrice) float6
 }
 
 func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -2240,11 +2236,7 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 }
 
 func costForTimelinePoint(point store.TimelinePoint, prices map[string]store.ModelPrice) float64 {
-	model := point.BillingModel
-	if model == "" {
-		model = point.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, point.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
 		InputTokens:         point.InputTokens,
 		OutputTokens:        point.OutputTokens,
 		CachedTokens:        point.CachedTokens,
@@ -2254,11 +2246,7 @@ func costForTimelinePoint(point store.TimelinePoint, prices map[string]store.Mod
 }
 
 func costForHeatmapPoint(point store.HeatmapPoint, prices map[string]store.ModelPrice) float64 {
-	model := point.BillingModel
-	if model == "" {
-		model = point.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, point.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
 		InputTokens:         point.InputTokens,
 		OutputTokens:        point.OutputTokens,
 		CachedTokens:        point.CachedTokens,
@@ -2268,11 +2256,7 @@ func costForHeatmapPoint(point store.HeatmapPoint, prices map[string]store.Model
 }
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -2282,11 +2266,7 @@ func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.Mod
 }
 
 func costForAccountModelStat(stat store.AccountModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -2296,11 +2276,7 @@ func costForAccountModelStat(stat store.AccountModelStat, prices map[string]stor
 }
 
 func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -2310,11 +2286,7 @@ func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.
 }
 
 func costForCredentialModelStat(stat store.CredentialModelStat, prices map[string]store.ModelPrice) float64 {
-	model := stat.BillingModel
-	if model == "" {
-		model = stat.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, stat.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		InputTokens:         stat.InputTokens,
 		OutputTokens:        stat.OutputTokens,
 		CachedTokens:        stat.CachedTokens,
@@ -2324,11 +2296,7 @@ func costForCredentialModelStat(stat store.CredentialModelStat, prices map[strin
 }
 
 func costForCredentialTimelinePoint(point store.CredentialTimelinePoint, prices map[string]store.ModelPrice) float64 {
-	model := point.BillingModel
-	if model == "" {
-		model = point.Model
-	}
-	return pricing.CostForModelWithServiceTier(model, point.ServiceTier, pricing.ModelTokens{
+	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
 		InputTokens:         point.InputTokens,
 		OutputTokens:        point.OutputTokens,
 		CachedTokens:        point.CachedTokens,

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -523,6 +523,59 @@ func TestAnalyticsUsesResolvedModelPricingInAggregates(t *testing.T) {
 	}
 }
 
+func TestAnalyticsFallsBackToRequestedModelPriceWhenResolvedPriceIsMissing(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_005_000_000)
+	toMS := fromMS + 60*60*1000
+
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"GLM-5.2": {Prompt: 3},
+	}); err != nil {
+		t.Fatalf("save model prices: %v", err)
+	}
+	event := monitoringEvent("alias-fallback-cost", fromMS+1_000, "GLM-5.2", "auth-1", "source-a", false, 1_000_000, 0, 0, 0, 1_000_000, nil)
+	event.RequestedModel = "GLM-5.2"
+	event.ResolvedModel = "zai/glm-5.2"
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Include: Include{
+			Summary:      true,
+			ModelShare:   true,
+			ModelStats:   true,
+			ChannelShare: true,
+			Timeline:     true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+
+	if resp.Summary == nil || math.Abs(resp.Summary.TotalCost-3) > 0.000001 {
+		t.Fatalf("summary cost = %#v", resp.Summary)
+	}
+	if len(resp.ModelStats) != 1 || resp.ModelStats[0].Model != "GLM-5.2" ||
+		math.Abs(resp.ModelStats[0].Cost-3) > 0.000001 {
+		t.Fatalf("model stats = %#v", resp.ModelStats)
+	}
+	if len(resp.ModelShare) != 1 || resp.ModelShare[0].Model != "GLM-5.2" ||
+		math.Abs(resp.ModelShare[0].Cost-3) > 0.000001 {
+		t.Fatalf("model share = %#v", resp.ModelShare)
+	}
+	if len(resp.ChannelShare) != 1 || resp.ChannelShare[0].AuthIndex != "auth-1" ||
+		math.Abs(resp.ChannelShare[0].Cost-3) > 0.000001 {
+		t.Fatalf("channel share = %#v", resp.ChannelShare)
+	}
+	if len(resp.Timeline) != 1 || math.Abs(resp.Timeline[0].Cost-3) > 0.000001 {
+		t.Fatalf("timeline = %#v", resp.Timeline)
+	}
+}
+
 func TestAnalyticsPricesPriorityAndDefaultServiceTiersSeparately(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/pricing/cost.go
+++ b/apps/manager-server/internal/service/pricing/cost.go
@@ -86,6 +86,25 @@ func CostForModelWithServiceTier(modelName string, serviceTier string, tokens Mo
 	return CostForModel(modelName, tokens, prices) * ServiceTierMultiplier(modelName, serviceTier)
 }
 
+// CostForModelCandidatesWithServiceTier computes cost using the first priced
+// model name from the candidate list. Callers should pass resolved/upstream
+// model first, followed by the requested display model or alias as fallback.
+func CostForModelCandidatesWithServiceTier(modelNames []string, serviceTier string, tokens ModelTokens, prices map[string]model.ModelPrice) float64 {
+	seen := map[string]bool{}
+	for _, modelName := range modelNames {
+		modelName = strings.TrimSpace(modelName)
+		if modelName == "" || seen[modelName] {
+			continue
+		}
+		seen[modelName] = true
+		if _, ok := prices[modelName]; !ok {
+			continue
+		}
+		return CostForModelWithServiceTier(modelName, serviceTier, tokens, prices)
+	}
+	return 0
+}
+
 // SumCost folds CostForModel over a slice of (model, tokens) tuples.
 type Item struct {
 	Model  string

--- a/apps/manager-server/internal/service/pricing/cost_test.go
+++ b/apps/manager-server/internal/service/pricing/cost_test.go
@@ -117,6 +117,41 @@ func TestCostForModelWithServiceTier(t *testing.T) {
 	}
 }
 
+func TestCostForModelCandidatesWithServiceTierFallsBackToRequestedModel(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.4": {Prompt: 2.5, Completion: 5, Cache: 1},
+	}
+
+	cost := CostForModelCandidatesWithServiceTier(
+		[]string{"missing-upstream", "gpt-5.4"},
+		"priority",
+		ModelTokens{InputTokens: 1_000_000},
+		prices,
+	)
+
+	if math.Abs(cost-5) > 0.000001 {
+		t.Fatalf("fallback cost = %v, want 5", cost)
+	}
+}
+
+func TestCostForModelCandidatesWithServiceTierPrefersResolvedModel(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-resolved": {Prompt: 1, Completion: 2, Cache: 0.5},
+		"gpt-5.4":      {Prompt: 2.5, Completion: 5, Cache: 1},
+	}
+
+	cost := CostForModelCandidatesWithServiceTier(
+		[]string{"gpt-resolved", "gpt-5.4"},
+		"priority",
+		ModelTokens{InputTokens: 1_000_000},
+		prices,
+	)
+
+	if math.Abs(cost-1) > 0.000001 {
+		t.Fatalf("resolved cost = %v, want 1", cost)
+	}
+}
+
 func TestCostForModelWithServiceTierPreservesCacheBuckets(t *testing.T) {
 	prices := map[string]model.ModelPrice{
 		"gpt-5.4": {Prompt: 2, Completion: 4, Cache: 1, CacheRead: 0.5, CacheCreation: 3},


### PR DESCRIPTION
## Summary
Fix backend aggregate cost calculation for aliased models whose resolved/upstream model has no configured price.
This keeps resolved-model pricing as the first choice, then falls back to the requested display model or alias so channel totals match realtime request costs.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add a shared pricing helper that tries resolved/upstream model names before requested model aliases.
- Use the helper across monitoring and dashboard aggregate cost paths.
- Add regression coverage for prefixed resolved models with alias-only price entries.

## User Impact
Users with CPA model aliases on prefixed upstream model names will see channel, dashboard, and analytics aggregate costs match realtime request costs instead of showing zero.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the same Manager Server aggregate API behavior; no panel contract change.
- Manager Server mode: Cost aggregation now falls back to requested model price when resolved model price is unavailable.
- Full Docker / native packages: No config or packaging changes.

## Data / Security Notes
N/A. No schema, credential, key, raw usage data, or security-sensitive storage changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore exact resolved-model-only aggregate pricing.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
cd apps/manager-server && go test ./internal/service/pricing ./internal/service/monitoring ./internal/service/dashboard
npm run manager-server:test
```

## Screenshots / Recordings
N/A. Backend-only change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #275