### PR TITLE
docs(release): add v1.10.1 release notes

### DIFF
--- a/docs/release-notes/v1.10.1-en.md
+++ b/docs/release-notes/v1.10.1-en.md
@@ -1,0 +1,47 @@
+# CPA Manager Plus v1.10.1
+
+> 17 commits · 36 files changed · +3084 / -174
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.1/docs/release-notes/v1.10.1-zh.md)
+
+## Overview
+
+This release focuses on native package background control, quota provider adaptation, and more accurate cost aggregation. Native packages now include hardened background start/stop scripts, Antigravity and Codex quota displays cover more provider edge cases, and Manager Server falls back to requested model alias pricing when resolved model pricing is unavailable so channel aggregate costs no longer show zero for prefixed aliases.
+
+## Highlights
+
+### Features
+
+- Add native package background control scripts for Unix and Windows deployments, including start, stop, status, and PID file management support (`native`).
+- Prefer Antigravity quota summary data and show subscription plan details on quota cards, while still falling back to available model data when summaries are absent (`web/quota`).
+- Run bulk provider quota refreshes through a bounded concurrency queue to reduce burst pressure during paged or all-account refreshes (`web/quota`).
+
+### Fixes
+
+- Harden native background control scripts with PID ownership checks, safe parent-directory validation, custom directory preservation, and Windows behavior that avoids ACL cmdlet compatibility issues (`native`).
+- Harden Codex quota adapters by sharing request header construction between quota fetch and reset-credit APIs, preserving existing usage quota data when reset-credit details fail, and localizing invalid payload errors (`web/quota`).
+- Cover additional provider quota edge cases, including Kimi limit-window unit parsing, Claude profile-failure paths, and xAI billing normalization (`web/quota`).
+- Fall back from resolved/upstream model names to requested model aliases in Manager Server cost calculation, fixing zero channel aggregate costs for prefixed model aliases (`manager-server/pricing`).
+
+### Docs
+
+- Move the native background control guide into the VitePress documentation site and update README, deployment pages, and sidebar links so users reach the maintained docs location (`docs/native`).
+
+### Tests
+
+- Add regression coverage for native control script safety, model pricing fallback, Antigravity subscription parsing, provider quota edge cases, and Codex reset-credit headers (`tests`).
+
+## Upgrade Notes
+
+- No database migration is required.
+- Native package users can use the new `cpa-manager-plusctl.sh` / `cpa-manager-plusctl.ps1` scripts for background process control; keep custom PID and log directories owned and permissioned safely.
+- This release tightens quota provider behavior, so after upgrading it is worth checking Antigravity, Codex, Kimi, Claude, and xAI quota cards.
+- Suggested screenshots for this release: native background control command examples, Antigravity subscription quota cards, and channel statistics after the model-alias cost aggregation fix.
+
+## Acknowledgements
+
+- [@duangkuacha](https://github.com/duangkuacha) - Contributed native background control scripts and follow-up hardening for Unix and Windows control flows.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.0...v1.10.1

--- a/docs/release-notes/v1.10.1-zh.md
+++ b/docs/release-notes/v1.10.1-zh.md
@@ -1,0 +1,47 @@
+# CPA Manager Plus v1.10.1
+
+> 17 commits · 36 files changed · +3084 / -174
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.1/docs/release-notes/v1.10.1-en.md)
+
+## Overview
+
+本次发布聚焦 native package 的后台控制能力、配额提供商适配和计费聚合准确性。原生包新增并加固后台启动/停止脚本,Antigravity 与 Codex quota 展示覆盖更多边界场景,Manager Server 也会在模型别名场景下回退到请求模型价格,避免通道聚合成本显示为 0。
+
+## Highlights
+
+### Features
+
+- 新增 native package 后台控制脚本,为 Unix 和 Windows 原生部署提供启动、停止、状态检查和 PID 文件管理能力(`native`)。
+- Antigravity quota 优先读取 summary 数据,并在 quota 卡片中展示订阅套餐信息,缺失 summary 时仍可回退到可用模型数据(`web/quota`)。
+- 批量 provider quota 刷新改为有界并发队列,降低分页或全量刷新时对上游 provider 的瞬时请求压力(`web/quota`)。
+
+### Fixes
+
+- 原生后台控制脚本会校验 PID 文件所有权、父目录安全性和自定义目录处理,并避免 Windows ACL cmdlet 兼容性问题(`native`)。
+- 加固 Codex quota adapter:统一 quota fetch 与 reset-credit API 的请求 header,reset-credit 明细失败时保留已有 usage quota 数据,并补齐无效 payload 的本地化错误(`web/quota`)。
+- 补齐多个 provider quota 边界处理,包括 Kimi limit window 单位解析、Claude profile 失败路径和 xAI billing 归一化(`web/quota`)。
+- Manager Server 成本计算会在 resolved/upstream model 没有价格时回退到请求模型别名,修复带前缀别名模型的通道聚合成本为 0 的问题(`manager-server/pricing`)。
+
+### Docs
+
+- 将 native 后台控制文档移入 VitePress 文档站,并更新 README、部署页面和侧边栏链接,避免用户落到已迁移的旧文档位置(`docs/native`)。
+
+### Tests
+
+- 补充 native control 脚本安全性、模型价格回退、Antigravity 订阅解析、provider quota 边界和 Codex reset-credit header 相关回归测试(`tests`)。
+
+## Upgrade Notes
+
+- 无需数据库迁移。
+- Native package 用户可以使用新增的 `cpa-manager-plusctl.sh` / `cpa-manager-plusctl.ps1` 管理后台运行;如果使用自定义 PID 或日志目录,请保持目录归属和权限安全。
+- 本次包含 quota provider 行为收敛,建议升级后重点检查 Antigravity、Codex、Kimi、Claude 和 xAI 账号的 quota 卡片显示。
+- 建议为本版本补充截图:native 后台控制命令示例、Antigravity subscription quota 卡片、模型别名成本聚合修复后的通道统计。
+
+## Acknowledgements
+
+- [@duangkuacha](https://github.com/duangkuacha) - 贡献 native 后台控制脚本并持续加固 Unix/Windows 控制流程。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.0...v1.10.1


### PR DESCRIPTION
## Summary
Prepare curated release notes for CPA Manager Plus v1.10.1 before tagging the release.

This PR adds both Chinese and English release note files and includes the external contributor acknowledgement for @duangkuacha.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add Chinese release notes at `docs/release-notes/v1.10.1-zh.md`.
- Add English release notes at `docs/release-notes/v1.10.1-en.md`.
- Document native background control, quota provider hardening, model-alias pricing fallback, and acknowledgement for @duangkuacha.

## User Impact
Users will see curated release notes for v1.10.1 when the release tag is pushed. No runtime behavior changes are introduced by this PR itself.

## Compatibility / Runtime Notes
- CPA panel mode: No runtime change in this PR.
- Manager Server mode: No runtime change in this PR.
- Full Docker / native packages: Release notes document native package background control changes included in the release range.

## Data / Security Notes
No data or security behavior changes in this PR. The release notes mention native PID/log path safety improvements that are already present in the release range.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this release notes PR before pushing the `v1.10.1` tag if the release should be delayed.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
Release preflight: main matches origin/main, worktree clean, v1.10.1 tag absent, release/v1.10.1 branch created from main.
Release notes follow docs/release.md naming and use tag-pinned language links.
```

## Screenshots / Recordings
N/A for release notes only.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
N/A