### PR TITLE
fix(manager-server): raise auth-files fetch response limit

### DIFF
--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -73,7 +73,7 @@ func (c *Client) Fetch(ctx context.Context, baseURL string, managementKey string
 		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 8*1024*1024))
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return nil, fmt.Errorf("GET %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
 	}


### PR DESCRIPTION
Increase the CPA auth-files response read limit from 1 MiB to 8 MiB so quota cooldown recovery can verify larger auth file lists without truncating JSON and returning unexpected EOF.

## Summary
<!-- What changed and why. Keep it short, 2-4 lines. -->

## Scope
<!-- Check all areas touched by this PR. -->
- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
<!-- List concrete changes, not implementation trivia. -->
-
-
-

## User Impact
<!-- What users will notice. Use "No user-facing behavior change" if applicable. -->


## Compatibility / Runtime Notes
<!-- Mention mode-specific behavior, config changes, queue behavior, or N/A. -->
- CPA panel mode:
- Manager Server mode:
- Full Docker / native packages:

## Data / Security Notes
<!-- Required for SQLite, admin key, CPA Management Key, auth files, logs, raw usage data, or plugins. Use N/A if not relevant. -->


## Risk / Rollback
Risk level: Low / Medium / High

Rollback notes:
-

## Verification
<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->
- [x] Type check
- [x] Lint
- [ ] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
```

## Screenshots / Recordings
<!-- Required for visible UI changes. Use N/A for backend/docs-only changes. -->


## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [ ] Not needed

## Related
<!-- Closes #123 / Fixes #123 / Refs #123 / N/A -->
