### PR TITLE
fix(manager-server): stream CPA auth file lookups

### DIFF
--- a/apps/manager-server/internal/service/accountaction/service.go
+++ b/apps/manager-server/internal/service/accountaction/service.go
@@ -67,7 +67,7 @@ func (s *Service) Enable(ctx context.Context, id int64) (model.AccountActionCand
 	if _, err := s.verifyCurrentAuthFile(ctx, setup, item); err != nil {
 		return model.AccountActionCandidate{}, err
 	}
-	if err := s.patchAuthFile(ctx, setup, item.AuthFileName, false); err != nil {
+	if err := s.patchAuthFile(ctx, setup, item.AuthFileName, item.AuthIndex, false); err != nil {
 		_ = s.store.RecordAccountActionCandidateFailure(ctx, id, err.Error())
 		return model.AccountActionCandidate{}, err
 	}
@@ -135,12 +135,7 @@ func (s *Service) resolveCandidateAndSetup(ctx context.Context, id int64) (model
 }
 
 func (s *Service) verifyCurrentAuthFile(ctx context.Context, setup store.Setup, item model.AccountActionCandidate) (authFile, error) {
-	files, err := cpaauthfiles.New(s.client).Fetch(ctx, setup.CPAUpstreamURL, setup.ManagementKey)
-	if err != nil {
-		_ = s.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
-		return authFile{}, err
-	}
-	file, err := cpaauthfiles.VerifyIdentity(files, cpaauthfiles.Identity{
+	file, err := cpaauthfiles.New(s.client).Verify(ctx, setup.CPAUpstreamURL, setup.ManagementKey, cpaauthfiles.Identity{
 		AuthFileName:      item.AuthFileName,
 		AuthIndex:         item.AuthIndex,
 		Provider:          item.Provider,
@@ -148,14 +143,18 @@ func (s *Service) verifyCurrentAuthFile(ctx context.Context, setup store.Setup, 
 		AccountIDSnapshot: item.AccountIDSnapshot,
 	})
 	if err != nil {
+		if !errors.Is(err, cpaauthfiles.ErrAuthFileNotFound) && !errors.Is(err, cpaauthfiles.ErrIdentityMismatch) {
+			_ = s.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
+			return authFile{}, err
+		}
 		return authFile{}, ErrCandidateConflict
 	}
 	return file, nil
 
 }
 
-func (s *Service) patchAuthFile(ctx context.Context, setup store.Setup, fileName string, disabled bool) error {
-	return cpaauthfiles.New(s.client).PatchDisabled(ctx, setup.CPAUpstreamURL, setup.ManagementKey, fileName, disabled)
+func (s *Service) patchAuthFile(ctx context.Context, setup store.Setup, fileName string, authIndex string, disabled bool) error {
+	return cpaauthfiles.New(s.client).PatchDisabled(ctx, setup.CPAUpstreamURL, setup.ManagementKey, fileName, disabled, authIndex)
 }
 
 func (s *Service) deleteAuthFile(ctx context.Context, setup store.Setup, fileName string) error {

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -59,6 +59,21 @@ func New(client *http.Client, timeout ...time.Duration) *Client {
 const authFilesPath = "/v0/management/auth-files"
 const authFilesStatusPath = "/v0/management/auth-files/status"
 
+func authFilesEndpoint(baseURL string, fileName string, authIndex string) string {
+	endpoint := baseURL + authFilesPath
+	query := url.Values{}
+	if fileName = strings.TrimSpace(fileName); fileName != "" {
+		query.Set("name", fileName)
+	}
+	if authIndex = strings.TrimSpace(authIndex); authIndex != "" {
+		query.Set("auth_index", authIndex)
+	}
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	return endpoint
+}
+
 func (c *Client) Fetch(ctx context.Context, baseURL string, managementKey string) ([]File, error) {
 	base := cpa.NormalizeBaseURL(baseURL)
 	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
@@ -73,15 +88,67 @@ func (c *Client) Fetch(ctx context.Context, baseURL string, managementKey string
 		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
 		return nil, fmt.Errorf("GET %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
 	}
-	files, err := Parse(body)
-	if err != nil {
+	files := make([]File, 0)
+	if err := scanFiles(res.Body, func(file File) (bool, error) {
+		files = append(files, file)
+		return false, nil
+	}); err != nil {
 		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
 	return files, nil
+}
+
+func (c *Client) Find(ctx context.Context, baseURL string, managementKey string, fileName string, authIndex string) (File, bool, error) {
+	base := cpa.NormalizeBaseURL(baseURL)
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, authFilesEndpoint(base, fileName, authIndex), nil)
+	if err != nil {
+		return File{}, false, fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+managementKey)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return File{}, false, fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return File{}, false, fmt.Errorf("GET %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var matched File
+	found := false
+	err = scanFiles(res.Body, func(file File) (bool, error) {
+		if !matches(file, fileName, authIndex) {
+			return false, nil
+		}
+		matched = file
+		found = true
+		return true, nil
+	})
+	if err != nil {
+		return File{}, false, fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	return matched, found, nil
+}
+
+func (c *Client) Verify(ctx context.Context, baseURL string, managementKey string, identity Identity) (File, error) {
+	file, ok, err := c.Find(ctx, baseURL, managementKey, identity.AuthFileName, identity.AuthIndex)
+	if err != nil {
+		return File{}, err
+	}
+	if !ok {
+		return File{}, ErrAuthFileNotFound
+	}
+	if err := verifyFileIdentity(file, identity); err != nil {
+		return File{}, err
+	}
+	return file, nil
 }
 
 func Parse(body []byte) ([]File, error) {
@@ -98,19 +165,162 @@ func Parse(body []byte) ([]File, error) {
 	return files, nil
 }
 
+func scanFiles(body io.Reader, visit func(File) (bool, error)) error {
+	decoder := json.NewDecoder(body)
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return fmt.Errorf("expected JSON object or array")
+	}
+	switch delimiter {
+	case '[':
+		_, err := scanFileArray(decoder, visit)
+		return err
+	case '{':
+		raw := make(map[string]any)
+		scannedList := false
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("expected object key")
+			}
+			if !isAuthFilesListKey(key) {
+				var value any
+				if err := decoder.Decode(&value); err != nil {
+					return err
+				}
+				raw[key] = value
+				continue
+			}
+			valueToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			valueDelimiter, ok := valueToken.(json.Delim)
+			if !ok || valueDelimiter != '[' {
+				value, err := decodeValueAfterToken(decoder, valueToken)
+				if err != nil {
+					return err
+				}
+				raw[key] = value
+				continue
+			}
+			scannedList = true
+			stopped, err := scanFileArray(decoder, visit)
+			if err != nil || stopped {
+				return err
+			}
+		}
+		if _, err := decoder.Token(); err != nil {
+			return err
+		}
+		if !scannedList && stringField(raw, "name", "file_name", "fileName", "id") != "" {
+			_, err := visit(FromMap(raw))
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("expected JSON object or array")
+	}
+}
+
+func decodeValueAfterToken(decoder *json.Decoder, token json.Token) (any, error) {
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+	switch delimiter {
+	case '{':
+		value := make(map[string]any)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, fmt.Errorf("expected object key")
+			}
+			var child any
+			if err := decoder.Decode(&child); err != nil {
+				return nil, err
+			}
+			value[key] = child
+		}
+		_, err := decoder.Token()
+		return value, err
+	case '[':
+		value := make([]any, 0)
+		for decoder.More() {
+			var child any
+			if err := decoder.Decode(&child); err != nil {
+				return nil, err
+			}
+			value = append(value, child)
+		}
+		_, err := decoder.Token()
+		return value, err
+	default:
+		return nil, fmt.Errorf("unexpected delimiter %q", delimiter)
+	}
+}
+
+func scanFileArray(decoder *json.Decoder, visit func(File) (bool, error)) (bool, error) {
+	for decoder.More() {
+		var raw map[string]any
+		if err := decoder.Decode(&raw); err != nil {
+			return false, err
+		}
+		if len(raw) == 0 {
+			continue
+		}
+		stop, err := visit(FromMap(raw))
+		if err != nil || stop {
+			return stop, err
+		}
+	}
+	_, err := decoder.Token()
+	return false, err
+}
+
+func isAuthFilesListKey(key string) bool {
+	switch key {
+	case "auth_files", "authFiles", "files", "items", "data":
+		return true
+	default:
+		return false
+	}
+}
+
 func Find(files []File, fileName string, authIndex string) (File, bool) {
 	fileName = strings.TrimSpace(fileName)
 	authIndex = strings.TrimSpace(authIndex)
 	for _, file := range files {
-		if file.Name != fileName {
-			continue
+		if matches(file, fileName, authIndex) {
+			return file, true
 		}
-		if authIndex != "" && file.AuthIndex != authIndex {
-			continue
-		}
-		return file, true
 	}
 	return File{}, false
+}
+
+func matches(file File, fileName string, authIndex string) bool {
+	fileName = strings.TrimSpace(fileName)
+	authIndex = strings.TrimSpace(authIndex)
+	if fileName != "" && file.Name != fileName {
+		return false
+	}
+	if authIndex != "" && file.AuthIndex != authIndex {
+		return false
+	}
+	return true
 }
 
 func VerifyIdentity(files []File, identity Identity) (File, error) {
@@ -118,20 +328,32 @@ func VerifyIdentity(files []File, identity Identity) (File, error) {
 	if !ok {
 		return File{}, ErrAuthFileNotFound
 	}
-	if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
-		return File{}, fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountIDSnapshot), file.AccountID)
-	}
-	if identity.Provider != "" && !strings.EqualFold(file.Provider, strings.TrimSpace(identity.Provider)) {
-		return File{}, fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
-	}
-	if identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
-		return File{}, fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
+	if err := verifyFileIdentity(file, identity); err != nil {
+		return File{}, err
 	}
 	return file, nil
 }
 
-func (c *Client) PatchDisabled(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {
+func verifyFileIdentity(file File, identity Identity) error {
+	if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
+		return fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountIDSnapshot), file.AccountID)
+	}
+	if identity.Provider != "" && !strings.EqualFold(file.Provider, strings.TrimSpace(identity.Provider)) {
+		return fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
+	}
+	if identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
+		return fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
+	}
+	return nil
+}
+
+func (c *Client) PatchDisabled(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool, authIndex ...string) error {
 	payload := map[string]any{"name": fileName, "disabled": disabled}
+	if len(authIndex) > 0 {
+		if trimmed := strings.TrimSpace(authIndex[0]); trimmed != "" {
+			payload["auth_index"] = trimmed
+		}
+	}
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -259,6 +481,15 @@ func actionFailed(body []byte) bool {
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return false
 	}
-	failed, ok := payload["failed"].([]any)
-	return ok && len(failed) > 0
+	if failed, ok := payload["failed"].([]any); ok && len(failed) > 0 {
+		return true
+	}
+	if ok, _ := payload["success"].(bool); ok {
+		return false
+	}
+	if ok, _ := payload["ok"].(bool); ok {
+		return false
+	}
+	status := strings.ToLower(strings.TrimSpace(fmt.Sprint(payload["status"])))
+	return status == "error" || status == "failed"
 }

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -58,14 +59,15 @@ func TestClientPatchDisabledAndDelete(t *testing.T) {
 			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "codex-auth.json", "auth_index": "7"}})
 		case "PATCH /v0/management/auth-files/status":
 			var payload struct {
-				Name     string `json:"name"`
-				Disabled bool   `json:"disabled"`
+				Name      string `json:"name"`
+				AuthIndex string `json:"auth_index"`
+				Disabled  bool   `json:"disabled"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			if payload.Name != "codex-auth.json" || !payload.Disabled {
+			if payload.Name != "codex-auth.json" || payload.AuthIndex != "7" || !payload.Disabled {
 				t.Fatalf("patch payload = %#v", payload)
 			}
 			patched = true
@@ -90,7 +92,7 @@ func TestClientPatchDisabledAndDelete(t *testing.T) {
 	if _, ok := Find(files, "codex-auth.json", "7"); !ok {
 		t.Fatalf("find files = %#v", files)
 	}
-	if err := client.PatchDisabled(context.Background(), server.URL, "mgmt", "codex-auth.json", true); err != nil {
+	if err := client.PatchDisabled(context.Background(), server.URL, "mgmt", "codex-auth.json", true, "7"); err != nil {
 		t.Fatalf("patch disabled: %v", err)
 	}
 	if err := client.Delete(context.Background(), server.URL, "mgmt", "codex-auth.json"); err != nil {
@@ -98,5 +100,82 @@ func TestClientPatchDisabledAndDelete(t *testing.T) {
 	}
 	if !patched || !deleted {
 		t.Fatalf("patched=%t deleted=%t", patched, deleted)
+	}
+}
+
+func TestClientFindStreamsLargeAuthFilesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v0/management/auth-files" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("name") != "target.json" || r.URL.Query().Get("auth_index") != "target-index" {
+			t.Fatalf("query = %s", r.URL.RawQuery)
+		}
+		if r.Header.Get("Authorization") != "Bearer mgmt" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"files":[`)
+		padding := strings.Repeat("x", 2048)
+		for i := 0; i < 650; i++ {
+			if i > 0 {
+				_, _ = io.WriteString(w, ",")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":           "filler.json",
+				"auth_index":     "filler",
+				"status_message": padding,
+			})
+		}
+		_, _ = io.WriteString(w, `,{"name":"target.json","auth_index":"target-index","provider":"codex","account":"user@example.com","account_id":"acct-123","disabled":false}]}`)
+	}))
+	defer server.Close()
+
+	client := New(server.Client())
+	file, ok, err := client.Find(context.Background(), server.URL, "mgmt", "target.json", "target-index")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected target auth file to be found")
+	}
+	if file.Name != "target.json" || file.AuthIndex != "target-index" || file.AccountID != "acct-123" {
+		t.Fatalf("file = %#v", file)
+	}
+}
+
+func TestClientFetchAndFindAcceptSingleAuthFileObject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v0/management/auth-files" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":       "single.json",
+			"auth_index": "single-index",
+			"provider":   "codex",
+			"account":    "user@example.com",
+			"account_id": "acct-123",
+			"disabled":   false,
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.Client())
+	files, err := client.Fetch(context.Background(), server.URL, "mgmt")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "single.json" || files[0].AuthIndex != "single-index" {
+		t.Fatalf("files = %#v", files)
+	}
+	file, ok, err := client.Find(context.Background(), server.URL, "mgmt", "single.json", "single-index")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if !ok || file.Name != "single.json" || file.AuthIndex != "single-index" {
+		t.Fatalf("file=%#v ok=%t", file, ok)
 	}
 }

--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -158,13 +159,7 @@ func (w *AccountActionCandidateWorker) maybeAutoDisable(ctx context.Context, ite
 		return
 	}
 	client := cpaauthfiles.New(nil)
-	files, err := client.Fetch(ctx, baseURL, managementKey)
-	if err != nil {
-		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
-		log.Printf("[account-action] auto-disable verification failed for pending candidate %d authFile=%q: %v", item.ID, item.AuthFileName, err)
-		return
-	}
-	current, err := cpaauthfiles.VerifyIdentity(files, cpaauthfiles.Identity{
+	current, err := client.Verify(ctx, baseURL, managementKey, cpaauthfiles.Identity{
 		AuthFileName:      item.AuthFileName,
 		AuthIndex:         item.AuthIndex,
 		Provider:          item.Provider,
@@ -172,16 +167,21 @@ func (w *AccountActionCandidateWorker) maybeAutoDisable(ctx context.Context, ite
 		AccountIDSnapshot: item.AccountIDSnapshot,
 	})
 	if err != nil {
-		reason := "current CPA auth file identity verification failed: " + err.Error()
-		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, reason)
-		log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q reason=identity_verification_failed detail=%v", item.ID, item.AuthFileName, err)
+		if errors.Is(err, cpaauthfiles.ErrAuthFileNotFound) || errors.Is(err, cpaauthfiles.ErrIdentityMismatch) {
+			reason := "current CPA auth file identity verification failed: " + err.Error()
+			_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, reason)
+			log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q reason=identity_verification_failed detail=%v", item.ID, item.AuthFileName, err)
+			return
+		}
+		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
+		log.Printf("[account-action] auto-disable verification failed for pending candidate %d authFile=%q: %v", item.ID, item.AuthFileName, err)
 		return
 	}
 	if current.Disabled {
 		log.Printf("[account-action] auto-disable skipped for pending candidate %d authFile=%q reason=already_disabled", item.ID, item.AuthFileName)
 		return
 	}
-	if err := client.PatchDisabled(ctx, baseURL, managementKey, item.AuthFileName, true); err != nil {
+	if err := client.PatchDisabled(ctx, baseURL, managementKey, item.AuthFileName, true, item.AuthIndex); err != nil {
 		_ = w.store.RecordAccountActionCandidateFailure(ctx, item.ID, err.Error())
 		log.Printf("[account-action] auto-disable patch failed for pending candidate %d authFile=%q: %v", item.ID, item.AuthFileName, err)
 		return

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -256,6 +256,52 @@ func TestAccountActionCandidateWorkerAutoDisableRejectsIdentityMismatch(t *testi
 	}
 }
 
+func TestAccountActionCandidateWorkerAutoDisableRecordsVerificationTransportError(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	var patched bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v0/management/auth-files":
+			http.Error(w, "temporary CPA failure", http.StatusInternalServerError)
+		case "PATCH /v0/management/auth-files/status":
+			patched = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	worker := NewAccountActionCandidateWorker(st, true)
+	worker.handleCandidate(context.Background(), accountActionCandidate{
+		BaseURL:        server.URL,
+		ManagementKey:  "mgmt",
+		FileName:       "codex-auth.json",
+		AuthIndex:      "7",
+		DisplayAccount: "user@example.com",
+		AccountID:      "acct-123",
+		Provider:       "codex",
+		ActionType:     model.AccountActionTypeDelete,
+		Reason:         "token revoked",
+	})
+
+	if patched {
+		t.Fatal("PATCH should not be called when verification request fails")
+	}
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || !strings.Contains(items[0].LastError, "HTTP 500") || strings.Contains(items[0].LastError, "identity verification failed") {
+		t.Fatalf("items = %#v", items)
+	}
+}
+
 func TestAccountActionCandidateWorkerAutoDisablesReauth(t *testing.T) {
 	st, err := store.Open(t.TempDir() + "/usage.sqlite")
 	if err != nil {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -192,15 +192,16 @@ func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candid
 		return
 	}
 
+	resolvedAuthIndex := firstNonEmpty(candidate.AuthIndex, current.AuthIndex)
 	log.Printf("[quota-auto-disable] Codex usage limit reached for auth file %q account=%q provider=%q resetAt=%s, disabling", candidate.FileName, candidate.DisplayAccount, candidate.Provider, candidate.ResetAt.Format(time.RFC3339))
-	if err := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, true); err != nil {
+	if err := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, resolvedAuthIndex, true); err != nil {
 		log.Printf("[quota-auto-disable] failed to disable auth file %q: %v", candidate.FileName, err)
 		return
 	}
 
 	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:     candidate.FileName,
-		AuthIndex:        firstNonEmpty(candidate.AuthIndex, current.AuthIndex),
+		AuthIndex:        resolvedAuthIndex,
 		AccountSnapshot:  candidate.DisplayAccount,
 		Provider:         strings.ToLower(strings.TrimSpace(candidate.Provider)),
 		RecoverAtMS:      candidate.ResetAt.UnixMilli(),
@@ -211,7 +212,7 @@ func (w *RateLimitAutoDisableWorker) handleCandidate(ctx context.Context, candid
 	})
 	if err != nil {
 		log.Printf("[quota-auto-disable] disabled auth file %q but failed to persist cooldown ownership: %v", candidate.FileName, err)
-		if rollbackErr := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, false); rollbackErr != nil {
+		if rollbackErr := w.patchAuthFile(ctx, candidate.BaseURL, candidate.ManagementKey, candidate.FileName, resolvedAuthIndex, false); rollbackErr != nil {
 			log.Printf("[quota-auto-disable] failed to roll back auth file %q after cooldown persistence error: %v", candidate.FileName, rollbackErr)
 		}
 		return
@@ -308,7 +309,7 @@ func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseUR
 	}
 
 	log.Printf("[quota-auto-disable] reset time reached for auth file %q account=%q, enabling", item.AuthFileName, item.AccountSnapshot)
-	if err := w.patchAuthFile(ctx, baseURL, managementKey, item.AuthFileName, false); err != nil {
+	if err := w.patchAuthFile(ctx, baseURL, managementKey, item.AuthFileName, item.AuthIndex, false); err != nil {
 		_ = w.store.RecordQuotaCooldownFailure(ctx, item.ID, err.Error())
 		log.Printf("[quota-auto-disable] failed to enable auth file %q: %v", item.AuthFileName, err)
 		return
@@ -638,16 +639,12 @@ func parseCommonTime(text string) (time.Time, bool) {
 }
 
 func (w *RateLimitAutoDisableWorker) currentAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, authIndex string) (authFile, bool, error) {
-	files, err := cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).Fetch(ctx, baseURL, managementKey)
-	if err != nil {
-		return authFile{}, false, err
-	}
-	file, ok := cpaauthfiles.Find(files, fileName, authIndex)
-	return file, ok, nil
+	file, ok, err := cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).Find(ctx, baseURL, managementKey, fileName, authIndex)
+	return file, ok, err
 }
 
-func (w *RateLimitAutoDisableWorker) patchAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, disabled bool) error {
-	return cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).PatchDisabled(ctx, baseURL, managementKey, fileName, disabled)
+func (w *RateLimitAutoDisableWorker) patchAuthFile(ctx context.Context, baseURL string, managementKey string, fileName string, authIndex string, disabled bool) error {
+	return cpaauthfiles.New(w.client, quotaAutoDisableActionTimeout).PatchDisabled(ctx, baseURL, managementKey, fileName, disabled, authIndex)
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
## Summary
Fix CPA auth-file verification paths so Manager Server no longer depends on reading the entire `/v0/management/auth-files` response into memory before finding one auth entry.

This addresses large CPA auth list responses that can exceed the previous read cap and produce truncated JSON / `unexpected EOF` during quota and account-action automation.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Stream CPA auth-file responses and stop once the target auth entry is found.
- Send optional `name` and `auth_index` lookup parameters for CPA versions that support server-side filtering.
- Forward optional `auth_index` in status PATCH requests so newer CPA versions can verify the target identity server-side.
- Keep fallback behavior for existing CPA versions by scanning the full response stream client-side.
- Preserve and test single-object response compatibility and distinguish CPA verification transport errors from identity mismatches.

## User Impact
Quota cooldown and account-action auto-disable flows can handle large CPA auth-file lists without failing with `unexpected EOF`. Users with many auth files or large recent request snapshots should see more reliable auto-disable and recovery behavior.

## Compatibility / Runtime Notes
- CPA panel mode: Browser-hosted CPA panel behavior is unchanged; Manager Server requests remain compatible with older CPA versions and can take advantage of server-side filtering once https://github.com/router-for-me/CLIProxyAPI/pull/4083 is available.
- Manager Server mode: Auth-file lookup and identity verification now stream responses and include optional `auth_index` when patching status.
- Full Docker / native packages: No config or data migration required.

## Data / Security Notes
No stored secrets, SQLite schema, CPA Management Key storage, or auth file contents are changed. The CPA Management Key continues to be used only as the bearer token for CPA management API calls.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Revert this PR to restore the previous full-response auth-file fetch behavior.
- Older CPA versions remain supported because the new query parameters and `auth_index` patch field are optional/fallback-safe.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
cd apps/manager-server && go test ./internal/service/cpaauthfiles ./internal/worker
cd apps/manager-server && go test ./...
```

## Screenshots / Recordings
N/A, backend-only change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #277
Related upstream CPA PR: https://github.com/router-for-me/CLIProxyAPI/pull/4083