### PR TITLE
fix(web): render full expanded sidebar labels

### DIFF
--- a/apps/web/src/components/layout/MainLayout.tsx
+++ b/apps/web/src/components/layout/MainLayout.tsx
@@ -964,9 +964,7 @@ export function MainLayout({ routeBase = '', demoMode = false }: MainLayoutProps
                     title={item.label}
                   >
                     <span className="nav-icon">{item.icon}</span>
-                    {showSidebarLabels && (
-                      <span className="nav-label">{item.shortLabel ?? item.label}</span>
-                    )}
+                    {showSidebarLabels && <span className="nav-label">{item.label}</span>}
                   </NavLink>
                 ))}
               </div>

--- a/apps/web/src/features/usage-analytics/usageAnalyticsWiring.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsWiring.test.ts
@@ -347,6 +347,13 @@ describe('usage analytics app wiring', () => {
     expect(monitoringIndex).toBeGreaterThan(usageIndex);
   });
 
+  it('renders full sidebar labels when the sidebar is expanded', () => {
+    expect(layoutSource).toContain(
+      '{showSidebarLabels && <span className="nav-label">{item.label}</span>}'
+    );
+    expect(layoutSource).not.toContain('item.shortLabel ?? item.label');
+  });
+
   it('escapes user-controlled chart tooltip labels before returning tooltip HTML', () => {
     expect(pageSource).toContain('const escapeHtml = (value: string | number | null | undefined)');
     expect(pageSource).not.toContain('<b>${item.name}</b>');


### PR DESCRIPTION
## Summary
Restore full labels in the expanded sidebar while keeping the newly added short i18n keys available.
This fixes Chinese navigation items rendering as shortened labels such as "配置", "AI", and "认证" in the wide sidebar.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Render expanded sidebar nav items from `item.label`.
- Keep `shortLabel` data available for other compact UI uses.
- Add a regression test for expanded sidebar label rendering.

## User Impact
Users see the full sidebar labels again in Chinese and other locales when the sidebar is expanded.

## Compatibility / Runtime Notes
- CPA panel mode: frontend-only label rendering change.
- Manager Server mode: frontend-only label rendering change.
- Full Docker / native packages: frontend-only label rendering change.

## Data / Security Notes
N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the sidebar label rendering change and related regression test.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- usageAnalyticsWiring
```

## Screenshots / Recordings
N/A; the change restores text selection behavior shown in the supplied comparison.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A