### PR TITLE
fix(auth-files): refresh Codex quota after cooldown recovery

### DIFF
--- a/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
@@ -22,6 +22,9 @@ const { mocks } = vi.hoisted(() => {
       getCodexInspectionRun: vi.fn(),
       getActiveQuotaCooldowns: vi.fn(),
       getHeaderSnapshots: vi.fn(),
+      apiCallRequest: vi.fn(),
+      setCodexQuota: vi.fn(),
+      intervalCallbacks: [] as Array<{ callback: () => void; delay: number | null }>,
       codexQuota: {} as Record<string, unknown>,
       panelFeatureAvailability: {
         checking: false,
@@ -62,7 +65,9 @@ vi.mock('motion/mini', () => ({
 }));
 
 vi.mock('@/hooks/useInterval', () => ({
-  useInterval: () => {},
+  useInterval: (callback: () => void, delay: number | null) => {
+    mocks.intervalCallbacks.push({ callback, delay });
+  },
 }));
 
 vi.mock('@/hooks/useHeaderRefresh', () => ({
@@ -98,6 +103,13 @@ vi.mock('@/services/api/usageService', () => ({
   },
 }));
 
+vi.mock('@/services/api/apiCall', () => ({
+  apiCallApi: {
+    request: mocks.apiCallRequest,
+  },
+  getApiCallErrorMessage: () => 'api call failed',
+}));
+
 vi.mock('@/stores', () => ({
   useNotificationStore: (
     selector?: (state: {
@@ -125,8 +137,16 @@ vi.mock('@/stores', () => ({
     }),
   useThemeStore: (selector: (state: { resolvedTheme: 'dark' }) => unknown) =>
     selector({ resolvedTheme: 'dark' }),
-  useQuotaStore: (selector: (state: { codexQuota: Record<string, unknown> }) => unknown) =>
-    selector({ codexQuota: mocks.codexQuota }),
+  useQuotaStore: (
+    selector: (state: {
+      codexQuota: Record<string, unknown>;
+      setCodexQuota: typeof mocks.setCodexQuota;
+    }) => unknown
+  ) =>
+    selector({
+      codexQuota: mocks.codexQuota,
+      setCodexQuota: mocks.setCodexQuota,
+    }),
 }));
 
 vi.mock('@/features/authFiles/hooks/useAuthFilesData', () => ({
@@ -228,7 +248,7 @@ vi.mock('@/features/authFiles/uiState', () => ({
 
 vi.mock('@/features/authFiles/components/AuthFileCard', () => ({
   AuthFileCard: (props: {
-    file: { name: string };
+    file: { name: string; authIndex?: unknown; auth_index?: unknown };
     quotaCooldown?: { authFileName: string; recoverAtMs: number } | null;
     codexDisplayQuota?: {
       status?: string;
@@ -249,6 +269,7 @@ vi.mock('@/features/authFiles/components/AuthFileCard', () => ({
     return (
       <div
         data-auth-card={props.file.name}
+        data-auth-index={String(props.file.authIndex ?? props.file.auth_index ?? '')}
         data-quota-cooldown={cooldown}
         data-codex-quota-status={props.codexDisplayQuota?.status ?? ''}
         data-codex-quota-plan={props.codexDisplayQuota?.planType ?? ''}
@@ -328,7 +349,7 @@ const setManagementKey = (value: string) => {
 };
 
 // A controllable promise so a test can resolve a cooldown fetch at a chosen
-// moment — used to cover the "request in flight, context changes, stale
+// moment; used to cover the "request in flight, context changes, stale
 // response lands" race.
 const createDeferred = () => {
   let resolve!: (value: unknown[]) => void;
@@ -345,7 +366,17 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     mocks.listCodexInspectionRuns.mockReset();
     mocks.getCodexInspectionRun.mockReset();
     mocks.getHeaderSnapshots.mockReset();
+    mocks.apiCallRequest.mockReset();
+    mocks.intervalCallbacks = [];
     mocks.codexQuota = {};
+    mocks.setCodexQuota = vi.fn((updater: unknown) => {
+      mocks.codexQuota =
+        typeof updater === 'function'
+          ? (updater as (prev: Record<string, unknown>) => Record<string, unknown>)(
+              mocks.codexQuota
+            )
+          : (updater as Record<string, unknown>);
+    });
     mocks.connectionStatus = 'connected';
     mocks.managementKey = 'test-key';
     mocks.pageTransitionStatus = 'current';
@@ -442,6 +473,433 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     expect(card.props['data-codex-quota-observed']).toBe('true');
     expect(card.props['data-codex-quota-window-percent']).toBe('20');
     expect(card.props['data-codex-quota-window-seconds']).toBe('2592000');
+  });
+
+  it('refreshes Codex quota instead of showing expired usage response headers', async () => {
+    mocks.list.mockReturnValue([
+      { name: 'codex-one.json', type: 'codex', authIndex: '0' },
+      { name: 'codex-two.json', type: 'codex' },
+    ]);
+    mocks.getHeaderSnapshots.mockResolvedValue({
+      generated_at_ms: 1_700_018_000_001,
+      from_ms: 1_700_000_000_000,
+      to_ms: 1_700_018_000_001,
+      items: [
+        {
+          event_hash: 'event-expired',
+          timestamp_ms: 1_700_000_000_000,
+          auth_file_snapshot: 'codex-one.json',
+          auth_index: '0',
+          auth_provider_snapshot: 'codex',
+          response_metadata: {
+            quota: {
+              plan_type: 'free',
+              rate_limit_reached_type: 'primary',
+              reached_window_kind: 'five_hour',
+              reached_window_source: 'primary',
+              primary: {
+                used_percent: 100,
+                reset_at_ms: 1_700_018_000_000,
+                window_minutes: 300,
+              },
+              secondary: {
+                used_percent: 84,
+                reset_at_ms: 1_700_604_800_000,
+                window_minutes: 10_080,
+              },
+            },
+          },
+        },
+      ],
+    });
+    mocks.apiCallRequest
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 12,
+              reset_after_seconds: 12_000,
+              limit_window_seconds: 18_000,
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({ available_count: 1, credits: [] }),
+      });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.apiCallRequest).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    const card = renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' });
+    expect(card.props['data-codex-quota-status']).toBe('success');
+    expect(card.props['data-codex-quota-observed']).toBe('false');
+    expect(card.props['data-codex-quota-plan']).toBe('plus');
+    expect(card.props['data-codex-quota-window-percent']).toBe('12');
+  });
+
+  it('refreshes Codex quota when a CPAMP cooldown recovers', async () => {
+    const recoveredAtMs = Date.now() - 1_000;
+    mocks.list.mockReturnValue([
+      { name: 'codex-one.json', type: 'codex', authIndex: '0' },
+      { name: 'codex-two.json', type: 'codex' },
+    ]);
+    mocks.getActiveQuotaCooldowns
+      .mockResolvedValueOnce([
+        {
+          authFileName: 'codex-one.json',
+          authIndex: '0',
+          owner: 'cpamp_usage_429',
+          recoverAtMs: recoveredAtMs,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mocks.apiCallRequest
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 12,
+              reset_after_seconds: 12_000,
+              limit_window_seconds: 18_000,
+            },
+          },
+          rate_limit_reset_credits: { available_count: 1 },
+        }),
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({ available_count: 1, credits: [] }),
+      });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+          'data-quota-cooldown'
+        ]
+      ).toBe(`codex-one.json@${recoveredAtMs}`);
+    });
+
+    const quotaInterval = mocks.intervalCallbacks.find((item) => item.delay === 60_000);
+    await act(async () => {
+      quotaInterval?.callback();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.apiCallRequest).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    const card = renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' });
+    expect(card.props['data-quota-cooldown']).toBe('');
+    expect(card.props['data-codex-quota-status']).toBe('success');
+    expect(card.props['data-codex-quota-observed']).toBe('false');
+    expect(card.props['data-codex-quota-plan']).toBe('plus');
+    expect(card.props['data-codex-quota-window-percent']).toBe('12');
+    expect(card.props['data-codex-quota-window-seconds']).toBe('18000');
+  });
+
+  it('refreshes only the recovered auth index for shared Codex auth files', async () => {
+    const recoveredAtMs = Date.now() - 1_000;
+    mocks.list.mockReturnValue([
+      { name: 'shared-codex.json', type: 'codex', authIndex: '0' },
+      { name: 'shared-codex.json', type: 'codex', authIndex: '1' },
+    ]);
+    mocks.getActiveQuotaCooldowns
+      .mockResolvedValueOnce([
+        {
+          authFileName: 'shared-codex.json',
+          authIndex: '1',
+          owner: 'cpamp_usage_429',
+          recoverAtMs: recoveredAtMs,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mocks.apiCallRequest
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 12,
+              reset_after_seconds: 12_000,
+              limit_window_seconds: 18_000,
+            },
+          },
+          rate_limit_reset_credits: { available_count: 1 },
+        }),
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({ available_count: 1, credits: [] }),
+      });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      const cards = renderer!.root.findAllByProps({ 'data-auth-card': 'shared-codex.json' });
+      const card0 = cards.find((card) => card.props['data-auth-index'] === '0');
+      const card1 = cards.find((card) => card.props['data-auth-index'] === '1');
+      expect(card0?.props['data-quota-cooldown']).toBe('');
+      expect(card1?.props['data-quota-cooldown']).toBe(`shared-codex.json@${recoveredAtMs}`);
+    });
+
+    const quotaInterval = mocks.intervalCallbacks.find((item) => item.delay === 60_000);
+    await act(async () => {
+      quotaInterval?.callback();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.apiCallRequest).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mocks.apiCallRequest.mock.calls.map(([payload]) => payload.authIndex)).toEqual([
+      '1',
+      '1',
+    ]);
+
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    const cards = renderer!.root.findAllByProps({ 'data-auth-card': 'shared-codex.json' });
+    const card0 = cards.find((card) => card.props['data-auth-index'] === '0');
+    const card1 = cards.find((card) => card.props['data-auth-index'] === '1');
+    expect(card0?.props['data-codex-quota-status']).toBe('');
+    expect(card1?.props['data-quota-cooldown']).toBe('');
+    expect(card1?.props['data-codex-quota-status']).toBe('success');
+    expect(card1?.props['data-codex-quota-observed']).toBe('false');
+    expect(card1?.props['data-codex-quota-plan']).toBe('plus');
+  });
+
+  it('uses file-only cooldowns for unique Codex auth file rows', async () => {
+    const recoveredAtMs = Date.now() - 1_000;
+    mocks.list.mockReturnValue([
+      { name: 'legacy-codex.json', type: 'codex', authIndex: '0' },
+      { name: 'codex-two.json', type: 'codex' },
+    ]);
+    mocks.getActiveQuotaCooldowns
+      .mockResolvedValueOnce([
+        {
+          authFileName: 'legacy-codex.json',
+          owner: 'cpamp_usage_429',
+          recoverAtMs: recoveredAtMs,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mocks.apiCallRequest
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 12,
+              reset_after_seconds: 12_000,
+              limit_window_seconds: 18_000,
+            },
+          },
+          rate_limit_reset_credits: { available_count: 1 },
+        }),
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({ available_count: 1, credits: [] }),
+      });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'legacy-codex.json' }).props[
+          'data-quota-cooldown'
+        ]
+      ).toBe(`legacy-codex.json@${recoveredAtMs}`);
+    });
+
+    const quotaInterval = mocks.intervalCallbacks.find((item) => item.delay === 60_000);
+    await act(async () => {
+      quotaInterval?.callback();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.apiCallRequest).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mocks.apiCallRequest.mock.calls.map(([payload]) => payload.authIndex)).toEqual([
+      '0',
+      '0',
+    ]);
+  });
+
+  it('does not apply file-only cooldowns to shared Codex auth files', async () => {
+    const recoveredAtMs = Date.now() - 1_000;
+    mocks.list.mockReturnValue([
+      { name: 'shared-codex.json', type: 'codex', authIndex: '0' },
+      { name: 'shared-codex.json', type: 'codex', authIndex: '1' },
+    ]);
+    mocks.getActiveQuotaCooldowns
+      .mockResolvedValueOnce([
+        {
+          authFileName: 'shared-codex.json',
+          owner: 'cpamp_usage_429',
+          recoverAtMs: recoveredAtMs,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      const cards = renderer!.root.findAllByProps({ 'data-auth-card': 'shared-codex.json' });
+      expect(cards).toHaveLength(2);
+      expect(cards.every((card) => card.props['data-quota-cooldown'] === '')).toBe(true);
+    });
+
+    const quotaInterval = mocks.intervalCallbacks.find((item) => item.delay === 60_000);
+    await act(async () => {
+      quotaInterval?.callback();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.apiCallRequest).not.toHaveBeenCalled();
+  });
+
+  it('retries expired usage response header refreshes after the next header poll', async () => {
+    mocks.list.mockReturnValue([{ name: 'codex-one.json', type: 'codex', authIndex: '0' }]);
+    const buildExpiredHeaderResponse = () => ({
+      generated_at_ms: 1_700_018_000_001,
+      from_ms: 1_700_000_000_000,
+      to_ms: 1_700_018_000_001,
+      items: [
+        {
+          event_hash: 'event-expired-retry',
+          timestamp_ms: 1_700_000_000_000,
+          auth_file_snapshot: 'codex-one.json',
+          auth_index: '0',
+          auth_provider_snapshot: 'codex',
+          response_metadata: {
+            quota: {
+              plan_type: 'free',
+              rate_limit_reached_type: 'primary',
+              reached_window_kind: 'five_hour',
+              reached_window_source: 'primary',
+              primary: {
+                used_percent: 100,
+                reset_at_ms: 1_700_018_000_000,
+                window_minutes: 300,
+              },
+            },
+          },
+        },
+      ],
+    });
+    mocks.getHeaderSnapshots.mockImplementation(async () => buildExpiredHeaderResponse());
+    mocks.apiCallRequest
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 12,
+              reset_after_seconds: 12_000,
+              limit_window_seconds: 18_000,
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({ available_count: 1, credits: [] }),
+      });
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        Object.values(mocks.codexQuota).some(
+          (quota) =>
+            quota !== null &&
+            typeof quota === 'object' &&
+            'status' in quota &&
+            quota.status === 'error'
+        )
+      ).toBe(true);
+    });
+    expect(mocks.apiCallRequest).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.apiCallRequest).toHaveBeenCalledTimes(1);
+
+    const quotaInterval = mocks.intervalCallbacks.find((item) => item.delay === 60_000);
+    await act(async () => {
+      quotaInterval?.callback();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.apiCallRequest).toHaveBeenCalledTimes(3);
+    });
+
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+    });
+
+    const card = renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' });
+    expect(card.props['data-codex-quota-status']).toBe('success');
+    expect(card.props['data-codex-quota-observed']).toBe('false');
+    expect(card.props['data-codex-quota-plan']).toBe('plus');
   });
 
   it('merges observed Codex header quota without clearing stored quota-only fields', async () => {
@@ -662,6 +1120,49 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     expect(card.props['data-codex-quota-window-ids']).toBe('five-hour,spark-five-hour-0');
   });
 
+  it('does not treat cooldown context changes as recovered cooldowns', async () => {
+    const recoveredAtMs = Date.now() - 1_000;
+    mocks.list.mockReturnValue([{ name: 'codex-one.json', type: 'codex', authIndex: '0' }]);
+    mocks.getActiveQuotaCooldowns
+      .mockResolvedValueOnce([
+        {
+          authFileName: 'codex-one.json',
+          authIndex: '0',
+          owner: 'cpamp_usage_429',
+          recoverAtMs: recoveredAtMs,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<AuthFilesPage />);
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        renderer!.root.findByProps({ 'data-auth-card': 'codex-one.json' }).props[
+          'data-quota-cooldown'
+        ]
+      ).toBe(`codex-one.json@${recoveredAtMs}`);
+    });
+
+    setManagerServiceBase('http://manager-two.local:18317');
+    await act(async () => {
+      renderer!.update(<AuthFilesPage />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledWith(
+        'http://manager-two.local:18317',
+        'test-key'
+      );
+    });
+    expect(mocks.apiCallRequest).not.toHaveBeenCalled();
+  });
+
   it('clears stale cooldowns when managerServiceBase becomes empty', async () => {
     mocks.getActiveQuotaCooldowns.mockResolvedValue([
       { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
@@ -733,11 +1234,9 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
       renderer!.update(<AuthFilesPage />);
     });
 
-    // The stale response finally lands — it must not resurrect the badge.
+    // The stale response finally lands; it must not resurrect the badge.
     await act(async () => {
-      deferred.resolve([
-        { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
-      ]);
+      deferred.resolve([{ authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 }]);
       await deferred.promise.catch(() => {});
     });
 
@@ -775,19 +1274,15 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
 
     expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledTimes(2);
 
-    // The new-context request resolves first with its own data — applied.
+    // The new-context request resolves first with its own data; applied.
     await act(async () => {
-      second.resolve([
-        { authFileName: 'codex-two.json', recoverAtMs: 1_700_000_000_000 },
-      ]);
+      second.resolve([{ authFileName: 'codex-two.json', recoverAtMs: 1_700_000_000_000 }]);
       await second.promise.catch(() => {});
     });
 
     // The stale (old-key) response lands afterwards and must be ignored.
     await act(async () => {
-      first.resolve([
-        { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
-      ]);
+      first.resolve([{ authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 }]);
       await first.promise.catch(() => {});
     });
 
@@ -828,12 +1323,10 @@ describe('AuthFilesPage quota cooldown derived badge', () => {
     });
     expect(mocks.getActiveQuotaCooldowns).toHaveBeenCalledTimes(1);
 
-    // The old-context response lands before a new loader runs — it must be
+    // The old-context response lands before a new loader runs; it must be
     // dropped by the layout-effect invalidation alone.
     await act(async () => {
-      first.resolve([
-        { authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 },
-      ]);
+      first.resolve([{ authFileName: 'codex-one.json', recoverAtMs: 2_000_000_000_000 }]);
       await first.promise.catch(() => {});
     });
 

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -24,9 +24,14 @@ import { Select } from '@/components/ui/Select';
 import { IconFilterAll, IconSearch } from '@/components/ui/icons';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
-import { buildObservedCodexQuotaState, resolveQuotaDisplayState } from '@/components/quota';
+import {
+  CODEX_CONFIG,
+  buildObservedCodexQuotaState,
+  getQuotaStoreKey,
+  resolveQuotaDisplayState,
+} from '@/components/quota';
 import { copyToClipboard } from '@/utils/clipboard';
-import { resolveAuthProvider } from '@/utils/quota';
+import { getStatusFromError, resolveAuthProvider } from '@/utils/quota';
 import {
   MAX_CARD_PAGE_SIZE,
   MIN_CARD_PAGE_SIZE,
@@ -64,6 +69,7 @@ import {
 import {
   buildUsageHeaderSnapshotLookup,
   getHighConfidenceUsageHeaderSnapshotForAuthFile,
+  isUsageHeaderQuotaSnapshotExpired,
 } from '@/utils/usageHeaderSnapshots';
 import { useAuthFilesData } from '@/features/authFiles/hooks/useAuthFilesData';
 import { useAuthFilesModels } from '@/features/authFiles/hooks/useAuthFilesModels';
@@ -174,6 +180,14 @@ const isStaleCodexReauthSnapshot = (item: AuthFileCodexInspectionSnapshot): bool
   return action === 'reauth' || statusCode === 401;
 };
 
+type QuotaCooldownState = {
+  contextKey: string;
+  items: Map<string, QuotaCooldownInfo>;
+};
+
+const getQuotaCooldownContextKey = (managerServiceBase: string, managementKey: string): string =>
+  `${managerServiceBase}\u0000${managementKey}`;
+
 export function AuthFilesPage() {
   const { t } = useTranslation();
   const showNotification = useNotificationStore((state) => state.showNotification);
@@ -182,6 +196,7 @@ export function AuthFilesPage() {
   const managementKey = useAuthStore((state) => state.managementKey);
   const resolvedTheme: ResolvedTheme = useThemeStore((state) => state.resolvedTheme);
   const codexQuota = useQuotaStore((state) => state.codexQuota);
+  const setCodexQuota = useQuotaStore((state) => state.setCodexQuota);
   const featureAvailability = usePanelFeatureAvailability();
   const managerServiceBase = featureAvailability.managerServiceBase;
   const pageTransitionLayer = usePageTransitionLayer();
@@ -213,17 +228,28 @@ export function AuthFilesPage() {
   const [lastCodexInspectionResults, setLastCodexInspectionResults] = useState<
     AuthFileCodexInspectionSnapshot[]
   >([]);
-  const [quotaCooldowns, setQuotaCooldowns] = useState<Map<string, QuotaCooldownInfo>>(
-    () => new Map()
-  );
+  const [quotaCooldownState, setQuotaCooldownState] = useState<QuotaCooldownState>(() => ({
+    contextKey: getQuotaCooldownContextKey(managerServiceBase, managementKey),
+    items: new Map(),
+  }));
+  const quotaCooldowns = quotaCooldownState.items;
   const [headerSnapshots, setHeaderSnapshots] = useState<UsageHeaderSnapshot[]>([]);
+  const [headerSnapshotGeneratedAtMs, setHeaderSnapshotGeneratedAtMs] = useState(0);
   const floatingBatchActionsRef = useRef<HTMLDivElement>(null);
   const batchActionAnimationRef = useRef<AnimationPlaybackControlsWithThen | null>(null);
   const previousSelectionCountRef = useRef(0);
   const selectionCountRef = useRef(0);
+  const quotaCooldownsRef = useRef<QuotaCooldownState>({
+    contextKey: getQuotaCooldownContextKey(managerServiceBase, managementKey),
+    items: new Map(),
+  });
+  const pendingRecoveredCodexQuotaRefreshRef = useRef<Set<string>>(new Set());
+  const autoRefreshingCodexQuotaRef = useRef<Set<string>>(new Set());
+  const expiredHeaderCodexQuotaRefreshRef = useRef<Set<string>>(new Set());
+  const skipNextRecoveredCooldownRefreshRef = useRef(false);
   // Generation token for in-flight cooldown fetches. Every fetch and every
   // context identity change bump it, so a slow, superseded response can be
-  // detected and dropped — otherwise it would re-introduce stale badges after
+  // detected and dropped; otherwise it would re-introduce stale badges after
   // the old context was invalidated.
   const cooldownReqId = useRef(0);
   const headerSnapshotReqId = useRef(0);
@@ -231,6 +257,7 @@ export function AuthFilesPage() {
   // transitions synchronously (before passive effects fire) and invalidate any
   // in-flight request that belongs to the old context.
   const cooldownContextRef = useRef({ managerServiceBase, managementKey });
+  const cooldownRecoveryContextRef = useRef({ managerServiceBase, managementKey });
   const headerSnapshotContextRef = useRef({ managerServiceBase, managementKey });
 
   const {
@@ -266,6 +293,43 @@ export function AuthFilesPage() {
   } = useAuthFilesData();
 
   const statusBarCache = useAuthFilesStatusBarCache(files);
+  const uniqueAuthFileKeyByFallbackCooldownKey = useMemo(() => {
+    const fallbackEntries = new Map<string, { authFileKey: string; count: number }>();
+    files.forEach((file) => {
+      if (isRuntimeOnlyAuthFile(file) || resolveAuthProvider(file) !== 'codex') return;
+      const fallbackKey = getAuthFileCodexInspectionKey(file.name, null);
+      const authFileKey = getAuthFileCodexInspectionKeyForFile(file);
+      const existing = fallbackEntries.get(fallbackKey);
+      if (existing) {
+        existing.count += 1;
+        return;
+      }
+      fallbackEntries.set(fallbackKey, { authFileKey, count: 1 });
+    });
+
+    const uniqueKeys = new Map<string, string>();
+    fallbackEntries.forEach((entry, fallbackKey) => {
+      if (entry.count === 1) uniqueKeys.set(fallbackKey, entry.authFileKey);
+    });
+    return uniqueKeys;
+  }, [files]);
+  const getQuotaCooldownForFile = useCallback(
+    (file: AuthFileItem): QuotaCooldownInfo | undefined => {
+      if (isRuntimeOnlyAuthFile(file) || resolveAuthProvider(file) !== 'codex') {
+        return undefined;
+      }
+      const authFileKey = getAuthFileCodexInspectionKeyForFile(file);
+      const exactCooldown = quotaCooldowns.get(authFileKey);
+      if (exactCooldown) return exactCooldown;
+
+      const fallbackKey = getAuthFileCodexInspectionKey(file.name, null);
+      if (uniqueAuthFileKeyByFallbackCooldownKey.get(fallbackKey) !== authFileKey) {
+        return undefined;
+      }
+      return quotaCooldowns.get(fallbackKey);
+    },
+    [quotaCooldowns, uniqueAuthFileKeyByFallbackCooldownKey]
+  );
 
   const {
     excluded,
@@ -577,6 +641,7 @@ export function AuthFilesPage() {
     // invalidation can supersede it. If the generation has changed by the time
     // we land, we drop the result instead of writing stale badges back.
     const id = ++cooldownReqId.current;
+    const contextKey = getQuotaCooldownContextKey(managerServiceBase, managementKey);
     try {
       const items = await usageServiceApi.getActiveQuotaCooldowns(
         managerServiceBase,
@@ -586,12 +651,16 @@ export function AuthFilesPage() {
       const next = new Map<string, QuotaCooldownInfo>();
       for (const item of items) {
         if (!item.authFileName) continue;
-        const existing = next.get(item.authFileName);
+        const cooldownKey = getAuthFileCodexInspectionKey(
+          item.authFileName,
+          item.authIndex ?? null
+        );
+        const existing = next.get(cooldownKey);
         if (!existing || (item.recoverAtMs ?? 0) > (existing.recoverAtMs ?? 0)) {
-          next.set(item.authFileName, item);
+          next.set(cooldownKey, item);
         }
       }
-      setQuotaCooldowns(next);
+      setQuotaCooldownState({ contextKey, items: next });
     } catch {
       // The cooldown badge is a derived hint; fail silently and keep the last known state.
     }
@@ -600,6 +669,7 @@ export function AuthFilesPage() {
   const loadHeaderSnapshots = useCallback(async () => {
     if (!managerServiceBase) {
       setHeaderSnapshots([]);
+      setHeaderSnapshotGeneratedAtMs(0);
       return;
     }
     const id = ++headerSnapshotReqId.current;
@@ -613,15 +683,84 @@ export function AuthFilesPage() {
         }
       );
       if (id !== headerSnapshotReqId.current) return;
+      const generatedAtMs =
+        response.generated_at_ms ??
+        (response as { generatedAtMs?: number }).generatedAtMs ??
+        Date.now();
+      expiredHeaderCodexQuotaRefreshRef.current.clear();
       setHeaderSnapshots(response.items ?? []);
+      setHeaderSnapshotGeneratedAtMs(generatedAtMs);
     } catch {
       // Header snapshots are passive hints; keep the current page usable if Manager data is unavailable.
     }
   }, [managementKey, managerServiceBase]);
 
+  const refreshRecoveredCodexQuotaForFile = useCallback(
+    async (file: AuthFileItem) => {
+      if (resolveAuthProvider(file) !== 'codex') return false;
+      if (isRuntimeOnlyAuthFile(file) || file.disabled) return false;
+
+      const authFileKey = getAuthFileCodexInspectionKeyForFile(file);
+      if (autoRefreshingCodexQuotaRef.current.has(authFileKey)) return false;
+      autoRefreshingCodexQuotaRef.current.add(authFileKey);
+
+      const storeKey = getQuotaStoreKey(CODEX_CONFIG, file);
+      const previousQuota =
+        (codexQuota[storeKey] as CodexQuotaState | undefined) ??
+        (codexQuota[file.name] as CodexQuotaState | undefined);
+      setCodexQuota((prev) => ({
+        ...prev,
+        [storeKey]: CODEX_CONFIG.buildLoadingState(file),
+      }));
+
+      try {
+        const data = await CODEX_CONFIG.fetchQuota(file, t);
+        setCodexQuota((prev) => ({
+          ...prev,
+          [storeKey]: CODEX_CONFIG.buildSuccessState(data, file),
+        }));
+        return true;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : t('common.unknown_error');
+        const status = getStatusFromError(err);
+        setCodexQuota((prev) => ({
+          ...prev,
+          [storeKey]: CODEX_CONFIG.buildFailureState
+            ? CODEX_CONFIG.buildFailureState(message, status, file, previousQuota, Date.now())
+            : CODEX_CONFIG.buildErrorState(message, status, file),
+        }));
+        return false;
+      } finally {
+        autoRefreshingCodexQuotaRef.current.delete(authFileKey);
+      }
+    },
+    [codexQuota, setCodexQuota, t]
+  );
+
+  const refreshPendingRecoveredCodexQuotas = useCallback(() => {
+    if (pendingRecoveredCodexQuotaRefreshRef.current.size === 0) return;
+
+    for (const file of files) {
+      const authFileKey = getAuthFileCodexInspectionKeyForFile(file);
+      const fallbackKey = getAuthFileCodexInspectionKey(file.name, null);
+      const hasExactPending = pendingRecoveredCodexQuotaRefreshRef.current.has(authFileKey);
+      const hasFallbackPending =
+        fallbackKey !== authFileKey &&
+        pendingRecoveredCodexQuotaRefreshRef.current.has(fallbackKey) &&
+        uniqueAuthFileKeyByFallbackCooldownKey.get(fallbackKey) === authFileKey;
+      if (!hasExactPending && !hasFallbackPending) continue;
+      if (file.disabled || resolveAuthProvider(file) !== 'codex' || isRuntimeOnlyAuthFile(file)) {
+        continue;
+      }
+      if (hasExactPending) pendingRecoveredCodexQuotaRefreshRef.current.delete(authFileKey);
+      if (hasFallbackPending) pendingRecoveredCodexQuotaRefreshRef.current.delete(fallbackKey);
+      void refreshRecoveredCodexQuotaForFile(file);
+    }
+  }, [files, refreshRecoveredCodexQuotaForFile, uniqueAuthFileKeyByFallbackCooldownKey]);
+
   // Synchronously invalidate in-flight cooldown requests when the context
   // (managerServiceBase or managementKey) changes, regardless of direction
-  // (A→B, A→empty, empty→A). This runs in the layout phase, before any
+  // (A to B, A to empty, empty to A). This runs in the layout phase, before any
   // passive effect that might fire a new loadQuotaCooldowns, so a stale
   // response that resolves between renders or inside the gap between a
   // re-render and its passive effects will find its generation token already
@@ -633,7 +772,15 @@ export function AuthFilesPage() {
     }
     cooldownContextRef.current = { managerServiceBase, managementKey };
     cooldownReqId.current += 1;
-    setQuotaCooldowns((current) => (current.size === 0 ? current : new Map()));
+    const contextKey = getQuotaCooldownContextKey(managerServiceBase, managementKey);
+    quotaCooldownsRef.current = { contextKey, items: new Map() };
+    pendingRecoveredCodexQuotaRefreshRef.current.clear();
+    skipNextRecoveredCooldownRefreshRef.current = true;
+    setQuotaCooldownState((current) =>
+      current.contextKey === contextKey && current.items.size === 0
+        ? current
+        : { contextKey, items: new Map() }
+    );
   }, [managerServiceBase, managementKey]);
 
   useLayoutEffect(() => {
@@ -643,7 +790,9 @@ export function AuthFilesPage() {
     }
     headerSnapshotContextRef.current = { managerServiceBase, managementKey };
     headerSnapshotReqId.current += 1;
+    expiredHeaderCodexQuotaRefreshRef.current.clear();
     setHeaderSnapshots((current) => (current.length === 0 ? current : []));
+    setHeaderSnapshotGeneratedAtMs(0);
   }, [managerServiceBase, managementKey]);
 
   useEffect(() => {
@@ -659,6 +808,54 @@ export function AuthFilesPage() {
     },
     isCurrentLayer && managerServiceBase ? 60_000 : null
   );
+
+  useEffect(() => {
+    const previous = quotaCooldownsRef.current;
+    const currentContextKey = getQuotaCooldownContextKey(managerServiceBase, managementKey);
+    const previousContext = cooldownRecoveryContextRef.current;
+    const contextChanged =
+      previousContext.managerServiceBase !== managerServiceBase ||
+      previousContext.managementKey !== managementKey;
+    cooldownRecoveryContextRef.current = { managerServiceBase, managementKey };
+    quotaCooldownsRef.current = quotaCooldownState;
+    if (
+      contextChanged ||
+      previous.contextKey !== quotaCooldownState.contextKey ||
+      quotaCooldownState.contextKey !== currentContextKey ||
+      skipNextRecoveredCooldownRefreshRef.current
+    ) {
+      skipNextRecoveredCooldownRefreshRef.current = false;
+      pendingRecoveredCodexQuotaRefreshRef.current.clear();
+      return;
+    }
+    if (!isCurrentLayer || !managerServiceBase) return;
+
+    const nowMs = Date.now();
+    let hasRecovered = false;
+    previous.items.forEach((item, authFileKey) => {
+      if (quotaCooldowns.has(authFileKey)) return;
+      if (item.owner && item.owner !== 'cpamp_usage_429') return;
+      if (item.recoverAtMs > nowMs + 60_000) return;
+      pendingRecoveredCodexQuotaRefreshRef.current.add(authFileKey);
+      hasRecovered = true;
+    });
+
+    if (!hasRecovered) return;
+    void loadFiles().catch(() => {});
+    refreshPendingRecoveredCodexQuotas();
+  }, [
+    isCurrentLayer,
+    loadFiles,
+    managerServiceBase,
+    managementKey,
+    quotaCooldowns,
+    quotaCooldownState,
+    refreshPendingRecoveredCodexQuotas,
+  ]);
+
+  useEffect(() => {
+    refreshPendingRecoveredCodexQuotas();
+  }, [files, refreshPendingRecoveredCodexQuotas]);
 
   const existingTypes = useMemo(() => {
     const types = new Set<string>(['all']);
@@ -683,37 +880,81 @@ export function AuthFilesPage() {
     (file: AuthFileItem): CodexQuotaState | undefined => {
       if (resolveAuthProvider(file) !== 'codex') return undefined;
       const storeKey = getAuthFileCodexInspectionKeyForFile(file);
-      return getAuthFileScopedCodexQuota(
-        file,
-        codexQuota[storeKey] ?? codexQuota[file.name]
-      );
+      return getAuthFileScopedCodexQuota(file, codexQuota[storeKey] ?? codexQuota[file.name]);
     },
     [codexQuota]
   );
 
+  useEffect(() => {
+    if (!isCurrentLayer || !managerServiceBase) return;
+    const nowMs = headerSnapshotGeneratedAtMs || Date.now();
+    for (const file of files) {
+      if (resolveAuthProvider(file) !== 'codex' || isRuntimeOnlyAuthFile(file) || file.disabled) {
+        continue;
+      }
+      const headerSnapshot = getHighConfidenceUsageHeaderSnapshotForAuthFile(
+        headerSnapshotLookup,
+        file
+      );
+      if (!isUsageHeaderQuotaSnapshotExpired(headerSnapshot, nowMs)) continue;
+
+      const activeQuota = getActiveCodexQuota(file);
+      const fetchedAtMs =
+        activeQuota?.status === 'success' && typeof activeQuota.fetchedAtMs === 'number'
+          ? activeQuota.fetchedAtMs
+          : 0;
+      const headerAtMs =
+        typeof headerSnapshot?.timestamp_ms === 'number' ? headerSnapshot.timestamp_ms : 0;
+      if (fetchedAtMs > headerAtMs) continue;
+
+      const authFileKey = getAuthFileCodexInspectionKeyForFile(file);
+      const marker = `${authFileKey}:${headerSnapshot?.event_hash ?? ''}:${headerAtMs}`;
+      if (expiredHeaderCodexQuotaRefreshRef.current.has(marker)) continue;
+      expiredHeaderCodexQuotaRefreshRef.current.add(marker);
+      void refreshRecoveredCodexQuotaForFile(file);
+    }
+  }, [
+    files,
+    getActiveCodexQuota,
+    headerSnapshotGeneratedAtMs,
+    headerSnapshotLookup,
+    isCurrentLayer,
+    managerServiceBase,
+    refreshRecoveredCodexQuotaForFile,
+  ]);
+
   const codexStatusSourcesByAuthFileKey = useMemo(() => {
-    const sourcesMap = new Map<
-      string,
-      ReturnType<typeof getFreshAuthFileCodexStatusSources>
-    >();
+    const sourcesMap = new Map<string, ReturnType<typeof getFreshAuthFileCodexStatusSources>>();
     files.forEach((file) => {
       const statusKey = getAuthFileCodexInspectionKeyForFile(file);
       const headerSnapshot = getHighConfidenceUsageHeaderSnapshotForAuthFile(
         headerSnapshotLookup,
         file
       );
+      const freshHeaderSnapshot = isUsageHeaderQuotaSnapshotExpired(
+        headerSnapshot,
+        headerSnapshotGeneratedAtMs || Date.now()
+      )
+        ? undefined
+        : headerSnapshot;
       sourcesMap.set(
         statusKey,
         getFreshAuthFileCodexStatusSources(
           file,
           getActiveCodexQuota(file),
           codexInspectionByAuthFile.get(statusKey),
-          headerSnapshot
+          freshHeaderSnapshot
         )
       );
     });
     return sourcesMap;
-  }, [codexInspectionByAuthFile, files, getActiveCodexQuota, headerSnapshotLookup]);
+  }, [
+    codexInspectionByAuthFile,
+    files,
+    getActiveCodexQuota,
+    headerSnapshotGeneratedAtMs,
+    headerSnapshotLookup,
+  ]);
 
   const getDisplayCodexQuota = useCallback(
     (file: AuthFileItem): CodexQuotaState | undefined => {
@@ -857,8 +1098,7 @@ export function AuthFilesPage() {
         headerSnapshotLookup,
         item
       );
-      const statusHeaderSnapshot =
-        codexStatusSourcesByAuthFileKey.get(authFileKey)?.headerSnapshot;
+      const statusHeaderSnapshot = codexStatusSourcesByAuthFileKey.get(authFileKey)?.headerSnapshot;
       const matchSearch =
         !normalizedSearch ||
         stringifySearchValue(
@@ -980,9 +1220,7 @@ export function AuthFilesPage() {
   const selectedWebsocketPatchTargets = useMemo(
     () =>
       selectedTargetFiles
-        .filter(
-          (file) => supportsAuthFileWebsockets(String(file.type ?? file.provider ?? ''))
-        )
+        .filter((file) => supportsAuthFileWebsockets(String(file.type ?? file.provider ?? '')))
         .map(getAuthFilePatchTarget),
     [selectedTargetFiles]
   );
@@ -1495,7 +1733,7 @@ export function AuthFilesPage() {
                       codexDisplayQuota={getDisplayCodexQuota(file)}
                       antigravitySubscription={antigravitySubscriptions[file.name]}
                       onRefreshAntigravitySubscription={refreshSubscription}
-                      quotaCooldown={quotaCooldowns.get(file.name)}
+                      quotaCooldown={getQuotaCooldownForFile(file)}
                       onShowModels={showModels}
                       onReauth={(targetFile) =>
                         setCodexReauthTarget(createCodexReauthTargetFromAuthFile(targetFile))

--- a/apps/web/src/utils/usageHeaderSnapshots.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.ts
@@ -307,8 +307,100 @@ export const getHeaderSnapshotRecoverAtMs = (
   const value =
     snapshot?.header_quota_recover_at_ms ??
     snapshot?.response_metadata?.quota?.recover_at_ms ??
+    snapshot?.response_metadata?.errors?.retry_after_recover_at_ms ??
     null;
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+};
+
+const getHeaderQuotaWindowResetAtMs = (
+  snapshot: UsageHeaderSnapshot | null | undefined,
+  window: ResponseHeaderQuotaWindow | null | undefined
+): number | null => {
+  const resetAtMs = readNumber(window?.reset_at_ms);
+  if (resetAtMs !== null && resetAtMs > 0) return resetAtMs;
+
+  const resetAfterSeconds = readNumber(window?.reset_after_seconds);
+  const timestampMs = readNumber(snapshot?.timestamp_ms);
+  if (resetAfterSeconds !== null && resetAfterSeconds > 0 && timestampMs !== null) {
+    return timestampMs + resetAfterSeconds * 1000;
+  }
+
+  return null;
+};
+
+const getHeaderQuotaWindowSourcesByKind = (
+  quota: ResponseHeaderQuotaMetadata | undefined,
+  windowKind: string | null
+): Array<'primary' | 'secondary'> => {
+  if (!quota || !windowKind) return [];
+  return (['primary', 'secondary'] as const).filter(
+    (source) =>
+      classifyHeaderQuotaWindowKind(getHeaderQuotaWindowBySource(quota, source)) === windowKind
+  );
+};
+
+const isHeaderQuotaWindowDepleted = (
+  window: ResponseHeaderQuotaWindow | null | undefined
+): boolean => {
+  const usedPercent = readNumber(window?.used_percent);
+  return usedPercent !== null && usedPercent >= 100;
+};
+
+const getHeaderQuotaTargetResetAtMsCandidates = (
+  snapshot: UsageHeaderSnapshot | null | undefined
+): number[] => {
+  const candidates: number[] = [];
+  const addCandidate = (value: number | null) => {
+    if (value !== null && Number.isFinite(value)) candidates.push(value);
+  };
+
+  addCandidate(getHeaderSnapshotRecoverAtMs(snapshot));
+
+  const quota = getHeaderSnapshotQuotaMetadata(snapshot);
+  if (!quota) return candidates;
+
+  const sourceCandidates: Array<'primary' | 'secondary'> = [];
+  const addSourceCandidate = (value: unknown) => {
+    const source = normalizeHeaderQuotaWindowSource(value);
+    if (source && !sourceCandidates.includes(source)) sourceCandidates.push(source);
+  };
+
+  addSourceCandidate(quota.reached_window_source);
+  addSourceCandidate(quota.rate_limit_reached_type);
+
+  const reachedWindowKind = getHeaderSnapshotReachedWindowKind(snapshot);
+  if (sourceCandidates.length === 0) {
+    getHeaderQuotaWindowSourcesByKind(quota, reachedWindowKind).forEach(addSourceCandidate);
+  }
+
+  let targetedWindowCount = 0;
+  sourceCandidates.forEach((source) => {
+    targetedWindowCount += 1;
+    addCandidate(
+      getHeaderQuotaWindowResetAtMs(snapshot, getHeaderQuotaWindowBySource(quota, source))
+    );
+  });
+
+  if (targetedWindowCount > 0) return candidates;
+
+  (['primary', 'secondary'] as const).forEach((source) => {
+    const window = getHeaderQuotaWindowBySource(quota, source);
+    if (isHeaderQuotaWindowDepleted(window)) {
+      addCandidate(getHeaderQuotaWindowResetAtMs(snapshot, window));
+    }
+  });
+
+  return candidates;
+};
+
+export const isUsageHeaderQuotaSnapshotExpired = (
+  snapshot: UsageHeaderSnapshot | null | undefined,
+  nowMs = Date.now()
+): boolean => {
+  if (!hasUsageHeaderQuotaSignal(snapshot)) return false;
+  const candidates = getHeaderQuotaTargetResetAtMsCandidates(snapshot);
+  if (candidates.length === 0) return false;
+  return Math.max(...candidates) <= nowMs;
 };
 
 export const getHeaderSnapshotErrorKind = (


### PR DESCRIPTION
## Summary
Fix stale Codex quota display after a 5h quota cooldown ends.
Expired usage-header quota snapshots are no longer shown as current quota, and the auth files page refreshes Codex quota when CPAMP cooldowns recover.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add targeted expiry detection for usage-header quota snapshots based on recover/reset windows.
- Refresh Codex quota automatically after stale header detection or CPAMP cooldown recovery.
- Scope cooldown and refresh handling by auth file plus authIndex, including safe legacy fallback behavior.
- Add regression coverage for expired headers, recovered cooldowns, shared auth files, retry behavior, and context changes.

## User Impact
Codex auth files stop showing stale 5h quota-full header data after the reset window passes. The page refreshes and displays the latest Codex quota once recovery is detected.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the existing frontend quota fetch path and Manager analytics hints when available.
- Manager Server mode: Uses existing cooldown and header snapshot APIs; no backend contract changes.
- Full Docker / native packages: Frontend-only behavior change, no config or packaging changes.

## Data / Security Notes
No secrets, auth files, SQLite schema, raw usage data, or key storage behavior changed. Codex quota refreshes use the existing auth-file quota request path.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this frontend commit to restore the previous header-derived quota display behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- AuthFilesPage.quotaCooldown.test.tsx quotaConfigs.test.ts
npm run type-check
npm run lint
npm run test
npx prettier --check apps/web/src/features/authFiles/AuthFilesPage.tsx apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx apps/web/src/utils/usageHeaderSnapshots.ts
git diff --check
```

## Screenshots / Recordings
N/A. Behavior is covered by regression tests; no intentional visual layout change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A