### PR TITLE
docs(release): add v1.10.2 release notes

### DIFF
--- a/docs/release-notes/v1.10.2-en.md
+++ b/docs/release-notes/v1.10.2-en.md
@@ -1,0 +1,33 @@
+# CPA Manager Plus v1.10.2
+
+> 8 commits · 15 files changed · +1579 / -104
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.2/docs/release-notes/v1.10.2-zh.md)
+
+## Overview
+
+This patch release focuses on auth-files stability and management-panel readability. Manager Server now streams CPA auth-files target lookups for large responses instead of depending on full in-memory reads that can be truncated, keeping quota and account-action flows accurate. The panel also refreshes Codex quota after cooldown recovery or stale usage-header detection and fills missing runtime locale keys across navigation, logs, monitoring, and auth-files UI.
+
+## Highlights
+
+### Fixes
+
+- Stream CPA auth-files target lookups in Manager Server quota and account-action paths, forwarding `auth_index` to newer CPA status updates while preserving fallbacks for existing CPA versions (`manager-server/auth-files`).
+- Refresh Codex auth-file quota after CPAMP cooldown recovery or stale usage-header detection, so quota badges stop showing expired window data while preserving `authIndex` isolation (`web/auth-files`).
+- Restore full navigation labels in the expanded sidebar while keeping short labels available for compact navigation contexts (`web/navigation`).
+- Fill missing runtime translation keys for auth files, provider actions, navigation, logs, and monitoring, keeping English, Simplified Chinese, Traditional Chinese, and Russian key coverage aligned (`web/i18n`).
+
+### Tests
+
+- Add regression coverage for CPA auth-files streaming lookup, account-action candidate refresh, Codex cooldown quota refresh, sidebar labels, and i18n coverage (`tests`).
+
+## Upgrade Notes
+
+- No database migration is required.
+- Large CPA auth-files lists should behave more reliably for quota refresh and account-action candidate checks after upgrading; fallback behavior remains for older CPA versions.
+- Codex quota now refreshes after cooldown recovery, so after upgrading it is worth checking the Auth Files quota badge around recovery windows.
+- Suggested screenshots for this release: Codex quota badge after cooldown recovery in Auth Files and full navigation labels in the expanded sidebar.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.1...v1.10.2

--- a/docs/release-notes/v1.10.2-zh.md
+++ b/docs/release-notes/v1.10.2-zh.md
@@ -1,0 +1,33 @@
+# CPA Manager Plus v1.10.2
+
+> 8 commits · 15 files changed · +1579 / -104
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.2/docs/release-notes/v1.10.2-en.md)
+
+## Overview
+
+本次补丁发布聚焦 auth files 和管理面板可读性的稳定性修复。Manager Server 在 CPA auth-files 大响应场景下改为流式定位目标账号，避免读取被截断影响 quota 和账号操作；前端会在 Codex cooldown 恢复或过期 usage header 检测后主动刷新 quota，并补齐导航、日志、监控和 auth files 相关的多语言文案。
+
+## Highlights
+
+### Fixes
+
+- Manager Server 的 quota 与账号操作路径改为流式查找 CPA auth-files 目标账号，并在新版 CPA 状态更新中传递 `auth_index`，避免大体积 auth-files 响应被截断后误判账号状态（`manager-server/auth-files`）。
+- Codex auth file quota 会在 CPAMP cooldown 恢复或 usage header 过期后自动刷新，避免 quota badge 继续显示旧窗口数据，同时保持 `authIndex` 隔离（`web/auth-files`）。
+- 展开的侧边栏恢复显示完整导航标签，短标签仍保留给紧凑导航场景使用（`web/navigation`）。
+- 补齐 auth files、provider actions、导航、日志和监控相关的缺失运行时翻译 key，保持 English、简体中文、繁体中文和 Russian key 覆盖一致（`web/i18n`）。
+
+### Tests
+
+- 补充 CPA auth-files 流式查找、账号操作候选刷新、Codex cooldown quota 刷新、侧边栏标签和 i18n coverage 回归测试（`tests`）。
+
+## Upgrade Notes
+
+- 无需数据库迁移。
+- 如果 CPA auth-files 列表很大，升级后 quota 刷新和账号操作候选检查应更稳定；旧版 CPA 继续保留 fallback 行为。
+- 本次修复会在 Codex cooldown 恢复后重新拉取 quota，升级后建议检查 Auth Files 页面 quota badge 是否随恢复窗口正常更新。
+- 建议为本版本补充截图：Auth Files 中 Codex cooldown 恢复后的 quota badge、展开侧边栏的完整导航标签。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.1...v1.10.2


### PR DESCRIPTION
## Summary
Adds curated CPA Manager Plus v1.10.2 release notes in Chinese and English.
The notes cover auth-files streaming lookup fixes, Codex quota refresh after cooldown recovery, sidebar label rendering, and i18n key coverage.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add Chinese release notes for v1.10.2 under `docs/release-notes/`.
- Add English release notes for v1.10.2 under `docs/release-notes/`.
- Use tag-pinned GitHub blob URLs for release note language switch links.

## User Impact
No runtime behavior change in this PR. Users will get curated v1.10.2 release notes when the tag workflow creates the GitHub Release.

## Compatibility / Runtime Notes
- CPA panel mode: N/A, release notes only.
- Manager Server mode: N/A, release notes only.
- Full Docker / native packages: N/A, release notes only.

## Data / Security Notes
N/A. This PR only adds release note files and does not change runtime data handling, secrets, auth files, SQLite data, logs, or CPA Management Key behavior.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the release note commit or close this PR before tagging v1.10.2.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
git branch --show-current -> main
git status --porcelain=v1 -> clean
git rev-parse --verify main -> f355841ac7985247aa91d18798a34676b740ebff
git rev-parse --verify origin/main -> f355841ac7985247aa91d18798a34676b740ebff
git rev-list --left-right --count main...origin/main -> 0 0
git tag --list 'v*' --sort=-v:refname -> latest v1.10.1
git tag --list v1.10.2 -> no local tag
GitHub MCP list_tags -> v1.10.2 absent
GitHub MCP list_branches -> release/v1.10.2 absent before creation
git rev-list --count v1.10.1..HEAD -> 8
git diff --shortstat v1.10.1..HEAD -> 15 files changed, 1579 insertions(+), 104 deletions(-)
release note links use tag-pinned docs/release-notes URLs for v1.10.2
```

## Screenshots / Recordings
N/A. Release notes only.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
N/A