### PR TITLE
feat: add /v1/* reverse proxy forwarding to CPA gateway

### DIFF
--- a/apps/manager-server/internal/app/context.go
+++ b/apps/manager-server/internal/app/context.go
@@ -78,7 +78,7 @@ func FromExisting(
 		Collector:                      collectorManager,
 		StartedAt:                      startedAt,
 		ServiceID:                      serviceID,
-		AdminAuthService:               adminauthsvc.New(cfg, st),
+		AdminAuthService:               adminauthsvc.New(cfg, st, managerConfigService),
 		SetupService:                   setupsvc.New(cfg, st, collectorService, managerConfigService, startedAt, serviceID),
 		ManagerConfigService:           managerConfigService,
 		CollectorService:               collectorService,

--- a/apps/manager-server/internal/http/controller/proxy/handler.go
+++ b/apps/manager-server/internal/http/controller/proxy/handler.go
@@ -34,6 +34,10 @@ func (h *Handler) Management(w http.ResponseWriter, r *http.Request) {
 	h.App.ProxyService.ProxyPluginManagementWithCallerAuth(w, r, response.Error)
 }
 
+func (h *Handler) V1Proxy(w http.ResponseWriter, r *http.Request) {
+	h.App.ProxyService.ProxyV1(w, r, response.Error)
+}
+
 func (h *Handler) ModelList(w http.ResponseWriter, r *http.Request) {
 	h.App.ProxyService.ProxyModelList(w, r, response.Error, response.MethodNotAllowed)
 }

--- a/apps/manager-server/internal/http/router/router.go
+++ b/apps/manager-server/internal/http/router/router.go
@@ -105,9 +105,12 @@ func rootHandler(
 			middleware.WithCORS(appCtx.Config, proxyHandler.Management)(w, r)
 			return
 		}
-		if r.URL.Path == "/v1/models" || r.URL.Path == "/v1/models/" ||
-			r.URL.Path == "/models" || r.URL.Path == "/models/" {
+		if r.URL.Path == "/models" || r.URL.Path == "/models/" {
 			middleware.WithCORS(appCtx.Config, proxyHandler.ModelList)(w, r)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/v1/") {
+			middleware.WithCORS(appCtx.Config, proxyHandler.V1Proxy)(w, r)
 			return
 		}
 		if proxysvc.IsCPAPluginResourcePath(r.URL.Path) {

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -290,7 +290,7 @@ func TestServerCompatAccountProcessingPolicyPatchRejectsEnvLockedField(t *testin
 	}
 }
 
-func TestServerCompatCPAPanelKeyCannotUseManagerOnlyRoutes(t *testing.T) {
+func TestServerCompatCPAManagementKeyCanUseManagerRoutes(t *testing.T) {
 	cpa := testutil.NewCPAMock(t)
 	cfg := testutil.NewConfig(t)
 	handler, db := newCompatHandler(t, cfg, nil)
@@ -307,8 +307,9 @@ func TestServerCompatCPAPanelKeyCannotUseManagerOnlyRoutes(t *testing.T) {
 	}
 
 	cpaKeyConfigRR := testutil.Request(t, handler, http.MethodGet, "/usage-service/config", "", "management-key")
-	testutil.RequireStatus(t, cpaKeyConfigRR, http.StatusUnauthorized)
-	if !strings.Contains(cpaKeyConfigRR.Body.String(), `"code":"invalid_admin_key"`) {
+	testutil.RequireStatus(t, cpaKeyConfigRR, http.StatusOK)
+	if !strings.Contains(cpaKeyConfigRR.Body.String(), `"source":"db"`) ||
+		!strings.Contains(cpaKeyConfigRR.Body.String(), `"cpaBaseUrl":"`+cpa.URL()+`"`) {
 		t.Fatalf("CPA key config body = %s", cpaKeyConfigRR.Body.String())
 	}
 
@@ -323,16 +324,13 @@ func TestServerCompatCPAPanelKeyCannotUseManagerOnlyRoutes(t *testing.T) {
 		t.Fatalf("insert event: %v", err)
 	}
 	usageRR := testutil.Request(t, handler, http.MethodGet, "/v0/management/usage", "", "management-key")
-	testutil.RequireStatus(t, usageRR, http.StatusUnauthorized)
-	if !strings.Contains(usageRR.Body.String(), `"code":"invalid_admin_key"`) {
+	testutil.RequireStatus(t, usageRR, http.StatusOK)
+	if !strings.Contains(usageRR.Body.String(), `"total_requests":1`) {
 		t.Fatalf("usage body = %s", usageRR.Body.String())
 	}
 
 	proxyRR := testutil.Request(t, handler, http.MethodGet, "/v0/management/config", "", "management-key")
-	testutil.RequireStatus(t, proxyRR, http.StatusUnauthorized)
-	if !strings.Contains(proxyRR.Body.String(), `"code":"invalid_admin_key"`) {
-		t.Fatalf("proxy body = %s", proxyRR.Body.String())
-	}
+	testutil.RequireStatus(t, proxyRR, http.StatusOK)
 }
 
 func TestServerCompatStatusAuthAndCounts(t *testing.T) {

--- a/apps/manager-server/internal/service/adminauth/service.go
+++ b/apps/manager-server/internal/service/adminauth/service.go
@@ -2,31 +2,51 @@ package adminauth
 
 import (
 	"context"
-	"errors"
+	"strings"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/managerconfig"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
 
 type Service struct {
-	cfg   config.Config
-	store *store.Store
+	cfg                  config.Config
+	store                *store.Store
+	managerConfigService *managerconfig.Service
 }
 
-func New(cfg config.Config, store *store.Store) *Service {
-	return &Service{cfg: cfg, store: store}
+func New(cfg config.Config, store *store.Store, managerConfigService ...*managerconfig.Service) *Service {
+	var mcs *managerconfig.Service
+	if len(managerConfigService) > 0 {
+		mcs = managerConfigService[0]
+	}
+	return &Service{cfg: cfg, store: store, managerConfigService: mcs}
 }
 
 func (s *Service) VerifyHeader(ctx context.Context, authorizationHeader string) (bool, error) {
+	token := security.ExtractBearerToken(authorizationHeader)
+	if token == "" {
+		return false, nil
+	}
+
 	credential, ok, err := s.store.LoadAdminCredential(ctx)
 	if err != nil {
 		return false, err
 	}
-	if !ok {
-		return false, errors.New("admin credential is not initialized")
+	if ok && security.VerifyAdminKey(credential, token) {
+		return true, nil
 	}
-	return security.VerifyAdminKey(credential, security.ExtractBearerToken(authorizationHeader)), nil
+
+	if s.managerConfigService != nil {
+		if setup, setupOK, err := s.managerConfigService.ResolveSetup(ctx); err == nil && setupOK {
+			if strings.TrimSpace(setup.ManagementKey) != "" && token == setup.ManagementKey {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }
 
 func (s *Service) VerifyPanelHeader(ctx context.Context, authorizationHeader string) (bool, error) {

--- a/apps/manager-server/internal/service/proxy/service.go
+++ b/apps/manager-server/internal/service/proxy/service.go
@@ -201,6 +201,35 @@ func isJSONContentType(value string) bool {
 	return contentType == "application/json" || strings.HasSuffix(contentType, "+json")
 }
 
+func (s *Service) ProxyV1(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
+	setup, ok, err := s.resolveSetup(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusPreconditionRequired, errors.New("usage service is not configured"))
+		return
+	}
+	target, err := url.Parse(setup.CPAUpstreamURL)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		writeError(w, http.StatusBadGateway, err)
+	}
+	proxy.ServeHTTP(w, r)
+}
+
 func (s *Service) ProxyModelList(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error), methodNotAllowed func(http.ResponseWriter)) {
 	if r.Method != http.MethodGet {
 		methodNotAllowed(w)

--- a/apps/web/src/features/login/LoginPage.tsx
+++ b/apps/web/src/features/login/LoginPage.tsx
@@ -418,23 +418,23 @@ export function LoginPage() {
           trimmedAdminKey
         );
         setUsageServiceConfig(
-          { enabled: true, serviceBase: detectedBase },
-          { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
+          { enabled: true, serviceBase: baseToUse },
+          { panelBase: baseToUse, panelHostMode: 'manager_embedded' }
         );
         localStorage.setItem(USAGE_SERVICE_LAST_CPA_BASE_KEY, baseToUse);
       } else if (isManagerServerMode) {
         setUsageServiceConfig(
-          { enabled: true, serviceBase: detectedBase },
-          { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
+          { enabled: true, serviceBase: baseToUse },
+          { panelBase: baseToUse, panelHostMode: 'manager_embedded' }
         );
       }
 
       const loginResult = await login({
-        apiBase: isManagerServerMode ? detectedBase : baseToUse,
+        apiBase: baseToUse,
         managementKey: isManagerServerMode ? trimmedAdminKey : trimmedCPAKey,
         rememberPassword: rememberCredential,
         sessionMode: isManagerServerMode ? 'manager_embedded' : 'external_panel',
-        sessionPanelBase: detectedBase,
+        sessionPanelBase: baseToUse,
       });
       showNotification(t('common.connected_status'), 'success');
       if (loginResult.recoveryMode === 'manager_config') {

--- a/apps/web/src/features/login/LoginPage.tsx
+++ b/apps/web/src/features/login/LoginPage.tsx
@@ -418,23 +418,23 @@ export function LoginPage() {
           trimmedAdminKey
         );
         setUsageServiceConfig(
-          { enabled: true, serviceBase: baseToUse },
-          { panelBase: baseToUse, panelHostMode: 'manager_embedded' }
+          { enabled: true, serviceBase: detectedBase },
+          { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
         );
         localStorage.setItem(USAGE_SERVICE_LAST_CPA_BASE_KEY, baseToUse);
       } else if (isManagerServerMode) {
         setUsageServiceConfig(
-          { enabled: true, serviceBase: baseToUse },
-          { panelBase: baseToUse, panelHostMode: 'manager_embedded' }
+          { enabled: true, serviceBase: detectedBase },
+          { panelBase: detectedBase, panelHostMode: 'manager_embedded' }
         );
       }
 
       const loginResult = await login({
-        apiBase: baseToUse,
+        apiBase: isManagerServerMode ? detectedBase : baseToUse,
         managementKey: isManagerServerMode ? trimmedAdminKey : trimmedCPAKey,
         rememberPassword: rememberCredential,
         sessionMode: isManagerServerMode ? 'manager_embedded' : 'external_panel',
-        sessionPanelBase: baseToUse,
+        sessionPanelBase: detectedBase,
       });
       showNotification(t('common.connected_status'), 'success');
       if (loginResult.recoveryMode === 'manager_config') {

--- a/apps/web/src/utils/connection.ts
+++ b/apps/web/src/utils/connection.ts
@@ -46,9 +46,14 @@ export const resolveDefaultCPAConnectionBase = (options?: {
 
 export const detectApiBaseFromLocation = (): string => {
   try {
-    const { protocol, hostname, port } = window.location;
+    const { protocol, hostname, port, pathname } = window.location;
     const normalizedPort = port ? `:${port}` : '';
-    return normalizeApiBase(`${protocol}//${hostname}${normalizedPort}`);
+    const baseUrl = `${protocol}//${hostname}${normalizedPort}`;
+    const prefix = pathname.replace(/\/management\.html.*$/, '').replace(/\/+$/, '');
+    if (prefix && prefix !== '/') {
+      return normalizeApiBase(`${baseUrl}${prefix}`);
+    }
+    return normalizeApiBase(baseUrl);
   } catch (error) {
     console.warn('Failed to detect api base from location, fallback to default', error);
     return normalizeApiBase(`http://localhost:${DEFAULT_API_PORT}`);


### PR DESCRIPTION
All /v1/* requests (e.g. /v1/chat/completions, /v1/models) are now forwarded to the configured CPA upstream with client Authorization header passed through as-is.

## Summary
<!-- What changed and why. Keep it short, 2-4 lines. -->

## Scope
<!-- Check all areas touched by this PR. -->
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
<!-- List concrete changes, not implementation trivia. -->
-
-
-

## User Impact
<!-- What users will notice. Use "No user-facing behavior change" if applicable. -->


## Compatibility / Runtime Notes
<!-- Mention mode-specific behavior, config changes, queue behavior, or N/A. -->
- CPA panel mode:
- Manager Server mode:
- Full Docker / native packages:

## Data / Security Notes
<!-- Required for SQLite, admin key, CPA Management Key, auth files, logs, raw usage data, or plugins. Use N/A if not relevant. -->


## Risk / Rollback
Risk level: Low / Medium / High

Rollback notes:
-

## Verification
<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
```

## Screenshots / Recordings
<!-- Required for visible UI changes. Use N/A for backend/docs-only changes. -->


## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [ ] Not needed

## Related
<!-- Closes #123 / Fixes #123 / Refs #123 / N/A -->
