### PR TITLE
Fix management panel responses to include Content-Length

### DIFF
--- a/apps/manager-server/internal/http/controller/panel/handler.go
+++ b/apps/manager-server/internal/http/controller/panel/handler.go
@@ -12,5 +12,5 @@ type Handler struct {
 }
 
 func (h *Handler) ManagementHTML(w http.ResponseWriter, r *http.Request) {
-	h.App.PanelService.ServeManagementHTML(w, response.Error)
+	h.App.PanelService.ServeManagementHTML(w, r, response.Error)
 }

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -96,12 +96,16 @@ func TestServerCompatHealthInfoAndPanel(t *testing.T) {
 	if !strings.Contains(strings.ToLower(panelRR.Body.String()), "<html") {
 		t.Fatalf("panel body does not look like html")
 	}
+	if got, want := panelRR.Header().Get("Content-Length"), strconv.Itoa(panelRR.Body.Len()); got != want {
+		t.Fatalf("panel content length = %q, want %q", got, want)
+	}
 }
 
 func TestServerCompatPanelPathOverridesEmbeddedPanel(t *testing.T) {
 	cfg := testutil.NewConfig(t)
 	panelPath := filepath.Join(t.TempDir(), "management.html")
-	if err := osWriteFile(panelPath, []byte("<html><body>custom panel</body></html>")); err != nil {
+	customPanel := "<html><body>custom panel</body></html>"
+	if err := osWriteFile(panelPath, []byte(customPanel)); err != nil {
 		t.Fatalf("write panel: %v", err)
 	}
 	cfg.PanelPath = panelPath
@@ -109,8 +113,11 @@ func TestServerCompatPanelPathOverridesEmbeddedPanel(t *testing.T) {
 
 	rr := testutil.Request(t, handler, http.MethodGet, "/management.html", "", "")
 	testutil.RequireStatus(t, rr, http.StatusOK)
-	if rr.Body.String() != "<html><body>custom panel</body></html>" {
+	if rr.Body.String() != customPanel {
 		t.Fatalf("panel body = %q", rr.Body.String())
+	}
+	if got, want := rr.Header().Get("Content-Length"), strconv.Itoa(len(customPanel)); got != want {
+		t.Fatalf("panel content length = %q, want %q", got, want)
 	}
 }
 

--- a/apps/manager-server/internal/service/panel/service.go
+++ b/apps/manager-server/internal/service/panel/service.go
@@ -1,11 +1,12 @@
 package panel
 
 import (
-	"io"
 	"io/fs"
 	"mime"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 )
 
 type Service struct {
@@ -17,12 +18,17 @@ func New(panelPath string, embedded fs.FS) *Service {
 	return &Service{PanelPath: panelPath, Embedded: embedded}
 }
 
-func (s *Service) ServeManagementHTML(w http.ResponseWriter, writeError func(http.ResponseWriter, int, error)) {
+func (s *Service) ServeManagementHTML(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
 	if s.PanelPath != "" {
 		if file, err := os.Open(s.PanelPath); err == nil {
 			defer file.Close()
+			info, statErr := file.Stat()
+			if statErr != nil {
+				writeError(w, http.StatusInternalServerError, statErr)
+				return
+			}
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			_, _ = io.Copy(w, file)
+			http.ServeContent(w, r, "management.html", info.ModTime(), file)
 			return
 		}
 	}
@@ -31,6 +37,11 @@ func (s *Service) ServeManagementHTML(w http.ResponseWriter, writeError func(htt
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	w.Header().Set("Content-Type", mime.TypeByExtension(".html"))
+	contentType := mime.TypeByExtension(".html")
+	if !strings.Contains(contentType, "charset=") {
+		contentType += "; charset=utf-8"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	_, _ = w.Write(data)
 }


### PR DESCRIPTION
## Summary
This PR changes the manager panel HTML response to use static-file style response semantics instead of streaming the file with a bare `io.Copy`.

For `PANEL_PATH`-backed panels, the server now uses `http.ServeContent`, which provides `Content-Length`, `Accept-Ranges`, `Last-Modified`, and proper handling for `HEAD` / range / conditional requests.

For the embedded panel fallback, the server now sets `Content-Length` explicitly before writing the embedded HTML bytes.

## Scope
<!-- Check all areas touched by this PR. -->
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
<!-- List concrete changes, not implementation trivia. -->
- Serve `PANEL_PATH` management panel HTML with `http.ServeContent` instead of manual streaming.
- Set explicit `Content-Length` for embedded management panel responses.
- Add compatibility tests covering `Content-Length` for both embedded and `PANEL_PATH` panel responses.

## User Impact
Users loading `/management.html` through nginx/reverse proxies should get a more stable panel download, especially for large single-file panel builds.

This does not change the panel UI or management API behavior.

## Compatibility / Runtime Notes
<!-- Mention mode-specific behavior, config changes, queue behavior, or N/A. -->
- CPA panel mode: improves `PANEL_PATH`-backed `/management.html` serving by making it behave like a normal static file response.
- Manager Server mode: embedded panel fallback now includes an explicit `Content-Length`.
- Full Docker / native packages: no config or packaging changes required.

## Data / Security Notes
<!-- Required for SQLite, admin key, CPA Management Key, auth files, logs, raw usage data, or plugins. Use N/A if not relevant. -->
N/A. This PR only changes HTTP response semantics for the management panel HTML.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this commit to restore the previous manual `io.Copy` response behavior.

## Verification
<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->
- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
go test ./...
go test ./internal/service/panel ./internal/httpapi
npm run build
```

Build output confirms the panel is a large single-file HTML asset:

```text
dist/index.html  4,541.63 kB │ gzip: 1,240.28 kB
```

Production evidence before the fix showed the upstream app serving `/management.html` as a chunked response:

```http
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked
```

Nginx access logs showed multiple partial-size `200` responses while proxying the old chunked route:

```text
****:****::**** - - [04/Jul/2026:13:46:14 +0000] "GET /management.html HTTP/1.1" 200 3702962 "-" "curl/8.21.0" "-"
****:****::**** - - [04/Jul/2026:13:47:01 +0000] "GET /management.html HTTP/1.1" 200 3882724 "-" "curl/8.21.0" "-"
****:****::**** - - [04/Jul/2026:13:53:29 +0000] "GET /__codex_mgmt_proxy_probe_20260704.html HTTP/2.0" 200 3604348 "-" "curl/8.21.0" "-"
****:****::**** - - [04/Jul/2026:13:53:30 +0000] "GET /__codex_mgmt_proxy_probe_20260704.html HTTP/1.1" 200 3751642 "-" "curl/8.21.0" "-"
****:****::**** - - [04/Jul/2026:13:53:57 +0000] "GET /__codex_mgmt_proxy_probe_20260704.html HTTP/1.1" 200 3636954 "-" "curl/8.21.0" "-"
```

Nginx also repeatedly buffered the old upstream response to temporary files:

```text
2026/07/04 13:41:34 [warn] 2279961#2279961: *47899 an upstream response is buffered to a temporary file /var/lib/nginx/proxy/7/58/0000007587 while reading upstream, client: ****:****::****, server: ****.********.***, request: "GET /management.html HTTP/2.0", upstream: "http://127.0.0.1:18317/management.html", host: "****.********.***"
2026/07/04 13:43:51 [warn] 2314986#2314986: *47925 an upstream response is buffered to a temporary file /var/lib/nginx/proxy/3/60/0000007603 while reading upstream, client: ****:****::****, server: ****.********.***, request: "GET /management.html HTTP/1.1", upstream: "http://127.0.0.1:18317/management.html", host: "****.********.***"
```

Local verification after the fix returned stable static-file style headers:

```http
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 4541639
Content-Type: text/html; charset=utf-8
Last-Modified: Sat, 04 Jul 2026 14:27:01 GMT
```

Repeated local downloads returned the full expected size.

## Screenshots / Recordings
<!-- Required for visible UI changes. Use N/A for backend/docs-only changes. -->
N/A. Backend response behavior change only; no visible UI changes.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
<!-- Closes #123 / Fixes #123 / Refs #123 / N/A -->
N/A