### PR TITLE
feat(web): show xAI pay-as-you-go quota

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -216,6 +216,10 @@ docker compose -f docker-compose.manager.yml up --build
 - 感谢上游项目 [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) 和 [Cli-Proxy-API-Management-Center](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) 提供基础与参考。
 - 感谢 [Linux.do](https://linux.do/) 社区对项目推广与反馈的支持。
 
+## 社区与反馈
+
+- Telegram 交流群: https://t.me/cpa_mp
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=seakee%2FCPA-Manager-Plus&type=date&logscale=&legend=top-left">

--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -1219,7 +1219,6 @@ const renderKimiItems = (
           'div',
           { className: styleMap.quotaMeta },
           h('span', { className: styleMap.quotaPercent }, percentLabel),
-          limit > 0 ? h('span', { className: styleMap.quotaAmount }, `${used} / ${limit}`) : null,
           resetLabel ? h('span', { className: styleMap.quotaReset }, resetLabel) : null
         )
       ),
@@ -1260,6 +1259,22 @@ const formatXaiCurrency = (value: number | null): string => {
   return `$${(value / 100).toFixed(2)}`;
 };
 
+const formatXaiRemainingAmount = (billing: XaiBillingSummary): string => {
+  const remainingCents =
+    billing.monthlyLimitCents !== null && billing.includedUsedCents !== null
+      ? Math.max(0, billing.monthlyLimitCents - billing.includedUsedCents)
+      : null;
+  return `${formatXaiCurrency(remainingCents)} / ${formatXaiCurrency(billing.monthlyLimitCents)}`;
+};
+
+const formatXaiOnDemandAmount = (billing: XaiBillingSummary): string => {
+  const remainingCents =
+    billing.onDemandCapCents !== null && billing.onDemandUsedCents !== null
+      ? Math.max(0, billing.onDemandCapCents - billing.onDemandUsedCents)
+      : null;
+  return `${formatXaiCurrency(remainingCents)} / ${formatXaiCurrency(billing.onDemandCapCents)}`;
+};
+
 const XAI_SUPERGROK_LIMIT_CENTS = 15_000;
 const XAI_SUPERGROK_HEAVY_LIMIT_CENTS = 150_000;
 
@@ -1288,21 +1303,24 @@ const renderXaiItems = (
     return h('div', { className: styleMap.quotaMessage }, t('xai_quota.empty_data'));
   }
 
-  const usedPercent = billing.usedPercent;
-  const clampedUsed = usedPercent === null ? null : Math.max(0, Math.min(100, usedPercent));
+  const clampedUsed =
+    billing.usedPercent === null ? null : Math.max(0, Math.min(100, billing.usedPercent));
   const remaining = clampedUsed === null ? null : Math.max(0, Math.min(100, 100 - clampedUsed));
   const percentLabel = remaining === null ? '--' : `${Math.round(remaining)}%`;
-  const remainingCents =
-    billing.monthlyLimitCents !== null && billing.usedCents !== null
-      ? Math.max(0, billing.monthlyLimitCents - billing.usedCents)
-      : null;
-  const amountLabel = t('xai_quota.usage_amount', {
-    remaining: formatXaiCurrency(remainingCents),
-    limit: formatXaiCurrency(billing.monthlyLimitCents),
-  });
+  const amountLabel = formatXaiRemainingAmount(billing);
   const resetLabel = billing.billingPeriodEnd
     ? formatQuotaResetTime(billing.billingPeriodEnd)
     : t('xai_quota.reset_unknown');
+  const onDemandCap = billing.onDemandCapCents ?? 0;
+  const clampedOnDemandUsed =
+    billing.onDemandUsedPercent === null
+      ? null
+      : Math.max(0, Math.min(100, billing.onDemandUsedPercent));
+  const onDemandRemaining =
+    clampedOnDemandUsed === null ? null : Math.max(0, Math.min(100, 100 - clampedOnDemandUsed));
+  const onDemandPercentLabel =
+    onDemandRemaining === null ? '--' : `${Math.round(onDemandRemaining)}%`;
+  const onDemandAmountLabel = formatXaiOnDemandAmount(billing);
   const plan = resolveXaiPlan(billing.monthlyLimitCents);
 
   const nodes: ReactNode[] = [
@@ -1318,13 +1336,40 @@ const renderXaiItems = (
           )
         )
       : null,
+    onDemandCap > 0
+      ? h(
+          'div',
+          { key: 'pay-as-you-go', className: styleMap.quotaRow },
+          h(
+            'div',
+            { className: styleMap.quotaRowHeader },
+            h('span', { className: styleMap.quotaModel }, t('xai_quota.pay_as_you_go_label')),
+            h(
+              'div',
+              { className: styleMap.quotaMeta },
+              h('span', { className: styleMap.quotaPercent }, onDemandPercentLabel),
+              h('span', { className: styleMap.quotaAmount }, onDemandAmountLabel)
+            )
+          ),
+          h(QuotaProgressBar, {
+            percent: onDemandRemaining,
+            highThreshold: QUOTA_PROGRESS_HIGH_THRESHOLD,
+            mediumThreshold: QUOTA_PROGRESS_MEDIUM_THRESHOLD,
+          })
+        )
+      : h(
+          'div',
+          { key: 'pay-as-you-go', className: styleMap.codexPlan },
+          h('span', { className: styleMap.codexPlanLabel }, t('xai_quota.pay_as_you_go_label')),
+          h('span', { className: styleMap.codexPlanValue }, t('xai_quota.pay_as_you_go_disabled'))
+        ),
     h(
       'div',
       { key: 'billing', className: styleMap.quotaRow },
       h(
         'div',
         { className: styleMap.quotaRowHeader },
-        h('span', { className: styleMap.quotaModel }, t('xai_quota.monthly_limit')),
+        h('span', { className: styleMap.quotaModel }, t('xai_quota.monthly_credits')),
         h(
           'div',
           { className: styleMap.quotaMeta },
@@ -1340,21 +1385,6 @@ const renderXaiItems = (
       })
     ),
   ];
-
-  if (billing.onDemandCapCents !== null) {
-    nodes.push(
-      h(
-        'div',
-        { key: 'on-demand-cap', className: styleMap.codexPlan },
-        h('span', { className: styleMap.codexPlanLabel }, t('xai_quota.on_demand_cap')),
-        h(
-          'span',
-          { className: styleMap.codexPlanValue },
-          formatXaiCurrency(billing.onDemandCapCents)
-        )
-      )
-    );
-  }
 
   return h(React.Fragment, null, ...nodes);
 };

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -4,6 +4,7 @@ import {
   fetchAntigravityQuota,
   fetchClaudeQuota,
   fetchCodexQuota,
+  fetchKimiQuota,
   fetchXaiQuota,
 } from '@/utils/quota';
 import type { MonitoringAccountQuotaTarget } from '@/features/monitoring/accountOverviewQuotaTargets';
@@ -57,6 +58,8 @@ const t = ((key: string, options?: Record<string, unknown>) => {
     'xai_quota.title': 'xAI Quota',
     'xai_quota.empty_data': 'No xAI quota data',
     'xai_quota.monthly_limit': 'Monthly billing limit',
+    'xai_quota.monthly_credits': 'Monthly credits',
+    'xai_quota.pay_as_you_go_label': 'Pay-as-you-go',
     'xai_quota.on_demand_cap': 'On-demand cap',
     'xai_quota.usage_amount': '{{remaining}} / {{limit}} remaining',
   };
@@ -844,14 +847,51 @@ describe('monitoringCenterPageModel account quota', () => {
     ]);
   });
 
+  it('maps Kimi quota rows without amount labels in account quota entries', async () => {
+    vi.mocked(fetchKimiQuota).mockResolvedValue([
+      {
+        id: 'daily',
+        label: 'Daily',
+        used: 25,
+        limit: 100,
+        resetHint: '2026-07-31T00:00:00Z',
+      },
+    ]);
+
+    const entry = await requestAccountQuota(
+      createTarget({
+        provider: 'kimi',
+        authIndex: '4',
+        fileName: 'kimi.json',
+      }),
+      t
+    );
+
+    expect(entry).toMatchObject({
+      provider: 'kimi',
+      providerLabel: 'Kimi Quota',
+      windows: [
+        {
+          id: 'daily',
+          label: 'Daily',
+          remainingPercent: 75,
+          usageLabel: null,
+        },
+      ],
+    });
+  });
+
   it('maps xAI billing into account quota entries', async () => {
     vi.mocked(fetchXaiQuota).mockResolvedValue({
       monthlyLimitCents: 10000,
-      usedCents: 2500,
+      usedCents: 12500,
+      includedUsedCents: 10000,
       onDemandCapCents: 5000,
+      onDemandUsedCents: 2500,
+      onDemandUsedPercent: 50,
       billingPeriodStart: '2026-05-01T00:00:00Z',
       billingPeriodEnd: '2026-06-01T00:00:00Z',
-      usedPercent: 25,
+      usedPercent: 100,
     });
 
     const entry = await requestAccountQuota(
@@ -870,9 +910,15 @@ describe('monitoringCenterPageModel account quota', () => {
       windows: [
         {
           id: 'monthly-limit',
-          label: 'Monthly billing limit',
-          remainingPercent: 75,
-          usageLabel: '$75.00 / $100.00 remaining',
+          label: 'Monthly credits',
+          remainingPercent: 0,
+          usageLabel: '$0.00 / $100.00 remaining',
+        },
+        {
+          id: 'pay-as-you-go',
+          label: 'Pay-as-you-go',
+          remainingPercent: 50,
+          usageLabel: '$25.00 / $50.00 remaining',
         },
       ],
     });

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -1055,7 +1055,7 @@ const buildKimiAccountQuotaWindows = (rows: KimiQuotaRow[], t: TFunction): Accou
       label: rowLabel,
       remainingPercent,
       resetLabel: resetLabel || '-',
-      usageLabel: limit > 0 ? `${used} / ${limit}` : null,
+      usageLabel: null,
     };
   });
 
@@ -1069,14 +1069,13 @@ const buildXaiAccountQuotaWindows = (
   t: TFunction
 ): AccountQuotaWindow[] => {
   const remainingCents =
-    billing.monthlyLimitCents !== null && billing.usedCents !== null
-      ? Math.max(0, billing.monthlyLimitCents - billing.usedCents)
+    billing.monthlyLimitCents !== null && billing.includedUsedCents !== null
+      ? Math.max(0, billing.monthlyLimitCents - billing.includedUsedCents)
       : null;
-
-  return [
+  const windows: AccountQuotaWindow[] = [
     {
       id: 'monthly-limit',
-      label: t('xai_quota.monthly_limit'),
+      label: t('xai_quota.monthly_credits'),
       remainingPercent: buildRemainingFromUsedPercent(billing.usedPercent),
       resetLabel: billing.billingPeriodEnd ? formatQuotaResetTime(billing.billingPeriodEnd) : '-',
       usageLabel: t('xai_quota.usage_amount', {
@@ -1085,6 +1084,25 @@ const buildXaiAccountQuotaWindows = (
       }),
     },
   ];
+
+  if (billing.onDemandCapCents !== null && billing.onDemandCapCents > 0) {
+    const onDemandRemainingCents =
+      billing.onDemandUsedCents !== null
+        ? Math.max(0, billing.onDemandCapCents - billing.onDemandUsedCents)
+        : null;
+    windows.push({
+      id: 'pay-as-you-go',
+      label: t('xai_quota.pay_as_you_go_label'),
+      remainingPercent: buildRemainingFromUsedPercent(billing.onDemandUsedPercent),
+      resetLabel: '-',
+      usageLabel: t('xai_quota.usage_amount', {
+        remaining: formatXaiCurrency(onDemandRemainingCents),
+        limit: formatXaiCurrency(billing.onDemandCapCents),
+      }),
+    });
+  }
+
+  return windows;
 };
 
 export const getAccountQuotaProviderLabel = (

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1127,9 +1127,12 @@
     "refresh_button": "Refresh Quota",
     "fetch_all": "Fetch All",
     "monthly_limit": "Monthly billing limit",
+    "monthly_credits": "Monthly credits",
     "plan_label": "Plan",
     "plan_supergrok": "SuperGrok",
     "plan_supergrok_heavy": "SuperGrok Heavy",
+    "pay_as_you_go_label": "Pay-as-you-go",
+    "pay_as_you_go_disabled": "Disabled",
     "on_demand_cap": "On-demand cap",
     "usage_amount": "{{remaining}} / {{limit}} remaining",
     "reset_unknown": "reset unknown"

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -1127,9 +1127,12 @@
     "refresh_button": "Обновить квоту",
     "fetch_all": "Получить все",
     "monthly_limit": "Месячный лимит биллинга",
+    "monthly_credits": "Месячные кредиты",
     "plan_label": "План",
     "plan_supergrok": "SuperGrok",
     "plan_supergrok_heavy": "SuperGrok Heavy",
+    "pay_as_you_go_label": "Pay-as-you-go",
+    "pay_as_you_go_disabled": "Отключено",
     "on_demand_cap": "Лимит on-demand",
     "usage_amount": "Осталось {{remaining}} / {{limit}}",
     "reset_unknown": "сброс неизвестен"

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -1127,9 +1127,12 @@
     "refresh_button": "刷新额度",
     "fetch_all": "获取全部",
     "monthly_limit": "月度账单限额",
+    "monthly_credits": "月度额度",
     "plan_label": "套餐",
     "plan_supergrok": "SuperGrok",
     "plan_supergrok_heavy": "SuperGrok Heavy",
+    "pay_as_you_go_label": "按量付费",
+    "pay_as_you_go_disabled": "未启用",
     "on_demand_cap": "按需上限",
     "usage_amount": "剩余 {{remaining}} / {{limit}}",
     "reset_unknown": "重置时间未知"

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -1127,9 +1127,12 @@
     "refresh_button": "重新整理配額",
     "fetch_all": "取得全部",
     "monthly_limit": "月度帳單限額",
+    "monthly_credits": "月度配額",
     "plan_label": "方案",
     "plan_supergrok": "SuperGrok",
     "plan_supergrok_heavy": "SuperGrok Heavy",
+    "pay_as_you_go_label": "按量付費",
+    "pay_as_you_go_disabled": "未啟用",
     "on_demand_cap": "按需上限",
     "usage_amount": "剩餘 {{remaining}} / {{limit}}",
     "reset_unknown": "重置時間未知"

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -434,7 +434,10 @@ export interface XaiBillingPayload {
 export interface XaiBillingSummary {
   monthlyLimitCents: number | null;
   usedCents: number | null;
+  includedUsedCents: number | null;
   onDemandCapCents: number | null;
+  onDemandUsedCents: number | null;
+  onDemandUsedPercent: number | null;
   billingPeriodStart?: string;
   billingPeriodEnd?: string;
   usedPercent: number | null;

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -237,9 +237,30 @@ describe('buildXaiBillingSummary', () => {
     expect(summary).toMatchObject({
       monthlyLimitCents: 15000,
       usedCents: 3750,
+      includedUsedCents: 3750,
       onDemandCapCents: 2500,
+      onDemandUsedCents: 0,
+      onDemandUsedPercent: 0,
       billingPeriodEnd: '2026-07-31T00:00:00Z',
       usedPercent: 25,
+    });
+  });
+
+  it('splits included and pay-as-you-go usage after monthly credits are exhausted', () => {
+    const summary = buildXaiBillingSummary({
+      monthly_limit: 10000,
+      used: 12500,
+      on_demand_cap: 5000,
+    });
+
+    expect(summary).toMatchObject({
+      monthlyLimitCents: 10000,
+      usedCents: 12500,
+      includedUsedCents: 10000,
+      onDemandCapCents: 5000,
+      onDemandUsedCents: 2500,
+      usedPercent: 100,
+      onDemandUsedPercent: 50,
     });
   });
 });

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -582,15 +582,32 @@ export const buildXaiBillingSummary = (
     return null;
   }
 
+  const includedUsedCents =
+    usedCents === null
+      ? null
+      : monthlyLimitCents !== null && monthlyLimitCents > 0
+        ? Math.min(usedCents, monthlyLimitCents)
+        : usedCents;
+  const onDemandUsedCents =
+    usedCents !== null && monthlyLimitCents !== null
+      ? Math.max(0, usedCents - monthlyLimitCents)
+      : null;
   const usedPercent =
-    monthlyLimitCents !== null && monthlyLimitCents > 0 && usedCents !== null
-      ? (usedCents / monthlyLimitCents) * 100
+    monthlyLimitCents !== null && monthlyLimitCents > 0 && includedUsedCents !== null
+      ? (includedUsedCents / monthlyLimitCents) * 100
+      : null;
+  const onDemandUsedPercent =
+    onDemandCapCents !== null && onDemandCapCents > 0 && onDemandUsedCents !== null
+      ? (onDemandUsedCents / onDemandCapCents) * 100
       : null;
 
   return {
     monthlyLimitCents,
     usedCents,
+    includedUsedCents,
     onDemandCapCents,
+    onDemandUsedCents,
+    onDemandUsedPercent,
     billingPeriodStart,
     billingPeriodEnd,
     usedPercent,


### PR DESCRIPTION
## Summary
Show xAI monthly credits separately from pay-as-you-go quota usage in the frontend quota display and monitoring account summaries.
Also adds the Telegram community link to the Chinese README.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Split xAI usage into included monthly credit usage and pay-as-you-go usage.
- Display remaining pay-as-you-go quota when an on-demand cap is configured, or a disabled state otherwise.
- Remove Kimi amount labels from monitoring account quota entries and add test coverage for the behavior.
- Add Telegram community and feedback link to `README_CN.md`.

## User Impact
Users can see when xAI monthly credits are exhausted and how much pay-as-you-go quota remains.
Chinese README readers can find the Telegram community channel directly.

## Compatibility / Runtime Notes
- CPA panel mode: no runtime or configuration changes.
- Manager Server mode: no backend changes.
- Full Docker / native packages: no packaging or deployment changes.

## Data / Security Notes
N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the frontend quota display commit to restore the previous xAI billing presentation.
- Revert the README commit to remove the community link.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test

Test Files  82 passed (82)
Tests       673 passed (673)
```

## Screenshots / Recordings
Not captured. The quota behavior is covered by model and provider request tests in this PR.

## Docs
- [x] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [ ] Not needed

## Related
N/A