### PR TITLE
chore(release): prepare v1.10.3

### DIFF
--- a/docs/release-notes/v1.10.3-en.md
+++ b/docs/release-notes/v1.10.3-en.md
@@ -1,0 +1,47 @@
+# CPA Manager Plus v1.10.3
+
+> 7 commits · 14 files changed · +1067 / -898
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.3/docs/release-notes/v1.10.3-zh.md)
+
+## Overview
+
+This patch release focuses on quota visibility, management-panel response stability, and clearer user-facing copy. The frontend now separates xAI monthly credits from pay-as-you-go usage, Manager Server adds `Content-Length` and static-file response semantics for `/management.html`, and the Chinese README now links directly to the Telegram community.
+
+## Highlights
+
+### Features
+
+- Show xAI quota summaries and monitoring account rows as separate monthly-credit and pay-as-you-go usage, including remaining on-demand quota when a cap is configured and a disabled state when it is not (`web/quota`).
+
+### Fixes
+
+- Add `Content-Length` for embedded management-panel responses and serve `PANEL_PATH` panel HTML with `http.ServeContent`, improving large single-file HTML delivery through nginx and reverse proxies while covering HEAD, range, and conditional response semantics (`manager-server/panel`).
+- Remove Kimi amount labels from monitoring account quota entries so provider-specific quota displays do not mix unrelated amount labels (`web/monitoring`).
+
+### Docs
+
+- Add a Telegram Community and Feedback entry to the Chinese README so Chinese-language users can find the discussion and feedback channel directly (`docs/readme`).
+
+### Chore
+
+- Refine visible copy across zh-CN, zh-TW, en, and ru for request monitoring, auth issues, plugins, quota, model pricing, and analytics while keeping locale key coverage aligned (`web/i18n`).
+
+### Tests
+
+- Add or update regression coverage for xAI billing split behavior, monitoring mapping, provider quota requests, management-panel `Content-Length` compatibility, and locale key parity (`tests`).
+
+## Upgrade Notes
+
+- No database migration is required.
+- Deployments that proxy `/management.html` should get more stable panel downloads after upgrading; if you use custom nginx caching or buffering rules, confirm the response now includes `Content-Length`.
+- xAI quota display is more granular, so after upgrading it is worth checking the Quota and Monitoring views against provider-returned monthly-credit and pay-as-you-go data.
+- This release includes visible quota display changes; consider adding screenshots of xAI quota and Monitoring views to the GitHub Release.
+
+## Acknowledgements
+
+- [@kcocoa](https://github.com/kcocoa) - Fixed Manager Server management-panel `Content-Length` and static-file response semantics.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.2...v1.10.3

--- a/docs/release-notes/v1.10.3-zh.md
+++ b/docs/release-notes/v1.10.3-zh.md
@@ -1,0 +1,47 @@
+# CPA Manager Plus v1.10.3
+
+> 7 commits · 14 files changed · +1067 / -898
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.3/docs/release-notes/v1.10.3-en.md)
+
+## Overview
+
+本次补丁发布聚焦 quota 可见性、管理面板静态文件响应稳定性和用户文案打磨。前端现在能拆分 xAI 月度赠送额度与 pay-as-you-go 用量，Manager Server 为 `/management.html` 补齐 `Content-Length` 和静态文件响应语义，中文 README 也新增 Telegram 社区入口。
+
+## Highlights
+
+### Features
+
+- xAI quota 摘要和监控账号行现在区分月度赠送额度与按量付费用量，并在配置 on-demand 上限时展示剩余额度；未配置上限时显示禁用状态（`web/quota`）。
+
+### Fixes
+
+- Manager Server 的 embedded panel 和 `PANEL_PATH` 管理面板响应补齐 `Content-Length`，`PANEL_PATH` 路径改用 `http.ServeContent`，改善 nginx/反向代理代理大体积 single-file HTML 时的下载稳定性，并覆盖 HEAD、range 和 conditional response 语义（`manager-server/panel`）。
+- 监控账号 quota 条目移除 Kimi amount labels，避免不同 provider 的额度展示混杂（`web/monitoring`）。
+
+### Docs
+
+- 中文 README 增加 Telegram Community and Feedback 入口，方便中文用户找到讨论与反馈渠道（`docs/readme`）。
+
+### Chore
+
+- 优化 zh-CN、zh-TW、en、ru 的请求监控、auth issue、插件、quota、模型价格和分析等可见文案，降低技术术语暴露并保持 key 覆盖一致（`web/i18n`）。
+
+### Tests
+
+- 补充 xAI billing split、监控映射、provider quota request、管理面板 `Content-Length` 兼容性和 locale key parity 相关回归验证（`tests`）。
+
+## Upgrade Notes
+
+- 无需数据库迁移。
+- 反向代理 `/management.html` 的部署在升级后应获得更稳定的面板下载；如果有自定义 nginx 缓存或缓冲策略，建议确认响应头现在包含 `Content-Length`。
+- xAI quota 显示逻辑更精细，升级后建议检查 Quota 与 Monitoring 页面中月度额度和 pay-as-you-go 剩余额度是否符合 provider 返回数据。
+- 本次有可视 quota 显示变化，建议在 GitHub Release 补充 xAI quota 与 Monitoring 截图。
+
+## Acknowledgements
+
+- [@kcocoa](https://github.com/kcocoa) - 修复 Manager Server 管理面板响应的 `Content-Length` 和静态文件语义。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.2...v1.10.3


### PR DESCRIPTION
## Summary
Prepare the curated v1.10.3 release notes before tagging the release.
This PR adds the Chinese source notes and English mirror notes so the tag workflow can publish the curated GitHub Release body.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add `docs/release-notes/v1.10.3-zh.md` with the curated Chinese release notes.
- Add `docs/release-notes/v1.10.3-en.md` with the English mirror release notes.
- Use tag-pinned language switch links for both release note files.

## User Impact
No product behavior change from this PR itself. Users will see curated release notes when `v1.10.3` is tagged and the release workflow publishes the GitHub Release.

## Compatibility / Runtime Notes
- CPA panel mode: N/A, release notes only.
- Manager Server mode: N/A, release notes only.
- Full Docker / native packages: The tag workflow will use `docs/release-notes/v1.10.3-zh.md` as the GitHub Release body.

## Data / Security Notes
N/A. This PR only adds release note markdown files and does not touch data, keys, auth files, logs, raw usage data, or runtime configuration.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR before tagging if the release notes need to be regenerated.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
Preflight:
current branch: main
git status --porcelain: clean
main: b71b4864525f9860d77a40ac0404ee6d22b84f87
origin/main: b71b4864525f9860d77a40ac0404ee6d22b84f87
git rev-list --left-right --count main...origin/main: 0 0
previous tag: v1.10.2
planned tag: v1.10.3, not present locally or on GitHub
planned branch: release/v1.10.3, created from main
release data: 7 commits, 14 files changed, +1067 / -898

Release note link validation:
docs/release-notes/v1.10.3-zh.md -> https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.3/docs/release-notes/v1.10.3-en.md
docs/release-notes/v1.10.3-en.md -> https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.3/docs/release-notes/v1.10.3-zh.md
```

## Screenshots / Recordings
N/A. Docs-only release preparation.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
N/A