### PR TITLE
feat(web): show full number below 10,000 instead of compact K suffix

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
@@ -148,7 +148,7 @@ describe('MonitoringCenterPage summary cards', () => {
     expect(html).toContain('_summaryGrid');
     expect(html.match(/<strong/g)).toHaveLength(8);
     expect(html).toContain('25.5K');
-    expect(html).toContain('1.9K');
+    expect(html).toContain('1900');
     expect(html).toContain('2.8B');
     expect(html).toContain('3.6B');
     expect(html).toContain('role="tooltip"');

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -289,7 +289,7 @@ const compactNumber = (value: number) => {
   if (!Number.isFinite(value)) return '0';
   if (Math.abs(value) >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`;
   if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
-  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  if (Math.abs(value) >= 10_000) return `${(value / 1_000).toFixed(1)}K`;
   return String(Math.round(value));
 };
 

--- a/apps/web/src/features/usage-analytics/usageAnalyticsPresentation.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsPresentation.ts
@@ -94,7 +94,7 @@ const formatCompactNumber = (value: number) => {
   if (!Number.isFinite(value)) return '0';
   if (Math.abs(value) >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`;
   if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  if (Math.abs(value) >= 10_000) return `${(value / 1_000).toFixed(1)}K`;
   return String(Math.round(value));
 };
 

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -16,7 +16,9 @@ import { maskSensitiveText } from './format';
 describe('formatCompactNumber', () => {
   it('keeps large values compact as data grows beyond millions', () => {
     expect(formatCompactNumber(999)).toBe('999');
-    expect(formatCompactNumber(1_200)).toBe('1.2K');
+    expect(formatCompactNumber(1_200)).toBe('1200');
+    expect(formatCompactNumber(9_999)).toBe('9999');
+    expect(formatCompactNumber(12_000)).toBe('12.0K');
     expect(formatCompactNumber(999_950)).toBe('1.0M');
     expect(formatCompactNumber(2_795_200_000)).toBe('2.8B');
     expect(formatCompactNumber(1_200_000_000_000)).toBe('1.2T');

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -844,19 +844,19 @@ export function formatCompactNumber(value: number): string {
   const abs = Math.abs(num);
   if (abs === 0) return '0';
   const units = [
-    { threshold: 1_000_000_000_000_000, suffix: 'P' },
-    { threshold: 1_000_000_000_000, suffix: 'T' },
-    { threshold: 1_000_000_000, suffix: 'B' },
-    { threshold: 1_000_000, suffix: 'M' },
-    { threshold: 1_000, suffix: 'K' },
+    { threshold: 1_000_000_000_000_000, divisor: 1_000_000_000_000_000, suffix: 'P' },
+    { threshold: 1_000_000_000_000, divisor: 1_000_000_000_000, suffix: 'T' },
+    { threshold: 1_000_000_000, divisor: 1_000_000_000, suffix: 'B' },
+    { threshold: 1_000_000, divisor: 1_000_000, suffix: 'M' },
+    { threshold: 10_000, divisor: 1_000, suffix: 'K' },
   ];
   const unit = units.find((item) => abs >= item.threshold);
 
   if (unit) {
-    const formatted = (num / unit.threshold).toFixed(1);
+    const formatted = (num / unit.divisor).toFixed(1);
     const nextUnit = units[units.indexOf(unit) - 1];
     if (nextUnit && Math.abs(Number(formatted)) >= 1000) {
-      return `${(num / nextUnit.threshold).toFixed(1)}${nextUnit.suffix}`;
+      return `${(num / nextUnit.divisor).toFixed(1)}${nextUnit.suffix}`;
     }
     return `${formatted}${unit.suffix}`;
   }


### PR DESCRIPTION
## Summary

Display full numeric values for numbers below 10,000 instead of abbreviating them with the K suffix (e.g., `1200` instead of `1.2K`). Numbers >= 10,000 continue to use K format as before.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Raise the K-suffix threshold from 1,000 to 10,000 in the canonical `formatCompactNumber` (usage.ts) by separating `threshold` from `divisor`
- Apply the same threshold change in two local duplicates (`usageAnalyticsPresentation.ts`, `UsageAnalyticsPage.tsx`)
- Update unit tests and component tests to match

## User Impact

Token/usage values between 1,000–9,999 now display as full numbers (e.g., `1900` instead of `1.9K`), making it easier to distinguish exact reasoning token counts.

## Compatibility / Runtime Notes
- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: N/A

## Data / Security Notes

N/A

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the single commit to restore the original 1,000 threshold

## Verification
- [x] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test    # 82 passed, 673 tests
npm --workspace apps/web run type-check  # clean
```

## Screenshots / Recordings

N/A — display-only formatting change

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

Closes #249