### PR TITLE
fix(web): streamline quota metadata tooltips

### DIFF
--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -691,9 +691,6 @@ const formatCodexResetCreditExpiryTime = (expiresAt: string): string => {
   });
 };
 
-const formatCodexTooltipPercent = (value: number | null): string | null =>
-  value === null ? null : `${Math.round(value)}%`;
-
 const renderCodexResetCreditExpiryInfo = (
   quota: CodexQuotaState,
   t: TFunction,
@@ -751,101 +748,40 @@ const renderCodexResetCreditExpiryInfo = (
 
 const buildCodexWindowTooltipRows = (
   quota: CodexQuotaState,
-  window: CodexQuotaWindow,
-  windowLabel: string,
-  usedPercent: number | null,
-  remainingPercent: number | null,
   t: TFunction
 ): CodexQuotaTooltipRow[] => {
-  const rows: CodexQuotaTooltipRow[] = [];
-  const usedLabel = formatCodexTooltipPercent(usedPercent);
-  const remainingLabel = formatCodexTooltipPercent(remainingPercent);
+  const fromUsageHeaders = quota.observedFromUsageHeaders === true;
+  const timestampMs = fromUsageHeaders ? quota.observedAtMs : quota.fetchedAtMs;
+  const fetchedAt =
+    timestampMs && Number.isFinite(timestampMs) ? new Date(timestampMs).toLocaleString() : '--';
 
-  if (quota.observedFromUsageHeaders) {
-    rows.push({
+  return [
+    {
       key: 'source',
       label: t('codex_quota.tooltip_source_label'),
-      value: t('codex_quota.tooltip_source_header'),
-    });
-
-    if (quota.observedAtMs && Number.isFinite(quota.observedAtMs)) {
-      rows.push({
-        key: 'recorded-at',
-        label: t('codex_quota.tooltip_recorded_at_label'),
-        value: new Date(quota.observedAtMs).toLocaleString(),
-      });
-    }
-  } else {
-    rows.push({
-      key: 'source',
-      label: t('codex_quota.tooltip_source_label'),
-      value: t('codex_quota.tooltip_source_api'),
-    });
-
-    if (quota.fetchedAtMs && Number.isFinite(quota.fetchedAtMs)) {
-      rows.push({
-        key: 'fetched-at',
-        label: t('codex_quota.tooltip_fetched_at_label'),
-        value: new Date(quota.fetchedAtMs).toLocaleString(),
-      });
-    }
-  }
-
-  if (usedLabel) {
-    rows.push({
-      key: 'used',
-      label: t('codex_quota.tooltip_used_label'),
-      value: usedLabel,
-    });
-  }
-
-  if (remainingLabel) {
-    rows.push({
-      key: 'remaining',
-      label: t('codex_quota.tooltip_remaining_label'),
-      value: remainingLabel,
-    });
-  }
-
-  if (window.resetLabel && window.resetLabel !== '-') {
-    rows.push({
-      key: 'reset',
-      label: t('codex_quota.tooltip_reset_label'),
-      value: window.resetLabel,
-    });
-  }
-
-  return rows.length > 0
-    ? rows
-    : [
-        {
-          key: 'window',
-          label: t('codex_quota.tooltip_window_label'),
-          value: windowLabel,
-        },
-      ];
+      value: fromUsageHeaders
+        ? t('codex_quota.tooltip_source_header')
+        : t('codex_quota.tooltip_source_api'),
+    },
+    {
+      key: 'fetched-at',
+      label: t('codex_quota.tooltip_fetched_at_label'),
+      value: fetchedAt,
+    },
+  ];
 };
 
 const renderCodexWindowInfo = (
   quota: CodexQuotaState,
   window: CodexQuotaWindow,
   windowLabel: string,
-  usedPercent: number | null,
-  remainingPercent: number | null,
   t: TFunction,
   styleMap: QuotaRenderHelpers['styles']
 ): ReactNode => {
   if (!CODEX_INFO_WINDOW_IDS.has(window.id)) return null;
 
   const { createElement: h } = React;
-  const rows = buildCodexWindowTooltipRows(
-    quota,
-    window,
-    windowLabel,
-    usedPercent,
-    remainingPercent,
-    t
-  );
+  const rows = buildCodexWindowTooltipRows(quota, t);
 
   return h(
     'span',
@@ -953,8 +889,6 @@ const renderCodexItems = (
         quota,
         window,
         windowLabel,
-        clampedUsed,
-        remaining,
         t,
         styleMap
       );

--- a/apps/web/src/features/monitoring/accountOverviewCardMetrics.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewCardMetrics.test.ts
@@ -18,8 +18,6 @@ describe('accountOverviewCardMetrics', () => {
       'input-tokens',
       'output-tokens',
       'cached-tokens',
-      'cache-creation-tokens',
-      'cache-read-tokens',
     ]);
   });
 });

--- a/apps/web/src/features/monitoring/accountOverviewState.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.test.ts
@@ -219,8 +219,6 @@ describe('accountOverviewState', () => {
       'input-tokens',
       'output-tokens',
       'cached-tokens',
-      'cache-creation-tokens',
-      'cache-read-tokens',
     ]);
   });
 

--- a/apps/web/src/features/monitoring/accountOverviewState.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.ts
@@ -40,8 +40,6 @@ export const ACCOUNT_OVERVIEW_CARD_METRIC_KEYS = [
   'input-tokens',
   'output-tokens',
   'cached-tokens',
-  'cache-creation-tokens',
-  'cache-read-tokens',
 ] as const;
 const DEFAULT_ACCOUNT_OVERVIEW_CARD_PAGINATION = {
   page: 1,

--- a/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
@@ -34,6 +34,7 @@ import {
   getAccountStatusLabel,
   getAccountStatusTone,
   getSuccessRateClassName,
+  type AccountQuotaEntry,
   type AccountQuotaState,
   type AccountQuotaWindow,
   type AccountSummaryMetric,
@@ -137,20 +138,66 @@ function AccountQuotaPanel({
 }) {
   const quotaEntries = quotaState?.entries ?? [];
   const quotaLoading = quotaState?.status === 'loading';
-  const lastQuotaSync =
+  const lastQuotaSyncMs =
     quotaState?.lastRefreshedAt && Number.isFinite(quotaState.lastRefreshedAt)
-      ? new Date(quotaState.lastRefreshedAt).toLocaleString(locale)
-      : '';
+      ? quotaState.lastRefreshedAt
+      : undefined;
   const singleQuotaEntry = quotaEntries.length === 1 ? quotaEntries[0] : null;
-  const lastSyncLabel = shortLabel(t, 'monitoring.last_sync_short', 'monitoring.last_sync');
-  const quotaMetaText = [
-    ...(singleQuotaEntry?.metaLabels ?? []),
-    lastQuotaSync ? `${lastSyncLabel}: ${lastQuotaSync}` : '',
-  ]
-    .filter(Boolean)
-    .join(' · ');
 
-  const renderQuotaWindows = (windows: AccountQuotaWindow[]) => (
+  const buildQuotaInfoRows = (entry: AccountQuotaEntry) => {
+    const fromUsageHeaders = entry.observedFromUsageHeaders === true;
+    const timestampMs = fromUsageHeaders
+      ? entry.observedAtMs
+      : (entry.fetchedAtMs ?? lastQuotaSyncMs);
+    const formattedTime =
+      timestampMs && Number.isFinite(timestampMs)
+        ? new Date(timestampMs).toLocaleString(locale)
+        : '--';
+
+    return [
+      {
+        key: 'source',
+        label: t('codex_quota.tooltip_source_label'),
+        value: fromUsageHeaders
+          ? t('codex_quota.tooltip_source_header')
+          : t('codex_quota.tooltip_source_api'),
+      },
+      {
+        key: 'fetched-at',
+        label: t('codex_quota.tooltip_fetched_at_label'),
+        value: formattedTime,
+      },
+    ];
+  };
+
+  const renderQuotaInfo = (entry: AccountQuotaEntry, windowLabel: string) => {
+    const rows = buildQuotaInfoRows(entry);
+
+    return (
+      <span
+        className={styles.quotaInfoTrigger}
+        tabIndex={0}
+        aria-label={t('codex_quota.tooltip_label', { label: windowLabel })}
+      >
+        <IconInfo
+          size={14}
+          className={styles.quotaInfoIcon}
+          aria-hidden="true"
+          focusable={false}
+        />
+        <span className={styles.quotaInfoTooltip} role="tooltip">
+          {rows.map((row) => (
+            <span key={row.key} className={styles.quotaInfoTooltipRow}>
+              <span className={styles.quotaInfoTooltipLabel}>{row.label}</span>
+              <span className={styles.quotaInfoTooltipValue}>{row.value}</span>
+            </span>
+          ))}
+        </span>
+      </span>
+    );
+  };
+
+  const renderQuotaWindows = (windows: AccountQuotaWindow[], entry: AccountQuotaEntry) => (
     <div className={styles.quotaWindowList}>
       {windows.map((window) => {
         const percentLabel =
@@ -163,7 +210,10 @@ function AccountQuotaPanel({
         return (
           <div key={window.id} className={styles.quotaWindowRow}>
             <div className={styles.quotaWindowHeader}>
-              <span>{window.label}</span>
+              <span className={styles.quotaWindowLabel}>
+                <span>{window.label}</span>
+                {renderQuotaInfo(entry, window.label)}
+              </span>
               <strong>{percentLabel}</strong>
             </div>
             <div className={styles.quotaProgressTrack}>
@@ -220,7 +270,6 @@ function AccountQuotaPanel({
       <div className={styles.quotaSectionHeader}>
         <div className={styles.quotaSectionTitleGroup}>
           <strong>{t('monitoring.account_quota_title')}</strong>
-          {quotaMetaText ? <span>{quotaMetaText}</span> : null}
         </div>
         {renderRefreshButton()}
       </div>
@@ -261,7 +310,7 @@ function AccountQuotaPanel({
             true
           )
         ) : singleQuotaEntry.windows.length > 0 ? (
-          renderQuotaWindows(singleQuotaEntry.windows)
+          renderQuotaWindows(singleQuotaEntry.windows, singleQuotaEntry)
         ) : (
           renderStateMessage(
             singleQuotaEntry.emptyMessage ?? t('monitoring.account_quota_empty'),
@@ -271,10 +320,7 @@ function AccountQuotaPanel({
       ) : quotaEntries.length > 0 ? (
         <div className={styles.quotaEntryGrid}>
           {quotaEntries.map((entry) => {
-            const entryMetaText =
-              entry.metaLabels && entry.metaLabels.length > 0
-                ? entry.metaLabels.join(' · ')
-                : `${entry.providerLabel} · ${entry.fileName}`;
+            const entryMetaText = `${entry.providerLabel} · ${entry.fileName}`;
             return (
               <div key={entry.key} className={styles.quotaEntryCard}>
                 <div className={styles.quotaEntryHeader}>
@@ -291,7 +337,7 @@ function AccountQuotaPanel({
                       true
                     )
                   : entry.windows.length > 0
-                    ? renderQuotaWindows(entry.windows)
+                    ? renderQuotaWindows(entry.windows, entry)
                     : renderStateMessage(
                         entry.emptyMessage ?? t('monitoring.account_quota_empty'),
                         t('monitoring.account_quota_idle')
@@ -333,13 +379,7 @@ export function AccountTokenMetricGrid({
 
   if (variant === 'table') {
     const tokenStructureMetrics = metrics.filter((metric) =>
-      [
-        'input-tokens',
-        'output-tokens',
-        'cached-tokens',
-        'cache-creation-tokens',
-        'cache-read-tokens',
-      ].includes(metric.key)
+      ['input-tokens', 'output-tokens', 'cached-tokens'].includes(metric.key)
     );
     const getTokenStructureRowToneClassName = (key: string) => {
       if (key === 'input-tokens') return styles.tokenStructureRowInput;

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -28,6 +28,7 @@ export type AccountQuotaEntry = {
   windows: AccountQuotaWindow[];
   error?: string;
   failedAtMs?: number;
+  fetchedAtMs?: number;
   observedAtMs?: number;
   observedFromUsageHeaders?: boolean;
 };

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -890,6 +890,7 @@ export const mergeObservedAccountQuotaEntry = (
     planType: observedEntry.planType ?? mergeableActiveEntry.planType,
     metaLabels: mergeAccountQuotaEntryMetaLabels(mergeableActiveEntry, observedEntry),
     windows: mergeAccountQuotaWindows(mergeableActiveEntry.windows, observedEntry.windows),
+    fetchedAtMs: mergeableActiveEntry.fetchedAtMs,
     observedAtMs: observedEntry.observedAtMs ?? mergeableActiveEntry.observedAtMs,
     observedFromUsageHeaders:
       observedEntry.observedFromUsageHeaders ?? mergeableActiveEntry.observedFromUsageHeaders,
@@ -1158,6 +1159,11 @@ const buildBaseAccountQuotaEntry = (
   };
 };
 
+const stampAccountQuotaFetchTime = <T extends AccountQuotaEntry>(entry: T): T => ({
+  ...entry,
+  fetchedAtMs: Date.now(),
+});
+
 export const buildAccountQuotaErrorEntry = (
   target: MonitoringAccountQuotaTarget,
   error: string,
@@ -1246,10 +1252,10 @@ export const requestAccountQuota = async (
   switch (target.provider) {
     case 'antigravity': {
       const { groups } = await fetchAntigravityQuota(target.file, t);
-      return {
+      return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(target, t),
         windows: buildAntigravityAccountQuotaWindows(groups),
-      };
+      });
     }
     case 'claude': {
       const quota = await fetchClaudeQuota(target.file, t);
@@ -1262,18 +1268,18 @@ export const requestAccountQuota = async (
           `${t('claude_quota.extra_usage_label')}: $${(quota.extraUsage.used_credits / 100).toFixed(2)} / $${(quota.extraUsage.monthly_limit / 100).toFixed(2)}`
         );
       }
-      return {
+      return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(target, t, metaLabels),
         planType: quota.planType ?? target.planType,
         windows: buildClaudeAccountQuotaWindows(quota.windows, t),
-      };
+      });
     }
     case 'kimi': {
       const rows = await fetchKimiQuota(target.file, t);
-      return {
+      return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(target, t),
         windows: buildKimiAccountQuotaWindows(rows, t),
-      };
+      });
     }
     case 'xai': {
       const billing = await fetchXaiQuota(target.file, t);
@@ -1281,16 +1287,16 @@ export const requestAccountQuota = async (
         billing.onDemandCapCents !== null
           ? [`${t('xai_quota.on_demand_cap')}: ${formatXaiCurrency(billing.onDemandCapCents)}`]
           : [];
-      return {
+      return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(target, t, metaLabels),
         windows: buildXaiAccountQuotaWindows(billing, t),
-      };
+      });
     }
     case 'codex':
     default: {
       const quota = await fetchCodexQuota(target.file, t);
       const planLabel = getCodexPlanLabel(quota.planType ?? target.planType, t);
-      return {
+      return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(
           {
             ...target,
@@ -1301,7 +1307,7 @@ export const requestAccountQuota = async (
         ),
         planType: quota.planType ?? target.planType,
         windows: buildCodexAccountQuotaWindows(quota.windows, t),
-      };
+      });
     }
   }
 };

--- a/apps/web/src/features/monitoring/styles/_monitoring-account-overview.scss
+++ b/apps/web/src/features/monitoring/styles/_monitoring-account-overview.scss
@@ -987,11 +987,121 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+    min-width: 0;
   }
 
   .quotaWindowHeader span {
     color: var(--monitor-ink);
     font-size: 12px;
+  }
+
+  .quotaWindowLabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    max-width: 100%;
+    overflow: visible;
+  }
+
+  .quotaWindowLabel > span:first-child {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .quotaInfoTrigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    color: var(--monitor-muted);
+    cursor: help;
+    outline: none;
+  }
+
+  .quotaInfoTrigger:hover,
+  .quotaInfoTrigger:focus-visible {
+    color: var(--monitor-ink);
+  }
+
+  .quotaInfoTrigger:focus-visible {
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--monitor-accent) 24%, transparent);
+  }
+
+  .quotaInfoIcon {
+    display: block;
+  }
+
+  .quotaInfoTooltip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 0;
+    z-index: 20;
+    display: grid;
+    gap: 4px;
+    min-width: 210px;
+    max-width: min(320px, calc(100vw - 32px));
+    padding: 8px 10px;
+    border: 1px solid var(--monitor-line);
+    border-radius: 8px;
+    background: var(--monitor-surface);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.16);
+    color: var(--monitor-ink);
+    font-size: 11px;
+    line-height: 1.45;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(4px);
+    transition:
+      opacity 0.14s ease,
+      transform 0.14s ease,
+      visibility 0.14s ease;
+    visibility: hidden;
+    white-space: normal;
+  }
+
+  .quotaInfoTooltip::after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 6px;
+    width: 9px;
+    height: 9px;
+    border-right: 1px solid var(--monitor-line);
+    border-bottom: 1px solid var(--monitor-line);
+    background: inherit;
+    transform: rotate(45deg);
+  }
+
+  .quotaInfoTrigger:hover .quotaInfoTooltip,
+  .quotaInfoTrigger:focus-within .quotaInfoTooltip {
+    opacity: 1;
+    transform: translateY(0);
+    visibility: visible;
+  }
+
+  .quotaInfoTooltipRow {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 8px;
+    align-items: baseline;
+  }
+
+  .quotaInfoTooltipLabel {
+    color: var(--monitor-muted);
+    white-space: nowrap;
+  }
+
+  .quotaInfoTooltipValue {
+    color: var(--monitor-ink);
+    font-weight: 700;
+    overflow-wrap: anywhere;
   }
 
   .quotaProgressTrack {


### PR DESCRIPTION
## Summary
Move Codex quota source metadata out of inline request-monitoring panels and into compact info tooltips.
Limit Codex quota info popovers to source and fetch time, and remove cache creation/read rows from the request-monitoring token structure.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add request-monitoring quota info icons that show source and fetch time in a hover/focus tooltip.
- Reduce Codex quota-management tooltips to source and fetch time only.
- Remove cache creation/read token rows from account token-structure panels while keeping underlying stats intact.

## User Impact
Request monitoring is less visually noisy: quota provenance is available on hover, and token structure focuses on input, output, and cached totals.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only presentation change; no runtime or config changes.
- Manager Server mode: Frontend-only presentation change; no API or storage changes.
- Full Docker / native packages: No packaging or runtime behavior changes.

## Data / Security Notes
N/A. No SQLite, admin key, CPA Management Key, auth file, raw usage data, or plugin handling changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore inline quota metadata and the previous tooltip rows.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/features/monitoring/accountOverviewCardMetrics.test.ts src/features/monitoring/accountOverviewState.test.ts src/features/monitoring/MonitoringCenterPage.test.tsx src/components/quota/quotaConfigs.test.ts
npm run type-check
npm run lint
```

## Screenshots / Recordings
Not captured. Visible change is limited to quota metadata tooltip placement and token-structure row removal.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A