### PR TITLE
feat(web): simplify provider priority editing

### DIFF
--- a/apps/web/src/components/providers/ProviderTable/ProviderTable.module.scss
+++ b/apps/web/src/components/providers/ProviderTable/ProviderTable.module.scss
@@ -2,7 +2,7 @@
 @use '@/styles/mixins.scss' as *;
 
 // 类型 / 标识 / 地址 / 模型 / 优先级 / 近期请求 / 启用 / 操作
-$table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 152px minmax(188px, 0.68fr) 68px 112px;
+$table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 72px minmax(188px, 0.68fr) 68px 112px;
 
 @mixin provider-card-layout {
   @include narrow-laptop {
@@ -225,7 +225,6 @@ $table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 152px minmax(
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 5px;
   cursor: default;
 
   @include provider-card-layout {
@@ -233,20 +232,58 @@ $table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 152px minmax(
   }
 }
 
-.priorityButton:global(.btn) {
-  color: var(--text-secondary);
+.priorityValueButton {
+  max-width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0 4px;
+  border: 0;
+  border-radius: 6px;
+  outline: none;
+  background: transparent;
+  text-align: center;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 30px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  transition:
+    background $transition-fast,
+    color $transition-fast,
+    box-shadow $transition-fast;
+
+  &:hover:not(:disabled) {
+    background: var(--app-accent-soft);
+    color: var(--primary-color);
+  }
+
+  &:focus {
+    background: var(--focus-bg);
+    color: var(--focus-text);
+    box-shadow: inset 0 0 0 1px var(--focus-inset);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.62;
+  }
 }
 
 .priorityInput {
-  width: 30px;
-  min-width: 30px;
+  width: 36px;
+  min-width: 36px;
   height: 30px;
-  padding: 0 2px;
-  border: 1px solid var(--app-border);
-  border-radius: 10px;
+  padding: 0 3px;
+  border: 0;
+  border-radius: 6px;
   outline: none;
   appearance: textfield;
-  background: var(--app-surface-muted);
+  background: transparent;
   text-align: center;
   font: inherit;
   font-size: 12px;
@@ -254,19 +291,11 @@ $table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 152px minmax(
   font-variant-numeric: tabular-nums;
   color: var(--text-primary);
   transition:
-    border-color $transition-fast,
     background $transition-fast,
     color $transition-fast,
     box-shadow $transition-fast;
 
-  &:hover:not(:disabled) {
-    border-color: var(--border-hover);
-    background: var(--app-accent-soft);
-    color: var(--primary-color);
-  }
-
   &:focus {
-    border-color: var(--focus-border);
     background: var(--focus-bg);
     color: var(--focus-text);
     box-shadow: inset 0 0 0 1px var(--focus-inset);

--- a/apps/web/src/components/providers/ProviderTable/ProviderTable.test.tsx
+++ b/apps/web/src/components/providers/ProviderTable/ProviderTable.test.tsx
@@ -43,17 +43,6 @@ const clickButton = (button: ReactTestInstance) => {
   });
 };
 
-const mouseDownButton = (button: ReactTestInstance) => {
-  const onMouseDown = button.props.onMouseDown as
-    | ((event: { preventDefault: () => void }) => void)
-    | undefined;
-  if (!onMouseDown) throw new Error('Button mouse down handler not found');
-
-  act(() => {
-    onMouseDown({ preventDefault: vi.fn() });
-  });
-};
-
 const toggleSwitch = (toggle: ReactTestInstance, value: boolean) => {
   const onChange = toggle.props.onChange as ((value: boolean) => void) | undefined;
   if (!onChange) throw new Error('Toggle change handler not found');
@@ -103,6 +92,34 @@ const keyDownInput = (input: ReactTestInstance, key: string) => {
       },
     });
   });
+};
+
+const getPriorityEditTrigger = (row: ReactTestInstance) => {
+  const trigger = row
+    .findAll((node) => node.type === 'button')
+    .find(
+      (button) =>
+        button.props.type === 'button' &&
+        button.props['aria-label'] === 'ai_providers.priority_edit'
+    );
+  if (!trigger) throw new Error('Priority edit trigger not found');
+  return trigger;
+};
+
+const getPriorityInput = (row: ReactTestInstance) => {
+  const input = getPriorityInputs(row)[0];
+  if (!input) throw new Error('Priority input not found');
+  return input;
+};
+
+const getPriorityInputs = (row: ReactTestInstance) =>
+  row
+    .findAll((node) => node.type === 'input')
+    .filter((node) => node.props['aria-label'] === 'ai_providers.priority_edit');
+
+const openPriorityEditor = (renderer: ReactTestRenderer, rowIndex = 0) => {
+  clickButton(getPriorityEditTrigger(getRows(renderer)[rowIndex]));
+  return getPriorityInput(getRows(renderer)[rowIndex]);
 };
 
 describe('ProviderTable', () => {
@@ -208,48 +225,19 @@ describe('ProviderTable', () => {
     expect(lastToggle.props.checked).toBe(false);
   });
 
-  it('adjusts priority inline without opening row detail', () => {
+  it('shows priority as an edit trigger before entering edit mode', () => {
     const rows = filterAndSortProviderRows(
       buildProviderRows({ ...emptyInput, codex: codexConfigs })
     );
-    const onPriorityChange = vi.fn();
-    const onShowDetail = vi.fn();
-    const renderer = renderTable(rows, { onPriorityChange, onShowDetail });
+    const renderer = renderTable(rows);
 
     const firstRow = getRows(renderer)[0];
-    const increaseButton = firstRow
-      .findAllByType(Button)
-      .find((button) => button.props['aria-label'] === 'ai_providers.priority_increase');
-    expect(increaseButton).toBeTruthy();
+    const priorityTrigger = getPriorityEditTrigger(firstRow);
+    expect(getText(priorityTrigger)).toBe('9');
+    expect(getPriorityInputs(firstRow)).toHaveLength(0);
 
-    clickButton(increaseButton!);
-
-    expect(onPriorityChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ kind: 'codex', originalIndex: 2 }),
-      10
-    );
-    expect(onShowDetail).not.toHaveBeenCalled();
-  });
-
-  it('decreases priority inline without clamping existing priority semantics', () => {
-    const rows = filterAndSortProviderRows(
-      buildProviderRows({ ...emptyInput, codex: codexConfigs })
-    );
-    const onPriorityChange = vi.fn();
-    const renderer = renderTable(rows, { onPriorityChange });
-
-    const firstRow = getRows(renderer)[0];
-    const decreaseButton = firstRow
-      .findAllByType(Button)
-      .find((button) => button.props['aria-label'] === 'ai_providers.priority_decrease');
-    expect(decreaseButton).toBeTruthy();
-
-    clickButton(decreaseButton!);
-
-    expect(onPriorityChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ kind: 'codex', originalIndex: 2 }),
-      8
-    );
+    const priorityInput = openPriorityEditor(renderer);
+    expect(priorityInput.props.value).toBe('9');
   });
 
   it('commits a direct priority edit on blur without opening row detail', () => {
@@ -260,10 +248,7 @@ describe('ProviderTable', () => {
     const onShowDetail = vi.fn();
     const renderer = renderTable(rows, { onPriorityChange, onShowDetail });
 
-    const firstRow = getRows(renderer)[0];
-    const priorityInput = firstRow.findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
+    const priorityInput = openPriorityEditor(renderer);
 
     changeInput(priorityInput, '42');
     blurInput(priorityInput);
@@ -282,9 +267,7 @@ describe('ProviderTable', () => {
     const onPriorityChange = vi.fn();
     const renderer = renderTable(rows, { onPriorityChange });
 
-    const priorityInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
+    const priorityInput = openPriorityEditor(renderer);
 
     changeInput(priorityInput, '12');
     keyDownInput(priorityInput, 'Enter');
@@ -296,34 +279,6 @@ describe('ProviderTable', () => {
     );
   });
 
-  it('steps from an uncommitted direct priority draft without double submitting', () => {
-    const rows = filterAndSortProviderRows(
-      buildProviderRows({ ...emptyInput, codex: codexConfigs })
-    );
-    const onPriorityChange = vi.fn();
-    const renderer = renderTable(rows, { onPriorityChange });
-
-    const firstRow = getRows(renderer)[0];
-    const priorityInput = firstRow.findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
-    const increaseButton = firstRow
-      .findAllByType(Button)
-      .find((button) => button.props['aria-label'] === 'ai_providers.priority_increase');
-    expect(increaseButton).toBeTruthy();
-
-    changeInput(priorityInput, '12');
-    mouseDownButton(increaseButton!);
-    blurInput(priorityInput);
-    clickButton(increaseButton!);
-
-    expect(onPriorityChange).toHaveBeenCalledTimes(1);
-    expect(onPriorityChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ kind: 'codex', originalIndex: 2 }),
-      13
-    );
-  });
-
   it('cancels a direct priority edit with Escape without committing on blur', () => {
     const rows = filterAndSortProviderRows(
       buildProviderRows({ ...emptyInput, codex: codexConfigs })
@@ -331,17 +286,13 @@ describe('ProviderTable', () => {
     const onPriorityChange = vi.fn();
     const renderer = renderTable(rows, { onPriorityChange });
 
-    const priorityInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
+    const priorityInput = openPriorityEditor(renderer);
 
     changeInput(priorityInput, '12');
     keyDownInput(priorityInput, 'Escape');
 
-    const updatedInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
-    expect(updatedInput.props.value).toBe('9');
+    const updatedTrigger = getPriorityEditTrigger(getRows(renderer)[0]);
+    expect(getText(updatedTrigger)).toBe('9');
     expect(onPriorityChange).not.toHaveBeenCalled();
   });
 
@@ -352,23 +303,18 @@ describe('ProviderTable', () => {
     const onPriorityChange = vi.fn();
     const renderer = renderTable(rows, { onPriorityChange });
 
-    let priorityInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
+    let priorityInput = openPriorityEditor(renderer);
 
     changeInput(priorityInput, '');
     blurInput(priorityInput);
-    priorityInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
-    expect(priorityInput.props.value).toBe('9');
+    let priorityTrigger = getPriorityEditTrigger(getRows(renderer)[0]);
+    expect(getText(priorityTrigger)).toBe('9');
 
+    priorityInput = openPriorityEditor(renderer);
     changeInput(priorityInput, 'not-a-number');
     blurInput(priorityInput);
-    priorityInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
-    expect(priorityInput.props.value).toBe('9');
+    priorityTrigger = getPriorityEditTrigger(getRows(renderer)[0]);
+    expect(getText(priorityTrigger)).toBe('9');
     expect(onPriorityChange).not.toHaveBeenCalled();
   });
 
@@ -379,9 +325,7 @@ describe('ProviderTable', () => {
     const onPriorityChange = vi.fn();
     const renderer = renderTable(rows, { onPriorityChange });
 
-    const priorityInput = getRows(renderer)[0].findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
+    const priorityInput = openPriorityEditor(renderer);
 
     changeInput(priorityInput, '9');
     blurInput(priorityInput);
@@ -396,20 +340,10 @@ describe('ProviderTable', () => {
     const renderer = renderTable(rows, {}, { actionsDisabled: true });
 
     const firstRow = getRows(renderer)[0];
-    const priorityButtons = firstRow
-      .findAllByType(Button)
-      .filter((button) =>
-        ['ai_providers.priority_decrease', 'ai_providers.priority_increase'].includes(
-          button.props['aria-label']
-        )
-      );
-    const priorityInput = firstRow.findByProps({
-      'aria-label': 'ai_providers.priority_edit',
-    });
+    const priorityTrigger = getPriorityEditTrigger(firstRow);
 
-    expect(priorityButtons).toHaveLength(2);
-    expect(priorityButtons.every((button) => button.props.disabled)).toBe(true);
-    expect(priorityInput.props.disabled).toBe(true);
+    expect(priorityTrigger.props.disabled).toBe(true);
+    expect(getPriorityInputs(firstRow)).toHaveLength(0);
   });
 
   it('renders the provided empty state when there are no rows', () => {

--- a/apps/web/src/components/providers/ProviderTable/ProviderTable.tsx
+++ b/apps/web/src/components/providers/ProviderTable/ProviderTable.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useRef,
   useState,
   type ChangeEvent,
@@ -11,8 +12,6 @@ import { Button } from '@/components/ui/Button';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import {
   IconCheck,
-  IconChevronDown,
-  IconChevronUp,
   IconEye,
   IconPencil,
   IconTrash2,
@@ -47,8 +46,6 @@ const priorityToDraft = (priority: number | undefined) =>
 interface PriorityControlProps {
   row: ProviderRow;
   disabled: boolean;
-  decreaseLabel: string;
-  increaseLabel: string;
   editLabel: string;
   onPriorityChange: (row: ProviderRow, priority: number) => void;
 }
@@ -56,22 +53,21 @@ interface PriorityControlProps {
 function PriorityControl({
   row,
   disabled,
-  decreaseLabel,
-  increaseLabel,
   editLabel,
   onPriorityChange,
 }: PriorityControlProps) {
   const [draft, setDraft] = useState(() => priorityToDraft(row.priority));
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const skipNextBlurCommitRef = useRef(false);
   const currentPriority = Number.isFinite(row.priority) ? Math.trunc(row.priority ?? 0) : 0;
+  const displayPriority = priorityToDraft(row.priority) || '—';
 
-  const getDraftPriority = () => {
-    const trimmed = draft.trim();
-    if (!trimmed) return currentPriority;
-
-    const parsed = Number(trimmed);
-    return Number.isFinite(parsed) ? Math.trunc(parsed) : currentPriority;
-  };
+  useEffect(() => {
+    if (!isEditing) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [isEditing]);
 
   const commitDraft = () => {
     if (skipNextBlurCommitRef.current) {
@@ -82,33 +78,30 @@ function PriorityControl({
     const trimmed = draft.trim();
     if (!trimmed) {
       setDraft(priorityToDraft(row.priority));
+      setIsEditing(false);
       return;
     }
 
     const parsed = Number(trimmed);
     if (!Number.isFinite(parsed)) {
       setDraft(priorityToDraft(row.priority));
+      setIsEditing(false);
       return;
     }
 
     const nextPriority = Math.trunc(parsed);
     setDraft(String(nextPriority));
+    setIsEditing(false);
     if (nextPriority !== currentPriority || row.priority === undefined) {
       onPriorityChange(row, nextPriority);
     }
   };
 
-  const handleStepMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    skipNextBlurCommitRef.current = true;
-  };
-
-  const stepPriority = (delta: number) => {
-    const nextPriority = getDraftPriority() + delta;
-    setDraft(String(nextPriority));
-    if (nextPriority !== currentPriority || row.priority === undefined) {
-      onPriorityChange(row, nextPriority);
-    }
+  const startEditing = () => {
+    if (disabled) return;
+    skipNextBlurCommitRef.current = false;
+    setDraft(priorityToDraft(row.priority));
+    setIsEditing(true);
   };
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -125,52 +118,41 @@ function PriorityControl({
       event.preventDefault();
       skipNextBlurCommitRef.current = true;
       setDraft(priorityToDraft(row.priority));
+      setIsEditing(false);
       event.currentTarget.blur();
     }
   };
 
   return (
     <div className={styles.priorityControl} onClick={stopPropagation}>
-      <Button
-        variant="secondary"
-        size="xs"
-        iconOnly
-        className={styles.priorityButton}
-        onMouseDown={handleStepMouseDown}
-        onClick={() => stepPriority(-1)}
-        disabled={disabled}
-        aria-label={decreaseLabel}
-        title={decreaseLabel}
-      >
-        <IconChevronDown size={14} />
-      </Button>
-      <input
-        className={styles.priorityInput}
-        type="number"
-        step={1}
-        inputMode="numeric"
-        value={draft}
-        placeholder="—"
-        disabled={disabled}
-        aria-label={editLabel}
-        title={editLabel}
-        onChange={handleInputChange}
-        onBlur={commitDraft}
-        onKeyDown={handleInputKeyDown}
-      />
-      <Button
-        variant="secondary"
-        size="xs"
-        iconOnly
-        className={styles.priorityButton}
-        onMouseDown={handleStepMouseDown}
-        onClick={() => stepPriority(1)}
-        disabled={disabled}
-        aria-label={increaseLabel}
-        title={increaseLabel}
-      >
-        <IconChevronUp size={14} />
-      </Button>
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          className={styles.priorityInput}
+          type="number"
+          step={1}
+          inputMode="numeric"
+          value={draft}
+          placeholder="—"
+          disabled={disabled}
+          aria-label={editLabel}
+          title={editLabel}
+          onChange={handleInputChange}
+          onBlur={commitDraft}
+          onKeyDown={handleInputKeyDown}
+        />
+      ) : (
+        <button
+          type="button"
+          className={styles.priorityValueButton}
+          disabled={disabled}
+          aria-label={editLabel}
+          title={editLabel}
+          onClick={startEditing}
+        >
+          {displayPriority}
+        </button>
+      )}
     </div>
   );
 }
@@ -284,8 +266,6 @@ export function ProviderTable({
                 key={`${row.key}:${row.priority ?? 'unset'}`}
                 row={row}
                 disabled={actionsDisabled}
-                decreaseLabel={t('ai_providers.priority_decrease')}
-                increaseLabel={t('ai_providers.priority_increase')}
                 editLabel={t('ai_providers.priority_edit')}
                 onPriorityChange={onPriorityChange}
               />


### PR DESCRIPTION
## Summary
Simplify the AI provider priority control in the frontend panel.
The priority column now uses a compact click-to-edit value display instead of inline step controls, reducing visual noise and preventing large values from crowding the table.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Replace the provider priority inline control with a click-to-edit value trigger.
- Remove the priority increase/decrease buttons from provider rows.
- Adjust priority column styling so large values stay constrained without a bordered pill.

## User Impact
Users will see a cleaner AI provider priority column. Priority values remain editable by clicking the number and submitting with Enter or blur.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only UI change; no mode-specific runtime changes.
- Manager Server mode: No backend behavior or API contract changes.
- Full Docker / native packages: No packaging or runtime changes.

## Data / Security Notes
N/A. This change does not touch SQLite data, admin keys, CPA Management Keys, auth files, logs, raw usage data, or plugins.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this commit to restore the previous inline priority controls.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/components/providers/ProviderTable/ProviderTable.test.tsx
npm run type-check
npm run lint
npm run test
```

## Screenshots / Recordings
N/A. The change is a compact control styling update; no new screenshot was captured in this PR.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A