### PR TITLE
docs(release): add v1.10.4 release notes

### DIFF
--- a/docs/release-notes/v1.10.4-en.md
+++ b/docs/release-notes/v1.10.4-en.md
@@ -1,0 +1,46 @@
+# CPA Manager Plus v1.10.4
+
+> 11 commits · 30 files changed · +2743 / -177
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.4/docs/release-notes/v1.10.4-zh.md)
+
+## Overview
+
+This release focuses on account-history statistics and provider priority management. Manager Server adds SQLite-backed sidecar rollups for low-latency account summary reads, while the frontend moves provider priority changes into direct table editing and continues polishing monitoring quota details and Chinese filter copy.
+
+## Highlights
+
+### Features
+
+- Add `usage_rollup_checkpoints` and `usage_account_model_rollups` SQLite sidecar rollup tables, repository wiring, and Store access so Manager Server can derive account/model history totals from authoritative `usage_events` data (`manager-server/monitoring`).
+- Add the `/v0/management/monitoring/account-history` API with up to 200 account targets, optional catch-up, checkpoint/pending state, request totals, success/failure counts, token totals, cost, success rate, and first/last seen times (`manager-server/monitoring`).
+- Add a background account-history rollup worker that advances checkpoints on startup, incoming usage events, and periodic checks, avoiding synchronous raw-event scans for account summary reads (`manager-server/worker`).
+- Add inline priority editing to the Provider table, covering Gemini, OpenAI-compatible, Codex, Claude, and Vertex providers while reusing the existing save, optimistic update, rollback, and cache refresh paths (`web/providers`).
+- Simplify provider priority cells into lightweight click-to-edit value displays, removing inline step buttons and extra border chrome while constraining large values in the table column (`web/providers`).
+
+### Fixes
+
+- Move Codex quota source and fetch/observed time metadata into compact info tooltips, reducing inline noise in Monitoring account cards and the Quota panel while preserving quota refresh and header merge behavior (`web/monitoring`).
+- Keep the request-monitoring token structure table focused on input, output, and cached token rows by removing separate cache creation/read rows to match the current monitoring layout (`web/monitoring`).
+- Restore contextual Simplified and Traditional Chinese compact monitoring filter labels so multiple filters no longer collapse to identical all labels (`web/i18n`).
+
+### Tests
+
+- Add repository, controller, service, catch-up, read, and benchmark coverage for account-history rollups (`manager-server/tests`).
+- Add frontend coverage for Provider table inline priority editing, Enter/Escape/blur commits, disabled state, and rollback behavior (`web/tests`).
+- Add regression coverage for monitoring quota tooltips, token structure, and locale labels (`web/tests`).
+
+## Upgrade Notes
+
+- This release automatically creates `usage_rollup_checkpoints` and `usage_account_model_rollups` in the Manager Server SQLite database. No manual migration is required, but keep the normal SQLite files plus `data.key` backup before upgrading.
+- `usage_events` remains the authoritative data source. The new rollup tables are a rebuildable read-acceleration layer. After the first startup on an existing database, background catch-up may briefly show `pending` while account history data is filled in batches.
+- The account-history API accepts up to 200 account targets per request. External integrations that call it directly should batch larger target sets.
+- This release includes visible provider priority editing and monitoring quota tooltip changes; consider adding screenshots of the provider table and monitoring quota tooltips to the GitHub Release.
+
+## Acknowledgements
+
+- [@bc19sam-afk](https://github.com/bc19sam-afk) - Contributed inline priority controls for the Provider table.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.3...v1.10.4

--- a/docs/release-notes/v1.10.4-zh.md
+++ b/docs/release-notes/v1.10.4-zh.md
@@ -1,0 +1,46 @@
+# CPA Manager Plus v1.10.4
+
+> 11 commits · 30 files changed · +2743 / -177
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.4/docs/release-notes/v1.10.4-en.md)
+
+## Overview
+
+本次发布聚焦账号历史统计与 provider 优先级管理。Manager Server 新增基于 SQLite 侧边汇总的账号历史统计能力，为账号级摘要读取提供低延迟数据源；前端则把 provider 优先级调整收敛到表格内直接编辑，并继续打磨监控 quota 信息与中文筛选文案。
+
+## Highlights
+
+### Features
+
+- Manager Server 新增 `usage_rollup_checkpoints` 和 `usage_account_model_rollups` SQLite 侧边汇总表、repository 与 Store 接入，用 `usage_events` 作为权威来源累计账号/模型历史请求、token、成本与成功率统计（`manager-server/monitoring`）。
+- 新增 `/v0/management/monitoring/account-history` API，支持最多 200 个账号目标、可选 catch-up，并返回 checkpoint/pending 状态、总请求数、成功/失败次数、总 token、成本、成功率和首末次出现时间（`manager-server/monitoring`）。
+- 新增账号历史汇总后台 worker，在服务启动、使用事件进入和定时检查时推进汇总 checkpoint，避免账号摘要读取同步扫描原始事件（`manager-server/worker`）。
+- Provider 表格新增 inline 优先级编辑；Gemini、OpenAI-compatible、Codex、Claude、Vertex provider 都可以直接在表格里修改 priority，并复用已有保存、乐观更新、失败回滚和缓存刷新路径（`web/providers`）。
+- Provider priority 单元格改为更轻量的点击编辑值展示，移除表格内 step 按钮和多余边框，并约束大数值显示，降低列表视觉噪音（`web/providers`）。
+
+### Fixes
+
+- Codex quota 来源、抓取/观测时间移动到紧凑 info tooltip，减少监控账号卡和 Quota 面板的内联元数据噪音，同时保留 quota refresh 与 header merge 行为（`web/monitoring`）。
+- 请求监控 token structure 表格保留 input、output、cached 三类主 token 行，移除 cache creation/read 独立行，让展示与当前请求监控布局一致（`web/monitoring`）。
+- 请求监控 compact 筛选恢复简体中文和繁体中文的上下文标签，避免多个筛选项都显示为无上下文的“全部”（`web/i18n`）。
+
+### Tests
+
+- 补充账号历史 rollup repository、controller、service、catch-up 与读取 benchmark 覆盖（`manager-server/tests`）。
+- 补充 Provider 表格 inline priority 编辑、Enter/Escape/blur 提交、禁用态和失败回滚相关前端覆盖（`web/tests`）。
+- 补充 monitoring quota tooltip、token structure 和 locale label 回归覆盖（`web/tests`）。
+
+## Upgrade Notes
+
+- 本次会在 Manager Server SQLite 数据库中自动创建 `usage_rollup_checkpoints` 和 `usage_account_model_rollups`。无需手工迁移，但建议升级前按惯例备份 SQLite 文件与 `data.key`。
+- `usage_events` 仍是权威数据源；新增 rollup 表是可重建的读取加速层。升级后首次启动会后台 catch up 历史事件，大库可能短暂显示 `pending`，账号历史数据会逐批补齐。
+- 账号历史 API 单次最多接收 200 个账号目标；如果外部集成直接调用该 API，需要按批请求。
+- 本次包含 provider priority 编辑和 monitoring quota tooltip 的可视变化，建议在 GitHub Release 补充 provider table 与 monitoring quota 截图。
+
+## Acknowledgements
+
+- [@bc19sam-afk](https://github.com/bc19sam-afk) - 贡献 provider 表格 inline priority controls。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.3...v1.10.4


### PR DESCRIPTION
## Summary
Add curated release notes for CPA Manager Plus v1.10.4 in Chinese and English.
This prepares the release branch so the tag workflow can publish the curated GitHub Release body.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add `docs/release-notes/v1.10.4-zh.md` as the authored release notes.
- Add `docs/release-notes/v1.10.4-en.md` as the English mirror translation.
- Use tag-pinned GitHub blob URLs for the release-note language switch links.

## User Impact
No user-facing behavior change from this PR itself. The release notes describe the v1.10.4 changes for account-history rollups, provider priority editing, monitoring quota tooltip cleanup, and monitoring filter label fixes.

## Compatibility / Runtime Notes
- CPA panel mode: Release notes only; described frontend behavior applies once the v1.10.4 build is released.
- Manager Server mode: Release notes only; notes call out the automatic SQLite sidecar rollup migration and initial background catch-up behavior.
- Full Docker / native packages: Release notes only; the tag workflow will package v1.10.4 after merge and tagging.

## Data / Security Notes
This PR only adds release notes and does not include secrets, admin keys, CPA Management Keys, SQLite data, raw usage data, or generated runtime files. The notes disclose that v1.10.4 automatically creates rebuildable SQLite sidecar rollup tables while keeping `usage_events` authoritative.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR or remove the two `docs/release-notes/v1.10.4-*` files before pushing the `v1.10.4` tag.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
git status --porcelain -> clean
git rev-list --left-right --count main...origin/main -> 0 0
local main and origin/main -> 50616e28310e1a5592e1aa8e6727de21287aef7a
latest previous tag -> v1.10.3
planned tag v1.10.4 -> absent locally and on GitHub
remote release/v1.10.4 -> absent before branch creation
release range v1.10.3..HEAD -> 11 commits, 30 files changed, +2743 / -177
language links use tag-pinned GitHub blob URLs under docs/release-notes/
```

## Screenshots / Recordings
N/A, release-notes-only PR.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
N/A
