### PR TITLE
fix(providers): keep recent status inside provider rows

### DIFF
--- a/apps/web/src/components/providers/ProviderTable/ProviderTable.module.scss
+++ b/apps/web/src/components/providers/ProviderTable/ProviderTable.module.scss
@@ -2,7 +2,7 @@
 @use '@/styles/mixins.scss' as *;
 
 // 类型 / 标识 / 地址 / 模型 / 优先级 / 近期请求 / 启用 / 操作
-$table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 72px minmax(188px, 0.68fr) 68px 112px;
+$table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 72px minmax(220px, 0.82fr) 68px 112px;
 
 @mixin provider-card-layout {
   @include narrow-laptop {
@@ -363,14 +363,28 @@ $table-columns: 92px minmax(132px, 0.72fr) minmax(180px, 1fr) 96px 72px minmax(1
 
 // 中和 ProviderStatusBar 默认样式中的纵向留白，保证单行对齐
 .recentBarWrap {
-  flex: 1;
-  min-width: 150px;
+  flex: 1 1 88px;
+  min-width: 0;
   max-width: 220px;
 
   > div {
     margin-top: 0;
     padding: 0;
+    min-width: 0;
+    width: 100%;
     max-width: 100%;
+  }
+
+  > div > div:first-child {
+    min-width: 0;
+  }
+
+  > div > div:first-child > div {
+    min-width: 0;
+  }
+
+  > div > span:last-child {
+    flex-shrink: 0;
   }
 
   @include provider-card-layout {


### PR DESCRIPTION
## Summary
Fix a provider table layout regression where the AI Providers recent-request status bar could extend into the Enable column after the priority column was simplified. The recent-request column now keeps the status bar and success-rate badge inside its own grid cell while preserving the compact click-to-edit priority control.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Give the recent-request column a little more table width after the priority column was narrowed.
- Allow the embedded ProviderStatusBar blocks to shrink below their intrinsic width by resetting flex/grid min-width: 0 down the containment chain.
- Constrain the status bar itself without clipping ProviderStatusBar hover/touch tooltips.

## User Impact
Users with dense provider lists and non-empty recent-request stats no longer see the percentage badge or status bar visually overlap the Enable column.

## Compatibility / Runtime Notes
- CPA panel mode: frontend-only style fix; no config or API change.
- Manager Server mode: frontend-only style fix; no backend contract change.
- Full Docker / native packages: no packaging or runtime change.

## Data / Security Notes
N/A. This does not touch SQLite, admin keys, CPA Management Keys, auth files, logs, raw usage data, or plugins.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this commit to restore the previous provider-table recent-request column sizing.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/components/providers/ProviderTable/ProviderTable.test.tsx
npm --workspace apps/web run type-check
npm --workspace apps/web run lint -- --max-warnings=0
npm --workspace apps/web run build
git diff --check

Playwright/Chrome mock-data visual checks on #/ai-providers:
- 1522x858 desktop, 1280x720, 820x1180, 390x844
- no console warnings/errors
- no page horizontal overflow
- recent-request cells and children do not intersect the Enable column/toggle
- ProviderStatusBar tooltip still renders above the recent-request cell and is not clipped
```

## Screenshots / Recordings
Dense provider table with recent-request status bars after the fix:

![AI Providers recent-request status stays inside the row](https://raw.githubusercontent.com/bc19sam-afk/CPA-Manager-Plus/codex/pr-assets/.github/pr-screenshots/pr-306-provider-recent-status-overlap.png)

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Refs #304