### PR TITLE
docs(release): add v1.10.5 release notes

### DIFF
--- a/docs/release-notes/v1.10.5-en.md
+++ b/docs/release-notes/v1.10.5-en.md
@@ -1,0 +1,41 @@
+# CPA Manager Plus v1.10.5
+
+> 6 commits · 18 files changed · +1512 / -97
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.5/docs/release-notes/v1.10.5-zh.md)
+
+## Overview
+
+This release focuses on frontend quota visibility and plugin install control. Quota views and monitoring account rows now show xAI/Grok weekly quota summaries, the Plugin Store can install a selected GitHub Release or manual tag, and compact provider/quota status layouts are tightened to avoid overlap and wrapping.
+
+## Highlights
+
+### Features
+
+- Fetch xAI/Grok weekly quota data alongside monthly billing and merge both responses into one quota summary; quota cards and monitoring account rows can now show weekly limits and product usage (`web/quota`).
+- Add plugin install version modes so users can choose latest, select from GitHub Releases, or enter a manual tag, with prerelease toggling, release metadata caching, and localized UI copy (`web/plugins`).
+
+### Fixes
+
+- Convert compact quota status bars to fixed grid tracks so the block strip and rate badge keep stable widths in auth-file and provider cards, reducing wrapping and crowding in narrow layouts (`web/quota`).
+- Add width and min-width containment to the Provider table recent-status column so the status bar and percentage badge no longer extend into the Enable column or toggle (`web/providers`).
+
+### Tests
+
+- Add frontend regression coverage for xAI weekly quota payloads, quota request merging, and monitoring account quota windows (`web/tests`).
+- Add helper coverage for plugin release slug parsing, release response normalization, and version-selection behavior (`web/tests`).
+
+## Upgrade Notes
+
+- This release has no backend, database, configuration, or runtime migration.
+- xAI/Grok weekly quota display depends on the upstream billing payload. If weekly limits or product usage are absent, the existing monthly quota summary continues to render through the previous path.
+- The Plugin Store release list reads GitHub Releases through the existing API helper. Repository access restrictions or GitHub rate limits can affect release-list availability, while latest and manual tag installs remain available paths.
+- This release includes visible plugin version picker, xAI/Grok weekly quota, and provider recent-status changes; consider adding screenshots for those areas to the GitHub Release.
+
+## Acknowledgements
+
+- [@bc19sam-afk](https://github.com/bc19sam-afk) - Contributed the Provider table recent-status overlap fix.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.4...v1.10.5

--- a/docs/release-notes/v1.10.5-zh.md
+++ b/docs/release-notes/v1.10.5-zh.md
@@ -1,0 +1,41 @@
+# CPA Manager Plus v1.10.5
+
+> 6 commits · 18 files changed · +1512 / -97
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.10.5/docs/release-notes/v1.10.5-en.md)
+
+## Overview
+
+本次发布聚焦前端配额可视化与插件安装体验。Quota 视图和监控账号行新增 xAI/Grok 周额度摘要，插件商店支持按 GitHub Release 或手动 tag 安装版本，同时修复 provider 与 quota 状态条在紧凑布局下的重叠和换行问题。
+
+## Highlights
+
+### Features
+
+- xAI/Grok quota 请求现在会同时获取周额度与月度账单数据，并合并为统一的 quota summary；Quota 卡片和监控账号行会展示周限制与产品用量（`web/quota`）。
+- 插件商店新增安装版本模式，可在 latest、GitHub Release 列表和手动 tag 之间选择，并支持 prerelease 切换、release 元数据缓存和多语言文案（`web/plugins`）。
+
+### Fixes
+
+- 紧凑 quota 状态条改为固定 grid 轨道布局，让 block strip 和 rate badge 在认证文件与 provider 卡片中保持稳定宽度，减少窄卡片中的换行和拥挤（`web/quota`）。
+- Provider 表格 recent status 列增加宽度与 min-width 约束，避免状态条或百分比 badge 伸入 Enable 列和开关区域（`web/providers`）。
+
+### Tests
+
+- 补充 xAI 周额度 payload、quota 请求合并和监控账号 quota window 的前端回归覆盖（`web/tests`）。
+- 补充插件 release 版本 helper 的 slug 解析、release 响应标准化和版本选择逻辑覆盖（`web/tests`）。
+
+## Upgrade Notes
+
+- 本次没有后端、数据库、配置或运行时迁移。
+- xAI/Grok 周额度展示依赖上游 billing payload；如果上游未返回周额度或产品用量，现有月度 quota 摘要仍按原路径展示。
+- 插件 Release 列表通过现有 API helper 读取 GitHub Releases；仓库访问限制或 GitHub rate limit 可能影响 Release 列表可用性，latest 和手动 tag 仍可作为安装路径。
+- 本次包含插件版本选择、xAI/Grok 周额度和 provider recent status 的可视变化，建议在 GitHub Release 补充相关截图。
+
+## Acknowledgements
+
+- [@bc19sam-afk](https://github.com/bc19sam-afk) - 贡献 Provider 表格 recent status 重叠修复。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.4...v1.10.5


### PR DESCRIPTION
## Summary
Add curated release notes for CPA Manager Plus v1.10.5 in Chinese and English.
This prepares the release branch so the tag workflow can publish the curated GitHub Release body.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add `docs/release-notes/v1.10.5-zh.md` as the authored release notes.
- Add `docs/release-notes/v1.10.5-en.md` as the English mirror translation.
- Use tag-pinned GitHub blob URLs for the release-note language switch links.

## User Impact
No user-facing behavior change from this PR itself. The release notes describe the v1.10.5 changes for xAI/Grok weekly quota summaries, plugin release version selection, compact quota layout stabilization, and Provider table recent-status overlap fixes.

## Compatibility / Runtime Notes
- CPA panel mode: Release notes only; described frontend quota and plugin behavior applies once the v1.10.5 build is released.
- Manager Server mode: Release notes only; no backend API, config, or storage change is introduced by this PR.
- Full Docker / native packages: Release notes only; the tag workflow will package v1.10.5 after merge and tagging.

## Data / Security Notes
This PR only adds release notes and does not include secrets, admin keys, CPA Management Keys, SQLite data, raw usage data, generated runtime files, or local config. The notes call out that plugin release metadata is fetched through the existing API helper.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert this PR or remove the two `docs/release-notes/v1.10.5-*` files before pushing the `v1.10.5` tag.

## Verification
- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
git status --porcelain -> clean
git rev-list --left-right --count main...origin/main -> 0 0
local main and origin/main -> 3c69b7fc375ab36ef6b1cf1cc4488a87989e54e2
latest previous tag -> v1.10.4
planned tag v1.10.5 -> absent locally and on GitHub
remote release/v1.10.5 -> absent before branch creation
release range v1.10.4..HEAD -> 6 commits, 18 files changed, +1512 / -97
language links use tag-pinned GitHub blob URLs under docs/release-notes/
```

## Screenshots / Recordings
N/A, release-notes-only PR.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
Refs #308, #306, #309
