### PR TITLE
fix(web): prevent Codex header quota cross-workspace matches

### DIFF
--- a/apps/web/src/utils/usageHeaderSnapshots.test.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.test.ts
@@ -260,6 +260,34 @@ describe('buildObservedCodexQuotaFromHeaderSnapshot', () => {
     expect(getHighConfidenceUsageHeaderSnapshotForAuthFile(lookup, missingIndexFile)).toBeUndefined();
   });
 
+  it('does not use same-account header snapshots as high-confidence auth-file quota evidence', () => {
+    const lookup = buildUsageHeaderSnapshotLookup([
+      {
+        event_hash: 'free-workspace-header',
+        timestamp_ms: 1_700_000_000_200,
+        auth_file_snapshot: 'codex-free.json',
+        auth_index: 'free',
+        account_snapshot: 'user@example.com',
+        response_metadata: {
+          quota: {
+            plan_type: 'free',
+          },
+        },
+      },
+    ]);
+    const teamFile = {
+      name: 'codex-team.json',
+      provider: 'codex',
+      authIndex: 'team',
+      account: 'user@example.com',
+    } as AuthFileItem;
+
+    expect(getUsageHeaderSnapshotForAuthFile(lookup, teamFile)?.event_hash).toBe(
+      'free-workspace-header'
+    );
+    expect(getHighConfidenceUsageHeaderSnapshotForAuthFile(lookup, teamFile)).toBeUndefined();
+  });
+
   it('does not use active limit as the plan type', () => {
     const snapshot: UsageHeaderSnapshot = {
       event_hash: 'active-limit-only',

--- a/apps/web/src/utils/usageHeaderSnapshots.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.ts
@@ -173,7 +173,7 @@ export const getUsageHeaderSnapshotMatchForIdentity = (
   const candidates = [
     matchOf(lookup.byFileAuthIndex.get(fileAuthKey(fileName, authIndex ?? '')), 'high'),
     matchOf(hasAuthIndex ? undefined : lookup.byFileName.get(normalizeKey(fileName)), 'high'),
-    matchOf(lookup.byAccount.get(normalizeKey(account)), 'high'),
+    matchOf(lookup.byAccount.get(normalizeKey(account)), 'low'),
     matchOf(lookup.byAuthIndex.get(normalizeKey(authIndex)), 'low'),
     matchOf(lookup.bySource.get(normalizeKey(source)), 'low'),
   ];


### PR DESCRIPTION
## Summary
Fix Codex usage header snapshot matching so same-email snapshots do not drive quota display for different auth files or workspaces.
This keeps account-based matches available as low-confidence diagnostics while preventing misleading quota UI.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Lower same-account usage header snapshot matches from high to low confidence.
- Keep auth-file quota display tied to high-confidence identity matches.
- Add a regression test for same-email free/team Codex workspaces.

## User Impact
Users with the same email across multiple Codex workspaces or plans will no longer see one workspace's recent usage Header quota displayed on another auth file.

## Compatibility / Runtime Notes
- CPA panel mode: Frontend-only display logic change; no config or API change.
- Manager Server mode: Manager APIs and stored usage data are unchanged.
- Full Docker / native packages: No runtime behavior change beyond the bundled panel UI.

## Data / Security Notes
N/A. No SQLite schema, admin key, CPA Management Key, auth file, log, raw usage data, or plugin changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore the previous account-based high-confidence header matching behavior.

## Verification
- [x] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/utils/usageHeaderSnapshots.test.ts
npm --workspace apps/web run test -- src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx src/features/authFiles/model/authFilesPageModel.test.ts
npm --workspace apps/web run type-check
```

## Screenshots / Recordings
N/A. Behavior is covered by regression tests and no visible layout changed.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #311