### PR TITLE
perf: reduce monitoring and usage memory pressure

### DIFF
--- a/apps/docs/en/operations/manager-server.md
+++ b/apps/docs/en/operations/manager-server.md
@@ -178,6 +178,7 @@ Saving CPAMP configuration does not rewrite the full CPA `config.yaml`.
 |---|---|---|
 | `CPA_MANAGER_CONFIG` | empty | Optional config file path. Native packages default to `config.json` next to the binary. |
 | `HTTP_ADDR` | `0.0.0.0:18317` | Manager Server listen address. |
+| `CPA_MANAGER_PPROF_ADDR` | empty | Optional Go pprof listen address; only `localhost`, `127.0.0.1`, or `::1` is accepted. |
 | `USAGE_DATA_DIR` | Docker: `/data`; native: `./data` | Base data directory. |
 | `USAGE_DB_PATH` | Docker: `/data/usage.sqlite`; native: `./data/usage.sqlite` | SQLite database path. |
 | `CPA_MANAGER_ADMIN_KEY` | empty | Optional admin key. |
@@ -207,6 +208,15 @@ Startup precedence:
 environment variables > config.json > defaults
 ```
 
+Temporarily enable the loopback-only pprof server when diagnosing CPU, heap, or goroutine behavior:
+
+```bash
+CPA_MANAGER_PPROF_ADDR=127.0.0.1:6060 ./cpa-manager-plus
+go tool pprof http://127.0.0.1:6060/debug/pprof/heap
+```
+
+The equivalent config-file field is `pprofAddr`. The service is disabled by default and should not be exposed through Docker port mappings or a reverse proxy.
+
 When `USAGE_QUOTA_COOLDOWN_ENABLED`, `USAGE_ACCOUNT_ACTIONS_ENABLED`, or `USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE` is set through the environment, the matching panel switch is shown as environment-sourced and locked. Remove the environment variable and restart Manager Server if you want the setting to be editable from the panel.
 
 ## Runtime Endpoints
@@ -225,6 +235,7 @@ When `USAGE_QUOTA_COOLDOWN_ENABLED`, `USAGE_ACCOUNT_ACTIONS_ENABLED`, or `USAGE_
 | `GET /v0/management/usage` | Compatible usage data. |
 | `GET /v0/management/usage/export` | Export JSONL usage events. |
 | `POST /v0/management/usage/import` | Import JSONL or compatible legacy snapshots. |
+| `GET /v0/management/model-prices/usage-summary` | Return the lightweight model-call summary used by the Model Prices page. |
 | `GET /v0/management/model-prices` | Model pricing. |
 | `PUT /v0/management/model-prices` | Replace saved model pricing. |
 | `POST /v0/management/model-prices/sync` | Price sync. |

--- a/apps/docs/operations/manager-server.md
+++ b/apps/docs/operations/manager-server.md
@@ -176,6 +176,7 @@ Manager Server 管理：
 |---|---|---|
 | `CPA_MANAGER_CONFIG` | 空 | 可选配置文件路径；原生包默认使用二进制旁边的 `config.json`。 |
 | `HTTP_ADDR` | `0.0.0.0:18317` | Manager Server 监听地址。 |
+| `CPA_MANAGER_PPROF_ADDR` | 空 | 可选 Go pprof 监听地址；仅接受 `localhost`、`127.0.0.1` 或 `::1`。 |
 | `USAGE_DATA_DIR` | Docker: `/data`; native: `./data` | 数据目录。 |
 | `USAGE_DB_PATH` | Docker: `/data/usage.sqlite`; native: `./data/usage.sqlite` | SQLite 路径。 |
 | `CPA_MANAGER_ADMIN_KEY` | 空 | 可选管理员密钥。 |
@@ -205,6 +206,15 @@ Manager Server 管理：
 environment variables > config.json > defaults
 ```
 
+需要诊断 CPU、堆或 goroutine 时，可临时启用仅本机可访问的 pprof 服务：
+
+```bash
+CPA_MANAGER_PPROF_ADDR=127.0.0.1:6060 ./cpa-manager-plus
+go tool pprof http://127.0.0.1:6060/debug/pprof/heap
+```
+
+配置文件中的等价字段是 `pprofAddr`。该服务默认关闭，不应通过 Docker 端口映射或反向代理暴露。
+
 如果 `USAGE_QUOTA_COOLDOWN_ENABLED`、`USAGE_ACCOUNT_ACTIONS_ENABLED` 或 `USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE` 由环境变量设置，面板中的对应开关会显示为环境变量来源并被锁定。要改成面板可编辑，需要移除环境变量并重启 Manager Server。
 
 ## 运行时接口
@@ -223,6 +233,7 @@ environment variables > config.json > defaults
 | `GET /v0/management/usage` | 兼容 usage data。 |
 | `GET /v0/management/usage/export` | 导出 JSONL usage events。 |
 | `POST /v0/management/usage/import` | 导入 JSONL 或兼容旧快照。 |
+| `GET /v0/management/model-prices/usage-summary` | 返回模型价格页使用的轻量模型调用汇总。 |
 | `GET /v0/management/model-prices` | 模型价格。 |
 | `PUT /v0/management/model-prices` | 替换保存的模型价格。 |
 | `POST /v0/management/model-prices/sync` | 价格同步。 |

--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
+	"net"
 	"net/http"
+	httppprof "net/http/pprof"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 	_ "time/tzdata"
@@ -110,6 +115,18 @@ func runServer() {
 		Handler:           serverApp.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+	pprofServer, err := newPprofServer(cfg.PprofAddr)
+	if err != nil {
+		log.Fatalf("configure pprof: %v", err)
+	}
+	if pprofServer != nil {
+		go func() {
+			log.Printf("cpa-manager-plus pprof listening on %s", pprofServer.Addr)
+			if err := pprofServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Printf("pprof server: %v", err)
+			}
+		}()
+	}
 
 	go func() {
 		log.Printf("cpa-manager-plus listening on %s", cfg.HTTPAddr)
@@ -122,9 +139,43 @@ func runServer() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	collectorWorker.Stop(context.Background())
+	if pprofServer != nil {
+		if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+			log.Printf("shutdown pprof: %v", err)
+		}
+	}
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("shutdown: %v", err)
 	}
+}
+
+func newPprofServer(addr string) (*http.Server, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return nil, nil
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+	}
+	if !strings.EqualFold(host, "localhost") {
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			return nil, fmt.Errorf("pprof address must use a loopback host: %q", addr)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", httppprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", httppprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", httppprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", httppprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", httppprof.Trace)
+	return &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}, nil
 }
 
 func runUsageResponseMetadataBackfill(ctx context.Context, db *store.Store) {

--- a/apps/manager-server/cmd/cpa-manager-plus/main_test.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestNewPprofServer(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantNil bool
+		wantErr bool
+	}{
+		{name: "disabled", wantNil: true},
+		{name: "ipv4 loopback", addr: "127.0.0.1:6060"},
+		{name: "ipv6 loopback", addr: "[::1]:6060"},
+		{name: "localhost", addr: "localhost:6060"},
+		{name: "all interfaces", addr: ":6060", wantErr: true},
+		{name: "public address", addr: "0.0.0.0:6060", wantErr: true},
+		{name: "invalid", addr: "localhost", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, err := newPprofServer(tt.addr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("newPprofServer(%q) error = %v", tt.addr, err)
+			}
+			if tt.wantNil && server != nil {
+				t.Fatalf("newPprofServer(%q) = %#v, want nil", tt.addr, server)
+			}
+			if !tt.wantNil && !tt.wantErr && server == nil {
+				t.Fatalf("newPprofServer(%q) = nil", tt.addr)
+			}
+		})
+	}
+}

--- a/apps/manager-server/internal/config/config.go
+++ b/apps/manager-server/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	BatchSize                 int
 	PollInterval              time.Duration
 	QueryLimit                int
+	PprofAddr                 string
 	PanelPath                 string
 	CORSOrigins               []string
 	TLSSkipVerify             bool
@@ -63,6 +64,7 @@ type fileConfig struct {
 	BatchSize                 int      `json:"batchSize,omitempty"`
 	PollIntervalMS            int      `json:"pollIntervalMs,omitempty"`
 	QueryLimit                int      `json:"queryLimit,omitempty"`
+	PprofAddr                 string   `json:"pprofAddr,omitempty"`
 	PanelPath                 string   `json:"panelPath,omitempty"`
 	CORSOrigins               []string `json:"corsOrigins,omitempty"`
 	TLSSkipVerify             bool     `json:"tlsSkipVerify,omitempty"`
@@ -132,6 +134,7 @@ func LoadWithOptions(options LoadOptions) (Config, error) {
 		BatchSize:                 envInt("USAGE_BATCH_SIZE", intFallback(cfgFile.BatchSize, 100)),
 		PollInterval:              time.Duration(envInt("USAGE_POLL_INTERVAL_MS", intFallback(cfgFile.PollIntervalMS, 500))) * time.Millisecond,
 		QueryLimit:                envInt("USAGE_QUERY_LIMIT", intFallback(cfgFile.QueryLimit, 50000)),
+		PprofAddr:                 env("CPA_MANAGER_PPROF_ADDR", cfgFile.PprofAddr),
 		PanelPath:                 env("PANEL_PATH", resolveConfigPath(cfgFile.PanelPath, cfgDir)),
 		CORSOrigins:               splitCSV(env("USAGE_CORS_ORIGINS", strings.Join(sliceFallback(cfgFile.CORSOrigins, []string{"*"}), ","))),
 		TLSSkipVerify:             envBool("USAGE_RESP_TLS_SKIP_VERIFY", cfgFile.TLSSkipVerify),

--- a/apps/manager-server/internal/config/config_test.go
+++ b/apps/manager-server/internal/config/config_test.go
@@ -69,9 +69,10 @@ func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
   "queue": "custom-usage",
   "popSide": "left",
   "batchSize": 7,
-  "pollIntervalMs": 250,
-  "queryLimit": 900,
-  "panelPath": "panel.html",
+	  "pollIntervalMs": 250,
+	  "queryLimit": 900,
+	  "pprofAddr": "127.0.0.1:6060",
+	  "panelPath": "panel.html",
   "corsOrigins": ["http://panel.local"],
   "tlsSkipVerify": true,
   "quotaCooldownEnabled": true,
@@ -103,6 +104,9 @@ func TestLoadReadsConfigAndResolvesRelativePaths(t *testing.T) {
 	}
 	if cfg.BatchSize != 7 || cfg.PollInterval != 250*time.Millisecond || cfg.QueryLimit != 900 {
 		t.Fatalf("numeric config = %#v", cfg)
+	}
+	if cfg.PprofAddr != "127.0.0.1:6060" {
+		t.Fatalf("PprofAddr = %q", cfg.PprofAddr)
 	}
 	if want := filepath.Join(dir, "panel.html"); cfg.PanelPath != want {
 		t.Fatalf("PanelPath = %q, want %q", cfg.PanelPath, want)
@@ -141,6 +145,7 @@ func TestLoadEnvOverridesConfig(t *testing.T) {
 	t.Setenv("USAGE_DATA_DIR", filepath.Join(dir, "env-data"))
 	t.Setenv("CPA_MANAGEMENT_KEY", "env-secret")
 	t.Setenv("USAGE_BATCH_SIZE", "12")
+	t.Setenv("CPA_MANAGER_PPROF_ADDR", "[::1]:6061")
 
 	cfg, err := Load()
 	if err != nil {
@@ -157,6 +162,9 @@ func TestLoadEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.BatchSize != 12 {
 		t.Fatalf("BatchSize = %d", cfg.BatchSize)
+	}
+	if cfg.PprofAddr != "[::1]:6061" {
+		t.Fatalf("PprofAddr = %q", cfg.PprofAddr)
 	}
 }
 
@@ -197,6 +205,7 @@ func clearConfigEnv(t *testing.T) {
 		"USAGE_BATCH_SIZE",
 		"USAGE_POLL_INTERVAL_MS",
 		"USAGE_QUERY_LIMIT",
+		"CPA_MANAGER_PPROF_ADDR",
 		"USAGE_CORS_ORIGINS",
 		"USAGE_RESP_TLS_SKIP_VERIFY",
 		"USAGE_QUOTA_COOLDOWN_ENABLED",

--- a/apps/manager-server/internal/http/controller/modelprice/handler.go
+++ b/apps/manager-server/internal/http/controller/modelprice/handler.go
@@ -24,6 +24,13 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	path := strings.TrimRight(r.URL.Path, "/")
 	switch {
+	case path == "/v0/management/model-prices/usage-summary" && r.Method == http.MethodGet:
+		summary, err := h.App.ModelPriceService.UsageSummary(r.Context(), h.App.Config.QueryLimit)
+		if err != nil {
+			response.Error(w, http.StatusInternalServerError, err)
+			return
+		}
+		response.JSON(w, http.StatusOK, summary)
 	case path == "/v0/management/model-prices" && r.Method == http.MethodGet:
 		prices, err := h.App.ModelPriceService.List(r.Context())
 		if err != nil {

--- a/apps/manager-server/internal/http/controller/modelprice/handler_test.go
+++ b/apps/manager-server/internal/http/controller/modelprice/handler_test.go
@@ -1,0 +1,59 @@
+package modelprice
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/app"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	adminauthsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/adminauth"
+	modelpricesvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/modelprice"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/testutil"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestHandleUsageSummaryUsesQueryLimitAndPanelAuthorization(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	cfg.QueryLimit = 1
+	st := testutil.NewStore(t, cfg)
+	if _, err := st.UsageEvents.InsertBatch(context.Background(), []usage.Event{
+		{EventHash: "older", TimestampMS: 100, Timestamp: "2026-01-01T00:00:00Z", Model: "gpt-old", CreatedAtMS: 100},
+		{EventHash: "newer", TimestampMS: 200, Timestamp: "2026-01-01T00:00:01Z", Model: "gpt-new", CreatedAtMS: 200},
+	}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	handler := &Handler{App: &app.Context{
+		Config:            cfg,
+		AdminAuthService:  adminauthsvc.New(cfg, st),
+		ModelPriceService: modelpricesvc.New(st, nil),
+	}}
+
+	unauthorized := httptest.NewRecorder()
+	handler.Handle(unauthorized, httptest.NewRequest(http.MethodGet, "/v0/management/model-prices/usage-summary", nil))
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status = %d body = %s", unauthorized.Code, unauthorized.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/model-prices/usage-summary", nil)
+	req.Header.Set("Authorization", "Bearer "+testutil.AdminKey)
+	recorder := httptest.NewRecorder()
+	handler.Handle(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	var summary model.ModelUsageSummary
+	if err := json.NewDecoder(recorder.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if summary.SampledEvents != 1 || summary.TotalEvents != 2 || !summary.Truncated {
+		t.Fatalf("summary metadata = %#v", summary)
+	}
+	if len(summary.Models) != 1 || summary.Models[0].Model != "gpt-new" || summary.Models[0].Calls != 1 || summary.Models[0].RequestedCalls != 1 {
+		t.Fatalf("models = %#v", summary.Models)
+	}
+}

--- a/apps/manager-server/internal/http/controller/usage/handler.go
+++ b/apps/manager-server/internal/http/controller/usage/handler.go
@@ -3,12 +3,14 @@ package usage
 import (
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/app"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/middleware"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/http/response"
+	usagesvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usage"
 )
 
 const maxUsageImportBytes int64 = 64 * 1024 * 1024
@@ -27,12 +29,17 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 			h.Export(w, r)
 			return
 		}
-		payload, err := h.App.UsageService.GetCompatibleUsage(r.Context(), h.App.Config.QueryLimit)
+		w.Header().Set("Content-Type", "application/json")
+		writer := &countingWriter{writer: w}
+		err := h.App.UsageService.WriteCompatibleUsage(r.Context(), writer, h.App.Config.QueryLimit)
 		if err != nil {
-			response.Error(w, http.StatusInternalServerError, err)
+			if writer.written == 0 {
+				response.Error(w, http.StatusInternalServerError, err)
+			} else {
+				log.Printf("usage compatible stream failed after %d bytes: %v", writer.written, err)
+			}
 			return
 		}
-		response.JSON(w, http.StatusOK, payload)
 	case http.MethodPost:
 		if strings.HasSuffix(r.URL.Path, "/import") {
 			h.Import(w, r)
@@ -45,33 +52,50 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) Export(w http.ResponseWriter, r *http.Request) {
-	data, err := h.App.UsageService.Export(r.Context())
-	if err != nil {
-		response.Error(w, http.StatusInternalServerError, err)
-		return
-	}
 	w.Header().Set("Content-Type", "application/x-ndjson")
 	w.Header().Set("Content-Disposition", `attachment; filename="usage-events.jsonl"`)
-	_, _ = w.Write(data)
+	writer := &countingWriter{writer: w}
+	if err := h.App.UsageService.WriteExport(r.Context(), writer, h.App.Config.QueryLimit); err != nil {
+		if writer.written == 0 {
+			w.Header().Del("Content-Disposition")
+			response.Error(w, http.StatusInternalServerError, err)
+		} else {
+			log.Printf("usage export stream failed after %d bytes: %v", writer.written, err)
+		}
+	}
+}
+
+type countingWriter struct {
+	writer  io.Writer
+	written int64
+}
+
+func (w *countingWriter) Write(data []byte) (int, error) {
+	written, err := w.writer.Write(data)
+	w.written += int64(written)
+	return written, err
 }
 
 func (h *Handler) Import(w http.ResponseWriter, r *http.Request) {
+	if r.ContentLength > maxUsageImportBytes {
+		response.Error(w, http.StatusRequestEntityTooLarge, errors.New("http: request body too large"))
+		return
+	}
 	body := http.MaxBytesReader(w, r.Body, maxUsageImportBytes)
-	data, err := io.ReadAll(body)
+	result, parsed, err := h.App.UsageService.Import(r.Context(), body)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			response.Error(w, http.StatusRequestEntityTooLarge, err)
 			return
 		}
-		response.Error(w, http.StatusBadRequest, err)
-		return
-	}
-
-	result, parsed, err := h.App.UsageService.Import(r.Context(), data)
-	if err != nil {
-		if parsed != nil && len(parsed.Events) > 0 {
+		var persistenceErr *usagesvc.ImportPersistenceError
+		if errors.As(err, &persistenceErr) || result.Added+result.Skipped > 0 {
 			response.Error(w, http.StatusInternalServerError, err)
+			return
+		}
+		if parsed == nil {
+			response.Error(w, http.StatusBadRequest, err)
 			return
 		}
 		response.JSON(w, http.StatusBadRequest, map[string]any{

--- a/apps/manager-server/internal/http/controller/usage/handler_test.go
+++ b/apps/manager-server/internal/http/controller/usage/handler_test.go
@@ -1,0 +1,55 @@
+package usage
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/app"
+	usagesvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/testutil"
+)
+
+func TestImportReturnsBadRequestWhenUncommittedArrayParsingFails(t *testing.T) {
+	st := testutil.NewStore(t, testutil.NewConfig(t))
+	handler := &Handler{App: &app.Context{UsageService: usagesvc.New(st)}}
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", strings.NewReader(`[{"event_hash":"one","timestamp_ms":1,"timestamp":"2026-01-01T00:00:00Z","model":"gpt-test"},`))
+	recorder := httptest.NewRecorder()
+
+	handler.Import(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestImportReturnsInternalServerErrorForPersistenceFailure(t *testing.T) {
+	st := testutil.NewStore(t, testutil.NewConfig(t))
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	handler := &Handler{App: &app.Context{UsageService: usagesvc.New(st)}}
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", strings.NewReader(`{"event_hash":"one","timestamp_ms":1,"timestamp":"2026-01-01T00:00:00Z","model":"gpt-test"}`))
+	recorder := httptest.NewRecorder()
+
+	handler.Import(recorder, req)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestImportRejectsKnownOversizedContentLengthBeforeReading(t *testing.T) {
+	st := testutil.NewStore(t, testutil.NewConfig(t))
+	handler := &Handler{App: &app.Context{UsageService: usagesvc.New(st)}}
+	req := httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", strings.NewReader("{}"))
+	req.ContentLength = maxUsageImportBytes + 1
+	recorder := httptest.NewRecorder()
+
+	handler.Import(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/apps/manager-server/internal/model/model_price.go
+++ b/apps/manager-server/internal/model/model_price.go
@@ -17,3 +17,17 @@ type ModelPriceSyncResult struct {
 	Imported int `json:"imported"`
 	Skipped  int `json:"skipped"`
 }
+
+type ModelUsageStat struct {
+	Model          string `json:"model"`
+	Calls          int64  `json:"calls"`
+	RequestedCalls int64  `json:"requested_calls"`
+	ResolvedCalls  int64  `json:"resolved_calls"`
+}
+
+type ModelUsageSummary struct {
+	SampledEvents int64            `json:"sampled_events"`
+	TotalEvents   int64            `json:"total_events"`
+	Truncated     bool             `json:"truncated"`
+	Models        []ModelUsageStat `json:"models"`
+}

--- a/apps/manager-server/internal/repository/sqlite/db.go
+++ b/apps/manager-server/internal/repository/sqlite/db.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -16,13 +17,29 @@ func OpenWithOptions(options Options) (*sql.DB, error) {
 	if err := os.MkdirAll(filepath.Dir(options.Path), 0o755); err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite", options.Path)
+	db, err := sql.Open("sqlite", dataSourceName(options.Path))
 	if err != nil {
 		return nil, err
 	}
+	db.SetMaxOpenConns(options.maxOpenConns())
+	db.SetMaxIdleConns(options.maxIdleConns())
+	db.SetConnMaxIdleTime(options.connMaxIdleTime())
 	if err := Migrate(db); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 	return db, nil
+}
+
+func dataSourceName(path string) string {
+	dsn := &url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(path),
+	}
+	query := dsn.Query()
+	query.Add("_pragma", "busy_timeout(5000)")
+	query.Add("_pragma", "foreign_keys(1)")
+	query.Add("_pragma", "synchronous(FULL)")
+	dsn.RawQuery = query.Encode()
+	return dsn.String()
 }

--- a/apps/manager-server/internal/repository/sqlite/db_test.go
+++ b/apps/manager-server/internal/repository/sqlite/db_test.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenWithOptionsAppliesConnectionDefaults(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage ? #.sqlite")
+	db, err := OpenWithOptions(Options{Path: dbPath})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	connections := make([]*sql.Conn, 0, defaultMaxOpenConns)
+	for i := 0; i < defaultMaxOpenConns; i++ {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("open connection %d: %v", i, err)
+		}
+		connections = append(connections, conn)
+		assertConnectionPragmas(t, conn)
+	}
+
+	stats := db.Stats()
+	if stats.MaxOpenConnections != defaultMaxOpenConns {
+		t.Fatalf("MaxOpenConnections = %d, want %d", stats.MaxOpenConnections, defaultMaxOpenConns)
+	}
+	if stats.OpenConnections != defaultMaxOpenConns || stats.InUse != defaultMaxOpenConns {
+		t.Fatalf("open/in-use connections = %d/%d, want %d/%d", stats.OpenConnections, stats.InUse, defaultMaxOpenConns, defaultMaxOpenConns)
+	}
+
+	for i, conn := range connections {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("close connection %d: %v", i, err)
+		}
+	}
+	stats = db.Stats()
+	if stats.Idle != defaultMaxIdleConns {
+		t.Fatalf("idle connections = %d, want %d", stats.Idle, defaultMaxIdleConns)
+	}
+	if stats.MaxIdleClosed != int64(defaultMaxOpenConns-defaultMaxIdleConns) {
+		t.Fatalf("MaxIdleClosed = %d, want %d", stats.MaxIdleClosed, defaultMaxOpenConns-defaultMaxIdleConns)
+	}
+}
+
+func assertConnectionPragmas(t *testing.T, conn *sql.Conn) {
+	t.Helper()
+	for _, test := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{name: "busy timeout", query: "pragma busy_timeout", want: 5000},
+		{name: "foreign keys", query: "pragma foreign_keys", want: 1},
+		{name: "synchronous", query: "pragma synchronous", want: 2},
+	} {
+		var got int
+		if err := conn.QueryRowContext(context.Background(), test.query).Scan(&got); err != nil {
+			t.Fatalf("query %s: %v", test.name, err)
+		}
+		if got != test.want {
+			t.Fatalf("%s = %d, want %d", test.name, got, test.want)
+		}
+	}
+}

--- a/apps/manager-server/internal/repository/sqlite/options.go
+++ b/apps/manager-server/internal/repository/sqlite/options.go
@@ -1,5 +1,37 @@
 package sqlite
 
+import "time"
+
+const (
+	defaultMaxOpenConns    = 4
+	defaultMaxIdleConns    = 2
+	defaultConnMaxIdleTime = 5 * time.Minute
+)
+
 type Options struct {
-	Path string
+	Path            string
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxIdleTime time.Duration
+}
+
+func (o Options) maxOpenConns() int {
+	if o.MaxOpenConns > 0 {
+		return o.MaxOpenConns
+	}
+	return defaultMaxOpenConns
+}
+
+func (o Options) maxIdleConns() int {
+	if o.MaxIdleConns > 0 {
+		return o.MaxIdleConns
+	}
+	return defaultMaxIdleConns
+}
+
+func (o Options) connMaxIdleTime() time.Duration {
+	if o.ConnMaxIdleTime > 0 {
+		return o.ConnMaxIdleTime
+	}
+	return defaultConnMaxIdleTime
 }

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -623,12 +623,26 @@ order by timestamp_ms`, where)
 	}
 	defer rows.Close()
 
-	type samples struct {
-		latencies []float64
-		ttfts     []float64
+	result := make([]LatencyPercentiles, 0)
+	var currentBucketMS int64
+	hasCurrentBucket := false
+	latencies := make([]float64, 0)
+	ttfts := make([]float64, 0)
+	flushBucket := func() {
+		if !hasCurrentBucket {
+			return
+		}
+		point := LatencyPercentiles{BucketMS: currentBucketMS}
+		if value, ok := percentile95(latencies); ok {
+			point.P95LatencyMS = sql.NullFloat64{Float64: value, Valid: true}
+		}
+		if value, ok := percentile95(ttfts); ok {
+			point.P95TTFTMS = sql.NullFloat64{Float64: value, Valid: true}
+		}
+		result = append(result, point)
+		latencies = latencies[:0]
+		ttfts = ttfts[:0]
 	}
-	grouped := map[int64]*samples{}
-	order := make([]int64, 0)
 	for rows.Next() {
 		var timestampMS int64
 		var latency sql.NullFloat64
@@ -637,55 +651,10 @@ order by timestamp_ms`, where)
 			return nil, err
 		}
 		bucketMS := resolveBucketMS(timestampMS, granularity, location)
-		entry := grouped[bucketMS]
-		if entry == nil {
-			entry = &samples{}
-			grouped[bucketMS] = entry
-			order = append(order, bucketMS)
-		}
-		if latency.Valid && latency.Float64 > 0 {
-			entry.latencies = append(entry.latencies, latency.Float64)
-		}
-		if ttft.Valid && ttft.Float64 > 0 {
-			entry.ttfts = append(entry.ttfts, ttft.Float64)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	result := make([]LatencyPercentiles, 0, len(order))
-	for _, bucketMS := range order {
-		entry := grouped[bucketMS]
-		point := LatencyPercentiles{BucketMS: bucketMS}
-		if value, ok := percentile95(entry.latencies); ok {
-			point.P95LatencyMS = sql.NullFloat64{Float64: value, Valid: true}
-		}
-		if value, ok := percentile95(entry.ttfts); ok {
-			point.P95TTFTMS = sql.NullFloat64{Float64: value, Valid: true}
-		}
-		result = append(result, point)
-	}
-	return result, nil
-}
-
-func (r *repository) LatencySummaryWithFilter(ctx context.Context, filter AnalyticsFilter) (LatencySummary, error) {
-	where, args := analyticsWhere(filter)
-	rows, err := r.db.QueryContext(ctx, `select latency_ms, ttft_ms
-from usage_events `+where+`
-and (latency_ms > 0 or ttft_ms > 0)`, args...)
-	if err != nil {
-		return LatencySummary{}, err
-	}
-	defer rows.Close()
-
-	latencies := make([]float64, 0)
-	ttfts := make([]float64, 0)
-	for rows.Next() {
-		var latency sql.NullFloat64
-		var ttft sql.NullFloat64
-		if err := rows.Scan(&latency, &ttft); err != nil {
-			return LatencySummary{}, err
+		if !hasCurrentBucket || bucketMS != currentBucketMS {
+			flushBucket()
+			currentBucketMS = bucketMS
+			hasCurrentBucket = true
 		}
 		if latency.Valid && latency.Float64 > 0 {
 			latencies = append(latencies, latency.Float64)
@@ -695,15 +664,54 @@ and (latency_ms > 0 or ttft_ms > 0)`, args...)
 		}
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	flushBucket()
+	return result, nil
+}
+
+func (r *repository) LatencySummaryWithFilter(ctx context.Context, filter AnalyticsFilter) (LatencySummary, error) {
+	where, args := analyticsWhere(filter)
+	query := fmt.Sprintf(`with samples(kind, value) as (
+	select 'latency', latency_ms from usage_events %s and latency_ms > 0
+	union all
+	select 'ttft', ttft_ms from usage_events %s and ttft_ms > 0
+), ranked as (
+	select
+		kind,
+		value,
+		row_number() over (partition by kind order by value) as sample_number,
+		count(*) over (partition by kind) as sample_count
+	from samples
+)
+select kind, value
+from ranked
+where sample_number = ((sample_count * 95) + 99) / 100`, where, where)
+	queryArgs := make([]any, 0, len(args)*2)
+	queryArgs = append(queryArgs, args...)
+	queryArgs = append(queryArgs, args...)
+	rows, err := r.db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
 		return LatencySummary{}, err
 	}
+	defer rows.Close()
 
 	var summary LatencySummary
-	if value, ok := percentile95(latencies); ok {
-		summary.P95LatencyMS = sql.NullFloat64{Float64: value, Valid: true}
+	for rows.Next() {
+		var kind string
+		var value float64
+		if err := rows.Scan(&kind, &value); err != nil {
+			return LatencySummary{}, err
+		}
+		switch kind {
+		case "latency":
+			summary.P95LatencyMS = sql.NullFloat64{Float64: value, Valid: true}
+		case "ttft":
+			summary.P95TTFTMS = sql.NullFloat64{Float64: value, Valid: true}
+		}
 	}
-	if value, ok := percentile95(ttfts); ok {
-		summary.P95TTFTMS = sql.NullFloat64{Float64: value, Valid: true}
+	if err := rows.Err(); err != nil {
+		return LatencySummary{}, err
 	}
 	return summary, nil
 }

--- a/apps/manager-server/internal/repository/usageevent/analytics_latency_test.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics_latency_test.go
@@ -1,0 +1,88 @@
+package usageevent
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestLatencyPercentilesUseNearestRankAcrossSummaryAndBuckets(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := New(db)
+	base := time.Date(2026, time.January, 1, 10, 0, 0, 0, time.UTC)
+	events := make([]usage.Event, 0, 40)
+	for hour := 0; hour < 2; hour++ {
+		for sample := int64(1); sample <= 20; sample++ {
+			latency := sample + int64(hour*100)
+			ttft := latency * 2
+			timestamp := base.Add(time.Duration(hour) * time.Hour).Add(time.Duration(sample) * time.Second)
+			events = append(events, usage.Event{
+				EventHash:   fmt.Sprintf("%d-%d", hour, sample),
+				TimestampMS: timestamp.UnixMilli(),
+				Timestamp:   timestamp.Format(time.RFC3339Nano),
+				Model:       "gpt-test",
+				LatencyMS:   &latency,
+				TTFTMS:      &ttft,
+				CreatedAtMS: timestamp.UnixMilli(),
+			})
+		}
+	}
+	if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	filter := AnalyticsFilter{
+		FromMS: base.UnixMilli(),
+		ToMS:   base.Add(2 * time.Hour).UnixMilli(),
+	}
+	summary, err := repo.LatencySummaryWithFilter(context.Background(), filter)
+	if err != nil {
+		t.Fatalf("latency summary: %v", err)
+	}
+	if !summary.P95LatencyMS.Valid || summary.P95LatencyMS.Float64 != 118 {
+		t.Fatalf("summary latency p95 = %#v, want 118", summary.P95LatencyMS)
+	}
+	if !summary.P95TTFTMS.Valid || summary.P95TTFTMS.Float64 != 236 {
+		t.Fatalf("summary ttft p95 = %#v, want 236", summary.P95TTFTMS)
+	}
+
+	points, err := repo.LatencyPercentilesWithFilter(context.Background(), filter, "hour", time.UTC)
+	if err != nil {
+		t.Fatalf("latency percentiles: %v", err)
+	}
+	if len(points) != 2 {
+		t.Fatalf("points = %#v", points)
+	}
+	if points[0].P95LatencyMS.Float64 != 19 || points[0].P95TTFTMS.Float64 != 38 {
+		t.Fatalf("first bucket = %#v", points[0])
+	}
+	if points[1].P95LatencyMS.Float64 != 119 || points[1].P95TTFTMS.Float64 != 238 {
+		t.Fatalf("second bucket = %#v", points[1])
+	}
+}
+
+func TestLatencySummaryReturnsInvalidPercentilesWithoutSamples(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	summary, err := New(db).LatencySummaryWithFilter(context.Background(), AnalyticsFilter{})
+	if err != nil {
+		t.Fatalf("latency summary: %v", err)
+	}
+	if summary.P95LatencyMS.Valid || summary.P95TTFTMS.Valid {
+		t.Fatalf("summary = %#v", summary)
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/model_usage.go
+++ b/apps/manager-server/internal/repository/usageevent/model_usage.go
@@ -1,0 +1,75 @@
+package usageevent
+
+import (
+	"context"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+)
+
+const defaultModelUsageLimit = 50000
+
+func (r *repository) ModelUsageSummary(ctx context.Context, limit int) (model.ModelUsageSummary, error) {
+	if limit <= 0 {
+		limit = defaultModelUsageLimit
+	}
+
+	rows, err := r.db.QueryContext(ctx, `with recent as (
+		select model, coalesce(resolved_model, '') as resolved_model
+		from usage_events
+		order by timestamp_ms desc, id desc
+		limit ?
+	), model_counts as (
+		select model, count(*) as requested_calls, 0 as resolved_calls
+		from recent
+		where model <> ''
+		group by model
+		union all
+		select resolved_model as model, 0 as requested_calls, count(*) as resolved_calls
+		from recent
+		where resolved_model <> '' and resolved_model <> model
+		group by resolved_model
+	), aggregated as (
+		select
+			model,
+			sum(requested_calls) as requested_calls,
+			sum(resolved_calls) as resolved_calls
+		from model_counts
+		group by model
+	)
+	select model, requested_calls, resolved_calls
+	from aggregated
+	order by requested_calls + resolved_calls desc, model asc`, limit)
+	if err != nil {
+		return model.ModelUsageSummary{}, err
+	}
+	defer rows.Close()
+
+	models := make([]model.ModelUsageStat, 0)
+	for rows.Next() {
+		var stat model.ModelUsageStat
+		if err := rows.Scan(&stat.Model, &stat.RequestedCalls, &stat.ResolvedCalls); err != nil {
+			return model.ModelUsageSummary{}, err
+		}
+		stat.Calls = stat.RequestedCalls + stat.ResolvedCalls
+		models = append(models, stat)
+	}
+	if err := rows.Err(); err != nil {
+		return model.ModelUsageSummary{}, err
+	}
+
+	var totalEvents int64
+	if err := r.db.QueryRowContext(ctx, `select count(*) from usage_events`).Scan(&totalEvents); err != nil {
+		return model.ModelUsageSummary{}, err
+	}
+
+	sampledEvents := totalEvents
+	if sampledEvents > int64(limit) {
+		sampledEvents = int64(limit)
+	}
+	return model.ModelUsageSummary{
+		SampledEvents: sampledEvents,
+		TotalEvents:   totalEvents,
+		Truncated:     sampledEvents < totalEvents,
+		Models:        models,
+	}, nil
+}

--- a/apps/manager-server/internal/repository/usageevent/model_usage_test.go
+++ b/apps/manager-server/internal/repository/usageevent/model_usage_test.go
@@ -1,0 +1,84 @@
+package usageevent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestModelUsageSummaryAggregatesRecentRequestedAndResolvedModels(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := New(db)
+	events := []usage.Event{
+		modelUsageTestEvent("old", 100, "old-model", "old-resolved"),
+		modelUsageTestEvent("a-resolved", 200, "gpt-a", "gpt-b"),
+		modelUsageTestEvent("a-same", 300, "gpt-a", "gpt-a"),
+		modelUsageTestEvent("c-requested", 400, "gpt-c", ""),
+	}
+	if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	summary, err := repo.ModelUsageSummary(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("model usage summary: %v", err)
+	}
+	if summary.SampledEvents != 3 || summary.TotalEvents != 4 || !summary.Truncated {
+		t.Fatalf("summary metadata = %#v", summary)
+	}
+	want := []struct {
+		model                      string
+		calls, requested, resolved int64
+	}{
+		{model: "gpt-a", calls: 2, requested: 2},
+		{model: "gpt-b", calls: 1, resolved: 1},
+		{model: "gpt-c", calls: 1, requested: 1},
+	}
+	if len(summary.Models) != len(want) {
+		t.Fatalf("models = %#v", summary.Models)
+	}
+	for index, expected := range want {
+		actual := summary.Models[index]
+		if actual.Model != expected.model || actual.Calls != expected.calls || actual.RequestedCalls != expected.requested || actual.ResolvedCalls != expected.resolved {
+			t.Fatalf("models[%d] = %#v, want %#v", index, actual, expected)
+		}
+	}
+}
+
+func TestModelUsageSummaryReturnsEmptyModels(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	summary, err := New(db).ModelUsageSummary(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("model usage summary: %v", err)
+	}
+	if summary.SampledEvents != 0 || summary.TotalEvents != 0 || summary.Truncated {
+		t.Fatalf("summary metadata = %#v", summary)
+	}
+	if summary.Models == nil || len(summary.Models) != 0 {
+		t.Fatalf("models = %#v", summary.Models)
+	}
+}
+
+func modelUsageTestEvent(hash string, timestampMS int64, requestedModel, resolvedModel string) usage.Event {
+	return usage.Event{
+		EventHash:     hash,
+		TimestampMS:   timestampMS,
+		Timestamp:     "2026-01-01T00:00:00Z",
+		Model:         requestedModel,
+		ResolvedModel: resolvedModel,
+		CreatedAtMS:   timestampMS,
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -3,7 +3,7 @@ package usageevent
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"io"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
@@ -13,9 +13,12 @@ import (
 type Repository interface {
 	InsertBatch(ctx context.Context, events []model.UsageEvent) (model.InsertResult, error)
 	ListRecent(ctx context.Context, limit int) ([]model.UsageEvent, error)
+	ModelUsageSummary(ctx context.Context, limit int) (model.ModelUsageSummary, error)
 	BackfillResponseMetadata(ctx context.Context, batchLimit int) (int, error)
 	Count(ctx context.Context) (int64, error)
 	ExportJSONL(ctx context.Context) ([]byte, error)
+	WriteCompatibleUsage(ctx context.Context, writer io.Writer, limit int) error
+	WriteExportJSONL(ctx context.Context, writer io.Writer, limit int) error
 	AggregateBetween(ctx context.Context, fromMs, toMs int64) (Aggregate, error)
 	TopModelsBetween(ctx context.Context, fromMs, toMs int64, limit int) ([]ModelStat, error)
 	ModelStatsBetween(ctx context.Context, fromMs, toMs int64) ([]ModelStat, error)
@@ -303,28 +306,6 @@ func (r *repository) Count(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 	return count, nil
-}
-
-func (r *repository) ExportJSONL(ctx context.Context) ([]byte, error) {
-	events, err := r.ListRecent(ctx, 0)
-	if err != nil {
-		return nil, err
-	}
-	output := make([]byte, 0)
-	for i := len(events) - 1; i >= 0; i-- {
-		event := events[i]
-		// Export intentionally omits raw_json and raw fail_body. fail_summary is
-		// the redacted/truncated diagnostic field intended for portable JSONL.
-		event.FailBody = ""
-		event.RawJSON = ""
-		line, err := json.Marshal(event)
-		if err != nil {
-			return nil, err
-		}
-		output = append(output, line...)
-		output = append(output, '\n')
-	}
-	return output, nil
 }
 
 func nullString(value string) any {

--- a/apps/manager-server/internal/repository/usageevent/stream.go
+++ b/apps/manager-server/internal/repository/usageevent/stream.go
@@ -1,0 +1,608 @@
+package usageevent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+const (
+	defaultUsageStreamLimit = 50000
+	usageStreamBufferSize   = 64 * 1024
+	usageExportBatchSize    = 512
+)
+
+type usageSnapshot struct {
+	maxID             int64
+	cutoffTimestampMS int64
+	cutoffID          int64
+	empty             bool
+}
+
+type compatibleUsageTotals struct {
+	totalRequests int64
+	successCount  int64
+	failureCount  int64
+	totalTokens   int64
+}
+
+type rawMetadataDetail struct {
+	usage.Detail
+	ResponseMetadata json.RawMessage `json:"response_metadata,omitempty"`
+}
+
+type exportRow struct {
+	id               int64
+	timestampMS      int64
+	event            model.UsageEvent
+	responseMetadata json.RawMessage
+}
+
+type rawMetadataEvent struct {
+	usage.Event
+	ResponseMetadata json.RawMessage `json:"response_metadata,omitempty"`
+}
+
+func (r *repository) WriteCompatibleUsage(ctx context.Context, writer io.Writer, limit int) error {
+	limit = normalizeUsageStreamLimit(limit)
+	snapshot, err := r.captureUsageSnapshot(ctx, limit)
+	if err != nil {
+		return err
+	}
+	totals, err := r.compatibleUsageTotals(ctx, snapshot)
+	if err != nil {
+		return err
+	}
+
+	buffer := bufio.NewWriterSize(writer, usageStreamBufferSize)
+	if err := writeCompatibleUsageHeader(buffer, totals); err != nil {
+		return err
+	}
+	if snapshot.empty {
+		if _, err := io.WriteString(buffer, "}}\n"); err != nil {
+			return err
+		}
+		return buffer.Flush()
+	}
+
+	rows, err := r.db.QueryContext(ctx, `select
+		coalesce(nullif(endpoint, ''), '-') as group_endpoint,
+		coalesce(nullif(model, ''), '-') as group_model,
+		timestamp,
+		coalesce(source, ''),
+		coalesce(auth_index, ''),
+		coalesce(api_key_hash, ''),
+		coalesce(account_snapshot, ''),
+		coalesce(auth_label_snapshot, ''),
+		coalesce(auth_file_snapshot, ''),
+		coalesce(auth_provider_snapshot, ''),
+		coalesce(auth_project_id_snapshot, ''),
+		auth_snapshot_at_ms,
+		latency_ms,
+		ttft_ms,
+		coalesce(resolved_model, ''),
+		coalesce(reasoning_effort, ''),
+		coalesce(service_tier, ''),
+		coalesce(executor_type, ''),
+		input_tokens,
+		output_tokens,
+		reasoning_tokens,
+		cached_tokens,
+		cache_tokens,
+		cache_read_tokens,
+		cache_creation_tokens,
+		total_tokens,
+		failed,
+		fail_status_code,
+		coalesce(fail_summary, ''),
+		coalesce(response_metadata_json, '')
+	from usage_events
+	where id <= ? and (
+		timestamp_ms > ? or (timestamp_ms = ? and id >= ?)
+	)
+	order by group_endpoint asc, group_model asc, timestamp_ms desc, id desc`,
+		snapshot.maxID,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffID,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var currentEndpoint string
+	var currentModel string
+	endpointOpen := false
+	modelOpen := false
+	firstEndpoint := true
+	firstModel := true
+	firstDetail := true
+
+	for rows.Next() {
+		endpoint, modelName, detail, err := scanCompatibleDetail(rows)
+		if err != nil {
+			return err
+		}
+
+		if !endpointOpen || endpoint != currentEndpoint {
+			if modelOpen {
+				if _, err := io.WriteString(buffer, "]}"); err != nil {
+					return err
+				}
+				modelOpen = false
+			}
+			if endpointOpen {
+				if _, err := io.WriteString(buffer, "}}"); err != nil {
+					return err
+				}
+			}
+			if !firstEndpoint {
+				if err := buffer.WriteByte(','); err != nil {
+					return err
+				}
+			}
+			if err := writeJSONString(buffer, endpoint); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(buffer, `:{"models":{`); err != nil {
+				return err
+			}
+			currentEndpoint = endpoint
+			currentModel = ""
+			endpointOpen = true
+			firstEndpoint = false
+			firstModel = true
+		}
+
+		if !modelOpen || modelName != currentModel {
+			if modelOpen {
+				if _, err := io.WriteString(buffer, "]}"); err != nil {
+					return err
+				}
+			}
+			if !firstModel {
+				if err := buffer.WriteByte(','); err != nil {
+					return err
+				}
+			}
+			if err := writeJSONString(buffer, modelName); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(buffer, `:{"details":[`); err != nil {
+				return err
+			}
+			currentModel = modelName
+			modelOpen = true
+			firstModel = false
+			firstDetail = true
+		}
+
+		if !firstDetail {
+			if err := buffer.WriteByte(','); err != nil {
+				return err
+			}
+		}
+		encoded, err := json.Marshal(detail)
+		if err != nil {
+			return err
+		}
+		if _, err := buffer.Write(encoded); err != nil {
+			return err
+		}
+		firstDetail = false
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if modelOpen {
+		if _, err := io.WriteString(buffer, "]}"); err != nil {
+			return err
+		}
+	}
+	if endpointOpen {
+		if _, err := io.WriteString(buffer, "}}"); err != nil {
+			return err
+		}
+	}
+	if _, err := io.WriteString(buffer, "}}\n"); err != nil {
+		return err
+	}
+	return buffer.Flush()
+}
+
+func (r *repository) WriteExportJSONL(ctx context.Context, writer io.Writer, limit int) error {
+	limit = normalizeUsageStreamLimit(limit)
+	snapshot, err := r.captureUsageSnapshot(ctx, limit)
+	if err != nil {
+		return err
+	}
+	if snapshot.empty {
+		return nil
+	}
+
+	buffer := bufio.NewWriterSize(writer, usageStreamBufferSize)
+	cursorTimestampMS := snapshot.cutoffTimestampMS
+	cursorID := snapshot.cutoffID - 1
+	for {
+		batch, err := r.exportBatch(ctx, snapshot, cursorTimestampMS, cursorID)
+		if err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, row := range batch {
+			encoded, err := json.Marshal(rawMetadataEvent{
+				Event:            row.event,
+				ResponseMetadata: row.responseMetadata,
+			})
+			if err != nil {
+				return err
+			}
+			if _, err := buffer.Write(encoded); err != nil {
+				return err
+			}
+			if err := buffer.WriteByte('\n'); err != nil {
+				return err
+			}
+		}
+		last := batch[len(batch)-1]
+		cursorTimestampMS = last.timestampMS
+		cursorID = last.id
+		if len(batch) < usageExportBatchSize {
+			break
+		}
+	}
+	return buffer.Flush()
+}
+
+func (r *repository) ExportJSONL(ctx context.Context) ([]byte, error) {
+	var output bytes.Buffer
+	if err := r.WriteExportJSONL(ctx, &output, defaultUsageStreamLimit); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func (r *repository) captureUsageSnapshot(ctx context.Context, limit int) (usageSnapshot, error) {
+	var snapshot usageSnapshot
+	if err := r.db.QueryRowContext(ctx, `select coalesce(max(id), 0) from usage_events`).Scan(&snapshot.maxID); err != nil {
+		return usageSnapshot{}, err
+	}
+	if snapshot.maxID == 0 {
+		snapshot.empty = true
+		return snapshot, nil
+	}
+
+	err := r.db.QueryRowContext(ctx, `select timestamp_ms, id
+	from (
+		select timestamp_ms, id
+		from usage_events
+		where id <= ?
+		order by timestamp_ms desc, id desc
+		limit ?
+	)
+	order by timestamp_ms asc, id asc
+	limit 1`, snapshot.maxID, limit).Scan(&snapshot.cutoffTimestampMS, &snapshot.cutoffID)
+	if errors.Is(err, sql.ErrNoRows) {
+		snapshot.empty = true
+		return snapshot, nil
+	}
+	if err != nil {
+		return usageSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (r *repository) compatibleUsageTotals(ctx context.Context, snapshot usageSnapshot) (compatibleUsageTotals, error) {
+	if snapshot.empty {
+		return compatibleUsageTotals{}, nil
+	}
+	var totals compatibleUsageTotals
+	if err := r.db.QueryRowContext(ctx, `select
+		count(*),
+		count(*) - coalesce(sum(case when failed <> 0 then 1 else 0 end), 0),
+		coalesce(sum(case when failed <> 0 then 1 else 0 end), 0),
+		coalesce(sum(total_tokens), 0)
+	from usage_events
+	where id <= ? and (
+		timestamp_ms > ? or (timestamp_ms = ? and id >= ?)
+	)`,
+		snapshot.maxID,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffID,
+	).Scan(&totals.totalRequests, &totals.successCount, &totals.failureCount, &totals.totalTokens); err != nil {
+		return compatibleUsageTotals{}, err
+	}
+	return totals, nil
+}
+
+func (r *repository) exportBatch(ctx context.Context, snapshot usageSnapshot, cursorTimestampMS, cursorID int64) ([]exportRow, error) {
+	rows, err := r.db.QueryContext(ctx, `select
+		id,
+		request_id, event_hash, timestamp_ms, timestamp, provider, executor_type, model, endpoint, method, path,
+		auth_type, auth_index, source, source_hash, api_key_hash,
+		account_snapshot, auth_label_snapshot, auth_file_snapshot, auth_provider_snapshot, auth_project_id_snapshot, auth_snapshot_at_ms,
+		requested_model, resolved_model, reasoning_effort, service_tier,
+		input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_tokens, cache_read_tokens, cache_creation_tokens, total_tokens,
+		latency_ms, ttft_ms, failed, fail_status_code, fail_summary,
+		coalesce(response_metadata_json, ''), header_quota_recover_at_ms, header_quota_used_percent, coalesce(header_quota_plan_type, ''), coalesce(header_error_kind, ''), coalesce(header_error_code, ''), coalesce(header_trace_id, ''),
+		created_at_ms
+	from usage_events
+	where id <= ?
+		and (timestamp_ms > ? or (timestamp_ms = ? and id >= ?))
+		and (timestamp_ms > ? or (timestamp_ms = ? and id > ?))
+	order by timestamp_ms asc, id asc
+	limit ?`,
+		snapshot.maxID,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffID,
+		cursorTimestampMS,
+		cursorTimestampMS,
+		cursorID,
+		usageExportBatchSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	batch := make([]exportRow, 0, usageExportBatchSize)
+	for rows.Next() {
+		row, err := scanExportRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return batch, nil
+}
+
+func scanCompatibleDetail(rows *sql.Rows) (string, string, rawMetadataDetail, error) {
+	var endpoint string
+	var modelName string
+	var detail usage.Detail
+	var authSnapshotAt sql.NullInt64
+	var latency sql.NullInt64
+	var ttft sql.NullInt64
+	var failStatusCode sql.NullInt64
+	var responseMetadataJSON string
+	var failed int
+	var cachedTokens int64
+	var cacheTokens int64
+
+	err := rows.Scan(
+		&endpoint,
+		&modelName,
+		&detail.Timestamp,
+		&detail.Source,
+		&detail.AuthIndex,
+		&detail.APIKeyHash,
+		&detail.AccountSnapshot,
+		&detail.AuthLabelSnapshot,
+		&detail.AuthFileSnapshot,
+		&detail.AuthProviderSnapshot,
+		&detail.AuthProjectIDSnapshot,
+		&authSnapshotAt,
+		&latency,
+		&ttft,
+		&detail.ResolvedModel,
+		&detail.ReasoningEffort,
+		&detail.ServiceTier,
+		&detail.ExecutorType,
+		&detail.Tokens.InputTokens,
+		&detail.Tokens.OutputTokens,
+		&detail.Tokens.ReasoningTokens,
+		&cachedTokens,
+		&cacheTokens,
+		&detail.Tokens.CacheReadTokens,
+		&detail.Tokens.CacheCreationTokens,
+		&detail.Tokens.TotalTokens,
+		&failed,
+		&failStatusCode,
+		&detail.FailSummary,
+		&responseMetadataJSON,
+	)
+	if err != nil {
+		return "", "", rawMetadataDetail{}, err
+	}
+	if authSnapshotAt.Valid {
+		detail.AuthSnapshotAtMS = authSnapshotAt.Int64
+	}
+	if latency.Valid {
+		value := latency.Int64
+		detail.LatencyMS = &value
+	}
+	if ttft.Valid {
+		value := ttft.Int64
+		detail.TTFTMS = &value
+	}
+	if failStatusCode.Valid {
+		detail.FailStatusCode = int(failStatusCode.Int64)
+	}
+	detail.Failed = failed != 0
+	compatibleCachedTokens := usage.CompatibleCachedTokens(
+		cachedTokens,
+		cacheTokens,
+		detail.Tokens.CacheReadTokens,
+		detail.Tokens.CacheCreationTokens,
+	)
+	detail.Tokens.CachedTokens = compatibleCachedTokens
+	detail.Tokens.CacheTokens = compatibleCachedTokens
+	return endpoint, modelName, rawMetadataDetail{
+		Detail:           detail,
+		ResponseMetadata: validatedMetadataJSON(responseMetadataJSON),
+	}, nil
+}
+
+func scanExportRow(rows *sql.Rows) (exportRow, error) {
+	var row exportRow
+	event := &row.event
+	var requestID, provider, executorType, endpoint, method, path, authType, authIndex, source, sourceHash, apiKeyHash, accountSnapshot, authLabelSnapshot, authFileSnapshot, authProviderSnapshot, authProjectIDSnapshot, requestedModel, resolvedModel, reasoningEffort, serviceTier, failSummary sql.NullString
+	var responseMetadataJSON, quotaPlanType, errorKind, errorCode, traceID string
+	var authSnapshotAt sql.NullInt64
+	var latency, ttft sql.NullInt64
+	var failStatusCode sql.NullInt64
+	var quotaRecoverAt sql.NullInt64
+	var quotaUsedPercent sql.NullFloat64
+	var failed int
+	if err := rows.Scan(
+		&row.id,
+		&requestID,
+		&event.EventHash,
+		&event.TimestampMS,
+		&event.Timestamp,
+		&provider,
+		&executorType,
+		&event.Model,
+		&endpoint,
+		&method,
+		&path,
+		&authType,
+		&authIndex,
+		&source,
+		&sourceHash,
+		&apiKeyHash,
+		&accountSnapshot,
+		&authLabelSnapshot,
+		&authFileSnapshot,
+		&authProviderSnapshot,
+		&authProjectIDSnapshot,
+		&authSnapshotAt,
+		&requestedModel,
+		&resolvedModel,
+		&reasoningEffort,
+		&serviceTier,
+		&event.InputTokens,
+		&event.OutputTokens,
+		&event.ReasoningTokens,
+		&event.CachedTokens,
+		&event.CacheTokens,
+		&event.CacheReadTokens,
+		&event.CacheCreationTokens,
+		&event.TotalTokens,
+		&latency,
+		&ttft,
+		&failed,
+		&failStatusCode,
+		&failSummary,
+		&responseMetadataJSON,
+		&quotaRecoverAt,
+		&quotaUsedPercent,
+		&quotaPlanType,
+		&errorKind,
+		&errorCode,
+		&traceID,
+		&event.CreatedAtMS,
+	); err != nil {
+		return exportRow{}, err
+	}
+	event.RequestID = requestID.String
+	event.Provider = provider.String
+	event.ExecutorType = executorType.String
+	event.Endpoint = endpoint.String
+	event.Method = method.String
+	event.Path = path.String
+	event.AuthType = authType.String
+	event.AuthIndex = authIndex.String
+	event.Source = source.String
+	event.SourceHash = sourceHash.String
+	event.APIKeyHash = apiKeyHash.String
+	event.AccountSnapshot = accountSnapshot.String
+	event.AuthLabelSnapshot = authLabelSnapshot.String
+	event.AuthFileSnapshot = authFileSnapshot.String
+	event.AuthProviderSnapshot = authProviderSnapshot.String
+	event.AuthProjectIDSnapshot = authProjectIDSnapshot.String
+	event.RequestedModel = requestedModel.String
+	event.ResolvedModel = resolvedModel.String
+	event.ReasoningEffort = reasoningEffort.String
+	event.ServiceTier = serviceTier.String
+	event.FailSummary = failSummary.String
+	event.HeaderQuotaPlanType = quotaPlanType
+	event.HeaderErrorKind = errorKind
+	event.HeaderErrorCode = errorCode
+	event.HeaderTraceID = traceID
+	event.Failed = failed != 0
+	if authSnapshotAt.Valid {
+		event.AuthSnapshotAtMS = authSnapshotAt.Int64
+	}
+	if latency.Valid {
+		value := latency.Int64
+		event.LatencyMS = &value
+	}
+	if ttft.Valid {
+		value := ttft.Int64
+		event.TTFTMS = &value
+	}
+	if failStatusCode.Valid {
+		event.FailStatusCode = int(failStatusCode.Int64)
+	}
+	if quotaRecoverAt.Valid {
+		event.HeaderQuotaRecoverAtMS = quotaRecoverAt.Int64
+	}
+	if quotaUsedPercent.Valid {
+		value := quotaUsedPercent.Float64
+		event.HeaderQuotaUsedPercent = &value
+	}
+	row.timestampMS = event.TimestampMS
+	row.responseMetadata = validatedMetadataJSON(responseMetadataJSON)
+	return row, nil
+}
+
+func validatedMetadataJSON(raw string) json.RawMessage {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+		return nil
+	}
+	metadata := json.RawMessage(trimmed)
+	if !json.Valid(metadata) {
+		return nil
+	}
+	return metadata
+}
+
+func normalizeUsageStreamLimit(limit int) int {
+	if limit <= 0 {
+		return defaultUsageStreamLimit
+	}
+	return limit
+}
+
+func writeCompatibleUsageHeader(writer io.Writer, totals compatibleUsageTotals) error {
+	_, err := io.WriteString(writer,
+		`{"total_requests":`+int64String(totals.totalRequests)+
+			`,"success_count":`+int64String(totals.successCount)+
+			`,"failure_count":`+int64String(totals.failureCount)+
+			`,"total_tokens":`+int64String(totals.totalTokens)+
+			`,"apis":{`,
+	)
+	return err
+}
+
+func int64String(value int64) string {
+	return strconv.FormatInt(value, 10)
+}
+
+func writeJSONString(writer io.Writer, value string) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(encoded)
+	return err
+}

--- a/apps/manager-server/internal/repository/usageevent/stream_test.go
+++ b/apps/manager-server/internal/repository/usageevent/stream_test.go
@@ -1,0 +1,145 @@
+package usageevent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestWriteCompatibleUsageMatchesBuildPayload(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+
+	latency := int64(125)
+	events := []usage.Event{
+		streamTestEvent("old", 100, "GET /old", "old-model"),
+		streamTestEvent("b-model", 200, "POST /v1/responses", "gpt-b"),
+		streamTestEvent("a-success", 300, "GET /v1/models", "gpt-a"),
+		streamTestEvent("a-failure", 400, "GET /v1/models", "gpt-a"),
+	}
+	events[1].ResolvedModel = "gpt-b-resolved"
+	events[2].LatencyMS = &latency
+	events[2].CachedTokens = 7
+	events[2].CacheTokens = 7
+	events[2].CacheReadTokens = 3
+	events[2].CacheCreationTokens = 2
+	events[3].Failed = true
+	events[3].FailStatusCode = 429
+	events[3].FailSummary = "rate limited"
+	usage.AttachResponseHeaderMetadata(&events[3], &usage.ResponseHeaderMetadata{
+		Trace: &usage.HeaderTraceMetadata{PrimaryTraceID: "trace-stream"},
+	})
+	if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	recent, err := repo.ListRecent(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("list recent: %v", err)
+	}
+	expected := usage.BuildPayload(recent)
+	var output bytes.Buffer
+	if err := repo.WriteCompatibleUsage(context.Background(), &output, 3); err != nil {
+		t.Fatalf("write compatible usage: %v", err)
+	}
+	if !json.Valid(output.Bytes()) {
+		t.Fatalf("invalid JSON: %s", output.String())
+	}
+	var actual usage.Payload
+	if err := json.Unmarshal(output.Bytes(), &actual); err != nil {
+		t.Fatalf("decode compatible usage: %v", err)
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("streamed payload mismatch\nactual: %#v\nexpected: %#v", actual, expected)
+	}
+}
+
+func TestWriteExportJSONLUsesRecentLimitAndAscendingKeysetOrder(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+
+	events := make([]usage.Event, 0, usageExportBatchSize+3)
+	for index := 1; index <= usageExportBatchSize+3; index++ {
+		event := streamTestEvent(fmt.Sprintf("event-%03d", index), int64(index), "POST /v1/responses", "gpt-test")
+		event.RawJSON = `{"secret":"must-not-export"}`
+		event.FailBody = "must-not-export"
+		events = append(events, event)
+	}
+	usage.AttachResponseHeaderMetadata(&events[len(events)-1], &usage.ResponseHeaderMetadata{
+		Trace: &usage.HeaderTraceMetadata{PrimaryTraceID: "trace-export"},
+	})
+	if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	var output bytes.Buffer
+	if err := repo.WriteExportJSONL(context.Background(), &output, usageExportBatchSize+1); err != nil {
+		t.Fatalf("write export: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != usageExportBatchSize+1 {
+		t.Fatalf("line count = %d", len(lines))
+	}
+	for index, line := range lines {
+		var event usage.Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decode line %d: %v", index, err)
+		}
+		wantTimestamp := int64(index + 3)
+		if event.TimestampMS != wantTimestamp {
+			t.Fatalf("line %d timestamp = %d, want %d", index, event.TimestampMS, wantTimestamp)
+		}
+		if event.RawJSON != "" || event.FailBody != "" {
+			t.Fatalf("line %d exposes sensitive fields: %#v", index, event)
+		}
+	}
+	var last usage.Event
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &last); err != nil {
+		t.Fatalf("decode last line: %v", err)
+	}
+	if last.ResponseMetadata == nil || last.ResponseMetadata.Trace == nil || last.ResponseMetadata.Trace.PrimaryTraceID != "trace-export" {
+		t.Fatalf("last metadata = %#v", last.ResponseMetadata)
+	}
+}
+
+func TestValidatedMetadataJSONRequiresJSONObject(t *testing.T) {
+	for _, raw := range []string{"", "null", "[]", `{"trace":`, `"text"`} {
+		if metadata := validatedMetadataJSON(raw); metadata != nil {
+			t.Fatalf("metadata for %q = %s", raw, metadata)
+		}
+	}
+	if metadata := validatedMetadataJSON(`{"trace":{"primary_trace_id":"trace"}}`); metadata == nil {
+		t.Fatal("valid metadata was rejected")
+	}
+}
+
+func streamTestEvent(hash string, timestampMS int64, endpoint, model string) usage.Event {
+	return usage.Event{
+		EventHash:    hash,
+		TimestampMS:  timestampMS,
+		Timestamp:    fmt.Sprintf("2026-01-01T00:00:%02dZ", timestampMS%60),
+		Model:        model,
+		Endpoint:     endpoint,
+		Source:       "test-source",
+		InputTokens:  1,
+		OutputTokens: 2,
+		TotalTokens:  3,
+		CreatedAtMS:  timestampMS,
+	}
+}

--- a/apps/manager-server/internal/service/modelprice/service.go
+++ b/apps/manager-server/internal/service/modelprice/service.go
@@ -115,6 +115,10 @@ func (s *Service) List(ctx context.Context) (map[string]store.ModelPrice, error)
 	return s.store.LoadModelPrices(ctx)
 }
 
+func (s *Service) UsageSummary(ctx context.Context, limit int) (store.ModelUsageSummary, error) {
+	return s.store.ModelUsageSummary(ctx, limit)
+}
+
 func (s *Service) Replace(ctx context.Context, prices map[string]store.ModelPrice) (map[string]store.ModelPrice, error) {
 	if prices == nil {
 		return nil, errors.New("prices are required")

--- a/apps/manager-server/internal/service/modelprice/service_test.go
+++ b/apps/manager-server/internal/service/modelprice/service_test.go
@@ -7,7 +7,31 @@ import (
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/testutil"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
+
+func TestUsageSummaryUsesConfiguredRecentLimit(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	st := testutil.NewStore(t, cfg)
+	if _, err := st.UsageEvents.InsertBatch(context.Background(), []usage.Event{
+		{EventHash: "older", TimestampMS: 100, Timestamp: "2026-01-01T00:00:00Z", Model: "gpt-old", CreatedAtMS: 100},
+		{EventHash: "newer", TimestampMS: 200, Timestamp: "2026-01-01T00:00:01Z", Model: "gpt-new", ResolvedModel: "gpt-resolved", CreatedAtMS: 200},
+	}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	summary, err := New(st, nil).UsageSummary(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("usage summary: %v", err)
+	}
+	if summary.SampledEvents != 1 || summary.TotalEvents != 2 || !summary.Truncated {
+		t.Fatalf("summary metadata = %#v", summary)
+	}
+	if len(summary.Models) != 2 || summary.Models[0].Model != "gpt-new" || summary.Models[1].Model != "gpt-resolved" {
+		t.Fatalf("models = %#v", summary.Models)
+	}
+}
 
 func TestSelectModelPricesIncludesResolvedAndProviderVariants(t *testing.T) {
 	remote := map[string]store.ModelPrice{

--- a/apps/manager-server/internal/service/usage/service.go
+++ b/apps/manager-server/internal/service/usage/service.go
@@ -2,6 +2,8 @@ package usage
 
 import (
 	"context"
+	"fmt"
+	"io"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	usageparser "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
@@ -17,45 +19,61 @@ type ImportResult struct {
 	Warnings    []string `json:"warnings"`
 }
 
+type ImportPersistenceError struct {
+	err error
+}
+
+func (e *ImportPersistenceError) Error() string {
+	return fmt.Sprintf("persist usage import batch: %v", e.err)
+}
+
+func (e *ImportPersistenceError) Unwrap() error {
+	return e.err
+}
+
 type Service struct {
 	store *store.Store
 }
+
+const importBatchSize = 256
 
 func New(store *store.Store) *Service {
 	return &Service{store: store}
 }
 
-func (s *Service) GetCompatibleUsage(ctx context.Context, limit int) (usageparser.Payload, error) {
-	events, err := s.store.RecentEvents(ctx, limit)
-	if err != nil {
-		return usageparser.Payload{}, err
-	}
-	return usageparser.BuildPayload(events), nil
+func (s *Service) WriteCompatibleUsage(ctx context.Context, writer io.Writer, limit int) error {
+	return s.store.WriteCompatibleUsage(ctx, writer, limit)
 }
 
-func (s *Service) Export(ctx context.Context) ([]byte, error) {
-	return s.store.ExportJSONL(ctx)
+func (s *Service) WriteExport(ctx context.Context, writer io.Writer, limit int) error {
+	return s.store.WriteExportJSONL(ctx, writer, limit)
 }
 
-func (s *Service) Import(ctx context.Context, data []byte) (ImportResult, *usageparser.ImportParseResult, error) {
-	parsed, err := usageparser.ParseImportPayload(data)
-	if err != nil {
-		return ImportResult{}, &parsed, err
-	}
-
-	result, err := s.store.InsertEvents(ctx, parsed.Events)
-	if err != nil {
-		return ImportResult{}, &parsed, err
-	}
-	return ImportResult{
+func (s *Service) Import(ctx context.Context, reader io.Reader) (ImportResult, *usageparser.ImportStreamResult, error) {
+	var added int
+	var skipped int
+	parsed, err := usageparser.StreamImportPayload(reader, importBatchSize, func(events []usageparser.Event) error {
+		result, err := s.store.InsertEvents(ctx, events)
+		if err != nil {
+			return &ImportPersistenceError{err: err}
+		}
+		added += result.Inserted
+		skipped += result.Skipped
+		return nil
+	})
+	result := ImportResult{
 		Format:      parsed.Format,
-		Added:       result.Inserted,
-		Skipped:     result.Skipped,
-		Total:       len(parsed.Events),
+		Added:       added,
+		Skipped:     skipped,
+		Total:       parsed.Total,
 		Failed:      parsed.Failed,
 		Unsupported: parsed.Unsupported,
 		Warnings:    parsed.Warnings,
-	}, &parsed, nil
+	}
+	if err != nil {
+		return result, &parsed, err
+	}
+	return result, &parsed, nil
 }
 
 func (s *Service) Counts(ctx context.Context) (events int64, deadLetters int64, err error) {

--- a/apps/manager-server/internal/service/usage/service_test.go
+++ b/apps/manager-server/internal/service/usage/service_test.go
@@ -1,0 +1,85 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/testutil"
+)
+
+func TestImportStreamsBatchesIntoStore(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	st := testutil.NewStore(t, cfg)
+	var payload strings.Builder
+	for index := 0; index < 300; index++ {
+		writeImportTestEvent(&payload, fmt.Sprintf("event-%d", index), int64(index+1))
+	}
+	writeImportTestEvent(&payload, "event-0", 1)
+
+	result, parsed, err := New(st).Import(context.Background(), strings.NewReader(payload.String()))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if parsed == nil || parsed.Total != 301 || result.Total != 301 || result.Added != 300 || result.Skipped != 1 {
+		t.Fatalf("result = %#v parsed = %#v", result, parsed)
+	}
+	events, _, err := st.Counts(context.Background())
+	if err != nil {
+		t.Fatalf("counts: %v", err)
+	}
+	if events != 300 {
+		t.Fatalf("events = %d", events)
+	}
+}
+
+func TestImportKeepsCompletedBatchesWhenReaderFails(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	st := testutil.NewStore(t, cfg)
+	var payload strings.Builder
+	for index := 0; index < 300; index++ {
+		writeImportTestEvent(&payload, fmt.Sprintf("event-%d", index), int64(index+1))
+	}
+	readerErr := errors.New("reader failed")
+	reader := &errorAtEOFReader{reader: strings.NewReader(payload.String()), err: readerErr}
+
+	_, parsed, err := New(st).Import(context.Background(), reader)
+	if !errors.Is(err, readerErr) {
+		t.Fatalf("error = %v", err)
+	}
+	if parsed == nil || parsed.Total != 300 {
+		t.Fatalf("parsed = %#v", parsed)
+	}
+	events, _, countErr := st.Counts(context.Background())
+	if countErr != nil {
+		t.Fatalf("counts: %v", countErr)
+	}
+	if events != importBatchSize {
+		t.Fatalf("events = %d, want committed batch %d", events, importBatchSize)
+	}
+}
+
+func writeImportTestEvent(builder *strings.Builder, hash string, timestampMS int64) {
+	_, _ = fmt.Fprintf(
+		builder,
+		`{"event_hash":%q,"timestamp_ms":%d,"timestamp":"2026-01-02T03:04:05Z","model":"gpt-test","endpoint":"POST /v1/responses"}`+"\n",
+		hash,
+		timestampMS,
+	)
+}
+
+type errorAtEOFReader struct {
+	reader *strings.Reader
+	err    error
+}
+
+func (r *errorAtEOFReader) Read(buffer []byte) (int, error) {
+	read, err := r.reader.Read(buffer)
+	if errors.Is(err, io.EOF) {
+		return read, r.err
+	}
+	return read, err
+}

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -1,8 +1,10 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"io"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
@@ -35,6 +37,8 @@ type CodexInspectionLog = model.CodexInspectionLog
 type InsertResult = model.InsertResult
 type ModelPrice = model.ModelPrice
 type ModelPriceSyncResult = model.ModelPriceSyncResult
+type ModelUsageStat = model.ModelUsageStat
+type ModelUsageSummary = model.ModelUsageSummary
 type APIKeyAlias = model.APIKeyAlias
 type QuotaCooldown = model.QuotaCooldown
 type QuotaCooldownUpsert = model.QuotaCooldownUpsert
@@ -168,6 +172,10 @@ func (s *Store) SaveModelPrices(ctx context.Context, prices map[string]ModelPric
 
 func (s *Store) UpsertSyncedModelPrices(ctx context.Context, prices map[string]ModelPrice) (ModelPriceSyncResult, error) {
 	return s.ModelPrices.UpsertSynced(ctx, prices)
+}
+
+func (s *Store) ModelUsageSummary(ctx context.Context, limit int) (ModelUsageSummary, error) {
+	return s.UsageEvents.ModelUsageSummary(ctx, limit)
 }
 
 func (s *Store) LoadAPIKeyAliases(ctx context.Context) ([]APIKeyAlias, error) {
@@ -319,7 +327,19 @@ func (s *Store) Counts(ctx context.Context) (events int64, deadLetters int64, er
 }
 
 func (s *Store) ExportJSONL(ctx context.Context) ([]byte, error) {
-	return s.UsageEvents.ExportJSONL(ctx)
+	var output bytes.Buffer
+	if err := s.WriteExportJSONL(ctx, &output, 0); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func (s *Store) WriteCompatibleUsage(ctx context.Context, writer io.Writer, limit int) error {
+	return s.UsageEvents.WriteCompatibleUsage(ctx, writer, limit)
+}
+
+func (s *Store) WriteExportJSONL(ctx context.Context, writer io.Writer, limit int) error {
+	return s.UsageEvents.WriteExportJSONL(ctx, writer, limit)
 }
 
 // AggregateBetween computes summary metrics over [fromMs, toMs).

--- a/apps/manager-server/internal/usage/import.go
+++ b/apps/manager-server/internal/usage/import.go
@@ -32,6 +32,226 @@ type ImportParseResult struct {
 	Warnings    []string
 }
 
+type ImportStreamResult struct {
+	Format      string
+	Total       int
+	Failed      int
+	Unsupported int
+	Warnings    []string
+}
+
+type importBatcher struct {
+	batchSize int
+	batch     []Event
+	total     int
+	consume   func([]Event) error
+}
+
+func StreamImportPayload(reader io.Reader, batchSize int, consume func([]Event) error) (ImportStreamResult, error) {
+	if batchSize <= 0 {
+		batchSize = 256
+	}
+	buffered := bufio.NewReader(reader)
+	first, err := peekNonWhitespaceByte(buffered)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return ImportStreamResult{}, errors.New("empty usage import payload")
+		}
+		return ImportStreamResult{}, err
+	}
+
+	batcher := &importBatcher{
+		batchSize: batchSize,
+		batch:     make([]Event, 0, batchSize),
+		consume:   consume,
+	}
+	var result ImportStreamResult
+	switch first {
+	case '[':
+		result, err = streamJSONArrayImport(buffered, batcher)
+	case '{':
+		result, err = streamJSONObjectOrJSONLImport(buffered, batcher)
+	default:
+		result = ImportStreamResult{Format: ImportFormatJSONL}
+		err = streamJSONLImport(buffered, batcher, &result)
+	}
+	result.Total = batcher.total
+	return result, err
+}
+
+func streamJSONArrayImport(reader io.Reader, batcher *importBatcher) (ImportStreamResult, error) {
+	result := ImportStreamResult{Format: ImportFormatJSONL}
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil {
+		return result, err
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '[' {
+		return result, ErrUnsupportedImportFormat
+	}
+	for decoder.More() {
+		var item json.RawMessage
+		if err := decoder.Decode(&item); err != nil {
+			return result, err
+		}
+		event, err := eventFromJSONRecord(item)
+		if err != nil {
+			result.Failed++
+			continue
+		}
+		if err := batcher.add(event); err != nil {
+			return result, err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return result, err
+	}
+	if err := ensureDecoderEOF(decoder); err != nil {
+		return result, err
+	}
+	return result, batcher.flush()
+}
+
+func streamJSONObjectOrJSONLImport(reader io.Reader, batcher *importBatcher) (ImportStreamResult, error) {
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+	var first json.RawMessage
+	if err := decoder.Decode(&first); err != nil {
+		return ImportStreamResult{Format: ImportFormatJSONL}, err
+	}
+
+	parsed, err := parseJSONObjectImport(first)
+	if parsed.Format == ImportFormatLegacyExport || parsed.Format == ImportFormatLegacyPayload {
+		result := ImportStreamResult{
+			Format:      parsed.Format,
+			Failed:      parsed.Failed,
+			Unsupported: parsed.Unsupported,
+			Warnings:    parsed.Warnings,
+		}
+		if err != nil {
+			return result, err
+		}
+		if err := ensureOnlyWhitespace(io.MultiReader(decoder.Buffered(), reader)); err != nil {
+			return result, err
+		}
+		for _, event := range parsed.Events {
+			if err := batcher.add(event); err != nil {
+				return result, err
+			}
+		}
+		return result, batcher.flush()
+	}
+	if err != nil {
+		return ImportStreamResult{Format: ImportFormatJSONL, Failed: parsed.Failed}, err
+	}
+
+	result := ImportStreamResult{Format: ImportFormatJSONL, Failed: parsed.Failed}
+	for _, event := range parsed.Events {
+		if err := batcher.add(event); err != nil {
+			return result, err
+		}
+	}
+	if err := streamJSONLImport(io.MultiReader(decoder.Buffered(), reader), batcher, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func streamJSONLImport(reader io.Reader, batcher *importBatcher, result *ImportStreamResult) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		event, err := eventFromJSONRecord([]byte(line))
+		if err != nil {
+			result.Failed++
+			continue
+		}
+		if err := batcher.add(event); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return batcher.flush()
+}
+
+func (b *importBatcher) add(event Event) error {
+	b.batch = append(b.batch, event)
+	b.total++
+	if len(b.batch) < b.batchSize {
+		return nil
+	}
+	return b.flush()
+}
+
+func (b *importBatcher) flush() error {
+	if len(b.batch) == 0 {
+		return nil
+	}
+	// Import is intentionally batched rather than all-or-nothing: batches that
+	// completed before a later parse, size-limit, or database error stay committed.
+	if err := b.consume(b.batch); err != nil {
+		return err
+	}
+	b.batch = b.batch[:0]
+	return nil
+}
+
+func peekNonWhitespaceByte(reader *bufio.Reader) (byte, error) {
+	for {
+		value, err := reader.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		switch value {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			if err := reader.UnreadByte(); err != nil {
+				return 0, err
+			}
+			return value, nil
+		}
+	}
+}
+
+func ensureDecoderEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("usage import payload contains multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func ensureOnlyWhitespace(reader io.Reader) error {
+	buffer := make([]byte, 4096)
+	for {
+		read, err := reader.Read(buffer)
+		for _, value := range buffer[:read] {
+			switch value {
+			case ' ', '\t', '\r', '\n':
+			default:
+				return errors.New("usage import payload contains multiple JSON values")
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
 func ParseImportPayload(data []byte) (ImportParseResult, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {

--- a/apps/manager-server/internal/usage/import_test.go
+++ b/apps/manager-server/internal/usage/import_test.go
@@ -2,6 +2,8 @@ package usage
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -160,6 +162,75 @@ not-json`
 	}
 	if result.Format != ImportFormatJSONL || len(result.Events) != 1 || result.Failed != 1 {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestStreamImportPayloadBatchesJSONLAndCountsBadLines(t *testing.T) {
+	var payload strings.Builder
+	for index := 0; index < 600; index++ {
+		_, _ = fmt.Fprintf(&payload, `{"event_hash":"stream-%d","timestamp_ms":%d,"timestamp":"2026-01-02T03:04:05Z","model":"gpt-4o","endpoint":"GET /v1/models"}`+"\n", index, index+1)
+		if index == 300 {
+			payload.WriteString("not-json\n")
+		}
+	}
+
+	var batchSizes []int
+	result, err := StreamImportPayload(strings.NewReader(payload.String()), 256, func(events []Event) error {
+		batchSizes = append(batchSizes, len(events))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("stream import: %v", err)
+	}
+	if result.Format != ImportFormatJSONL || result.Total != 600 || result.Failed != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if !reflect.DeepEqual(batchSizes, []int{256, 256, 88}) {
+		t.Fatalf("batch sizes = %#v", batchSizes)
+	}
+}
+
+func TestStreamImportPayloadStreamsTopLevelArray(t *testing.T) {
+	var payload strings.Builder
+	payload.WriteByte('[')
+	for index := 0; index < 300; index++ {
+		if index > 0 {
+			payload.WriteByte(',')
+		}
+		_, _ = fmt.Fprintf(&payload, `{"event_hash":"array-%d","timestamp_ms":%d,"timestamp":"2026-01-02T03:04:05Z","model":"gpt-4o","endpoint":"GET /v1/models"}`, index, index+1)
+	}
+	payload.WriteByte(']')
+
+	var batchSizes []int
+	result, err := StreamImportPayload(strings.NewReader(payload.String()), 256, func(events []Event) error {
+		batchSizes = append(batchSizes, len(events))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("stream import array: %v", err)
+	}
+	if result.Total != 300 || result.Failed != 0 || !reflect.DeepEqual(batchSizes, []int{256, 44}) {
+		t.Fatalf("result = %#v batches = %#v", result, batchSizes)
+	}
+}
+
+func TestStreamImportPayloadKeepsCompletedBatchesOnLaterConsumerError(t *testing.T) {
+	payload := strings.Repeat(`{"timestamp":"2026-01-02T03:04:05Z","model":"gpt-4o","endpoint":"GET /v1/models"}`+"\n", 600)
+	completed := 0
+	batchCalls := 0
+	result, err := StreamImportPayload(strings.NewReader(payload), 256, func(events []Event) error {
+		batchCalls++
+		if batchCalls == 2 {
+			return errors.New("insert failed")
+		}
+		completed += len(events)
+		return nil
+	})
+	if err == nil || err.Error() != "insert failed" {
+		t.Fatalf("error = %v", err)
+	}
+	if completed != 256 || result.Total != 512 {
+		t.Fatalf("completed = %d result = %#v", completed, result)
 	}
 }
 

--- a/apps/web/src/features/demo/demoFixtures.empty.ts
+++ b/apps/web/src/features/demo/demoFixtures.empty.ts
@@ -10,6 +10,12 @@ export const getDemoManagerConfig = () => emptyObject;
 export const getDemoDashboardSummary = () => emptyObject;
 export const getDemoMonitoringAnalytics = () => emptyObject;
 export const getDemoModelPrices = () => ({ prices: {} });
+export const getDemoModelPriceUsageSummary = () => ({
+  sampled_events: 0,
+  total_events: 0,
+  truncated: false,
+  models: [],
+});
 export const getDemoUsagePayload = () => emptyObject;
 export const getDemoUsageServiceInfo = () => emptyObject;
 export const getDemoUsageServiceStatus = () => emptyObject;

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -6,6 +6,7 @@ import type {
   CodexInspectionRunsResponse,
   DashboardSummaryResponse,
   ManagerConfigResponse,
+  ModelPriceUsageSummaryResponse,
   ModelPricesResponse,
   MonitoringAnalyticsRequest,
   MonitoringAnalyticsResponse,
@@ -62,10 +63,7 @@ const splitTokens = (totalTokens: number) => {
   const cachedTokens = Math.round(totalTokens * 0.13);
   const cacheReadTokens = Math.round(cachedTokens * 0.78);
   const cacheCreationTokens = cachedTokens - cacheReadTokens;
-  const reasoningTokens = Math.max(
-    0,
-    totalTokens - inputTokens - outputTokens - cachedTokens
-  );
+  const reasoningTokens = Math.max(0, totalTokens - inputTokens - outputTokens - cachedTokens);
   return {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
@@ -613,6 +611,18 @@ const demoModelPrices: ModelPricesResponse = {
   },
 };
 
+const demoModelPriceUsageSummary: ModelPriceUsageSummaryResponse = {
+  sampled_events: 1_638,
+  total_events: 1_638,
+  truncated: false,
+  models: [
+    { model: 'gpt-4.1-mini', calls: 520, requested_calls: 520, resolved_calls: 0 },
+    { model: 'claude-sonnet-4-5', calls: 416, requested_calls: 416, resolved_calls: 0 },
+    { model: 'gemini-2.5-pro', calls: 384, requested_calls: 384, resolved_calls: 0 },
+    { model: 'gpt-4.1', calls: 318, requested_calls: 318, resolved_calls: 0 },
+  ],
+};
+
 const demoApiAliases: ApiKeyAlias[] = [
   { apiKeyHash: 'hash_openai_primary', alias: 'OpenAI Primary', updatedAtMs: now() - day },
   { apiKeyHash: 'hash_codex_team', alias: 'Codex Team', updatedAtMs: now() - 2 * hour },
@@ -702,7 +712,10 @@ const dashboardBase = (inputNow = now()): DashboardSummaryResponse => {
   const todayTokens = splitTokens(totalTokens);
   const totalCost = round2((totalTokens / 1_000_000) * 22.9);
   const timeline = Array.from({ length: 24 }, (_, hourIndex) => {
-    const hourPoints = healthPoints.slice(hourIndex * bucketsPerHour, (hourIndex + 1) * bucketsPerHour);
+    const hourPoints = healthPoints.slice(
+      hourIndex * bucketsPerHour,
+      (hourIndex + 1) * bucketsPerHour
+    );
     const calls = hourPoints.reduce((sum, point) => sum + point.calls, 0);
     const tokens = hourPoints.reduce((sum, point) => sum + point.tokens, 0);
     const success = hourPoints.reduce((sum, point) => sum + point.success, 0);
@@ -724,11 +737,35 @@ const dashboardBase = (inputNow = now()): DashboardSummaryResponse => {
   const rollingCalls = rollingPoints.reduce((sum, point) => sum + point.calls, 0);
   const rollingTokens = rollingPoints.reduce((sum, point) => sum + point.tokens, 0);
   const modelMix = [
-    { model: 'gpt-4.1-mini', callShare: 0.28, tokenShare: 0.21, costShare: 0.11, successRate: 0.991 },
-    { model: 'claude-sonnet-4-5', callShare: 0.22, tokenShare: 0.27, costShare: 0.3, successRate: 0.982 },
-    { model: 'gemini-2.5-pro', callShare: 0.2, tokenShare: 0.23, costShare: 0.25, successRate: 0.986 },
+    {
+      model: 'gpt-4.1-mini',
+      callShare: 0.28,
+      tokenShare: 0.21,
+      costShare: 0.11,
+      successRate: 0.991,
+    },
+    {
+      model: 'claude-sonnet-4-5',
+      callShare: 0.22,
+      tokenShare: 0.27,
+      costShare: 0.3,
+      successRate: 0.982,
+    },
+    {
+      model: 'gemini-2.5-pro',
+      callShare: 0.2,
+      tokenShare: 0.23,
+      costShare: 0.25,
+      successRate: 0.986,
+    },
     { model: 'gpt-4.1', callShare: 0.17, tokenShare: 0.19, costShare: 0.24, successRate: 0.976 },
-    { model: 'gemini-2.5-flash', callShare: 0.13, tokenShare: 0.1, costShare: 0.1, successRate: 0.994 },
+    {
+      model: 'gemini-2.5-flash',
+      callShare: 0.13,
+      tokenShare: 0.1,
+      costShare: 0.1,
+      successRate: 0.994,
+    },
   ].map((item) => ({
     model: item.model,
     calls: Math.round(totalCalls * item.callShare),
@@ -787,10 +824,26 @@ const dashboardBase = (inputNow = now()): DashboardSummaryResponse => {
       points: healthPoints,
     },
     token_mix: [
-      { key: 'input', tokens: todayTokens.input_tokens, share: safeRate(todayTokens.input_tokens, totalTokens) },
-      { key: 'output', tokens: todayTokens.output_tokens, share: safeRate(todayTokens.output_tokens, totalTokens) },
-      { key: 'cached', tokens: todayTokens.cached_tokens, share: safeRate(todayTokens.cached_tokens, totalTokens) },
-      { key: 'reasoning', tokens: todayTokens.reasoning_tokens, share: safeRate(todayTokens.reasoning_tokens, totalTokens) },
+      {
+        key: 'input',
+        tokens: todayTokens.input_tokens,
+        share: safeRate(todayTokens.input_tokens, totalTokens),
+      },
+      {
+        key: 'output',
+        tokens: todayTokens.output_tokens,
+        share: safeRate(todayTokens.output_tokens, totalTokens),
+      },
+      {
+        key: 'cached',
+        tokens: todayTokens.cached_tokens,
+        share: safeRate(todayTokens.cached_tokens, totalTokens),
+      },
+      {
+        key: 'reasoning',
+        tokens: todayTokens.reasoning_tokens,
+        share: safeRate(todayTokens.reasoning_tokens, totalTokens),
+      },
     ],
     channel_health: [
       {
@@ -884,10 +937,11 @@ const paginateDemoEvents = (
   beforeMs?: number | null
 ): DemoMonitoringEventsResponse => {
   const sorted = [...items].sort((left, right) => right.timestamp_ms - left.timestamp_ms);
-  const filtered = beforeMs
-    ? sorted.filter((item) => item.timestamp_ms < beforeMs)
-    : sorted;
-  const safeLimit = Math.max(1, Math.min(Math.trunc(limit || filtered.length), filtered.length || 1));
+  const filtered = beforeMs ? sorted.filter((item) => item.timestamp_ms < beforeMs) : sorted;
+  const safeLimit = Math.max(
+    1,
+    Math.min(Math.trunc(limit || filtered.length), filtered.length || 1)
+  );
   const pageItems = filtered.slice(0, safeLimit);
   const last = pageItems[pageItems.length - 1];
   return {
@@ -937,7 +991,14 @@ const buildMonitoringAnalytics = (
 
   const modelStats = [
     buildNestedModelRow('gpt-4.1-mini', 6200, 48, 4_680_000, 56.2, analyticsNow - 8 * minute),
-    buildNestedModelRow('claude-sonnet-4-5', 4380, 96, 5_720_000, 158.7, analyticsNow - 13 * minute),
+    buildNestedModelRow(
+      'claude-sonnet-4-5',
+      4380,
+      96,
+      5_720_000,
+      158.7,
+      analyticsNow - 13 * minute
+    ),
     buildNestedModelRow('gemini-2.5-pro', 3620, 74, 4_960_000, 124.4, analyticsNow - 21 * minute),
     buildNestedModelRow('gpt-4.1', 2940, 81, 3_840_000, 102.8, analyticsNow - 16 * minute),
     buildNestedModelRow('gemini-2.5-flash', 2140, 24, 1_780_000, 28.9, analyticsNow - 6 * minute),
@@ -952,10 +1013,7 @@ const buildMonitoringAnalytics = (
   const summaryInputTokens = modelStats.reduce((sum, row) => sum + row.input_tokens, 0);
   const summaryOutputTokens = modelStats.reduce((sum, row) => sum + row.output_tokens, 0);
   const summaryCachedTokens = modelStats.reduce((sum, row) => sum + row.cached_tokens, 0);
-  const summaryCacheReadTokens = modelStats.reduce(
-    (sum, row) => sum + row.cache_read_tokens,
-    0
-  );
+  const summaryCacheReadTokens = modelStats.reduce((sum, row) => sum + row.cache_read_tokens, 0);
   const summaryCacheCreationTokens = modelStats.reduce(
     (sum, row) => sum + row.cache_creation_tokens,
     0
@@ -1007,14 +1065,7 @@ const buildMonitoringAnalytics = (
           145.6,
           analyticsNow - 13 * minute
         ),
-        buildNestedModelRow(
-          'claude-haiku-4-5',
-          460,
-          8,
-          600_000,
-          13.1,
-          analyticsNow - 52 * minute
-        ),
+        buildNestedModelRow('claude-haiku-4-5', 460, 8, 600_000, 13.1, analyticsNow - 52 * minute),
       ],
     },
     {
@@ -1065,14 +1116,7 @@ const buildMonitoringAnalytics = (
       average_latency_ms: 1080,
       last_seen_ms: analyticsNow - 10 * minute,
       models: [
-        buildNestedModelRow(
-          'gpt-4.1-mini',
-          2720,
-          24,
-          2_040_000,
-          25.0,
-          analyticsNow - 10 * minute
-        ),
+        buildNestedModelRow('gpt-4.1-mini', 2720, 24, 2_040_000, 25.0, analyticsNow - 10 * minute),
         buildNestedModelRow('gpt-4.1', 820, 15, 660_000, 20.8, analyticsNow - 36 * minute),
       ],
     },
@@ -1092,14 +1136,7 @@ const buildMonitoringAnalytics = (
       last_seen_ms: analyticsNow - 18 * minute,
       models: [
         buildNestedModelRow('gpt-4.1', 440, 24, 520_000, 22.6, analyticsNow - 18 * minute),
-        buildNestedModelRow(
-          'gpt-4.1-mini',
-          1120,
-          22,
-          740_000,
-          9.1,
-          analyticsNow - 28 * minute
-        ),
+        buildNestedModelRow('gpt-4.1-mini', 1120, 22, 740_000, 9.1, analyticsNow - 28 * minute),
       ],
     },
     {
@@ -1117,14 +1154,7 @@ const buildMonitoringAnalytics = (
       average_latency_ms: 980,
       last_seen_ms: analyticsNow - 11 * minute,
       models: [
-        buildNestedModelRow(
-          'gpt-4.1-mini',
-          1800,
-          18,
-          1_240_000,
-          15.2,
-          analyticsNow - 11 * minute
-        ),
+        buildNestedModelRow('gpt-4.1-mini', 1800, 18, 1_240_000, 15.2, analyticsNow - 11 * minute),
         buildNestedModelRow('gpt-4.1', 680, 10, 680_000, 17.2, analyticsNow - 32 * minute),
       ],
     },
@@ -1151,14 +1181,7 @@ const buildMonitoringAnalytics = (
           65.1,
           analyticsNow - 19 * minute
         ),
-        buildNestedModelRow(
-          'claude-haiku-4-5',
-          820,
-          12,
-          860_000,
-          18.4,
-          analyticsNow - 52 * minute
-        ),
+        buildNestedModelRow('claude-haiku-4-5', 820, 12, 860_000, 18.4, analyticsNow - 52 * minute),
       ],
     },
     {
@@ -1184,14 +1207,7 @@ const buildMonitoringAnalytics = (
           15.8,
           analyticsNow - 24 * minute
         ),
-        buildNestedModelRow(
-          'gemini-2.5-pro',
-          600,
-          11,
-          820_000,
-          22.4,
-          analyticsNow - 43 * minute
-        ),
+        buildNestedModelRow('gemini-2.5-pro', 600, 11, 820_000, 22.4, analyticsNow - 43 * minute),
       ],
     },
     {
@@ -1208,7 +1224,9 @@ const buildMonitoringAnalytics = (
       cost: 15.8,
       average_latency_ms: 1710,
       last_seen_ms: analyticsNow - 48 * minute,
-      models: [buildNestedModelRow('qwen-plus', 1220, 36, 980_000, 15.8, analyticsNow - 48 * minute)],
+      models: [
+        buildNestedModelRow('qwen-plus', 1220, 36, 980_000, 15.8, analyticsNow - 48 * minute),
+      ],
     },
     {
       id: 'acct_builder_lab',
@@ -1225,14 +1243,7 @@ const buildMonitoringAnalytics = (
       average_latency_ms: 1320,
       last_seen_ms: analyticsNow - 27 * minute,
       models: [
-        buildNestedModelRow(
-          'gemini-2.5-flash',
-          960,
-          12,
-          820_000,
-          14.4,
-          analyticsNow - 27 * minute
-        ),
+        buildNestedModelRow('gemini-2.5-flash', 960, 12, 820_000, 14.4, analyticsNow - 27 * minute),
       ],
     },
     {
@@ -1249,7 +1260,9 @@ const buildMonitoringAnalytics = (
       cost: 12.2,
       average_latency_ms: 1490,
       last_seen_ms: analyticsNow - 55 * minute,
-      models: [buildNestedModelRow('grok-4-fast', 860, 14, 690_000, 12.2, analyticsNow - 55 * minute)],
+      models: [
+        buildNestedModelRow('grok-4-fast', 860, 14, 690_000, 12.2, analyticsNow - 55 * minute),
+      ],
     },
     {
       id: 'acct_edge_experiments',
@@ -1265,7 +1278,9 @@ const buildMonitoringAnalytics = (
       cost: 6.8,
       average_latency_ms: 1580,
       last_seen_ms: analyticsNow - 44 * minute,
-      models: [buildNestedModelRow('deepseek-chat', 740, 20, 610_000, 6.8, analyticsNow - 44 * minute)],
+      models: [
+        buildNestedModelRow('deepseek-chat', 740, 20, 610_000, 6.8, analyticsNow - 44 * minute),
+      ],
     },
   ].map((row) => {
     const tokenSplit = splitTokens(row.total_tokens);
@@ -1333,7 +1348,16 @@ const buildMonitoringAnalytics = (
       cost: 124.4,
       average_latency_ms: 1160,
       last_seen_ms: analyticsNow - 21 * minute,
-      models: [buildNestedModelRow('gemini-2.5-pro', 3620, 74, 4_960_000, 124.4, analyticsNow - 21 * minute)],
+      models: [
+        buildNestedModelRow(
+          'gemini-2.5-pro',
+          3620,
+          74,
+          4_960_000,
+          124.4,
+          analyticsNow - 21 * minute
+        ),
+      ],
     },
     {
       id: 'vertex-regional-01',
@@ -1351,7 +1375,16 @@ const buildMonitoringAnalytics = (
       cost: 28.9,
       average_latency_ms: 1040,
       last_seen_ms: analyticsNow - 6 * minute,
-      models: [buildNestedModelRow('gemini-2.5-flash', 2140, 24, 1_400_000, 28.9, analyticsNow - 6 * minute)],
+      models: [
+        buildNestedModelRow(
+          'gemini-2.5-flash',
+          2140,
+          24,
+          1_400_000,
+          28.9,
+          analyticsNow - 6 * minute
+        ),
+      ],
     },
     {
       id: 'codex-fallback-02',
@@ -1824,7 +1857,8 @@ const buildMonitoringAnalytics = (
       provider: 'vertex',
       source: 'regional',
       sourceHash: 'src_vertex_regional',
-      endpoint: '/v1/projects/demo-vertex-regional/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent',
+      endpoint:
+        '/v1/projects/demo-vertex-regional/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent',
       executor: 'worker',
     },
     {
@@ -2213,10 +2247,7 @@ const buildMonitoringAnalytics = (
     timeline,
     hourly_distribution: Array.from({ length: 24 }, (_, hourIndex) => ({
       hour: hourIndex,
-      calls:
-        24 +
-        ((hourIndex * 11) % 80) +
-        (hourIndex >= 9 && hourIndex <= 18 ? 42 : 0),
+      calls: 24 + ((hourIndex * 11) % 80) + (hourIndex >= 9 && hourIndex <= 18 ? 42 : 0),
       tokens: 24_000 + ((hourIndex * 7100) % 90_000),
     })),
     heatmap,
@@ -2515,6 +2546,7 @@ export const getDemoDashboardSummary = () => clone(dashboardBase());
 export const getDemoMonitoringAnalytics = (request?: MonitoringAnalyticsRequest) =>
   clone(buildMonitoringAnalytics(undefined, request));
 export const getDemoModelPrices = () => clone(demoModelPrices);
+export const getDemoModelPriceUsageSummary = () => clone(demoModelPriceUsageSummary);
 export const getDemoUsagePayload = () => {
   const dashboard = dashboardBase();
   return {
@@ -2829,7 +2861,9 @@ export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
       paidTier: {
         id: 'g1-pro-tier',
         name: 'Pro',
-        availableCredits: [{ creditType: 'monthly', creditAmount: 260, minimumCreditAmountForUsage: 1 }],
+        availableCredits: [
+          { creditType: 'monthly', creditAmount: 260, minimumCreditAmountForUsage: 1 },
+        ],
       },
     };
   }

--- a/apps/web/src/features/monitoring/ModelPricesPage.tsx
+++ b/apps/web/src/features/monitoring/ModelPricesPage.tsx
@@ -5,15 +5,20 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { IconPencil, IconSearch, IconTrash2, IconX } from '@/components/ui/icons';
 import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
-import type { ModelPriceSyncCandidate, ModelPriceSyncResponse } from '@/services/api/usageService';
-import { useNotificationStore } from '@/stores';
+import {
+  usageServiceApi,
+  type ModelPriceSyncCandidate,
+  type ModelPriceSyncResponse,
+  type ModelPriceUsageSummaryResponse,
+} from '@/services/api/usageService';
+import { useAuthStore, useNotificationStore } from '@/stores';
 import { useUsageData } from '@/features/monitoring/hooks/useUsageData';
 import {
   applyCandidatePrice,
   buildModelPriceRows,
   buildModelPriceSummary,
   buildPriceFromDraft,
-  buildSyncPriceModelsFromUsage,
+  buildSyncPriceModelsFromSummary,
   createEmptyPriceDraft,
   createPriceDraft,
   filterModelPriceRows,
@@ -21,10 +26,7 @@ import {
   type ModelPriceFilter,
   type PriceDraft,
 } from '@/features/monitoring/model/modelPricesPageModel';
-import {
-  readModelPricesPageUiState,
-  writeModelPricesPageUiState,
-} from './modelPricesPageUiState';
+import { readModelPricesPageUiState, writeModelPricesPageUiState } from './modelPricesPageUiState';
 import styles from './ModelPricesPage.module.scss';
 
 const FILTERS: ModelPriceFilter[] = ['all', 'missing', 'candidates', 'saved'];
@@ -39,9 +41,12 @@ const resolveErrorMessage = (error: unknown, fallback: string) => {
 export function ModelPricesPage() {
   const { t } = useTranslation();
   const { showNotification } = useNotificationStore();
+  const managementKey = useAuthStore((state) => state.managementKey);
   const featureAvailability = usePanelFeatureAvailability();
-  const { usage, loading, modelPrices, setModelPrices, syncModelPrices, usageServiceAvailable } =
-    useUsageData();
+  const { loading, modelPrices, setModelPrices, syncModelPrices, usageServiceAvailable } =
+    useUsageData({ loadUsageEvents: false });
+  const [usageSummary, setUsageSummary] = useState<ModelPriceUsageSummaryResponse | null>(null);
+  const [usageSummaryLoading, setUsageSummaryLoading] = useState(false);
   const initialUiState = useRef(readModelPricesPageUiState());
   const [search, setSearch] = useState(() => initialUiState.current.search);
   const [filter, setFilter] = useState<ModelPriceFilter>(() => initialUiState.current.filter);
@@ -50,16 +55,19 @@ export function ModelPricesPage() {
   const [selectedCandidates, setSelectedCandidates] = useState<Record<string, string>>({});
   const [draft, setDraft] = useState<PriceDraft>(() => createEmptyPriceDraft());
   const [manualEditorOpen, setManualEditorOpen] = useState(false);
+  const modelPriceServiceBase = featureAvailability.modelPricesAvailable
+    ? featureAvailability.managerServiceBase
+    : '';
 
   const syncModels = useMemo(
-    () => buildSyncPriceModelsFromUsage(usage, modelPrices),
-    [modelPrices, usage]
+    () => buildSyncPriceModelsFromSummary(usageSummary, modelPrices),
+    [modelPrices, usageSummary]
   );
 
   const candidateSets = useMemo(() => syncResult?.candidates ?? [], [syncResult?.candidates]);
   const rows = useMemo(
-    () => buildModelPriceRows(usage, modelPrices, candidateSets),
-    [candidateSets, modelPrices, usage]
+    () => buildModelPriceRows(usageSummary, modelPrices, candidateSets),
+    [candidateSets, modelPrices, usageSummary]
   );
   const summary = useMemo(() => buildModelPriceSummary(rows), [rows]);
   const visibleRows = useMemo(
@@ -80,6 +88,38 @@ export function ModelPricesPage() {
   useEffect(() => {
     writeModelPricesPageUiState({ search, filter });
   }, [filter, search]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (!modelPriceServiceBase) {
+      setUsageSummary(null);
+      setUsageSummaryLoading(false);
+      return () => controller.abort();
+    }
+
+    setUsageSummaryLoading(true);
+    void usageServiceApi
+      .getModelPriceUsageSummary(modelPriceServiceBase, managementKey, controller.signal)
+      .then((response) => {
+        if (!controller.signal.aborted) {
+          setUsageSummary(response);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          // Older Manager Server versions do not expose this lightweight endpoint.
+          // Keep saved prices visible without falling back to the large /usage payload.
+          setUsageSummary(null);
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setUsageSummaryLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [managementKey, modelPriceServiceBase]);
 
   const handleSync = async () => {
     if (syncModels.length === 0) {
@@ -303,7 +343,7 @@ export function ModelPricesPage() {
           </div>
         ) : null}
 
-        {loading ? (
+        {loading || usageSummaryLoading ? (
           <div className={styles.emptyState}>{t('common.loading')}</div>
         ) : visibleRows.length === 0 ? (
           <div className={styles.emptyState}>{t('model_prices.empty')}</div>

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -187,6 +187,9 @@ export function MonitoringCenterPage() {
   const [autoRefreshMs, setAutoRefreshMs] = useState(
     () => initialMonitoringCenterUiState.current.autoRefreshMs
   );
+  const [documentVisible, setDocumentVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState !== 'hidden'
+  );
   const [headerSnapshots, setHeaderSnapshots] = useState<UsageHeaderSnapshot[]>([]);
   const [selectedAccount, setSelectedAccount] = useState(
     () => initialMonitoringCenterUiState.current.selectedAccount
@@ -371,6 +374,7 @@ export function MonitoringCenterPage() {
     filteredRows,
     eventsHasMore,
     eventsLoadingMore,
+    eventsRetentionLimited,
     eventsTotalCount,
     eventsLoadedCount,
     lastRefreshedAt: monitoringLastRefreshedAt,
@@ -425,11 +429,20 @@ export function MonitoringCenterPage() {
   }, [setCurrentAccountPage]);
 
   useHeaderRefresh(refreshAll, isCurrentLayer);
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const updateVisibility = () => setDocumentVisible(document.visibilityState !== 'hidden');
+    document.addEventListener('visibilitychange', updateVisibility);
+    return () => document.removeEventListener('visibilitychange', updateVisibility);
+  }, []);
   useInterval(
     () => {
       void refreshAll().catch(() => {});
     },
-    isCurrentLayer && connectionStatus === 'connected' && Number(autoRefreshMs) > 0
+    isCurrentLayer &&
+      documentVisible &&
+      connectionStatus === 'connected' &&
+      Number(autoRefreshMs) > 0
       ? Number(autoRefreshMs)
       : null
   );
@@ -1478,6 +1491,7 @@ export function MonitoringCenterPage() {
               failedOnlyActive={failedOnlyActive}
               eventsHasMore={eventsHasMore}
               eventsLoadingMore={eventsLoadingMore}
+              eventsRetentionLimited={eventsRetentionLimited}
               eventsTotalCount={eventsTotalCount}
               eventsLoadedCount={eventsLoadedCount}
               overallLoading={overallLoading}

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -34,6 +34,7 @@ const t = ((key: string, options?: Record<string, unknown>) => {
     'monitoring.no_more_events': 'No more events',
     'monitoring.events_loaded_summary': 'Loaded {{loaded}} of {{total}} events',
     'monitoring.events_all_loaded': 'All {{total}} events loaded',
+    'monitoring.events_retention_limited': 'Kept the newest {{loaded}} of {{total}} events',
     'monitoring.reasoning_effort': 'Effort',
     'monitoring.reasoning_effort_short': 'Effort',
     'monitoring.recent_failures': 'Failures',
@@ -71,6 +72,7 @@ type PanelOverrides = {
   accountDisplayMode?: AccountDisplayMode;
   eventsHasMore?: boolean;
   eventsLoadingMore?: boolean;
+  eventsRetentionLimited?: boolean;
   eventsTotalCount?: number;
   eventsLoadedCount?: number;
 };
@@ -142,6 +144,7 @@ const renderPanel = (row: PanelRow, overrides: PanelOverrides = {}) =>
       failedOnlyActive={false}
       eventsHasMore={overrides.eventsHasMore ?? false}
       eventsLoadingMore={overrides.eventsLoadingMore ?? false}
+      eventsRetentionLimited={overrides.eventsRetentionLimited ?? false}
       eventsTotalCount={overrides.eventsTotalCount ?? 1}
       eventsLoadedCount={overrides.eventsLoadedCount ?? 1}
       overallLoading={false}
@@ -372,6 +375,18 @@ describe('RealtimeEventsPanel', () => {
     });
 
     expect(markup).toContain('All 8000 events loaded');
+    expect(markup).not.toContain('Load more');
+  });
+
+  it('shows the retention limit without a load-more action at the memory cap', () => {
+    const markup = renderPanel(baseRow(), {
+      eventsHasMore: false,
+      eventsRetentionLimited: true,
+      eventsLoadedCount: 2000,
+      eventsTotalCount: 8000,
+    });
+
+    expect(markup).toContain('Kept the newest 2000 of 8000 events');
     expect(markup).not.toContain('Load more');
   });
 

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -52,6 +52,7 @@ type RealtimeEventsPanelProps = {
   failedOnlyActive: boolean;
   eventsHasMore: boolean;
   eventsLoadingMore: boolean;
+  eventsRetentionLimited: boolean;
   eventsTotalCount: number;
   eventsLoadedCount: number;
   overallLoading: boolean;
@@ -676,6 +677,7 @@ export function RealtimeEventsPanel({
   failedOnlyActive,
   eventsHasMore,
   eventsLoadingMore,
+  eventsRetentionLimited,
   eventsTotalCount,
   eventsLoadedCount,
   overallLoading,
@@ -966,7 +968,12 @@ export function RealtimeEventsPanel({
       {rows.length > 0 ? (
         <div className={styles.loadMoreEventsBar}>
           <span className={styles.loadMoreEventsSummary}>
-            {eventsHasMore
+            {eventsRetentionLimited
+              ? t('monitoring.events_retention_limited', {
+                  loaded: eventsLoadedCount,
+                  total: eventsTotalCount,
+                })
+              : eventsHasMore
               ? t('monitoring.events_loaded_summary', {
                   loaded: eventsLoadedCount,
                   total: eventsTotalCount,

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.test.tsx
@@ -177,6 +177,7 @@ describe('useMonitoringAnalytics', () => {
     });
 
     expect(getAnalyticsMock).toHaveBeenCalledTimes(2);
+    expect((getAnalyticsMock.mock.calls[0]?.[3] as AbortSignal | undefined)?.aborted).toBe(true);
     expect(getAnalyticsMock.mock.calls[1]?.[2]).toEqual({
       from_ms: 2,
       to_ms: 20_000,

--- a/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringAnalytics.ts
@@ -102,6 +102,7 @@ export function useMonitoringAnalytics({
   const lastRequestKeyRef = useRef('');
   const inFlightRequestIdentityKeyRef = useRef('');
   const inFlightRequestIdRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const filtersKey = useMemo(() => stableJson(filters), [filters]);
   const includeKey = useMemo(() => stableJson(include), [include]);
@@ -162,6 +163,8 @@ export function useMonitoringAnalytics({
   const refresh = useCallback(
     async (options: MonitoringAnalyticsRefreshOptions = {}) => {
       if (!enabled || !request || !serviceBase) {
+        abortControllerRef.current?.abort();
+        abortControllerRef.current = null;
         requestIdRef.current += 1;
         inFlightRequestIdentityKeyRef.current = '';
         inFlightRequestIdRef.current = 0;
@@ -187,6 +190,9 @@ export function useMonitoringAnalytics({
       }
 
       const requestId = requestIdRef.current + 1;
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
       requestIdRef.current = requestId;
       lastStartedAtRef.current = startedAt;
       lastRequestKeyRef.current = requestKey;
@@ -199,19 +205,24 @@ export function useMonitoringAnalytics({
         const response = await monitoringAnalyticsApi.getAnalytics(
           serviceBase,
           managementKey,
-          request
+          request,
+          controller.signal
         );
         if (requestIdRef.current !== requestId) return;
         setData(response);
         setDataScopeStateKey(activeDataScopeKey);
         setLastRefreshedAt(new Date());
       } catch (err) {
+        if (controller.signal.aborted) return;
         if (requestIdRef.current !== requestId) return;
         setError(err instanceof Error ? err.message : String(err));
       } finally {
         if (inFlightRequestIdRef.current === requestId) {
           inFlightRequestIdentityKeyRef.current = '';
           inFlightRequestIdRef.current = 0;
+        }
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
         }
         if (requestIdRef.current === requestId) {
           setLoading(false);
@@ -236,6 +247,14 @@ export function useMonitoringAnalytics({
     }
     void refresh({ force: true });
   }, [availability.checking, refresh]);
+
+  useEffect(
+    () => () => {
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+    },
+    []
+  );
 
   const dataStale = Boolean(dataScopeKey && data && dataScopeStateKey !== activeDataScopeKey);
   const scopedData = dataScopeKey || dataScopeStateKey === activeDataScopeKey ? data : null;

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -11,6 +11,7 @@ import {
   mergeMonitoringEventsPageItems,
   resolveMonitoringDisplayEventItems,
   resolveMonitoringPresentationSnapshot,
+  withoutMonitoringSnapshotEvents,
   type MonitoringEventRow,
   type MonitoringPresentationSnapshot,
 } from './useMonitoringData';
@@ -96,6 +97,7 @@ const createPresentationSnapshot = (id: string): MonitoringPresentationSnapshot 
     filteredRows: [row],
     eventsHasMore: id.includes('more'),
     eventsLoadingMore: false,
+    eventsRetentionLimited: false,
     eventsTotalCount: 1,
     eventsLoadedCount: 1,
     lastRefreshedAt: new Date(1_768_759_000_000),
@@ -560,6 +562,34 @@ describe('mergeMonitoringEventsPageItems', () => {
     expect(
       mergeMonitoringEventsPageItems(previous, nextPage, null).map((item) => item.event_hash)
     ).toEqual(['event-3', 'event-2', 'event-1']);
+  });
+
+  it('keeps only the newest 2000 deduplicated events', () => {
+    const previous = Array.from({ length: 2_000 }, (_, index) =>
+      createAnalyticsEvent(`old-${index}`, 10_000 - index)
+    );
+    const nextPage = Array.from({ length: 500 }, (_, index) =>
+      createAnalyticsEvent(`new-${index}`, 20_000 - index)
+    );
+
+    const merged = mergeMonitoringEventsPageItems(previous, nextPage, null);
+    expect(merged).toHaveLength(2_000);
+    expect(merged[0]?.event_hash).toBe('new-0');
+    expect(merged[499]?.event_hash).toBe('new-499');
+    expect(merged[merged.length - 1]?.event_hash).toBe('old-1499');
+  });
+});
+
+describe('withoutMonitoringSnapshotEvents', () => {
+  it('keeps aggregate presentation data without retaining event rows', () => {
+    const snapshot = createPresentationSnapshot('cached');
+    const cached = withoutMonitoringSnapshotEvents(snapshot);
+
+    expect(cached.summary).toBe(snapshot.summary);
+    expect(cached.filteredRows).toEqual([]);
+    expect(cached.eventsLoadedCount).toBe(0);
+    expect(cached.eventsTotalCount).toBe(0);
+    expect(cached.eventsHasMore).toBe(false);
   });
 });
 

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -95,7 +95,8 @@ export {
 } from '../model/rowBuilders';
 
 const MONITORING_EVENTS_PAGE_LIMIT = 500;
-const MONITORING_PRESENTATION_CACHE_LIMIT = 24;
+export const MONITORING_EVENTS_RETENTION_LIMIT = 2_000;
+const MONITORING_PRESENTATION_CACHE_LIMIT = 4;
 const EMPTY_MONITORING_ANALYTICS_EVENT_ROWS: MonitoringAnalyticsEventRow[] = [];
 
 interface MonitoringEventsPageState {
@@ -126,6 +127,7 @@ export type MonitoringPresentationSnapshot = Pick<
   | 'filteredRows'
   | 'eventsHasMore'
   | 'eventsLoadingMore'
+  | 'eventsRetentionLimited'
   | 'eventsTotalCount'
   | 'eventsLoadedCount'
   | 'lastRefreshedAt'
@@ -195,13 +197,31 @@ export const mergeMonitoringEventsPageItems = (
   requestBeforeMs: number | null
 ) => {
   if (requestBeforeMs) {
-    return mergeAnalyticsEventItems(previousItems, pageItems);
+    return mergeAnalyticsEventItems(previousItems, pageItems).slice(
+      0,
+      MONITORING_EVENTS_RETENTION_LIMIT
+    );
   }
   if (previousItems.length === 0) {
-    return pageItems;
+    return pageItems.slice(0, MONITORING_EVENTS_RETENTION_LIMIT);
   }
-  return mergeAnalyticsEventItems(pageItems, previousItems);
+  return mergeAnalyticsEventItems(pageItems, previousItems).slice(
+    0,
+    MONITORING_EVENTS_RETENTION_LIMIT
+  );
 };
+
+export const withoutMonitoringSnapshotEvents = (
+  snapshot: MonitoringPresentationSnapshot
+): MonitoringPresentationSnapshot => ({
+  ...snapshot,
+  filteredRows: [],
+  eventsHasMore: false,
+  eventsLoadingMore: false,
+  eventsRetentionLimited: false,
+  eventsTotalCount: 0,
+  eventsLoadedCount: 0,
+});
 
 const uniqueOptionValues = (values: Array<string | null | undefined>) =>
   Array.from(new Set(values.map((value) => String(value || '').trim()).filter(Boolean))).sort(
@@ -486,9 +506,15 @@ export function useMonitoringData({
       eventsBeforeMs,
     ]
   );
-  const displayEventsHasMore = currentAnalyticsData?.events?.has_more ?? eventsHasMore;
   const eventsLoadedCount = displayEventItems.length;
   const displayEventsTotalCount = currentAnalyticsData?.events?.total_count ?? eventsLoadedCount;
+  const eventsRetentionLimited =
+    eventsLoadedCount >= MONITORING_EVENTS_RETENTION_LIMIT &&
+    (Boolean(currentAnalyticsData?.events?.has_more) ||
+      eventsHasMore ||
+      displayEventsTotalCount > MONITORING_EVENTS_RETENTION_LIMIT);
+  const displayEventsHasMore =
+    !eventsRetentionLimited && (currentAnalyticsData?.events?.has_more ?? eventsHasMore);
 
   useEffect(() => {
     const page = currentAnalyticsData?.events;
@@ -508,12 +534,13 @@ export function useMonitoringData({
         const base =
           previous.scopeKey === eventsScopeKey ? previous : createEventsPageState(eventsScopeKey);
         if (base.lastPageKey === pageKey) return base;
+        const items = mergeMonitoringEventsPageItems(base.items, page.items, requestBeforeMs);
         return {
           scopeKey: eventsScopeKey,
           beforeMs: requestBeforeMs,
           beforeId: requestBeforeId,
-          items: mergeMonitoringEventsPageItems(base.items, page.items, requestBeforeMs),
-          hasMore: page.has_more,
+          items,
+          hasMore: page.has_more && items.length < MONITORING_EVENTS_RETENTION_LIMIT,
           loadingMore: false,
           lastPageKey: pageKey,
         };
@@ -540,7 +567,13 @@ export function useMonitoringData({
   }, [analytics.error]);
 
   const loadMoreEvents = useCallback(() => {
-    if (analytics.loading || eventsLoadingMore || !eventsHasMore) return;
+    if (
+      analytics.loading ||
+      eventsLoadingMore ||
+      !eventsHasMore ||
+      eventItems.length >= MONITORING_EVENTS_RETENTION_LIMIT
+    )
+      return;
     const nextBeforeMs = currentAnalyticsData?.events?.next_before_ms;
     if (!nextBeforeMs) return;
     const nextBeforeId = currentAnalyticsData?.events?.next_before_id ?? null;
@@ -554,6 +587,7 @@ export function useMonitoringData({
     currentAnalyticsData?.events?.next_before_ms,
     currentAnalyticsData?.events?.next_before_id,
     analytics.loading,
+    eventItems.length,
     eventsScopeKey,
     eventsHasMore,
     eventsLoadingMore,
@@ -787,6 +821,7 @@ export function useMonitoringData({
       filteredRows,
       eventsHasMore: displayEventsHasMore,
       eventsLoadingMore,
+      eventsRetentionLimited,
       eventsTotalCount: displayEventsTotalCount,
       eventsLoadedCount,
       lastRefreshedAt: analytics.lastRefreshedAt,
@@ -800,6 +835,7 @@ export function useMonitoringData({
       displayEventsTotalCount,
       eventsLoadedCount,
       eventsLoadingMore,
+      eventsRetentionLimited,
       failureSourceRows,
       filterOptions,
       filteredRows,
@@ -828,8 +864,10 @@ export function useMonitoringData({
           return previous;
         }
 
+        const cachedSnapshot = withoutMonitoringSnapshotEvents(computedPresentationSnapshot);
         const cachedSnapshots = new Map(previous.cachedSnapshots);
-        cachedSnapshots.set(eventsScopeKey, computedPresentationSnapshot);
+        cachedSnapshots.delete(eventsScopeKey);
+        cachedSnapshots.set(eventsScopeKey, cachedSnapshot);
         while (cachedSnapshots.size > MONITORING_PRESENTATION_CACHE_LIMIT) {
           const oldestKey = cachedSnapshots.keys().next().value;
           if (oldestKey === undefined) break;
@@ -837,7 +875,7 @@ export function useMonitoringData({
         }
         return {
           cachedSnapshots,
-          lastStableSnapshot: computedPresentationSnapshot,
+          lastStableSnapshot: cachedSnapshot,
         };
       });
     });
@@ -909,6 +947,7 @@ export function useMonitoringData({
     filteredRows: presentationSnapshot.filteredRows,
     eventsHasMore: presentationSnapshot.eventsHasMore,
     eventsLoadingMore: presentationSnapshot.eventsLoadingMore,
+    eventsRetentionLimited: presentationSnapshot.eventsRetentionLimited,
     eventsTotalCount: presentationSnapshot.eventsTotalCount,
     eventsLoadedCount: presentationSnapshot.eventsLoadedCount,
     lastRefreshedAt: presentationSnapshot.lastRefreshedAt,

--- a/apps/web/src/features/monitoring/model/modelPricesPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/modelPricesPageModel.test.ts
@@ -4,41 +4,57 @@ import {
   buildPriceFromDraft,
   buildModelPriceRows,
   buildModelPriceSummary,
-  buildSyncPriceModelsFromUsage,
+  buildSyncPriceModelsFromSummary,
   filterModelPriceRows,
 } from './modelPricesPageModel';
 
-const usage = {
-  apis: {
-    'POST /v1/chat/completions': {
-      models: {
-        'alias-fast': {
-          details: [
-            {
-              timestamp: '2026-05-22T00:00:00Z',
-              source: 'source',
-              resolved_model: 'gpt-5.5',
-              tokens: {},
-            },
-          ],
-        },
-      },
+const usageSummary = {
+  sampled_events: 1,
+  total_events: 1,
+  truncated: false,
+  models: [
+    {
+      model: 'alias-fast',
+      calls: 1,
+      requested_calls: 1,
+      resolved_calls: 0,
     },
-  },
+    {
+      model: 'gpt-5.5',
+      calls: 1,
+      requested_calls: 0,
+      resolved_calls: 1,
+    },
+  ],
 };
 
 describe('modelPricesPageModel', () => {
   it('builds sync models from requested, resolved, and saved prices', () => {
     expect(
-      buildSyncPriceModelsFromUsage(usage, {
+      buildSyncPriceModelsFromSummary(usageSummary, {
         'manual-model': { prompt: 1, completion: 2, cache: 0.5 },
       })
     ).toEqual(['alias-fast', 'gpt-5.5', 'manual-model']);
   });
 
+  it('keeps saved prices usable when the usage summary endpoint is unavailable', () => {
+    const prices = {
+      'manual-model': { prompt: 1, completion: 2, cache: 0.5 },
+    };
+
+    expect(buildSyncPriceModelsFromSummary(null, prices)).toEqual(['manual-model']);
+    expect(buildModelPriceRows(null, prices)).toEqual([
+      expect.objectContaining({
+        model: 'manual-model',
+        calls: 0,
+        hasPrice: true,
+      }),
+    ]);
+  });
+
   it('marks missing models with candidates before saved rows', () => {
     const rows = buildModelPriceRows(
-      usage,
+      usageSummary,
       {
         'gpt-5.5': { prompt: 1, completion: 2, cache: 0.5 },
       },
@@ -62,6 +78,12 @@ describe('modelPricesPageModel', () => {
       hasPrice: false,
       candidateCount: 1,
       requestedCalls: 1,
+    });
+    expect(rows[1]).toMatchObject({
+      model: 'gpt-5.5',
+      calls: 1,
+      requestedCalls: 0,
+      resolvedCalls: 1,
     });
     expect(buildModelPriceSummary(rows)).toMatchObject({
       total: 2,

--- a/apps/web/src/features/monitoring/model/modelPricesPageModel.ts
+++ b/apps/web/src/features/monitoring/model/modelPricesPageModel.ts
@@ -1,9 +1,9 @@
-import { collectUsageDetailsWithEndpoint, type ModelPrice } from '@/utils/usage';
+import type { ModelPrice } from '@/utils/usage';
 import type {
+  ModelPriceUsageSummaryResponse,
   ModelPriceSyncCandidate,
   ModelPriceSyncCandidateSet,
 } from '@/services/api/usageService';
-import type { UsagePayload } from '@/features/monitoring/hooks/useUsageData';
 
 export type ModelPriceFilter = 'all' | 'missing' | 'saved' | 'candidates';
 
@@ -72,14 +72,13 @@ export const applyCandidatePrice = (
   },
 });
 
-export const buildSyncPriceModelsFromUsage = (
-  usage: UsagePayload | null,
+export const buildSyncPriceModelsFromSummary = (
+  summary: ModelPriceUsageSummaryResponse | null,
   prices: Record<string, ModelPrice>
 ) => {
   const models = new Set<string>(Object.keys(prices));
-  collectUsageDetailsWithEndpoint(usage).forEach((detail) => {
-    if (detail.__modelName) models.add(detail.__modelName);
-    if (detail.__resolvedModel) models.add(detail.__resolvedModel);
+  summary?.models?.forEach((item) => {
+    if (item.model) models.add(item.model);
   });
   return Array.from(models)
     .filter(Boolean)
@@ -96,7 +95,7 @@ export const buildCandidateMap = (candidateSets: ModelPriceSyncCandidateSet[] = 
 };
 
 export const buildModelPriceRows = (
-  usage: UsagePayload | null,
+  summary: ModelPriceUsageSummaryResponse | null,
   prices: Record<string, ModelPrice>,
   candidateSets: ModelPriceSyncCandidateSet[] = []
 ): ModelPriceRow[] => {
@@ -123,17 +122,12 @@ export const buildModelPriceRows = (
   Object.keys(prices).forEach(ensureRow);
   candidateMap.forEach((_candidates, model) => ensureRow(model));
 
-  collectUsageDetailsWithEndpoint(usage).forEach((detail) => {
-    if (detail.__modelName) {
-      const row = ensureRow(detail.__modelName);
-      row.calls += 1;
-      row.requestedCalls += 1;
-    }
-    if (detail.__resolvedModel && detail.__resolvedModel !== detail.__modelName) {
-      const row = ensureRow(detail.__resolvedModel);
-      row.calls += 1;
-      row.resolvedCalls += 1;
-    }
+  summary?.models?.forEach((item) => {
+    if (!item.model) return;
+    const row = ensureRow(item.model);
+    row.calls += Number(item.calls) || 0;
+    row.requestedCalls += Number(item.requested_calls) || 0;
+    row.resolvedCalls += Number(item.resolved_calls) || 0;
   });
 
   return Array.from(rowMap.values()).sort(

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -390,6 +390,7 @@ export interface UseMonitoringDataReturn {
   filteredRows: MonitoringEventRow[];
   eventsHasMore: boolean;
   eventsLoadingMore: boolean;
+  eventsRetentionLimited: boolean;
   eventsTotalCount: number;
   eventsLoadedCount: number;
   lastRefreshedAt: Date | null;

--- a/apps/web/src/features/monitoring/monitoringCenterUiState.test.ts
+++ b/apps/web/src/features/monitoring/monitoringCenterUiState.test.ts
@@ -71,7 +71,7 @@ describe('monitoringCenterUiState', () => {
     expect(normalizeMonitoringStatusFilter('failed')).toBe('failed');
     expect(normalizeMonitoringStatusFilter('bad')).toBe('all');
     expect(normalizeMonitoringAutoRefreshMs(30000)).toBe('30000');
-    expect(normalizeMonitoringAutoRefreshMs('123')).toBe('5000');
+    expect(normalizeMonitoringAutoRefreshMs('123')).toBe('30000');
   });
 
   it('normalizes ui state from arbitrary input', () => {

--- a/apps/web/src/features/monitoring/monitoringCenterUiState.ts
+++ b/apps/web/src/features/monitoring/monitoringCenterUiState.ts
@@ -10,7 +10,7 @@ export const MONITORING_DATA_TABS: readonly MonitoringDataTab[] = [
 
 export const DEFAULT_MONITORING_DATA_TAB: MonitoringDataTab = 'accounts';
 export const DEFAULT_MONITORING_TIME_RANGE: MonitoringCenterTimeRange = 'today';
-export const DEFAULT_MONITORING_AUTO_REFRESH_MS = '5000';
+export const DEFAULT_MONITORING_AUTO_REFRESH_MS = '30000';
 export const DEFAULT_MONITORING_TABLE_PAGE_SIZE = 12;
 export const DEFAULT_MONITORING_REALTIME_PAGE_SIZE = 10;
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2185,7 +2185,8 @@
     "load_more_events": "Load more events",
     "no_more_events": "No more events",
     "events_loaded_summary": "Loaded {{loaded}} of {{total}} events",
-    "events_all_loaded": "All {{total}} events loaded"
+    "events_all_loaded": "All {{total}} events loaded",
+    "events_retention_limited": "Kept the newest {{loaded}} of {{total}} events"
   },
   "logs": {
     "title": "Logs Viewer",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -2185,7 +2185,8 @@
     "load_more_events": "Загрузить ещё события",
     "no_more_events": "Больше событий нет",
     "events_loaded_summary": "Загружено {{loaded}} из {{total}} событий",
-    "events_all_loaded": "Все {{total}} событий загружены"
+    "events_all_loaded": "Все {{total}} событий загружены",
+    "events_retention_limited": "Сохранены последние {{loaded}} из {{total}} событий"
   },
   "logs": {
     "title": "Просмотр журналов",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -2185,7 +2185,8 @@
     "load_more_events": "加载更多事件",
     "no_more_events": "没有更多事件",
     "events_loaded_summary": "已加载 {{loaded}} / 共 {{total}} 条",
-    "events_all_loaded": "已加载全部 {{total}} 条"
+    "events_all_loaded": "已加载全部 {{total}} 条",
+    "events_retention_limited": "仅保留最新 {{loaded}} / 共 {{total}} 条事件"
   },
   "logs": {
     "title": "日志查看",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -2185,7 +2185,8 @@
     "load_more_events": "載入更多事件",
     "no_more_events": "沒有更多事件",
     "events_loaded_summary": "已載入 {{loaded}} / 共 {{total}} 筆",
-    "events_all_loaded": "已載入全部 {{total}} 筆"
+    "events_all_loaded": "已載入全部 {{total}} 筆",
+    "events_retention_limited": "僅保留最新 {{loaded}} / 共 {{total}} 筆事件"
   },
   "logs": {
     "title": "記錄檢視",

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -9,6 +9,7 @@ import {
   getDemoDashboardSummary,
   getDemoHeaderSnapshots,
   getDemoManagerConfig,
+  getDemoModelPriceUsageSummary,
   getDemoModelPrices,
   getDemoMonitoringAnalytics,
   getDemoQuotaCooldowns,
@@ -301,6 +302,20 @@ export interface CodexInspectionActionsResponse {
 
 export interface ModelPricesResponse {
   prices: Record<string, ModelPrice>;
+}
+
+export interface ModelPriceUsageStat {
+  model: string;
+  calls: number;
+  requested_calls: number;
+  resolved_calls: number;
+}
+
+export interface ModelPriceUsageSummaryResponse {
+  sampled_events: number;
+  total_events: number;
+  truncated: boolean;
+  models: ModelPriceUsageStat[];
 }
 
 export interface ModelPriceSyncCandidate {
@@ -1399,9 +1414,7 @@ const getDemoModelPriceSyncResponse = (models?: string[]): ModelPriceSyncRespons
   const selectedModels = new Set((models || []).map((model) => model.trim()).filter(Boolean));
   const selectedPrices =
     selectedModels.size > 0
-      ? Object.fromEntries(
-          Object.entries(prices).filter(([model]) => selectedModels.has(model))
-        )
+      ? Object.fromEntries(Object.entries(prices).filter(([model]) => selectedModels.has(model)))
       : prices;
 
   return {
@@ -1680,6 +1693,28 @@ export const usageServiceApi = {
         {
           timeout: USAGE_SERVICE_TIMEOUT_MS,
           headers: authHeaders(managementKey),
+        }
+      );
+      return response.data;
+    });
+  },
+
+  getModelPriceUsageSummary: async (
+    base: string,
+    managementKey?: string,
+    signal?: AbortSignal
+  ): Promise<ModelPriceUsageSummaryResponse> => {
+    if (__DEMO_SITE__ && isDemoMode()) {
+      return getDemoModelPriceUsageSummary();
+    }
+
+    return withUsageServiceError(async () => {
+      const response = await axios.get<ModelPriceUsageSummaryResponse>(
+        buildUrl(base, '/v0/management/model-prices/usage-summary'),
+        {
+          timeout: USAGE_SERVICE_TIMEOUT_MS,
+          headers: authHeaders(managementKey),
+          signal,
         }
       );
       return response.data;
@@ -2030,7 +2065,8 @@ export const monitoringAnalyticsApi = {
   getAnalytics: async (
     base: string,
     managementKey: string | undefined,
-    request: MonitoringAnalyticsRequest
+    request: MonitoringAnalyticsRequest,
+    signal?: AbortSignal
   ): Promise<MonitoringAnalyticsResponse> => {
     if (__DEMO_SITE__ && isDemoMode()) {
       return getDemoMonitoringAnalytics(request);
@@ -2043,6 +2079,7 @@ export const monitoringAnalyticsApi = {
         {
           timeout: USAGE_SERVICE_TIMEOUT_MS,
           headers: authHeaders(managementKey),
+          signal,
         }
       );
       return response.data;


### PR DESCRIPTION
## Summary
Reduce Manager Server and frontend memory pressure when usage history grows large.
Replace full-payload buffering with bounded streaming, add a lightweight Model Prices summary, cap browser retention, and provide opt-in loopback-only pprof diagnostics.

## Scope
- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Stream compatible usage responses and JSONL exports from fixed SQLite snapshots; import JSONL and arrays in 256-event batches.
- Add a lightweight model-price usage summary, bounded SQLite connections, and lower-memory percentile calculation.
- Cap frontend event retention at 2,000, keep four aggregate-only snapshots, cancel stale requests, pause hidden-page polling, and default refresh to 30 seconds.
- Add an optional loopback-only pprof server and document safe usage.

## User Impact
The Model Prices page no longer downloads the full usage payload and opens substantially faster on large databases. Long-running monitoring and usage operations retain bounded memory, while compatible response formats remain unchanged.

## Compatibility / Runtime Notes
- CPA panel mode: Existing behavior is preserved. If the lightweight summary endpoint is unavailable, saved prices remain visible without falling back to the full usage payload.
- Manager Server mode: Adds `GET /v0/management/model-prices/usage-summary`; compatible usage and export formats are unchanged. Streaming imports commit completed batches if a later batch fails.
- Full Docker / native packages: No new port is exposed by default. `CPA_MANAGER_PPROF_ADDR` is optional and accepts only loopback hosts.

## Data / Security Notes
No SQLite schema migration is introduced. Exported usage still excludes raw JSON and raw failure bodies. Response metadata is emitted only after valid JSON-object checks. The pprof listener rejects wildcard and public addresses and remains disabled unless explicitly configured.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Revert the six commits in reverse order. Existing SQLite data remains compatible because there is no schema change.
- Operators using streaming imports should note that completed 256-event batches are not rolled back after a later parse, size-limit, or database error.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test                         # 83 files, 698 tests
npm run build                        # single-file Vite output
cd apps/manager-server && go test ./...
cd apps/manager-server && go test -race ./...
git diff --check

37,086-event database:
- Model Prices summary: 1.5 KB, 0.23 s, ~20.0 MB peak RSS
- Compatible /usage: 43.7 MB, 0.92 s, ~26.6 MB peak RSS (previously ~301.7 MB)
- JSONL export: 60.3 MB, 1.04 s, ~30.8 MB peak RSS
- Forced-GC live Go heap: ~4.5 MB; goroutines: 13 including the pprof request
```

## Screenshots / Recordings
N/A — the layout is unchanged; the new retention-limit message is covered by component tests.

## Docs
- [ ] README updated
- [x] Wiki updated
- [ ] Release notes needed
- [ ] Not needed

## Related
N/A
