### PR TITLE
perf(usage-analytics): scope queries to active tabs

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -89,6 +89,13 @@ type FilterOptionValues struct {
 	HeaderTraceIDs   []string
 }
 
+type FilterSelectorValues struct {
+	Models       []string
+	APIKeyHashes []string
+	Providers    []string
+	AuthFiles    []string
+}
+
 type TimelinePoint struct {
 	BucketMS            int64
 	Model               string
@@ -819,6 +826,31 @@ func (r *repository) FilterOptionValuesWithFilter(ctx context.Context, filter An
 		HeaderErrorCodes: headerErrorCodes,
 		HeaderQuotaPlans: headerQuotaPlans,
 		HeaderTraceIDs:   headerTraceIDs,
+	}, nil
+}
+
+func (r *repository) FilterSelectorValuesWithFilter(ctx context.Context, filter AnalyticsFilter) (FilterSelectorValues, error) {
+	models, err := r.distinctFilterValues(ctx, filter, "coalesce(nullif(model, ''), '')")
+	if err != nil {
+		return FilterSelectorValues{}, err
+	}
+	apiKeyHashes, err := r.distinctFilterValues(ctx, filter, "coalesce(api_key_hash, '')")
+	if err != nil {
+		return FilterSelectorValues{}, err
+	}
+	providers, err := r.distinctFilterValues(ctx, filter, "coalesce(nullif(auth_provider_snapshot, ''), nullif(provider, ''), '')")
+	if err != nil {
+		return FilterSelectorValues{}, err
+	}
+	authFiles, err := r.distinctFilterValues(ctx, filter, "coalesce(auth_file_snapshot, '')")
+	if err != nil {
+		return FilterSelectorValues{}, err
+	}
+	return FilterSelectorValues{
+		Models:       models,
+		APIKeyHashes: apiKeyHashes,
+		Providers:    providers,
+		AuthFiles:    authFiles,
 	}, nil
 }
 

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -32,6 +32,7 @@ type Repository interface {
 	LatencySummaryWithFilter(ctx context.Context, filter AnalyticsFilter) (LatencySummary, error)
 	HourlyDistributionWithFilter(ctx context.Context, filter AnalyticsFilter, location *time.Location) ([]HourlyPoint, error)
 	FilterOptionValuesWithFilter(ctx context.Context, filter AnalyticsFilter) (FilterOptionValues, error)
+	FilterSelectorValuesWithFilter(ctx context.Context, filter AnalyticsFilter) (FilterSelectorValues, error)
 	HeatmapWithFilter(ctx context.Context, filter AnalyticsFilter, location *time.Location) ([]HeatmapPoint, error)
 	ChannelModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]ChannelModelStat, error)
 	FailureSourcesWithFilter(ctx context.Context, filter AnalyticsFilter) ([]FailureSourceStat, error)

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -80,6 +80,7 @@ type Include struct {
 	CredentialTimeline bool              `json:"credential_timeline"`
 	APIKeyStats        bool              `json:"api_key_stats"`
 	FilterOptions      bool              `json:"filter_options"`
+	FilterSelectors    bool              `json:"filter_selectors"`
 	Heatmap            bool              `json:"heatmap"`
 	AnomalyPoints      bool              `json:"anomaly_points"`
 	TaskBuckets        bool              `json:"task_buckets"`
@@ -487,6 +488,8 @@ type FilterOptions struct {
 	APIKeyStats      []APIKeyStatRow   `json:"api_key_stats,omitempty"`
 	ChannelShare     []ChannelShareRow `json:"channel_share,omitempty"`
 	ModelStats       []ModelStat       `json:"model_stats,omitempty"`
+	Models           []string          `json:"models,omitempty"`
+	APIKeyHashes     []string          `json:"api_key_hashes,omitempty"`
 	Providers        []string          `json:"providers,omitempty"`
 	AuthFiles        []string          `json:"auth_files,omitempty"`
 	ProjectIDs       []string          `json:"project_ids,omitempty"`
@@ -798,7 +801,13 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		}
 		response.APIKeyStats = buildAPIKeyStats(stats, prices)
 	}
-	if req.Include.FilterOptions {
+	if req.Include.FilterSelectors {
+		selectors, err := s.filterSelectors(ctx, filter)
+		if err != nil {
+			return Response{}, err
+		}
+		response.FilterOptions = selectors
+	} else if req.Include.FilterOptions {
 		options, err := s.filterOptions(ctx, filter, prices)
 		if err != nil {
 			return Response{}, err
@@ -1031,24 +1040,7 @@ func buildFilter(req Request) store.AnalyticsFilter {
 }
 
 func (s *Service) filterOptions(ctx context.Context, filter store.AnalyticsFilter, prices map[string]store.ModelPrice) (*FilterOptions, error) {
-	optionFilter := filter
-	optionFilter.Models = nil
-	optionFilter.Providers = nil
-	optionFilter.Accounts = nil
-	optionFilter.AuthFiles = nil
-	optionFilter.AuthIndices = nil
-	optionFilter.APIKeyHashes = nil
-	optionFilter.SourceHashes = nil
-	optionFilter.ProjectIDs = nil
-	optionFilter.RequestTypes = nil
-	optionFilter.HeaderErrorKinds = nil
-	optionFilter.HeaderErrorCodes = nil
-	optionFilter.HeaderQuotaPlans = nil
-	optionFilter.HeaderTraceIDs = nil
-	optionFilter.IncludeFailed = true
-	optionFilter.FailedOnly = false
-	optionFilter.MinLatencyMS = 0
-	optionFilter.CacheStatus = ""
+	optionFilter := filterOptionsBaseFilter(filter)
 
 	accountStats, err := s.store.AccountModelStatsWithFilter(ctx, optionFilter)
 	if err != nil {
@@ -1085,6 +1077,41 @@ func (s *Service) filterOptions(ctx context.Context, filter store.AnalyticsFilte
 		HeaderQuotaPlans: optionValues.HeaderQuotaPlans,
 		HeaderTraceIDs:   optionValues.HeaderTraceIDs,
 	}, nil
+}
+
+func (s *Service) filterSelectors(ctx context.Context, filter store.AnalyticsFilter) (*FilterOptions, error) {
+	values, err := s.store.FilterSelectorValuesWithFilter(ctx, filterOptionsBaseFilter(filter))
+	if err != nil {
+		return nil, err
+	}
+	return &FilterOptions{
+		Models:       values.Models,
+		APIKeyHashes: values.APIKeyHashes,
+		Providers:    values.Providers,
+		AuthFiles:    values.AuthFiles,
+	}, nil
+}
+
+func filterOptionsBaseFilter(filter store.AnalyticsFilter) store.AnalyticsFilter {
+	optionFilter := filter
+	optionFilter.Models = nil
+	optionFilter.Providers = nil
+	optionFilter.Accounts = nil
+	optionFilter.AuthFiles = nil
+	optionFilter.AuthIndices = nil
+	optionFilter.APIKeyHashes = nil
+	optionFilter.SourceHashes = nil
+	optionFilter.ProjectIDs = nil
+	optionFilter.RequestTypes = nil
+	optionFilter.HeaderErrorKinds = nil
+	optionFilter.HeaderErrorCodes = nil
+	optionFilter.HeaderQuotaPlans = nil
+	optionFilter.HeaderTraceIDs = nil
+	optionFilter.IncludeFailed = true
+	optionFilter.FailedOnly = false
+	optionFilter.MinLatencyMS = 0
+	optionFilter.CacheStatus = ""
+	return optionFilter
 }
 
 func normalizeGranularity(input string, fromMS int64, toMS int64) string {

--- a/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
@@ -1,0 +1,190 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
+	db, err := store.Open(filepath.Join(b.TempDir(), "usage.sqlite"))
+	if err != nil {
+		b.Fatalf("open store: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	fromMS := int64(1_800_000_000_000)
+	toMS := fromMS + 30*24*60*60*1000
+	insertMonitoringBenchmarkEvents(b, ctx, db, fromMS, toMS, 100_000)
+	service := New(db)
+
+	request := func(include Include) Request {
+		return Request{
+			FromMS:   fromMS,
+			ToMS:     toMS,
+			NowMS:    toMS,
+			TimeZone: "UTC",
+			Include:  include,
+		}
+	}
+	selectors := request(Include{FilterOptions: true, FilterSelectors: true})
+	profiles := []struct {
+		name     string
+		requests []Request
+	}{
+		{
+			name: "legacy_full",
+			requests: []Request{request(Include{
+				Summary:            true,
+				SummaryComparison:  true,
+				Timeline:           true,
+				ModelStats:         true,
+				ChannelShare:       true,
+				APIKeyStats:        true,
+				CredentialStats:    true,
+				CredentialTimeline: true,
+				FilterOptions:      true,
+				Heatmap:            true,
+				AnomalyPoints:      true,
+				Granularity:        "day",
+			})},
+		},
+		{
+			name: "overview_initial",
+			requests: []Request{
+				request(Include{
+					Summary:           true,
+					SummaryComparison: true,
+					Timeline:          true,
+					ModelStats:        true,
+					ChannelShare:      true,
+					APIKeyStats:       true,
+					AnomalyPoints:     true,
+					Granularity:       "day",
+				}),
+				selectors,
+			},
+		},
+		{
+			name: "overview_tab_request",
+			requests: []Request{request(Include{
+				Summary:           true,
+				SummaryComparison: true,
+				Timeline:          true,
+				ModelStats:        true,
+				ChannelShare:      true,
+				APIKeyStats:       true,
+				AnomalyPoints:     true,
+				Granularity:       "day",
+			})},
+		},
+		{
+			name: "trends_tab_request",
+			requests: []Request{request(Include{
+				Summary:           true,
+				SummaryComparison: true,
+				Timeline:          true,
+				ModelStats:        true,
+				APIKeyStats:       true,
+				AnomalyPoints:     true,
+				Granularity:       "day",
+			})},
+		},
+		{
+			name: "models_tab_request",
+			requests: []Request{request(Include{
+				Summary:     true,
+				Timeline:    true,
+				ModelStats:  true,
+				APIKeyStats: true,
+				Granularity: "day",
+			})},
+		},
+		{
+			name: "api_keys_tab_request",
+			requests: []Request{request(Include{
+				Summary:     true,
+				APIKeyStats: true,
+				Granularity: "day",
+			})},
+		},
+		{
+			name: "credentials_tab_request",
+			requests: []Request{request(Include{
+				Summary:            true,
+				CredentialStats:    true,
+				CredentialTimeline: true,
+				Granularity:        "day",
+			})},
+		},
+		{
+			name: "heatmap_tab_request",
+			requests: []Request{request(Include{
+				Summary:     true,
+				Heatmap:     true,
+				Granularity: "day",
+			})},
+		},
+		{name: "filter_selectors", requests: []Request{selectors}},
+	}
+
+	for _, profile := range profiles {
+		b.Run(profile.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				for _, req := range profile.requests {
+					if _, err := service.Analytics(ctx, req); err != nil {
+						b.Fatalf("analytics: %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func insertMonitoringBenchmarkEvents(b *testing.B, ctx context.Context, db *store.Store, fromMS, toMS int64, count int) {
+	b.Helper()
+	const batchSize = 1000
+	stepMS := max(int64(1), (toMS-fromMS)/int64(count))
+	latencyMS := int64(250)
+	ttftMS := int64(50)
+	for offset := 0; offset < count; offset += batchSize {
+		end := min(offset+batchSize, count)
+		events := make([]usage.Event, 0, end-offset)
+		for index := offset; index < end; index++ {
+			timestampMS := fromMS + int64(index)*stepMS
+			authIndex := fmt.Sprintf("auth-%03d", index%100)
+			event := monitoringEvent(
+				fmt.Sprintf("analytics-benchmark-%06d", index),
+				timestampMS,
+				fmt.Sprintf("gpt-%02d", index%12),
+				authIndex,
+				fmt.Sprintf("source-%03d", index%100),
+				index%20 == 0,
+				int64(100+index%300),
+				int64(50+index%150),
+				int64(index%40),
+				int64(index%80),
+				int64(150+index%500),
+				&latencyMS,
+			)
+			event.APIKeyHash = fmt.Sprintf("key-%03d", index%50)
+			event.AccountSnapshot = fmt.Sprintf("account-%03d@example.com", index%100)
+			event.AuthLabelSnapshot = fmt.Sprintf("Account %03d", index%100)
+			event.AuthFileSnapshot = fmt.Sprintf("account-%03d.json", index%100)
+			event.AuthProviderSnapshot = []string{"codex", "claude", "gemini"}[index%3]
+			event.AuthProjectIDSnapshot = fmt.Sprintf("project-%02d", index%10)
+			event.ServiceTier = []string{"", "default", "priority"}[index%3]
+			event.TTFTMS = &ttftMS
+			events = append(events, event)
+		}
+		if _, err := db.InsertEvents(ctx, events); err != nil {
+			b.Fatalf("insert benchmark events: %v", err)
+		}
+	}
+}

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -1108,6 +1109,60 @@ func TestAnalyticsFilterOptionsIgnoreActiveScopeFilters(t *testing.T) {
 	}
 	if len(resp.FilterOptions.ChannelShare) != 2 {
 		t.Fatalf("channel/provider filter options should ignore active account/model filters: %#v", resp.FilterOptions.ChannelShare)
+	}
+}
+
+func TestAnalyticsFilterSelectorsReturnOnlyUsageAnalyticsOptions(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_350_000_000)
+	toMS := fromMS + 60*60*1000
+
+	alice := monitoringEvent("selector-alice", fromMS+1_000, "gpt-a", "auth-a", "source-a", false, 10, 5, 0, 0, 15, nil)
+	alice.AccountSnapshot = "alice@example.com"
+	alice.AuthProviderSnapshot = "codex"
+	alice.AuthFileSnapshot = "alice.json"
+	alice.APIKeyHash = "key-alice"
+	bob := monitoringEvent("selector-bob", fromMS+2_000, "gpt-b", "auth-b", "source-b", false, 10, 5, 0, 0, 15, nil)
+	bob.AccountSnapshot = "bob@example.com"
+	bob.AuthProviderSnapshot = "gemini"
+	bob.AuthFileSnapshot = "bob.json"
+	bob.APIKeyHash = "key-bob"
+
+	if _, err := db.InsertEvents(ctx, []usage.Event{alice, bob}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Filters: Filters{
+			Models:   []string{"gpt-a"},
+			Accounts: []string{"alice@example.com"},
+		},
+		Include: Include{FilterOptions: true, FilterSelectors: true},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if resp.FilterOptions == nil {
+		t.Fatal("filter selectors are nil")
+	}
+	if !slices.Equal(resp.FilterOptions.Models, []string{"gpt-a", "gpt-b"}) {
+		t.Fatalf("models = %#v", resp.FilterOptions.Models)
+	}
+	if !slices.Equal(resp.FilterOptions.APIKeyHashes, []string{"key-alice", "key-bob"}) {
+		t.Fatalf("api key hashes = %#v", resp.FilterOptions.APIKeyHashes)
+	}
+	if !slices.Equal(resp.FilterOptions.Providers, []string{"codex", "gemini"}) {
+		t.Fatalf("providers = %#v", resp.FilterOptions.Providers)
+	}
+	if !slices.Equal(resp.FilterOptions.AuthFiles, []string{"alice.json", "bob.json"}) {
+		t.Fatalf("auth files = %#v", resp.FilterOptions.AuthFiles)
+	}
+	if len(resp.FilterOptions.AccountStats) != 0 || len(resp.FilterOptions.APIKeyStats) != 0 ||
+		len(resp.FilterOptions.ChannelShare) != 0 || len(resp.FilterOptions.ModelStats) != 0 {
+		t.Fatalf("filter selectors returned full stats: %#v", resp.FilterOptions)
 	}
 }
 

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -59,6 +59,7 @@ type LatencyPercentiles = usageevent.LatencyPercentiles
 type LatencySummary = usageevent.LatencySummary
 type HourlyPoint = usageevent.HourlyPoint
 type FilterOptionValues = usageevent.FilterOptionValues
+type FilterSelectorValues = usageevent.FilterSelectorValues
 type HeatmapPoint = usageevent.HeatmapPoint
 type ChannelModelStat = usageevent.ChannelModelStat
 type FailureSourceStat = usageevent.FailureSourceStat
@@ -409,6 +410,10 @@ func (s *Store) HourlyDistributionWithFilter(ctx context.Context, filter Analyti
 
 func (s *Store) FilterOptionValuesWithFilter(ctx context.Context, filter AnalyticsFilter) (FilterOptionValues, error) {
 	return s.UsageEvents.FilterOptionValuesWithFilter(ctx, filter)
+}
+
+func (s *Store) FilterSelectorValuesWithFilter(ctx context.Context, filter AnalyticsFilter) (FilterSelectorValues, error) {
+	return s.UsageEvents.FilterSelectorValuesWithFilter(ctx, filter)
 }
 
 func (s *Store) HeatmapWithFilter(ctx context.Context, filter AnalyticsFilter, location *time.Location) ([]HeatmapPoint, error) {

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -2306,6 +2306,10 @@ function UsageAnalyticsPageInner() {
 
   const incomingOptionCache = useMemo<StableUsageOptionCache>(() => {
     const apiKeys = mergeSelectOptions([
+      ...(usage.filterOptions?.api_key_hashes ?? []).map((hash) => ({
+        value: hash,
+        label: resolveUsageApiKeyLabel(hash, usage.apiKeyDisplayMap),
+      })),
       ...(usage.filterOptions?.api_key_stats ?? []).map((row) => {
         const hash = row.api_key_hash || row.id;
         return {
@@ -2321,6 +2325,7 @@ function UsageAnalyticsPageInner() {
 
     return {
       models: buildOptionValues([
+        ...(usage.filterOptions?.models ?? []),
         ...(usage.filterOptions?.model_stats ?? []).map((row) => row.model),
         ...usage.modelRows.map((row) => row.model || row.label),
       ]),
@@ -2340,8 +2345,10 @@ function UsageAnalyticsPageInner() {
     usage.apiKeyDisplayMap,
     usage.apiKeyRows,
     usage.credentialRows,
+    usage.filterOptions?.api_key_hashes,
     usage.filterOptions?.api_key_stats,
     usage.filterOptions?.auth_files,
+    usage.filterOptions?.models,
     usage.filterOptions?.model_stats,
     usage.filterOptions?.providers,
     usage.modelRows,

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -15,6 +15,7 @@ import {
   buildProviderRows,
   buildUsageMatrix,
   buildUsageAnalyticsFilters,
+  buildUsageAnalyticsFilterSelectorsInclude,
   buildUsageAnalyticsInclude,
   buildUsageAnomalyCauseKeys,
   buildUsageHeatmapCellDetail,
@@ -66,7 +67,7 @@ describe('usage analytics request model', () => {
     ).toBe('day');
   });
 
-  it('maps model, API key, status, and granularity to analytics request fields', () => {
+  it('maps model, API key, and status filters to analytics request fields', () => {
     expect(
       buildUsageAnalyticsFilters({
         model: 'gpt-4o',
@@ -91,14 +92,66 @@ describe('usage analytics request model', () => {
     ).toEqual({
       failed_only: true,
     });
-    expect(buildUsageAnalyticsInclude('day')).toMatchObject({
+  });
+
+  it('builds the minimum analytics include for each active tab', () => {
+    expect(buildUsageAnalyticsInclude('overview', 'day')).toEqual({
+      summary: true,
+      summary_comparison: true,
+      timeline: true,
+      model_stats: true,
+      channel_share: true,
+      api_key_stats: true,
+      anomaly_points: true,
+      granularity: 'day',
+    });
+    expect(
+      buildUsageAnalyticsInclude('trends', 'hour', {
+        fromMs: 1_000,
+        toMs: 2_000,
+        limit: 8,
+      })
+    ).toEqual({
+      summary: true,
+      summary_comparison: true,
+      timeline: true,
+      model_stats: true,
+      api_key_stats: true,
+      anomaly_points: true,
+      granularity: 'hour',
+      drilldown_preview: { from_ms: 1_000, to_ms: 2_000, limit: 8 },
+    });
+    expect(buildUsageAnalyticsInclude('models', 'day')).toEqual({
       summary: true,
       timeline: true,
       model_stats: true,
       api_key_stats: true,
-      credential_timeline: true,
-      filter_options: true,
       granularity: 'day',
+    });
+    expect(buildUsageAnalyticsInclude('apiKeys', 'day')).toEqual({
+      summary: true,
+      api_key_stats: true,
+      granularity: 'day',
+    });
+    expect(buildUsageAnalyticsInclude('credentials', 'day')).toEqual({
+      summary: true,
+      credential_stats: true,
+      credential_timeline: true,
+      granularity: 'day',
+    });
+    expect(
+      buildUsageAnalyticsInclude('heatmap', 'day', {
+        fromMs: 1_000,
+        toMs: 2_000,
+      })
+    ).toEqual({
+      summary: true,
+      heatmap: true,
+      granularity: 'day',
+    });
+    expect(buildUsageAnalyticsFilterSelectorsInclude()).toEqual({
+      filter_options: true,
+      filter_selectors: true,
     });
   });
 });

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -703,24 +703,55 @@ export const buildUsageAnalyticsFilters = (
 };
 
 export const buildUsageAnalyticsInclude = (
+  activeTab: UsageAnalyticsTab,
   granularity: UsageAnalyticsResolvedGranularity,
   drilldownPreview?: { fromMs: number; toMs: number; limit?: number } | null
 ): MonitoringAnalyticsInclude => {
   const include: MonitoringAnalyticsInclude = {
     summary: true,
-    summary_comparison: true,
-    timeline: true,
-    model_stats: true,
-    channel_share: true,
-    api_key_stats: true,
-    credential_stats: true,
-    credential_timeline: true,
-    filter_options: true,
-    heatmap: true,
-    anomaly_points: true,
     granularity,
   };
-  if (drilldownPreview) {
+
+  switch (activeTab) {
+    case 'overview':
+      Object.assign(include, {
+        summary_comparison: true,
+        timeline: true,
+        model_stats: true,
+        channel_share: true,
+        api_key_stats: true,
+        anomaly_points: true,
+      });
+      break;
+    case 'trends':
+      Object.assign(include, {
+        summary_comparison: true,
+        timeline: true,
+        model_stats: true,
+        api_key_stats: true,
+        anomaly_points: true,
+      });
+      break;
+    case 'models':
+      Object.assign(include, {
+        timeline: true,
+        model_stats: true,
+        api_key_stats: true,
+      });
+      break;
+    case 'apiKeys':
+      include.api_key_stats = true;
+      break;
+    case 'credentials':
+      include.credential_stats = true;
+      include.credential_timeline = true;
+      break;
+    case 'heatmap':
+      include.heatmap = true;
+      break;
+  }
+
+  if ((activeTab === 'overview' || activeTab === 'trends') && drilldownPreview) {
     include.drilldown_preview = {
       from_ms: drilldownPreview.fromMs,
       to_ms: drilldownPreview.toMs,
@@ -729,6 +760,11 @@ export const buildUsageAnalyticsInclude = (
   }
   return include;
 };
+
+export const buildUsageAnalyticsFilterSelectorsInclude = (): MonitoringAnalyticsInclude => ({
+  filter_options: true,
+  filter_selectors: true,
+});
 
 export const buildUsageSummary = (
   summary?: MonitoringAnalyticsSummary | null

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -1,0 +1,166 @@
+import { useEffect } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useMonitoringAnalytics,
+  type UseMonitoringAnalyticsParams,
+  type UseMonitoringAnalyticsReturn,
+} from '@/features/monitoring/hooks/useMonitoringAnalytics';
+import { useUsageAnalytics } from './useUsageAnalytics';
+
+vi.mock('@/features/monitoring/hooks/useMonitoringAnalytics', () => ({
+  useMonitoringAnalytics: vi.fn(),
+}));
+
+vi.mock('@/features/monitoring/hooks/useUsageData', () => ({
+  useUsageData: () => ({ apiKeyAliases: [], loadApiKeyAliases: vi.fn() }),
+}));
+
+vi.mock('@/features/monitoring/services/monitoringMetaService', () => ({
+  loadMonitoringMetaPayload: () => Promise.resolve({ authFiles: [], channels: [] }),
+}));
+
+vi.mock('@/stores', () => ({
+  useConfigStore: (selector: (state: { config: null }) => unknown) => selector({ config: null }),
+}));
+
+const useMonitoringAnalyticsMock = vi.mocked(useMonitoringAnalytics);
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const emptyAnalyticsResponse = {
+  generated_at_ms: 1,
+  granularity: 'hour',
+};
+
+describe('useUsageAnalytics request orchestration', () => {
+  let renderer: ReactTestRenderer | null = null;
+  let latestResult: ReturnType<typeof useUsageAnalytics> | null = null;
+  let selectorError = '';
+  const mainRefresh = vi.fn();
+  const selectorRefresh = vi.fn();
+  const auxiliaryRefresh = vi.fn();
+
+  const resultFor = (params: UseMonitoringAnalyticsParams): UseMonitoringAnalyticsReturn => {
+    const selectors = Boolean(params.include?.filter_selectors);
+    const main = Boolean(params.include?.summary);
+    return {
+      enabled: Boolean(params.fromMs && params.toMs),
+      loading: false,
+      error: selectors ? selectorError : '',
+      data: selectors
+        ? selectorError
+          ? null
+          : {
+              ...emptyAnalyticsResponse,
+              filter_options: {
+                models: ['gpt-a'],
+                api_key_hashes: ['key-a'],
+                providers: ['codex'],
+                auth_files: ['account.json'],
+              },
+            }
+        : main
+          ? emptyAnalyticsResponse
+          : null,
+      dataStale: false,
+      lastRefreshedAt: null,
+      serviceBase: 'http://manager.local',
+      unavailableReason: '',
+      refresh: selectors ? selectorRefresh : main ? mainRefresh : auxiliaryRefresh,
+    };
+  };
+
+  const lastParams = (predicate: (params: UseMonitoringAnalyticsParams) => boolean) => {
+    const calls = useMonitoringAnalyticsMock.mock.calls.map(([params]) => params).filter(predicate);
+    return calls[calls.length - 1];
+  };
+
+  function Harness() {
+    const result = useUsageAnalytics();
+    useEffect(() => {
+      latestResult = result;
+    }, [result]);
+    return null;
+  }
+
+  beforeEach(() => {
+    selectorError = '';
+    latestResult = null;
+    mainRefresh.mockReset();
+    selectorRefresh.mockReset();
+    auxiliaryRefresh.mockReset();
+    useMonitoringAnalyticsMock.mockReset();
+    useMonitoringAnalyticsMock.mockImplementation(resultFor);
+  });
+
+  afterEach(() => {
+    renderer?.unmount();
+    renderer = null;
+  });
+
+  const renderHook = async () => {
+    await act(async () => {
+      renderer = create(
+        <MemoryRouter initialEntries={['/usage-analytics']}>
+          <Harness />
+        </MemoryRouter>
+      );
+      await Promise.resolve();
+    });
+  };
+
+  it('uses a tab-scoped main request and a tab-independent selector request', async () => {
+    await renderHook();
+
+    const overview = lastParams((params) => Boolean(params.include?.summary));
+    const selectors = lastParams((params) => Boolean(params.include?.filter_selectors));
+    expect(overview?.include).toEqual({
+      summary: true,
+      summary_comparison: true,
+      timeline: true,
+      model_stats: true,
+      channel_share: true,
+      api_key_stats: true,
+      anomaly_points: true,
+      granularity: 'hour',
+    });
+    expect(JSON.parse(overview?.dataScopeKey ?? '{}')).toMatchObject({ activeTab: 'overview' });
+    expect(selectors?.include).toEqual({ filter_options: true, filter_selectors: true });
+    expect(JSON.parse(selectors?.dataScopeKey ?? '{}')).not.toHaveProperty('activeTab');
+    expect(latestResult?.filterOptions).toMatchObject({
+      models: ['gpt-a'],
+      api_key_hashes: ['key-a'],
+    });
+
+    const selectorScope = selectors?.dataScopeKey;
+    await act(async () => {
+      latestResult?.setActiveTab('heatmap');
+    });
+
+    const heatmap = lastParams((params) => Boolean(params.include?.summary));
+    const selectorsAfterTab = lastParams((params) => Boolean(params.include?.filter_selectors));
+    expect(heatmap?.include).toEqual({
+      summary: true,
+      heatmap: true,
+      granularity: 'hour',
+    });
+    expect(JSON.parse(heatmap?.dataScopeKey ?? '{}')).toMatchObject({ activeTab: 'heatmap' });
+    expect(selectorsAfterTab?.dataScopeKey).toBe(selectorScope);
+  });
+
+  it('does not couple selector failures to the main page error and refreshes both requests', async () => {
+    selectorError = 'selector failed';
+    await renderHook();
+
+    expect(latestResult?.error).toBe('');
+    expect(latestResult?.filterOptions).toBeUndefined();
+
+    act(() => {
+      latestResult?.refresh();
+    });
+    expect(mainRefresh).toHaveBeenCalledTimes(1);
+    expect(selectorRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -29,6 +29,7 @@ import {
   buildUsageMatrix,
   buildUsageSummaryDelta,
   buildUsageAnalyticsFilters,
+  buildUsageAnalyticsFilterSelectorsInclude,
   buildUsageAnalyticsInclude,
   buildUsageTimeline,
   getUsageRangeBounds,
@@ -93,10 +94,7 @@ export function useUsageAnalytics() {
   );
   const [searchParams, setSearchParams] = useSearchParams();
   const [initialUiState] = useState<UsageAnalyticsUiState>(() =>
-    buildUsageAnalyticsUiStateFromSearchParams(
-      searchParams,
-      readUsageAnalyticsUiState()
-    )
+    buildUsageAnalyticsUiStateFromSearchParams(searchParams, readUsageAnalyticsUiState())
   );
   const [filters, setFiltersState] = useState<UsageAnalyticsFiltersState>(
     () => initialUiState.filters
@@ -251,19 +249,27 @@ export function useUsageAnalytics() {
     };
   }, [resolvedGranularity, selectedBucketMs]);
   const include = useMemo(
-    () => buildUsageAnalyticsInclude(resolvedGranularity, drilldownPreview),
-    [drilldownPreview, resolvedGranularity]
+    () => buildUsageAnalyticsInclude(activeTabState, resolvedGranularity, drilldownPreview),
+    [activeTabState, drilldownPreview, resolvedGranularity]
   );
   const dataScopeKey = useMemo(
     () =>
       JSON.stringify({
+        activeTab: activeTabState,
         bounds,
         drilldownPreview,
         filters: analyticsFilters,
         granularity: resolvedGranularity,
         searchQuery: debouncedSearchQuery,
       }),
-    [analyticsFilters, bounds, debouncedSearchQuery, drilldownPreview, resolvedGranularity]
+    [
+      activeTabState,
+      analyticsFilters,
+      bounds,
+      debouncedSearchQuery,
+      drilldownPreview,
+      resolvedGranularity,
+    ]
   );
 
   const analytics = useMonitoringAnalytics({
@@ -274,6 +280,25 @@ export function useUsageAnalytics() {
     searchQuery: debouncedSearchQuery,
     filters: analyticsFilters,
     include,
+    throttleMs: 0,
+  });
+
+  const filterSelectorsInclude = useMemo(() => buildUsageAnalyticsFilterSelectorsInclude(), []);
+  const filterSelectorsDataScopeKey = useMemo(
+    () =>
+      JSON.stringify({
+        bounds,
+        searchQuery: debouncedSearchQuery,
+      }),
+    [bounds, debouncedSearchQuery]
+  );
+  const filterSelectorsAnalytics = useMonitoringAnalytics({
+    fromMs: bounds?.fromMs,
+    toMs: bounds?.toMs,
+    nowMs,
+    dataScopeKey: filterSelectorsDataScopeKey,
+    searchQuery: debouncedSearchQuery,
+    include: filterSelectorsInclude,
     throttleMs: 0,
   });
 
@@ -311,6 +336,9 @@ export function useUsageAnalytics() {
   });
 
   const analyticsData = analytics.dataStale ? null : analytics.data;
+  const filterSelectorsData = filterSelectorsAnalytics.dataStale
+    ? null
+    : filterSelectorsAnalytics.data;
   const adapted = useMemo(
     () =>
       adaptUsageAnalyticsData(
@@ -537,6 +565,7 @@ export function useUsageAnalytics() {
     void loadApiKeyAliases();
     void loadMonitoringMeta();
     void analytics.refresh({ force: true });
+    void filterSelectorsAnalytics.refresh({ force: true });
     if (selectedApiKeyTimelineAnalytics.enabled) {
       void selectedApiKeyTimelineAnalytics.refresh({ force: true });
     }
@@ -545,6 +574,7 @@ export function useUsageAnalytics() {
     }
   }, [
     analytics,
+    filterSelectorsAnalytics,
     heatmapDateAnalytics,
     loadApiKeyAliases,
     loadMonitoringMeta,
@@ -608,7 +638,7 @@ export function useUsageAnalytics() {
     insights,
     anomalyPoints: adapted.anomalyPoints,
     drilldownPreview: adapted.drilldownPreview,
-    filterOptions: adapted.filterOptions,
+    filterOptions: filterSelectorsData?.filter_options ?? adapted.filterOptions,
     selectedBucket,
     selectBucket,
     anomalyAnalysis,

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -636,6 +636,7 @@ export interface MonitoringAnalyticsInclude {
   credential_timeline?: boolean;
   api_key_stats?: boolean;
   filter_options?: boolean;
+  filter_selectors?: boolean;
   heatmap?: boolean;
   anomaly_points?: boolean;
   task_buckets?: boolean;
@@ -965,6 +966,8 @@ export interface MonitoringAnalyticsFilterOptions {
   api_key_stats?: MonitoringAnalyticsApiKeyStatRow[];
   channel_share?: MonitoringAnalyticsChannelShareRow[];
   model_stats?: MonitoringAnalyticsModelStat[];
+  models?: string[];
+  api_key_hashes?: string[];
   providers?: string[];
   auth_files?: string[];
   project_ids?: string[];


### PR DESCRIPTION
## Summary

Reduce Usage Analytics query workload by requesting only the data required by the active tab.
Move filter selectors into a lightweight, tab-independent request while preserving compatibility with older Manager Server versions.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add lightweight model, API key, provider, and auth file selector queries without running the full filter option aggregates.
- Build minimum analytics include payloads for Overview, Trends, Models, API Keys, Credentials, and Heatmap tabs.
- Keep selector scope stable across tab and dimension-filter changes, with independent failure handling and manual refresh.
- Send both selector and legacy filter-option flags so older Manager Server versions automatically retain full-option behavior.

## User Impact

Usage Analytics opens and switches tabs with substantially less SQLite work and memory allocation. There are no visible layout or interaction changes.

## Compatibility / Runtime Notes

- CPA panel mode: New panels send both flags; older Manager Server versions ignore the new selector flag and return the existing full filter options.
- Manager Server mode: New servers prioritize the lightweight selector path when both compatibility flags are present.
- Full Docker / native packages: No migration, environment variable, or restart-specific behavior is introduced beyond the normal application upgrade.

## Data / Security Notes

No database schema or persistence behavior changes. Selector responses expose only model names, existing API key hashes, provider names, and auth file names already available through the authorized full filter-options response. Raw request bodies, failure bodies, management keys, and authentication secrets are not exposed.

## Risk / Rollback

Risk level: Medium

Rollback notes:
- Revert the two commits to restore the previous all-tabs analytics request.
- The existing full `filter_options` path remains intact and can continue serving old or reverted clients.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test
npm run build
npm run manager-server:test
go test ./internal/repository/usageevent ./internal/service/monitoring
go test -run '^$' -bench '^BenchmarkUsageAnalyticsIncludeProfiles$' -benchtime=3x -benchmem ./internal/service/monitoring
git diff --check

Vitest: 86 files / 719 tests passed
Manager Server: all packages passed
Legacy full 100k: ~7.00 s, ~215 MB/op
Overview initial 100k: ~3.63 s, ~34 MB/op
Specialized tab 100k: ~2.34-3.10 s
Filter selectors 100k: ~402 ms, ~25 KB/op
Two review passes completed; no blocking findings remain
```

## Screenshots / Recordings

N/A. Performance and request-orchestration changes only; no visible UI changes.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

N/A
