### PR TITLE
feat(usage): support GPT-5.6 pricing and cache creation costs

### DIFF
--- a/apps/manager-server/internal/model/model_price.go
+++ b/apps/manager-server/internal/model/model_price.go
@@ -1,16 +1,20 @@
 package model
 
 type ModelPrice struct {
-	Prompt        float64 `json:"prompt"`
-	Completion    float64 `json:"completion"`
-	Cache         float64 `json:"cache"`
-	CacheRead     float64 `json:"cacheRead,omitempty"`
-	CacheCreation float64 `json:"cacheCreation,omitempty"`
-	Source        string  `json:"source,omitempty"`
-	SourceModelID string  `json:"sourceModelId,omitempty"`
-	RawJSON       string  `json:"rawJson,omitempty"`
-	UpdatedAtMS   int64   `json:"updatedAtMs,omitempty"`
-	SyncedAtMS    *int64  `json:"syncedAtMs,omitempty"`
+	Prompt                  float64 `json:"prompt"`
+	Completion              float64 `json:"completion"`
+	Cache                   float64 `json:"cache"`
+	CacheRead               float64 `json:"cacheRead,omitempty"`
+	CacheCreation           float64 `json:"cacheCreation,omitempty"`
+	PromptConfigured        bool    `json:"promptConfigured,omitempty"`
+	CompletionConfigured    bool    `json:"completionConfigured,omitempty"`
+	CacheReadConfigured     bool    `json:"cacheReadConfigured,omitempty"`
+	CacheCreationConfigured bool    `json:"cacheCreationConfigured,omitempty"`
+	Source                  string  `json:"source,omitempty"`
+	SourceModelID           string  `json:"sourceModelId,omitempty"`
+	RawJSON                 string  `json:"rawJson,omitempty"`
+	UpdatedAtMS             int64   `json:"updatedAtMs,omitempty"`
+	SyncedAtMS              *int64  `json:"syncedAtMs,omitempty"`
 }
 
 type ModelPriceSyncResult struct {

--- a/apps/manager-server/internal/repository/modelprice/repository.go
+++ b/apps/manager-server/internal/repository/modelprice/repository.go
@@ -27,7 +27,8 @@ func New(db *sql.DB) Repository {
 
 func (r *repository) LoadAll(ctx context.Context) (map[string]model.ModelPrice, error) {
 	rows, err := r.db.QueryContext(ctx, `select
-		model, prompt_per_1m, completion_per_1m, cache_per_1m, cache_read_per_1m, cache_creation_per_1m, source, source_model_id, raw_json,
+		model, prompt_per_1m, completion_per_1m, cache_per_1m, cache_read_per_1m, cache_creation_per_1m,
+		prompt_configured, completion_configured, cache_read_configured, cache_creation_configured, source, source_model_id, raw_json,
 		updated_at_ms, synced_at_ms
 		from model_prices order by model`)
 	if err != nil {
@@ -41,6 +42,7 @@ func (r *repository) LoadAll(ctx context.Context) (map[string]model.ModelPrice, 
 		var price model.ModelPrice
 		var source, sourceModelID, rawJSON sql.NullString
 		var syncedAt sql.NullInt64
+		var promptConfigured, completionConfigured, cacheReadConfigured, cacheCreationConfigured int
 		if err := rows.Scan(
 			&modelID,
 			&price.Prompt,
@@ -48,6 +50,10 @@ func (r *repository) LoadAll(ctx context.Context) (map[string]model.ModelPrice, 
 			&price.Cache,
 			&price.CacheRead,
 			&price.CacheCreation,
+			&promptConfigured,
+			&completionConfigured,
+			&cacheReadConfigured,
+			&cacheCreationConfigured,
 			&source,
 			&sourceModelID,
 			&rawJSON,
@@ -57,6 +63,10 @@ func (r *repository) LoadAll(ctx context.Context) (map[string]model.ModelPrice, 
 			return nil, err
 		}
 		price.Source = source.String
+		price.PromptConfigured = promptConfigured != 0
+		price.CompletionConfigured = completionConfigured != 0
+		price.CacheReadConfigured = cacheReadConfigured != 0
+		price.CacheCreationConfigured = cacheCreationConfigured != 0
 		price.SourceModelID = sourceModelID.String
 		price.RawJSON = rawJSON.String
 		if syncedAt.Valid {
@@ -85,9 +95,10 @@ func (r *repository) ReplaceAll(ctx context.Context, prices map[string]model.Mod
 	}
 
 	stmt, err := tx.PrepareContext(ctx, `insert into model_prices (
-		model, prompt_per_1m, completion_per_1m, cache_per_1m, cache_read_per_1m, cache_creation_per_1m, source, source_model_id,
+		model, prompt_per_1m, completion_per_1m, cache_per_1m, cache_read_per_1m, cache_creation_per_1m,
+		prompt_configured, completion_configured, cache_read_configured, cache_creation_configured, source, source_model_id,
 		raw_json, updated_at_ms, synced_at_ms
-	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -106,6 +117,10 @@ func (r *repository) ReplaceAll(ctx context.Context, prices map[string]model.Mod
 			price.Cache,
 			price.CacheRead,
 			price.CacheCreation,
+			price.PromptConfigured,
+			price.CompletionConfigured,
+			price.CacheReadConfigured,
+			price.CacheCreationConfigured,
 			nullString(price.Source),
 			nullString(price.SourceModelID),
 			nullString(price.RawJSON),
@@ -131,15 +146,20 @@ func (r *repository) UpsertSynced(ctx context.Context, prices map[string]model.M
 	}()
 
 	stmt, err := tx.PrepareContext(ctx, `insert into model_prices (
-		model, prompt_per_1m, completion_per_1m, cache_per_1m, cache_read_per_1m, cache_creation_per_1m, source, source_model_id,
+		model, prompt_per_1m, completion_per_1m, cache_per_1m, cache_read_per_1m, cache_creation_per_1m,
+		prompt_configured, completion_configured, cache_read_configured, cache_creation_configured, source, source_model_id,
 		raw_json, updated_at_ms, synced_at_ms
-	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	on conflict(model) do update set
 		prompt_per_1m = excluded.prompt_per_1m,
 		completion_per_1m = excluded.completion_per_1m,
 		cache_per_1m = excluded.cache_per_1m,
 		cache_read_per_1m = excluded.cache_read_per_1m,
 		cache_creation_per_1m = excluded.cache_creation_per_1m,
+		prompt_configured = excluded.prompt_configured,
+		completion_configured = excluded.completion_configured,
+		cache_read_configured = excluded.cache_read_configured,
+		cache_creation_configured = excluded.cache_creation_configured,
 		source = excluded.source,
 		source_model_id = excluded.source_model_id,
 		raw_json = excluded.raw_json,
@@ -173,6 +193,10 @@ func (r *repository) UpsertSynced(ctx context.Context, prices map[string]model.M
 			price.Cache,
 			price.CacheRead,
 			price.CacheCreation,
+			price.PromptConfigured,
+			price.CompletionConfigured,
+			price.CacheReadConfigured,
+			price.CacheCreationConfigured,
 			nullString(price.Source),
 			nullString(price.SourceModelID),
 			nullString(price.RawJSON),

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -95,6 +95,11 @@ func Migrate(db *sql.DB) error {
 			cached_tokens integer not null default 0,
 			cache_read_tokens integer not null default 0,
 			cache_creation_tokens integer not null default 0,
+			long_input_tokens integer not null default 0,
+			long_output_tokens integer not null default 0,
+			long_cached_tokens integer not null default 0,
+			long_cache_read_tokens integer not null default 0,
+			long_cache_creation_tokens integer not null default 0,
 			total_tokens integer not null default 0,
 			first_seen_ms integer not null,
 			last_seen_ms integer not null,
@@ -117,6 +122,11 @@ func Migrate(db *sql.DB) error {
 			cached_tokens integer not null default 0,
 			cache_read_tokens integer not null default 0,
 			cache_creation_tokens integer not null default 0,
+			long_input_tokens integer not null default 0,
+			long_output_tokens integer not null default 0,
+			long_cached_tokens integer not null default 0,
+			long_cache_read_tokens integer not null default 0,
+			long_cache_creation_tokens integer not null default 0,
 			total_tokens integer not null default 0,
 			latency_sum_ms integer not null default 0,
 			latency_samples integer not null default 0,
@@ -142,6 +152,10 @@ func Migrate(db *sql.DB) error {
 			cache_per_1m real not null,
 			cache_read_per_1m real not null default 0,
 			cache_creation_per_1m real not null default 0,
+			prompt_configured integer not null default 0,
+			completion_configured integer not null default 0,
+			cache_read_configured integer not null default 0,
+			cache_creation_configured integer not null default 0,
 			source text,
 			source_model_id text,
 			raw_json text,
@@ -279,7 +293,78 @@ func Migrate(db *sql.DB) error {
 	if err := ensureAccountActionCandidateColumns(db); err != nil {
 		return err
 	}
+	if err := ensureUsageRollupLongContextColumns(db); err != nil {
+		return err
+	}
 	return ensureModelPriceColumns(db)
+}
+
+func ensureUsageRollupLongContextColumns(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "long_input_tokens", definition: "integer not null default 0"},
+		{name: "long_output_tokens", definition: "integer not null default 0"},
+		{name: "long_cached_tokens", definition: "integer not null default 0"},
+		{name: "long_cache_read_tokens", definition: "integer not null default 0"},
+		{name: "long_cache_creation_tokens", definition: "integer not null default 0"},
+	}
+	changed := false
+	for _, table := range []string{"usage_account_model_rollups", "usage_dashboard_hourly_rollups"} {
+		rows, err := tx.Query(`pragma table_info(` + table + `)`)
+		if err != nil {
+			return err
+		}
+		existing := map[string]struct{}{}
+		for rows.Next() {
+			var cid int
+			var name, typ string
+			var notNull int
+			var defaultValue any
+			var pk int
+			if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			existing[name] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		for _, column := range columns {
+			if _, ok := existing[column.name]; ok {
+				continue
+			}
+			if _, err := tx.Exec(fmt.Sprintf(`alter table %s add column %s %s`, table, column.name, column.definition)); err != nil {
+				return err
+			}
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	for _, statement := range []string{
+		`delete from usage_account_model_rollups`,
+		`delete from usage_dashboard_hourly_rollups`,
+		`delete from usage_rollup_checkpoints where name in ('account_history', 'dashboard_hourly')`,
+	} {
+		if _, err := tx.Exec(statement); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func ensureAccountActionCandidateColumns(db *sql.DB) error {
@@ -502,11 +587,16 @@ func ensureUsageEventSnapshotColumns(db *sql.DB) error {
 }
 
 func ensureModelPriceColumns(db *sql.DB) error {
-	rows, err := db.Query(`pragma table_info(model_prices)`)
+	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.Query(`pragma table_info(model_prices)`)
+	if err != nil {
+		return err
+	}
 
 	existing := map[string]struct{}{}
 	for rows.Next() {
@@ -522,6 +612,10 @@ func ensureModelPriceColumns(db *sql.DB) error {
 		existing[name] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
 		return err
 	}
 
@@ -531,18 +625,39 @@ func ensureModelPriceColumns(db *sql.DB) error {
 	}{
 		{name: "cache_read_per_1m", definition: "real not null default 0"},
 		{name: "cache_creation_per_1m", definition: "real not null default 0"},
+		{name: "prompt_configured", definition: "integer not null default 0"},
+		{name: "completion_configured", definition: "integer not null default 0"},
+		{name: "cache_read_configured", definition: "integer not null default 0"},
+		{name: "cache_creation_configured", definition: "integer not null default 0"},
 	}
+	added := map[string]bool{}
 	for _, column := range columns {
 		if _, ok := existing[column.name]; ok {
 			continue
 		}
-		if _, err := db.Exec(fmt.Sprintf(
+		if _, err := tx.Exec(fmt.Sprintf(
 			`alter table model_prices add column %s %s`,
 			column.name,
 			column.definition,
 		)); err != nil {
 			return err
 		}
+		added[column.name] = true
 	}
-	return nil
+	if added["prompt_configured"] || added["completion_configured"] {
+		if _, err := tx.Exec(`update model_prices set prompt_configured = 1, completion_configured = 1`); err != nil {
+			return err
+		}
+	}
+	if added["cache_read_configured"] {
+		if _, err := tx.Exec(`update model_prices set cache_read_configured = 1 where cache_read_per_1m != 0`); err != nil {
+			return err
+		}
+	}
+	if added["cache_creation_configured"] {
+		if _, err := tx.Exec(`update model_prices set cache_creation_configured = 1 where cache_creation_per_1m != 0`); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -1,0 +1,144 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureUsageRollupLongContextColumnsRollsBackAndRetries(t *testing.T) {
+	db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "rollup-migration.sqlite")))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, statement := range []string{
+		`create table usage_account_model_rollups (id integer primary key)`,
+		`create table usage_dashboard_hourly_rollups (id integer primary key)`,
+		`create table usage_rollup_checkpoints (name text primary key)`,
+		`insert into usage_account_model_rollups (id) values (1)`,
+		`insert into usage_dashboard_hourly_rollups (id) values (1)`,
+		`insert into usage_rollup_checkpoints (name) values ('account_history'), ('dashboard_hourly')`,
+		`create trigger reject_account_rollup_delete before delete on usage_account_model_rollups
+		begin select raise(abort, 'blocked'); end`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("setup migration fixture: %v", err)
+		}
+	}
+
+	if err := ensureUsageRollupLongContextColumns(db); err == nil {
+		t.Fatal("migration error = nil, want trigger failure")
+	}
+	for _, table := range []string{"usage_account_model_rollups", "usage_dashboard_hourly_rollups"} {
+		columns := migrationTableColumns(t, db, table)
+		if columns["long_input_tokens"] {
+			t.Fatalf("%s columns committed after failed migration: %#v", table, columns)
+		}
+	}
+	assertTableCount(t, db, "usage_account_model_rollups", 1)
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 1)
+	assertTableCount(t, db, "usage_rollup_checkpoints", 2)
+
+	if _, err := db.Exec(`drop trigger reject_account_rollup_delete`); err != nil {
+		t.Fatalf("drop failure trigger: %v", err)
+	}
+	if err := ensureUsageRollupLongContextColumns(db); err != nil {
+		t.Fatalf("retry migration: %v", err)
+	}
+	for _, table := range []string{"usage_account_model_rollups", "usage_dashboard_hourly_rollups"} {
+		columns := migrationTableColumns(t, db, table)
+		for _, column := range []string{
+			"long_input_tokens",
+			"long_output_tokens",
+			"long_cached_tokens",
+			"long_cache_read_tokens",
+			"long_cache_creation_tokens",
+		} {
+			if !columns[column] {
+				t.Fatalf("%s missing column %s after retry: %#v", table, column, columns)
+			}
+		}
+	}
+	assertTableCount(t, db, "usage_account_model_rollups", 0)
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 0)
+	assertTableCount(t, db, "usage_rollup_checkpoints", 0)
+}
+
+func TestEnsureModelPriceColumnsPreservesLegacyZeroBasePrices(t *testing.T) {
+	db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "model-price-migration.sqlite")))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, statement := range []string{
+		`create table model_prices (
+			model text primary key,
+			prompt_per_1m real not null,
+			completion_per_1m real not null,
+			cache_per_1m real not null
+		)`,
+		`insert into model_prices (model, prompt_per_1m, completion_per_1m, cache_per_1m)
+		values ('gpt-5.6-sol', 0, 0, 0)`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("setup model price fixture: %v", err)
+		}
+	}
+
+	if err := ensureModelPriceColumns(db); err != nil {
+		t.Fatalf("migrate model prices: %v", err)
+	}
+	var promptConfigured, completionConfigured, cacheReadConfigured, cacheCreationConfigured int
+	if err := db.QueryRow(`select prompt_configured, completion_configured, cache_read_configured, cache_creation_configured
+		from model_prices where model = 'gpt-5.6-sol'`).Scan(
+		&promptConfigured,
+		&completionConfigured,
+		&cacheReadConfigured,
+		&cacheCreationConfigured,
+	); err != nil {
+		t.Fatalf("read migrated price flags: %v", err)
+	}
+	if promptConfigured != 1 || completionConfigured != 1 || cacheReadConfigured != 0 || cacheCreationConfigured != 0 {
+		t.Fatalf("configured flags = %d/%d/%d/%d", promptConfigured, completionConfigured, cacheReadConfigured, cacheCreationConfigured)
+	}
+}
+
+func migrationTableColumns(t *testing.T, db *sql.DB, table string) map[string]bool {
+	t.Helper()
+	rows, err := db.Query(`pragma table_info(` + table + `)`)
+	if err != nil {
+		t.Fatalf("read %s columns: %v", table, err)
+	}
+	defer rows.Close()
+
+	columns := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull int
+		var defaultValue any
+		var primaryKey int
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatalf("scan %s columns: %v", table, err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s columns: %v", table, err)
+	}
+	return columns
+}
+
+func assertTableCount(t *testing.T, db *sql.DB, table string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(`select count(*) from ` + table).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if got != want {
+		t.Fatalf("%s count = %d, want %d", table, got, want)
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/aggregate.go
+++ b/apps/manager-server/internal/repository/usageevent/aggregate.go
@@ -3,12 +3,14 @@ package usageevent
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
 
 // Aggregate captures roll-up metrics for a usage_events window.
 type Aggregate struct {
+	usage.LongContextTokens
 	TotalCalls          int64
 	SuccessCalls        int64
 	FailureCalls        int64
@@ -26,6 +28,7 @@ type Aggregate struct {
 
 // ModelStat aggregates per-model totals.
 type ModelStat struct {
+	usage.LongContextTokens
 	Model               string
 	BillingModel        string
 	ServiceTier         string
@@ -65,7 +68,7 @@ type RecentFailure struct {
 	HeaderTraceID          string
 }
 
-const aggregateSQL = `select
+var aggregateSQL = fmt.Sprintf(`select
 	count(*),
 	sum(case when failed = 0 then 1 else 0 end),
 	sum(case when failed = 1 then 1 else 0 end),
@@ -75,12 +78,17 @@ const aggregateSQL = `select
 	coalesce(sum(max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(case when input_tokens > %[1]d then input_tokens else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then output_tokens else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0) else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then cache_read_tokens else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then cache_creation_tokens else 0 end), 0),
 	coalesce(sum(total_tokens), 0),
 	avg(nullif(latency_ms, 0)),
 	count(nullif(latency_ms, 0)),
 	coalesce(sum(case when total_tokens = 0 and failed = 0 then 1 else 0 end), 0)
 from usage_events
-where timestamp_ms >= ? and timestamp_ms < ?`
+where timestamp_ms >= ? and timestamp_ms < ?`, usage.LongContextInputTokenThreshold)
 
 // AggregateBetween computes summary metrics over [fromMs, toMs).
 func (r *repository) AggregateBetween(ctx context.Context, fromMs, toMs int64) (Aggregate, error) {
@@ -97,6 +105,11 @@ func (r *repository) AggregateBetween(ctx context.Context, fromMs, toMs int64) (
 		&agg.CachedTokens,
 		&agg.CacheReadTokens,
 		&agg.CacheCreationTokens,
+		&agg.LongInputTokens,
+		&agg.LongOutputTokens,
+		&agg.LongCachedTokens,
+		&agg.LongCacheReadTokens,
+		&agg.LongCacheCreationTokens,
 		&agg.TotalTokens,
 		&agg.AvgLatencyMS,
 		&agg.LatencySamples,
@@ -109,7 +122,7 @@ func (r *repository) AggregateBetween(ctx context.Context, fromMs, toMs int64) (
 	return agg, nil
 }
 
-const topModelsSQL = `with top_models as (
+var topModelsSQL = fmt.Sprintf(`with top_models as (
 	select
 		model,
 		count(*) as model_calls
@@ -131,12 +144,17 @@ select
 	coalesce(sum(max(max(e.cached_tokens, e.cache_tokens) - max(e.cache_read_tokens, 0) - max(e.cache_creation_tokens, 0), 0)), 0),
 	coalesce(sum(e.cache_read_tokens), 0),
 	coalesce(sum(e.cache_creation_tokens), 0),
+	coalesce(sum(case when e.input_tokens > %[1]d then e.input_tokens else 0 end), 0),
+	coalesce(sum(case when e.input_tokens > %[1]d then e.output_tokens else 0 end), 0),
+	coalesce(sum(case when e.input_tokens > %[1]d then max(max(e.cached_tokens, e.cache_tokens) - max(e.cache_read_tokens, 0) - max(e.cache_creation_tokens, 0), 0) else 0 end), 0),
+	coalesce(sum(case when e.input_tokens > %[1]d then e.cache_read_tokens else 0 end), 0),
+	coalesce(sum(case when e.input_tokens > %[1]d then e.cache_creation_tokens else 0 end), 0),
 	coalesce(sum(e.total_tokens), 0)
 from usage_events e
 join top_models t on t.model = e.model
 where e.timestamp_ms >= ? and e.timestamp_ms < ?
 group by e.model, billing_model, coalesce(e.service_tier, '')
-order by max(t.model_calls) desc, e.model, calls desc`
+order by max(t.model_calls) desc, e.model, calls desc`, usage.LongContextInputTokenThreshold)
 
 // TopModelsBetween returns the most active models ordered by call count.
 func (r *repository) TopModelsBetween(ctx context.Context, fromMs, toMs int64, limit int) ([]ModelStat, error) {
@@ -164,6 +182,11 @@ func (r *repository) TopModelsBetween(ctx context.Context, fromMs, toMs int64, l
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 		); err != nil {
 			return nil, err
@@ -173,7 +196,7 @@ func (r *repository) TopModelsBetween(ctx context.Context, fromMs, toMs int64, l
 	return stats, rows.Err()
 }
 
-const modelStatsSQL = `select
+var modelStatsSQL = fmt.Sprintf(`select
 	model,
 	coalesce(nullif(resolved_model, ''), model) as billing_model,
 	coalesce(service_tier, '') as service_tier,
@@ -185,11 +208,16 @@ const modelStatsSQL = `select
 	coalesce(sum(max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(case when input_tokens > %[1]d then input_tokens else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then output_tokens else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0) else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then cache_read_tokens else 0 end), 0),
+	coalesce(sum(case when input_tokens > %[1]d then cache_creation_tokens else 0 end), 0),
 	coalesce(sum(total_tokens), 0)
 from usage_events
 where timestamp_ms >= ? and timestamp_ms < ?
 group by model, billing_model, coalesce(service_tier, '')
-order by calls desc`
+order by calls desc`, usage.LongContextInputTokenThreshold)
 
 // ModelStatsBetween returns per-model totals for all models in a window.
 func (r *repository) ModelStatsBetween(ctx context.Context, fromMs, toMs int64) ([]ModelStat, error) {
@@ -214,6 +242,11 @@ func (r *repository) ModelStatsBetween(ctx context.Context, fromMs, toMs int64) 
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 		); err != nil {
 			return nil, err

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -5,15 +5,27 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
 
-const (
-	compatCachedExpr  = "max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)"
-	compatCachedFExpr = "max(max(f.cached_tokens, f.cache_tokens) - max(f.cache_read_tokens, 0) - max(f.cache_creation_tokens, 0), 0)"
+var (
+	longContextThresholdSQL = strconv.FormatInt(usage.LongContextInputTokenThreshold, 10)
+	compatCachedExpr        = "max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)"
+	compatCachedFExpr       = "max(max(f.cached_tokens, f.cache_tokens) - max(f.cache_read_tokens, 0) - max(f.cache_creation_tokens, 0), 0)"
+	longInputExpr           = "case when input_tokens > " + longContextThresholdSQL + " then input_tokens else 0 end"
+	longOutputExpr          = "case when input_tokens > " + longContextThresholdSQL + " then output_tokens else 0 end"
+	longCachedExpr          = "case when input_tokens > " + longContextThresholdSQL + " then " + compatCachedExpr + " else 0 end"
+	longCacheReadExpr       = "case when input_tokens > " + longContextThresholdSQL + " then cache_read_tokens else 0 end"
+	longCacheCreationExpr   = "case when input_tokens > " + longContextThresholdSQL + " then cache_creation_tokens else 0 end"
+	longInputFExpr          = "case when f.input_tokens > " + longContextThresholdSQL + " then f.input_tokens else 0 end"
+	longOutputFExpr         = "case when f.input_tokens > " + longContextThresholdSQL + " then f.output_tokens else 0 end"
+	longCachedFExpr         = "case when f.input_tokens > " + longContextThresholdSQL + " then " + compatCachedFExpr + " else 0 end"
+	longCacheReadFExpr      = "case when f.input_tokens > " + longContextThresholdSQL + " then f.cache_read_tokens else 0 end"
+	longCacheCreationFExpr  = "case when f.input_tokens > " + longContextThresholdSQL + " then f.cache_creation_tokens else 0 end"
 )
 
 type AnalyticsFilter struct {
@@ -97,6 +109,7 @@ type FilterSelectorValues struct {
 }
 
 type TimelinePoint struct {
+	usage.LongContextTokens
 	BucketMS            int64
 	Model               string
 	BillingModel        string
@@ -122,6 +135,7 @@ type HourlyPoint struct {
 }
 
 type HeatmapPoint struct {
+	usage.LongContextTokens
 	Weekday             int
 	Hour                int
 	Model               string
@@ -141,6 +155,7 @@ type HeatmapPoint struct {
 }
 
 type ChannelModelStat struct {
+	usage.LongContextTokens
 	AuthIndex            string
 	Source               string
 	AccountSnapshot      string
@@ -176,6 +191,7 @@ type FailureSourceStat struct {
 }
 
 type AccountModelStat struct {
+	usage.LongContextTokens
 	AccountSnapshot      string
 	AuthLabelSnapshot    string
 	AuthProviderSnapshot string
@@ -200,6 +216,7 @@ type AccountModelStat struct {
 }
 
 type CredentialModelStat struct {
+	usage.LongContextTokens
 	ID                    string
 	AuthFileSnapshot      string
 	AuthIndex             string
@@ -227,6 +244,7 @@ type CredentialModelStat struct {
 }
 
 type CredentialTimelinePoint struct {
+	usage.LongContextTokens
 	ID                    string
 	AuthFileSnapshot      string
 	AuthIndex             string
@@ -255,6 +273,7 @@ type CredentialTimelinePoint struct {
 }
 
 type APIKeyModelStat struct {
+	usage.LongContextTokens
 	APIKeyHash           string
 	AccountSnapshot      string
 	AuthLabelSnapshot    string
@@ -427,6 +446,11 @@ func (r *repository) ModelStatsWithFilter(ctx context.Context, filter AnalyticsF
 	coalesce(sum(` + compatCachedExpr + `), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(` + longInputExpr + `), 0),
+	coalesce(sum(` + longOutputExpr + `), 0),
+	coalesce(sum(` + longCachedExpr + `), 0),
+	coalesce(sum(` + longCacheReadExpr + `), 0),
+	coalesce(sum(` + longCacheCreationExpr + `), 0),
 	coalesce(sum(total_tokens), 0)
 from usage_events ` + where + `
 group by model, billing_model, coalesce(service_tier, '')
@@ -454,6 +478,11 @@ select
 	coalesce(sum(` + compatCachedFExpr + `), 0),
 	coalesce(sum(f.cache_read_tokens), 0),
 	coalesce(sum(f.cache_creation_tokens), 0),
+	coalesce(sum(` + longInputFExpr + `), 0),
+	coalesce(sum(` + longOutputFExpr + `), 0),
+	coalesce(sum(` + longCachedFExpr + `), 0),
+	coalesce(sum(` + longCacheReadFExpr + `), 0),
+	coalesce(sum(` + longCacheCreationFExpr + `), 0),
 	coalesce(sum(f.total_tokens), 0)
 from filtered f
 join top_models t on t.model = f.model
@@ -482,6 +511,11 @@ order by max(t.model_calls) desc, f.model, calls desc`
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 		); err != nil {
 			return nil, err
@@ -595,6 +629,7 @@ order by timestamp_ms, model`, where)
 		point.CachedTokens += cachedTokens
 		point.CacheReadTokens += cacheReadTokens
 		point.CacheCreationTokens += cacheCreationTokens
+		point.AddIfLongContext(inputTokens, outputTokens, cachedTokens, cacheReadTokens, cacheCreationTokens)
 		if latency.Valid && latency.Float64 > 0 {
 			point.AvgLatencyMS.Float64 += latency.Float64
 			point.LatencySamples += 1
@@ -979,6 +1014,7 @@ order by timestamp_ms, model`, args...)
 		point.CachedTokens += cachedTokens
 		point.CacheReadTokens += cacheReadTokens
 		point.CacheCreationTokens += cacheCreationTokens
+		point.AddIfLongContext(inputTokens, outputTokens, cachedTokens, cacheReadTokens, cacheCreationTokens)
 		point.TotalTokens += totalTokens
 	}
 	if err := rows.Err(); err != nil {
@@ -1010,6 +1046,11 @@ func (r *repository) ChannelModelStatsWithFilter(ctx context.Context, filter Ana
 	coalesce(sum(`+compatCachedExpr+`), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(`+longInputExpr+`), 0),
+	coalesce(sum(`+longOutputExpr+`), 0),
+	coalesce(sum(`+longCachedExpr+`), 0),
+	coalesce(sum(`+longCacheReadExpr+`), 0),
+	coalesce(sum(`+longCacheCreationExpr+`), 0),
 	coalesce(sum(total_tokens), 0),
 	avg(nullif(latency_ms, 0)),
 	count(nullif(latency_ms, 0))
@@ -1041,6 +1082,11 @@ order by count(*) desc`, args...)
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 			&stat.AvgLatencyMS,
 			&stat.LatencySamples,
@@ -1116,6 +1162,11 @@ func (r *repository) AccountModelStatsWithFilter(ctx context.Context, filter Ana
 	coalesce(sum(`+compatCachedExpr+`), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(`+longInputExpr+`), 0),
+	coalesce(sum(`+longOutputExpr+`), 0),
+	coalesce(sum(`+longCachedExpr+`), 0),
+	coalesce(sum(`+longCacheReadExpr+`), 0),
+	coalesce(sum(`+longCacheCreationExpr+`), 0),
 	coalesce(sum(total_tokens), 0),
 	max(timestamp_ms),
 	avg(nullif(latency_ms, 0)),
@@ -1149,6 +1200,11 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 			&stat.LastSeenMS,
 			&stat.AvgLatencyMS,
@@ -1184,6 +1240,11 @@ func (r *repository) CredentialModelStatsWithFilter(ctx context.Context, filter 
 	coalesce(sum(`+compatCachedExpr+`), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(`+longInputExpr+`), 0),
+	coalesce(sum(`+longOutputExpr+`), 0),
+	coalesce(sum(`+longCachedExpr+`), 0),
+	coalesce(sum(`+longCacheReadExpr+`), 0),
+	coalesce(sum(`+longCacheCreationExpr+`), 0),
 	coalesce(sum(total_tokens), 0),
 	max(timestamp_ms),
 	avg(nullif(latency_ms, 0)),
@@ -1220,6 +1281,11 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 			&stat.LastSeenMS,
 			&stat.AvgLatencyMS,
@@ -1353,6 +1419,7 @@ order by timestamp_ms, credential_id, model`, where)
 		entry.CachedTokens += point.CachedTokens
 		entry.CacheReadTokens += point.CacheReadTokens
 		entry.CacheCreationTokens += point.CacheCreationTokens
+		entry.AddIfLongContext(point.InputTokens, point.OutputTokens, point.CachedTokens, point.CacheReadTokens, point.CacheCreationTokens)
 		if latency.Valid && latency.Float64 > 0 {
 			entry.AvgLatencyMS.Float64 += latency.Float64
 			entry.LatencySamples += 1
@@ -1394,6 +1461,11 @@ func (r *repository) APIKeyModelStatsWithFilter(ctx context.Context, filter Anal
 	coalesce(sum(`+compatCachedExpr+`), 0),
 	coalesce(sum(cache_read_tokens), 0),
 	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(`+longInputExpr+`), 0),
+	coalesce(sum(`+longOutputExpr+`), 0),
+	coalesce(sum(`+longCachedExpr+`), 0),
+	coalesce(sum(`+longCacheReadExpr+`), 0),
+	coalesce(sum(`+longCacheCreationExpr+`), 0),
 	coalesce(sum(total_tokens), 0),
 	max(timestamp_ms),
 	avg(nullif(latency_ms, 0)),
@@ -1428,6 +1500,11 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 			&stat.CachedTokens,
 			&stat.CacheReadTokens,
 			&stat.CacheCreationTokens,
+			&stat.LongInputTokens,
+			&stat.LongOutputTokens,
+			&stat.LongCachedTokens,
+			&stat.LongCacheReadTokens,
+			&stat.LongCacheCreationTokens,
 			&stat.TotalTokens,
 			&stat.LastSeenMS,
 			&stat.AvgLatencyMS,

--- a/apps/manager-server/internal/repository/usagerollup/dashboard.go
+++ b/apps/manager-server/internal/repository/usagerollup/dashboard.go
@@ -12,6 +12,7 @@ import (
 const dashboardHourMS int64 = 60 * 60 * 1000
 
 type DashboardHourlyRow struct {
+	usage.LongContextTokens
 	BucketMS            int64
 	Model               string
 	BillingModel        string
@@ -135,6 +136,11 @@ func (r *repository) DashboardHourlyRows(ctx context.Context, fromMS, toMS int64
 	cached_tokens,
 	cache_read_tokens,
 	cache_creation_tokens,
+	long_input_tokens,
+	long_output_tokens,
+	long_cached_tokens,
+	long_cache_read_tokens,
+	long_cache_creation_tokens,
 	total_tokens,
 	latency_sum_ms,
 	latency_samples,
@@ -165,6 +171,11 @@ order by bucket_ms, model, billing_model, service_tier`, fromMS, toMS)
 			&row.CachedTokens,
 			&row.CacheReadTokens,
 			&row.CacheCreationTokens,
+			&row.LongInputTokens,
+			&row.LongOutputTokens,
+			&row.LongCachedTokens,
+			&row.LongCacheReadTokens,
+			&row.LongCacheCreationTokens,
 			&row.TotalTokens,
 			&row.LatencySumMS,
 			&row.LatencySamples,
@@ -282,6 +293,7 @@ func aggregateDashboardHourly(events []dashboardEventRow, nowMS int64) []Dashboa
 		row.CachedTokens += event.CachedTokens
 		row.CacheReadTokens += event.CacheReadTokens
 		row.CacheCreationTokens += event.CacheCreationTokens
+		row.AddIfLongContext(event.InputTokens, event.OutputTokens, event.CachedTokens, event.CacheReadTokens, event.CacheCreationTokens)
 		row.TotalTokens += event.TotalTokens
 		if event.LatencyMS.Valid && event.LatencyMS.Int64 != 0 {
 			row.LatencySumMS += event.LatencyMS.Int64
@@ -314,12 +326,17 @@ func upsertDashboardHourlyRows(ctx context.Context, tx *sql.Tx, rows []Dashboard
 	cached_tokens,
 	cache_read_tokens,
 	cache_creation_tokens,
+	long_input_tokens,
+	long_output_tokens,
+	long_cached_tokens,
+	long_cache_read_tokens,
+	long_cache_creation_tokens,
 	total_tokens,
 	latency_sum_ms,
 	latency_samples,
 	zero_token_calls,
 	updated_at_ms
-) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 on conflict(bucket_ms, model, billing_model, service_tier) do update set
 	calls = usage_dashboard_hourly_rollups.calls + excluded.calls,
 	success_calls = usage_dashboard_hourly_rollups.success_calls + excluded.success_calls,
@@ -330,6 +347,11 @@ on conflict(bucket_ms, model, billing_model, service_tier) do update set
 	cached_tokens = usage_dashboard_hourly_rollups.cached_tokens + excluded.cached_tokens,
 	cache_read_tokens = usage_dashboard_hourly_rollups.cache_read_tokens + excluded.cache_read_tokens,
 	cache_creation_tokens = usage_dashboard_hourly_rollups.cache_creation_tokens + excluded.cache_creation_tokens,
+	long_input_tokens = usage_dashboard_hourly_rollups.long_input_tokens + excluded.long_input_tokens,
+	long_output_tokens = usage_dashboard_hourly_rollups.long_output_tokens + excluded.long_output_tokens,
+	long_cached_tokens = usage_dashboard_hourly_rollups.long_cached_tokens + excluded.long_cached_tokens,
+	long_cache_read_tokens = usage_dashboard_hourly_rollups.long_cache_read_tokens + excluded.long_cache_read_tokens,
+	long_cache_creation_tokens = usage_dashboard_hourly_rollups.long_cache_creation_tokens + excluded.long_cache_creation_tokens,
 	total_tokens = usage_dashboard_hourly_rollups.total_tokens + excluded.total_tokens,
 	latency_sum_ms = usage_dashboard_hourly_rollups.latency_sum_ms + excluded.latency_sum_ms,
 	latency_samples = usage_dashboard_hourly_rollups.latency_samples + excluded.latency_samples,
@@ -356,6 +378,11 @@ on conflict(bucket_ms, model, billing_model, service_tier) do update set
 			row.CachedTokens,
 			row.CacheReadTokens,
 			row.CacheCreationTokens,
+			row.LongInputTokens,
+			row.LongOutputTokens,
+			row.LongCachedTokens,
+			row.LongCacheReadTokens,
+			row.LongCacheCreationTokens,
 			row.TotalTokens,
 			row.LatencySumMS,
 			row.LatencySamples,

--- a/apps/manager-server/internal/repository/usagerollup/repository.go
+++ b/apps/manager-server/internal/repository/usagerollup/repository.go
@@ -37,6 +37,7 @@ type CatchUpResult struct {
 }
 
 type AccountHistoryRow struct {
+	usage.LongContextTokens
 	AccountKey           string
 	AccountSnapshot      string
 	AuthLabelSnapshot    string
@@ -218,6 +219,11 @@ func (r *repository) AccountHistoryRows(ctx context.Context, accountKeys []strin
 	cached_tokens,
 	cache_read_tokens,
 	cache_creation_tokens,
+	long_input_tokens,
+	long_output_tokens,
+	long_cached_tokens,
+	long_cache_read_tokens,
+	long_cache_creation_tokens,
 	total_tokens,
 	first_seen_ms,
 	last_seen_ms,
@@ -253,6 +259,11 @@ order by account_key, last_seen_ms desc`, args...)
 			&row.CachedTokens,
 			&row.CacheReadTokens,
 			&row.CacheCreationTokens,
+			&row.LongInputTokens,
+			&row.LongOutputTokens,
+			&row.LongCachedTokens,
+			&row.LongCacheReadTokens,
+			&row.LongCacheCreationTokens,
 			&row.TotalTokens,
 			&row.FirstSeenMS,
 			&row.LastSeenMS,
@@ -457,6 +468,7 @@ func aggregateAccountHistory(events []eventRow, nowMS int64) []AccountHistoryRow
 		row.CachedTokens += event.CachedTokens
 		row.CacheReadTokens += event.CacheReadTokens
 		row.CacheCreationTokens += event.CacheCreationTokens
+		row.AddIfLongContext(event.InputTokens, event.OutputTokens, event.CachedTokens, event.CacheReadTokens, event.CacheCreationTokens)
 		row.TotalTokens += event.TotalTokens
 		if event.TimestampMS < row.FirstSeenMS {
 			row.FirstSeenMS = event.TimestampMS
@@ -517,11 +529,16 @@ func upsertAccountRollups(ctx context.Context, tx *sql.Tx, rows []AccountHistory
 	cached_tokens,
 	cache_read_tokens,
 	cache_creation_tokens,
+	long_input_tokens,
+	long_output_tokens,
+	long_cached_tokens,
+	long_cache_read_tokens,
+	long_cache_creation_tokens,
 	total_tokens,
 	first_seen_ms,
 	last_seen_ms,
 	updated_at_ms
-) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 on conflict(account_key, billing_model, service_tier) do update set
 	account_snapshot = coalesce(nullif(excluded.account_snapshot, ''), usage_account_model_rollups.account_snapshot),
 	auth_label_snapshot = coalesce(nullif(excluded.auth_label_snapshot, ''), usage_account_model_rollups.auth_label_snapshot),
@@ -539,6 +556,11 @@ on conflict(account_key, billing_model, service_tier) do update set
 	cached_tokens = usage_account_model_rollups.cached_tokens + excluded.cached_tokens,
 	cache_read_tokens = usage_account_model_rollups.cache_read_tokens + excluded.cache_read_tokens,
 	cache_creation_tokens = usage_account_model_rollups.cache_creation_tokens + excluded.cache_creation_tokens,
+	long_input_tokens = usage_account_model_rollups.long_input_tokens + excluded.long_input_tokens,
+	long_output_tokens = usage_account_model_rollups.long_output_tokens + excluded.long_output_tokens,
+	long_cached_tokens = usage_account_model_rollups.long_cached_tokens + excluded.long_cached_tokens,
+	long_cache_read_tokens = usage_account_model_rollups.long_cache_read_tokens + excluded.long_cache_read_tokens,
+	long_cache_creation_tokens = usage_account_model_rollups.long_cache_creation_tokens + excluded.long_cache_creation_tokens,
 	total_tokens = usage_account_model_rollups.total_tokens + excluded.total_tokens,
 	first_seen_ms = min(usage_account_model_rollups.first_seen_ms, excluded.first_seen_ms),
 	last_seen_ms = max(usage_account_model_rollups.last_seen_ms, excluded.last_seen_ms),
@@ -570,6 +592,11 @@ on conflict(account_key, billing_model, service_tier) do update set
 			row.CachedTokens,
 			row.CacheReadTokens,
 			row.CacheCreationTokens,
+			row.LongInputTokens,
+			row.LongOutputTokens,
+			row.LongCachedTokens,
+			row.LongCacheReadTokens,
+			row.LongCacheCreationTokens,
 			row.TotalTokens,
 			row.FirstSeenMS,
 			row.LastSeenMS,

--- a/apps/manager-server/internal/repository/usagerollup/repository_test.go
+++ b/apps/manager-server/internal/repository/usagerollup/repository_test.go
@@ -107,6 +107,47 @@ func TestCatchUpAccountHistoryAggregatesByCheckpoint(t *testing.T) {
 	}
 }
 
+func TestRollupsPreserveLongContextTokenBuckets(t *testing.T) {
+	db := newRollupTestDB(t)
+	ctx := context.Background()
+	events := usageevent.New(db)
+	repo := New(db)
+	baseMS := int64(1_700_000_000_000)
+	hourMS := baseMS - baseMS%dashboardHourMS
+
+	short := rollupTestEvent("long-boundary-short", hourMS+1_000, "gpt-5.6-sol", "", "alice@example.com", "", "auth-a", false, 272_000, 10, 0, 0, 20, 5, 272_010)
+	long := rollupTestEvent("long-boundary-over", hourMS+2_000, "gpt-5.6-sol", "", "alice@example.com", "", "auth-a", false, 272_001, 30, 0, 0, 40, 10, 272_031)
+	if _, err := events.InsertBatch(ctx, []usage.Event{short, long}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	if _, err := repo.CatchUpAccountHistory(ctx, 10, baseMS+10_000); err != nil {
+		t.Fatalf("account catch-up: %v", err)
+	}
+	if _, err := repo.CatchUpDashboardHourly(ctx, 10, baseMS+11_000); err != nil {
+		t.Fatalf("dashboard catch-up: %v", err)
+	}
+
+	accountRows, err := repo.AccountHistoryRows(ctx, []string{"alice@example.com"})
+	if err != nil || len(accountRows) != 1 {
+		t.Fatalf("account rows = %#v, err = %v", accountRows, err)
+	}
+	account := accountRows[0]
+	if account.LongInputTokens != 272_001 || account.LongOutputTokens != 30 ||
+		account.LongCacheReadTokens != 40 || account.LongCacheCreationTokens != 10 {
+		t.Fatalf("account long-context tokens = %#v", account.LongContextTokens)
+	}
+
+	dashboardRows, err := repo.DashboardHourlyRows(ctx, hourMS, hourMS+dashboardHourMS)
+	if err != nil || len(dashboardRows) != 1 {
+		t.Fatalf("dashboard rows = %#v, err = %v", dashboardRows, err)
+	}
+	dashboard := dashboardRows[0]
+	if dashboard.LongInputTokens != 272_001 || dashboard.LongOutputTokens != 30 ||
+		dashboard.LongCacheReadTokens != 40 || dashboard.LongCacheCreationTokens != 10 {
+		t.Fatalf("dashboard long-context tokens = %#v", dashboard.LongContextTokens)
+	}
+}
+
 func TestCatchUpAccountHistoryFailureDoesNotAdvanceCheckpoint(t *testing.T) {
 	db := newRollupTestDB(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -443,6 +443,11 @@ func dashboardMetricsFromHourlyRows(rows []store.DashboardHourlyRollupRow) (stor
 		agg.CachedTokens += row.CachedTokens
 		agg.CacheReadTokens += row.CacheReadTokens
 		agg.CacheCreationTokens += row.CacheCreationTokens
+		agg.LongInputTokens += row.LongInputTokens
+		agg.LongOutputTokens += row.LongOutputTokens
+		agg.LongCachedTokens += row.LongCachedTokens
+		agg.LongCacheReadTokens += row.LongCacheReadTokens
+		agg.LongCacheCreationTokens += row.LongCacheCreationTokens
 		agg.TotalTokens += row.TotalTokens
 		agg.LatencySamples += row.LatencySamples
 		agg.ZeroTokenCalls += row.ZeroTokenCalls
@@ -459,6 +464,7 @@ func dashboardMetricsFromHourlyRows(rows []store.DashboardHourlyRollupRow) (stor
 			CachedTokens:        row.CachedTokens,
 			CacheReadTokens:     row.CacheReadTokens,
 			CacheCreationTokens: row.CacheCreationTokens,
+			LongContextTokens:   row.LongContextTokens,
 			TotalTokens:         row.TotalTokens,
 		})
 		point := timelineByBucket[row.BucketMS]
@@ -494,6 +500,11 @@ func mergeDashboardAggregates(left, right store.Aggregate) store.Aggregate {
 	left.CachedTokens += right.CachedTokens
 	left.CacheReadTokens += right.CacheReadTokens
 	left.CacheCreationTokens += right.CacheCreationTokens
+	left.LongInputTokens += right.LongInputTokens
+	left.LongOutputTokens += right.LongOutputTokens
+	left.LongCachedTokens += right.LongCachedTokens
+	left.LongCacheReadTokens += right.LongCacheReadTokens
+	left.LongCacheCreationTokens += right.LongCacheCreationTokens
 	left.TotalTokens += right.TotalTokens
 	left.LatencySamples += right.LatencySamples
 	left.ZeroTokenCalls += right.ZeroTokenCalls
@@ -529,6 +540,11 @@ func mergeDashboardModelStats(left, right []store.ModelStat) []store.ModelStat {
 		entry.CachedTokens += stat.CachedTokens
 		entry.CacheReadTokens += stat.CacheReadTokens
 		entry.CacheCreationTokens += stat.CacheCreationTokens
+		entry.LongInputTokens += stat.LongInputTokens
+		entry.LongOutputTokens += stat.LongOutputTokens
+		entry.LongCachedTokens += stat.LongCachedTokens
+		entry.LongCacheReadTokens += stat.LongCacheReadTokens
+		entry.LongCacheCreationTokens += stat.LongCacheCreationTokens
 		entry.TotalTokens += stat.TotalTokens
 	}
 	result := make([]store.ModelStat, 0, len(order))
@@ -991,21 +1007,31 @@ func aggregateModelStats(stats []store.ModelStat, prices map[string]store.ModelP
 
 func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 

--- a/apps/manager-server/internal/service/modelprice/service.go
+++ b/apps/manager-server/internal/service/modelprice/service.go
@@ -303,16 +303,20 @@ func fetchLiteLLMModelPrices(ctx context.Context, syncURL string, client *http.C
 		}
 		rawEntry, _ := json.Marshal(entry)
 		prices[modelID] = store.ModelPrice{
-			Prompt:        promptCost * 1_000_000,
-			Completion:    completionCost * 1_000_000,
-			Cache:         cacheReadCost * 1_000_000,
-			CacheRead:     cacheReadCost * 1_000_000,
-			CacheCreation: cacheCreationCost * 1_000_000,
-			Source:        SyncSourceLiteLLM,
-			SourceModelID: modelID,
-			RawJSON:       string(rawEntry),
-			UpdatedAtMS:   now,
-			SyncedAtMS:    &now,
+			Prompt:                  promptCost * 1_000_000,
+			Completion:              completionCost * 1_000_000,
+			Cache:                   cacheReadCost * 1_000_000,
+			CacheRead:               cacheReadCost * 1_000_000,
+			CacheCreation:           cacheCreationCost * 1_000_000,
+			PromptConfigured:        hasPrompt,
+			CompletionConfigured:    hasCompletion,
+			CacheReadConfigured:     hasCacheRead,
+			CacheCreationConfigured: hasCacheCreation,
+			Source:                  SyncSourceLiteLLM,
+			SourceModelID:           modelID,
+			RawJSON:                 string(rawEntry),
+			UpdatedAtMS:             now,
+			SyncedAtMS:              &now,
 		}
 	}
 	return prices, skipped, nil
@@ -362,16 +366,20 @@ func fetchOpenRouterModelPrices(ctx context.Context, syncURL string, client *htt
 		}
 		rawEntry, _ := json.Marshal(entry)
 		prices[modelID] = store.ModelPrice{
-			Prompt:        promptCost * 1_000_000,
-			Completion:    completionCost * 1_000_000,
-			Cache:         cacheReadCost * 1_000_000,
-			CacheRead:     cacheReadCost * 1_000_000,
-			CacheCreation: cacheCreationCost * 1_000_000,
-			Source:        SyncSourceOpenRouter,
-			SourceModelID: modelID,
-			RawJSON:       string(rawEntry),
-			UpdatedAtMS:   now,
-			SyncedAtMS:    &now,
+			Prompt:                  promptCost * 1_000_000,
+			Completion:              completionCost * 1_000_000,
+			Cache:                   cacheReadCost * 1_000_000,
+			CacheRead:               cacheReadCost * 1_000_000,
+			CacheCreation:           cacheCreationCost * 1_000_000,
+			PromptConfigured:        hasPrompt,
+			CompletionConfigured:    hasCompletion,
+			CacheReadConfigured:     hasCacheRead,
+			CacheCreationConfigured: hasCacheCreation,
+			Source:                  SyncSourceOpenRouter,
+			SourceModelID:           modelID,
+			RawJSON:                 string(rawEntry),
+			UpdatedAtMS:             now,
+			SyncedAtMS:              &now,
 		}
 	}
 	return prices, skipped, nil

--- a/apps/manager-server/internal/service/modelprice/service_test.go
+++ b/apps/manager-server/internal/service/modelprice/service_test.go
@@ -96,7 +96,8 @@ func TestFetchOpenRouterModelPrices(t *testing.T) {
 	if price.Source != SyncSourceOpenRouter || price.SourceModelID != "openai/gpt-test" {
 		t.Fatalf("source metadata = %#v", price)
 	}
-	if !closePrice(price.Prompt, 1) || !closePrice(price.Completion, 2) || !closePrice(price.Cache, 0.25) {
+	if !closePrice(price.Prompt, 1) || !closePrice(price.Completion, 2) || !closePrice(price.Cache, 0.25) ||
+		!price.PromptConfigured || !price.CompletionConfigured || !price.CacheReadConfigured || price.CacheCreationConfigured {
 		t.Fatalf("price = %#v", price)
 	}
 }

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -2428,11 +2428,16 @@ func buildAccountHistoryTotals(rows []store.AccountHistoryRollupRow, prices map[
 			[]string{row.BillingModel, row.Model},
 			row.ServiceTier,
 			pricing.ModelTokens{
-				InputTokens:         row.InputTokens,
-				OutputTokens:        row.OutputTokens,
-				CachedTokens:        row.CachedTokens,
-				CacheReadTokens:     row.CacheReadTokens,
-				CacheCreationTokens: row.CacheCreationTokens,
+				InputTokens:             row.InputTokens,
+				OutputTokens:            row.OutputTokens,
+				CachedTokens:            row.CachedTokens,
+				CacheReadTokens:         row.CacheReadTokens,
+				CacheCreationTokens:     row.CacheCreationTokens,
+				LongInputTokens:         row.LongInputTokens,
+				LongOutputTokens:        row.LongOutputTokens,
+				LongCachedTokens:        row.LongCachedTokens,
+				LongCacheReadTokens:     row.LongCacheReadTokens,
+				LongCacheCreationTokens: row.LongCacheCreationTokens,
 			},
 			prices,
 		)
@@ -2473,81 +2478,121 @@ func sumCost(stats []store.ModelStat, prices map[string]store.ModelPrice) float6
 
 func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForTimelinePoint(point store.TimelinePoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
-		InputTokens:         point.InputTokens,
-		OutputTokens:        point.OutputTokens,
-		CachedTokens:        point.CachedTokens,
-		CacheReadTokens:     point.CacheReadTokens,
-		CacheCreationTokens: point.CacheCreationTokens,
+		InputTokens:             point.InputTokens,
+		OutputTokens:            point.OutputTokens,
+		CachedTokens:            point.CachedTokens,
+		CacheReadTokens:         point.CacheReadTokens,
+		CacheCreationTokens:     point.CacheCreationTokens,
+		LongInputTokens:         point.LongInputTokens,
+		LongOutputTokens:        point.LongOutputTokens,
+		LongCachedTokens:        point.LongCachedTokens,
+		LongCacheReadTokens:     point.LongCacheReadTokens,
+		LongCacheCreationTokens: point.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForHeatmapPoint(point store.HeatmapPoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
-		InputTokens:         point.InputTokens,
-		OutputTokens:        point.OutputTokens,
-		CachedTokens:        point.CachedTokens,
-		CacheReadTokens:     point.CacheReadTokens,
-		CacheCreationTokens: point.CacheCreationTokens,
+		InputTokens:             point.InputTokens,
+		OutputTokens:            point.OutputTokens,
+		CachedTokens:            point.CachedTokens,
+		CacheReadTokens:         point.CacheReadTokens,
+		CacheCreationTokens:     point.CacheCreationTokens,
+		LongInputTokens:         point.LongInputTokens,
+		LongOutputTokens:        point.LongOutputTokens,
+		LongCachedTokens:        point.LongCachedTokens,
+		LongCacheReadTokens:     point.LongCacheReadTokens,
+		LongCacheCreationTokens: point.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForAccountModelStat(stat store.AccountModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForCredentialModelStat(stat store.CredentialModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
-		InputTokens:         stat.InputTokens,
-		OutputTokens:        stat.OutputTokens,
-		CachedTokens:        stat.CachedTokens,
-		CacheReadTokens:     stat.CacheReadTokens,
-		CacheCreationTokens: stat.CacheCreationTokens,
+		InputTokens:             stat.InputTokens,
+		OutputTokens:            stat.OutputTokens,
+		CachedTokens:            stat.CachedTokens,
+		CacheReadTokens:         stat.CacheReadTokens,
+		CacheCreationTokens:     stat.CacheCreationTokens,
+		LongInputTokens:         stat.LongInputTokens,
+		LongOutputTokens:        stat.LongOutputTokens,
+		LongCachedTokens:        stat.LongCachedTokens,
+		LongCacheReadTokens:     stat.LongCacheReadTokens,
+		LongCacheCreationTokens: stat.LongCacheCreationTokens,
 	}, prices)
 }
 
 func costForCredentialTimelinePoint(point store.CredentialTimelinePoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
-		InputTokens:         point.InputTokens,
-		OutputTokens:        point.OutputTokens,
-		CachedTokens:        point.CachedTokens,
-		CacheReadTokens:     point.CacheReadTokens,
-		CacheCreationTokens: point.CacheCreationTokens,
+		InputTokens:             point.InputTokens,
+		OutputTokens:            point.OutputTokens,
+		CachedTokens:            point.CachedTokens,
+		CacheReadTokens:         point.CacheReadTokens,
+		CacheCreationTokens:     point.CacheCreationTokens,
+		LongInputTokens:         point.LongInputTokens,
+		LongOutputTokens:        point.LongOutputTokens,
+		LongCachedTokens:        point.LongCachedTokens,
+		LongCacheReadTokens:     point.LongCacheReadTokens,
+		LongCacheCreationTokens: point.LongCacheCreationTokens,
 	}, prices)
 }
 

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -664,6 +664,63 @@ func TestAnalyticsPricesPriorityAndDefaultServiceTiersSeparately(t *testing.T) {
 	assertCost("api key model stats", resp.APIKeyStats[0].Models[0].Cost)
 }
 
+func TestAnalyticsPricesGPT56LongContextPerRequest(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_020_000_000)
+	toMS := fromMS + 60*60*1000
+
+	short := monitoringEvent("gpt-56-short", fromMS+1_000, "gpt-5.6-sol", "auth-1", "source-a", false, 272_000, 0, 0, 0, 272_000, nil)
+	long := monitoringEvent("gpt-56-long", fromMS+2_000, "gpt-5.6-sol", "auth-1", "source-a", false, 272_001, 0, 0, 0, 272_001, nil)
+	for _, event := range []*usage.Event{&short, &long} {
+		event.AccountSnapshot = "team@example.com"
+		event.AuthLabelSnapshot = "Team"
+		event.APIKeyHash = "client-key"
+	}
+	if _, err := db.InsertEvents(ctx, []usage.Event{short, long}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Include: Include{
+			Summary:      true,
+			ModelStats:   true,
+			ChannelShare: true,
+			Timeline:     true,
+			AccountStats: true,
+			APIKeyStats:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+
+	const want = 4.08001
+	assertCost := func(name string, got float64) {
+		t.Helper()
+		if math.Abs(got-want) > 0.000001 {
+			t.Fatalf("%s cost = %v, want %v", name, got, want)
+		}
+	}
+	if resp.Summary == nil {
+		t.Fatal("summary is nil")
+	}
+	assertCost("summary", resp.Summary.TotalCost)
+	if len(resp.ModelStats) != 1 || len(resp.ChannelShare) != 1 || len(resp.Timeline) != 1 {
+		t.Fatalf("analytics rows = %#v %#v %#v", resp.ModelStats, resp.ChannelShare, resp.Timeline)
+	}
+	assertCost("model stats", resp.ModelStats[0].Cost)
+	assertCost("channel share", resp.ChannelShare[0].Cost)
+	assertCost("timeline", resp.Timeline[0].Cost)
+	if len(resp.AccountStats) != 1 || len(resp.APIKeyStats) != 1 {
+		t.Fatalf("identity stats = %#v %#v", resp.AccountStats, resp.APIKeyStats)
+	}
+	assertCost("account stats", resp.AccountStats[0].Cost)
+	assertCost("api key stats", resp.APIKeyStats[0].Cost)
+}
+
 func TestAnalyticsAppliesFilters(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/pricing/cost.go
+++ b/apps/manager-server/internal/service/pricing/cost.go
@@ -14,11 +14,16 @@ const PerMillion = 1_000_000.0
 // CachedTokens is the remaining legacy/OpenAI-style cached input after any
 // fine-grained cache_read/cache_creation values have already been removed.
 type ModelTokens struct {
-	InputTokens         int64
-	OutputTokens        int64
-	CachedTokens        int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
+	InputTokens             int64
+	OutputTokens            int64
+	CachedTokens            int64
+	CacheReadTokens         int64
+	CacheCreationTokens     int64
+	LongInputTokens         int64
+	LongOutputTokens        int64
+	LongCachedTokens        int64
+	LongCacheReadTokens     int64
+	LongCacheCreationTokens int64
 }
 
 // CostForModel computes the dollar cost for a single (model, tokens) pair.
@@ -28,10 +33,18 @@ type ModelTokens struct {
 // must pass the compatibility cached value, not CPA's Claude mirror copy.
 // Older payloads keep the OpenAI-style cached-in-input behavior.
 func CostForModel(modelName string, tokens ModelTokens, prices map[string]model.ModelPrice) float64 {
-	price, ok := prices[modelName]
+	price, ok := resolveModelPrice(modelName, prices)
 	if !ok {
 		return 0
 	}
+	return costForPrice(modelName, tokens, price)
+}
+
+func costForPrice(modelName string, tokens ModelTokens, price model.ModelPrice) float64 {
+	if isGPT56Model(modelName) {
+		return costForGPT56(tokens, enrichGPT56BasePrice(modelName, price))
+	}
+
 	inputTokens := maxInt64(tokens.InputTokens, 0)
 	outputTokens := maxInt64(tokens.OutputTokens, 0)
 	cachedTokens := maxInt64(tokens.CachedTokens, 0)
@@ -55,6 +68,69 @@ func CostForModel(modelName string, tokens ModelTokens, prices map[string]model.
 		float64(cachedTokens)*price.Cache/PerMillion
 }
 
+func costForGPT56(tokens ModelTokens, price model.ModelPrice) float64 {
+	inputTokens := maxInt64(tokens.InputTokens, 0)
+	outputTokens := maxInt64(tokens.OutputTokens, 0)
+	cachedTokens := maxInt64(tokens.CachedTokens, 0)
+	cacheReadTokens := maxInt64(tokens.CacheReadTokens, 0)
+	cacheCreationTokens := maxInt64(tokens.CacheCreationTokens, 0)
+
+	longInputTokens := clampTokens(tokens.LongInputTokens, inputTokens)
+	longOutputTokens := clampTokens(tokens.LongOutputTokens, outputTokens)
+	longCachedTokens := clampTokens(tokens.LongCachedTokens, cachedTokens)
+	longCacheReadTokens := clampTokens(tokens.LongCacheReadTokens, cacheReadTokens)
+	longCacheCreationTokens := clampTokens(tokens.LongCacheCreationTokens, cacheCreationTokens)
+
+	shortCost := costForGPT56Segment(
+		inputTokens-longInputTokens,
+		outputTokens-longOutputTokens,
+		cachedTokens-longCachedTokens,
+		cacheReadTokens-longCacheReadTokens,
+		cacheCreationTokens-longCacheCreationTokens,
+		price,
+		1,
+		1,
+	)
+	longCost := costForGPT56Segment(
+		longInputTokens,
+		longOutputTokens,
+		longCachedTokens,
+		longCacheReadTokens,
+		longCacheCreationTokens,
+		price,
+		2,
+		1.5,
+	)
+	return shortCost + longCost
+}
+
+func costForGPT56Segment(
+	inputTokens int64,
+	outputTokens int64,
+	cachedTokens int64,
+	cacheReadTokens int64,
+	cacheCreationTokens int64,
+	price model.ModelPrice,
+	inputMultiplier float64,
+	outputMultiplier float64,
+) float64 {
+	readTokens := cachedTokens + cacheReadTokens
+	promptTokens := maxInt64(inputTokens-readTokens-cacheCreationTokens, 0)
+	cacheReadPrice := price.CacheRead
+	if !configuredPriceValue(cacheReadPrice, price.CacheReadConfigured) {
+		cacheReadPrice = price.Prompt * 0.1
+	}
+	cacheCreationPrice := price.CacheCreation
+	if !configuredPriceValue(cacheCreationPrice, price.CacheCreationConfigured) {
+		cacheCreationPrice = price.Prompt * 1.25
+	}
+
+	return float64(promptTokens)*price.Prompt*inputMultiplier/PerMillion +
+		float64(readTokens)*cacheReadPrice*inputMultiplier/PerMillion +
+		float64(cacheCreationTokens)*cacheCreationPrice*inputMultiplier/PerMillion +
+		float64(outputTokens)*price.Completion*outputMultiplier/PerMillion
+}
+
 // ServiceTierMultiplier returns the OpenAI Priority processing multiplier for
 // the actual usage service tier. This compatibility layer keeps today's tier
 // multiplier rules centralized; a future price model should store explicit
@@ -67,6 +143,8 @@ func ServiceTierMultiplier(modelName string, serviceTier string) float64 {
 
 	modelName = strings.ToLower(strings.TrimSpace(modelName))
 	switch {
+	case isModelFamily(modelName, "gpt-5.6"):
+		return 2
 	case isModelFamily(modelName, "gpt-5.5"):
 		return 2.5
 	case isModelFamily(modelName, "gpt-5.4-mini"):
@@ -86,21 +164,38 @@ func CostForModelWithServiceTier(modelName string, serviceTier string, tokens Mo
 	return CostForModel(modelName, tokens, prices) * ServiceTierMultiplier(modelName, serviceTier)
 }
 
-// CostForModelCandidatesWithServiceTier computes cost using the first priced
-// model name from the candidate list. Callers should pass resolved/upstream
-// model first, followed by the requested display model or alias as fallback.
+// CostForModelCandidatesWithServiceTier uses the first candidate to determine
+// model-specific billing behavior and the first priced candidate for rates.
+// Callers should pass resolved/upstream model first, followed by the requested
+// display model or alias as a price fallback.
 func CostForModelCandidatesWithServiceTier(modelNames []string, serviceTier string, tokens ModelTokens, prices map[string]model.ModelPrice) float64 {
 	seen := map[string]bool{}
+	candidates := make([]string, 0, len(modelNames))
 	for _, modelName := range modelNames {
 		modelName = strings.TrimSpace(modelName)
 		if modelName == "" || seen[modelName] {
 			continue
 		}
 		seen[modelName] = true
-		if _, ok := prices[modelName]; !ok {
+		candidates = append(candidates, modelName)
+	}
+	behaviorModel := ""
+	if len(candidates) > 0 {
+		behaviorModel = candidates[0]
+	}
+	for _, modelName := range candidates {
+		price, ok := prices[modelName]
+		if !ok {
 			continue
 		}
-		return CostForModelWithServiceTier(modelName, serviceTier, tokens, prices)
+		return costForPrice(behaviorModel, tokens, price) * ServiceTierMultiplier(behaviorModel, serviceTier)
+	}
+	for _, modelName := range candidates {
+		price, ok := officialGPT56Price(modelName)
+		if !ok {
+			continue
+		}
+		return costForPrice(behaviorModel, tokens, price) * ServiceTierMultiplier(behaviorModel, serviceTier)
 	}
 	return 0
 }
@@ -135,5 +230,76 @@ func fallbackPrice(value float64, fallback float64) float64 {
 }
 
 func isModelFamily(modelName string, family string) bool {
+	modelName = normalizedModelSlug(modelName)
 	return modelName == family || strings.HasPrefix(modelName, family+"-")
+}
+
+func isGPT56Model(modelName string) bool {
+	return isModelFamily(modelName, "gpt-5.6")
+}
+
+func resolveModelPrice(modelName string, prices map[string]model.ModelPrice) (model.ModelPrice, bool) {
+	if price, ok := prices[modelName]; ok {
+		return price, true
+	}
+	return officialGPT56Price(modelName)
+}
+
+func enrichGPT56BasePrice(modelName string, price model.ModelPrice) model.ModelPrice {
+	fallback, ok := officialGPT56Price(modelName)
+	if !ok {
+		return price
+	}
+	if !configuredPriceValue(price.Prompt, price.PromptConfigured) {
+		price.Prompt = fallback.Prompt
+	}
+	if !configuredPriceValue(price.Completion, price.CompletionConfigured) {
+		price.Completion = fallback.Completion
+	}
+	return price
+}
+
+func officialGPT56Price(modelName string) (model.ModelPrice, bool) {
+	slug := normalizedModelSlug(modelName)
+	switch {
+	case isModelFamily(slug, "gpt-5.6-sol"):
+		return model.ModelPrice{
+			Prompt: 5, Completion: 30, Cache: 0.5, CacheRead: 0.5, CacheCreation: 6.25,
+			PromptConfigured: true, CompletionConfigured: true, CacheReadConfigured: true, CacheCreationConfigured: true,
+		}, true
+	case isModelFamily(slug, "gpt-5.6-terra"):
+		return model.ModelPrice{
+			Prompt: 2.5, Completion: 15, Cache: 0.25, CacheRead: 0.25, CacheCreation: 3.125,
+			PromptConfigured: true, CompletionConfigured: true, CacheReadConfigured: true, CacheCreationConfigured: true,
+		}, true
+	case isModelFamily(slug, "gpt-5.6-luna"):
+		return model.ModelPrice{
+			Prompt: 1, Completion: 6, Cache: 0.1, CacheRead: 0.1, CacheCreation: 1.25,
+			PromptConfigured: true, CompletionConfigured: true, CacheReadConfigured: true, CacheCreationConfigured: true,
+		}, true
+	default:
+		return model.ModelPrice{}, false
+	}
+}
+
+func normalizedModelSlug(modelName string) string {
+	modelName = strings.ToLower(strings.TrimSpace(modelName))
+	if index := strings.LastIndex(modelName, "/"); index >= 0 {
+		modelName = modelName[index+1:]
+	}
+	return modelName
+}
+
+func clampTokens(value int64, total int64) int64 {
+	if value <= 0 || total <= 0 {
+		return 0
+	}
+	if value > total {
+		return total
+	}
+	return value
+}
+
+func configuredPriceValue(value float64, configured bool) bool {
+	return configured || value > 0
 }

--- a/apps/manager-server/internal/service/pricing/cost_test.go
+++ b/apps/manager-server/internal/service/pricing/cost_test.go
@@ -81,6 +81,8 @@ func TestServiceTierMultiplier(t *testing.T) {
 		want        float64
 	}{
 		{name: "gpt-5.4 default", model: "gpt-5.4", serviceTier: "default", want: 1},
+		{name: "gpt-5.6 priority", model: "gpt-5.6-sol", serviceTier: "priority", want: 2},
+		{name: "namespaced gpt-5.6 fast", model: "openai/gpt-5.6-terra", serviceTier: "fast", want: 2},
 		{name: "gpt-5.4 priority", model: "gpt-5.4", serviceTier: "priority", want: 2},
 		{name: "gpt-5.4 fast", model: "gpt-5.4", serviceTier: "fast", want: 2},
 		{name: "gpt-5.4 mini priority", model: "gpt-5.4-mini", serviceTier: "priority", want: 2},
@@ -97,6 +99,129 @@ func TestServiceTierMultiplier(t *testing.T) {
 				t.Fatalf("ServiceTierMultiplier(%q, %q) = %v, want %v", tt.model, tt.serviceTier, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCostForGPT56UsesOfficialFallbackPrice(t *testing.T) {
+	cost := CostForModel("openai/gpt-5.6-sol", ModelTokens{
+		InputTokens:         1_000_000,
+		OutputTokens:        100_000,
+		CachedTokens:        100_000,
+		CacheReadTokens:     200_000,
+		CacheCreationTokens: 100_000,
+	}, nil)
+
+	if math.Abs(cost-6.775) > 0.000001 {
+		t.Fatalf("fallback cost = %v, want 6.775", cost)
+	}
+}
+
+func TestCostForGPT56PrefersConfiguredBasePrice(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.6-sol": {Prompt: 9, Completion: 18},
+	}
+
+	cost := CostForModel("gpt-5.6-sol", ModelTokens{InputTokens: 1_000_000}, prices)
+	if math.Abs(cost-9) > 0.000001 {
+		t.Fatalf("configured cost = %v, want 9", cost)
+	}
+}
+
+func TestCostForGPT56AppliesLongContextMultipliers(t *testing.T) {
+	tokens := ModelTokens{
+		InputTokens:             1_000_000,
+		OutputTokens:            100_000,
+		CacheReadTokens:         200_000,
+		CacheCreationTokens:     100_000,
+		LongInputTokens:         1_000_000,
+		LongOutputTokens:        100_000,
+		LongCacheReadTokens:     200_000,
+		LongCacheCreationTokens: 100_000,
+	}
+
+	cost := CostForModel("gpt-5.6-sol", tokens, nil)
+	if math.Abs(cost-12.95) > 0.000001 {
+		t.Fatalf("long-context cost = %v, want 12.95", cost)
+	}
+}
+
+func TestCostForGPT56KeepsExactly272KAtStandardRates(t *testing.T) {
+	cost := CostForModel("gpt-5.6-luna", ModelTokens{
+		InputTokens:  272_000,
+		OutputTokens: 100_000,
+	}, nil)
+
+	if math.Abs(cost-0.872) > 0.000001 {
+		t.Fatalf("272K cost = %v, want 0.872", cost)
+	}
+}
+
+func TestCostForGPT56UsesPromptRatiosWhenCachePricesAreMissing(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.6-terra": {Prompt: 10, Completion: 20, Cache: 10},
+	}
+	cost := CostForModelWithServiceTier("gpt-5.6-terra", "priority", ModelTokens{
+		InputTokens:         1_000_000,
+		CacheReadTokens:     200_000,
+		CacheCreationTokens: 100_000,
+	}, prices)
+
+	if math.Abs(cost-16.9) > 0.000001 {
+		t.Fatalf("priority fallback-ratio cost = %v, want 16.9", cost)
+	}
+}
+
+func TestCostForGPT56RespectsExplicitZeroPrices(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.6-sol": {
+			PromptConfigured: true, CompletionConfigured: true, CacheReadConfigured: true, CacheCreationConfigured: true,
+		},
+	}
+	cost := CostForModel("gpt-5.6-sol", ModelTokens{
+		InputTokens:         1_000_000,
+		OutputTokens:        100_000,
+		CacheReadTokens:     200_000,
+		CacheCreationTokens: 100_000,
+	}, prices)
+
+	if cost != 0 {
+		t.Fatalf("explicit-zero cost = %v, want 0", cost)
+	}
+}
+
+func TestCostForGPT56AliasPriceUsesResolvedModelBehavior(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"internal-fast": {Prompt: 2, Completion: 4},
+	}
+	cost := CostForModelCandidatesWithServiceTier(
+		[]string{"openai/gpt-5.6-luna", "internal-fast"},
+		"default",
+		ModelTokens{
+			InputTokens:         1_000_000,
+			CacheReadTokens:     200_000,
+			CacheCreationTokens: 100_000,
+		},
+		prices,
+	)
+
+	if math.Abs(cost-1.69) > 0.000001 {
+		t.Fatalf("alias cost = %v, want 1.69", cost)
+	}
+}
+
+func TestCostForModelCandidatesKeepsResolvedNonGPTBehavior(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"resolved-other": {Prompt: 2, Completion: 4},
+	}
+	cost := CostForModelCandidatesWithServiceTier(
+		[]string{"resolved-other", "gpt-5.6-sol"},
+		"priority",
+		ModelTokens{InputTokens: 1_000_000, LongInputTokens: 1_000_000},
+		prices,
+	)
+
+	if math.Abs(cost-2) > 0.000001 {
+		t.Fatalf("resolved non-GPT cost = %v, want 2", cost)
 	}
 }
 
@@ -129,8 +254,8 @@ func TestCostForModelCandidatesWithServiceTierFallsBackToRequestedModel(t *testi
 		prices,
 	)
 
-	if math.Abs(cost-5) > 0.000001 {
-		t.Fatalf("fallback cost = %v, want 5", cost)
+	if math.Abs(cost-2.5) > 0.000001 {
+		t.Fatalf("fallback cost = %v, want 2.5", cost)
 	}
 }
 

--- a/apps/manager-server/internal/store/store_compat_test.go
+++ b/apps/manager-server/internal/store/store_compat_test.go
@@ -353,8 +353,11 @@ func TestStoreCompatModelPricesAndAPIKeyAliases(t *testing.T) {
 	})
 
 	err = db.SaveModelPrices(context.Background(), map[string]ModelPrice{
-		"gpt-a": {Prompt: 1, Completion: 2, Cache: 0.5, CacheRead: 0.25, CacheCreation: 1.5},
-		"gpt-b": {Prompt: 3, Completion: 4, Cache: 0},
+		"gpt-a": {
+			Prompt: 1, Completion: 2, Cache: 0.5, CacheRead: 0.25, CacheCreation: 1.5,
+			PromptConfigured: true, CompletionConfigured: true, CacheReadConfigured: true, CacheCreationConfigured: true,
+		},
+		"gpt-b": {Prompt: 0, Completion: 0, Cache: 0, PromptConfigured: true, CompletionConfigured: true},
 	})
 	if err != nil {
 		t.Fatalf("save model prices: %v", err)
@@ -364,13 +367,19 @@ func TestStoreCompatModelPricesAndAPIKeyAliases(t *testing.T) {
 		t.Fatalf("load model prices: %v", err)
 	}
 	if len(prices) != 2 || prices["gpt-a"].Prompt != 1 || prices["gpt-a"].CacheRead != 0.25 ||
-		prices["gpt-a"].CacheCreation != 1.5 || prices["gpt-b"].Completion != 4 {
+		prices["gpt-a"].CacheCreation != 1.5 || !prices["gpt-a"].CacheReadConfigured ||
+		!prices["gpt-a"].CacheCreationConfigured || prices["gpt-b"].Completion != 0 ||
+		!prices["gpt-b"].PromptConfigured || !prices["gpt-b"].CompletionConfigured {
 		t.Fatalf("prices = %#v", prices)
 	}
 
 	result, err := db.UpsertSyncedModelPrices(context.Background(), map[string]ModelPrice{
-		"gpt-a": {Prompt: 5, Completion: 6, Cache: 1, CacheRead: 0.75, CacheCreation: 4, Source: "litellm"},
-		"bad":   {Prompt: -1, Completion: 0, Cache: 0},
+		"gpt-a": {
+			Prompt: 5, Completion: 6, Cache: 1, CacheRead: 0.75, CacheCreation: 4,
+			PromptConfigured: true, CompletionConfigured: true, CacheReadConfigured: true, CacheCreationConfigured: true,
+			Source: "litellm",
+		},
+		"bad": {Prompt: -1, Completion: 0, Cache: 0},
 	})
 	if err != nil {
 		t.Fatalf("upsert synced prices: %v", err)

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -79,6 +79,28 @@ type Tokens struct {
 	TotalTokens         int64 `json:"total_tokens"`
 }
 
+// LongContextTokens preserves the portions of token aggregates that came from
+// requests over a model-specific context threshold. It stays internal to
+// aggregation and pricing so public usage payloads remain backward compatible.
+type LongContextTokens struct {
+	LongInputTokens         int64
+	LongOutputTokens        int64
+	LongCachedTokens        int64
+	LongCacheReadTokens     int64
+	LongCacheCreationTokens int64
+}
+
+func (tokens *LongContextTokens) AddIfLongContext(input, output, cached, cacheRead, cacheCreation int64) {
+	if tokens == nil || !IsLongContextInput(input) {
+		return
+	}
+	tokens.LongInputTokens += input
+	tokens.LongOutputTokens += output
+	tokens.LongCachedTokens += cached
+	tokens.LongCacheReadTokens += cacheRead
+	tokens.LongCacheCreationTokens += cacheCreation
+}
+
 type Detail struct {
 	Timestamp             string                  `json:"timestamp"`
 	Source                string                  `json:"source"`
@@ -119,7 +141,14 @@ type Payload struct {
 	APIs          map[string]*APIAggregate `json:"apis"`
 }
 
-const maxFailSummaryBytes = 4096
+const (
+	maxFailSummaryBytes            = 4096
+	LongContextInputTokenThreshold = int64(272_000)
+)
+
+func IsLongContextInput(inputTokens int64) bool {
+	return inputTokens > LongContextInputTokenThreshold
+}
 
 var (
 	endpointPattern          = regexp.MustCompile(`^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\S+)`)
@@ -409,6 +438,8 @@ func readTokenFields(record map[string]any) (int64, int64, int64, int64, int64, 
 		"cacheCreationTokens",
 		"cache_creation_input_tokens",
 		"cacheCreationInputTokens",
+		"cache_write_tokens",
+		"cacheWriteTokens",
 		"cache_write_input_tokens",
 		"cacheWriteInputTokens",
 	)
@@ -418,6 +449,8 @@ func readTokenFields(record map[string]any) (int64, int64, int64, int64, int64, 
 			"cacheCreationTokens",
 			"cache_creation_input_tokens",
 			"cacheCreationInputTokens",
+			"cache_write_tokens",
+			"cacheWriteTokens",
 			"cache_write_input_tokens",
 			"cacheWriteInputTokens",
 		)

--- a/apps/manager-server/internal/usage/import_test.go
+++ b/apps/manager-server/internal/usage/import_test.go
@@ -411,6 +411,25 @@ func TestNormalizeRawReadsAnthropicCacheUsageFieldsAtTopLevel(t *testing.T) {
 	}
 }
 
+func TestNormalizeRawReadsCacheWriteTokenAliases(t *testing.T) {
+	payload := `{
+	  "timestamp": "2026-07-10T00:00:00Z",
+	  "model": "gpt-5.6-sol",
+	  "tokens": {
+	    "input_tokens": 100,
+	    "cache_write_tokens": 17
+	  }
+	}`
+
+	event, err := NormalizeRaw([]byte(payload))
+	if err != nil {
+		t.Fatalf("normalize raw: %v", err)
+	}
+	if event.CacheCreationTokens != 17 {
+		t.Fatalf("cache creation tokens = %d, want 17", event.CacheCreationTokens)
+	}
+}
+
 func TestCompatibleCachedTokensDoesNotDoubleCountFineGrainedCache(t *testing.T) {
 	if got := CompatibleCachedTokens(5, 0, 4, 1); got != 0 {
 		t.Fatalf("fully mirrored cached tokens = %d, want 0", got)

--- a/apps/web/src/features/monitoring/ModelPricesPage.tsx
+++ b/apps/web/src/features/monitoring/ModelPricesPage.tsx
@@ -317,15 +317,35 @@ export function ModelPricesPage() {
               placeholder="0.0000"
               step="0.0001"
             />
-            <Input
-              label={`${t('usage_stats.model_price_cache')} ($/1M)`}
-              className={styles.compactInput}
-              type="number"
-              value={draft.cache}
-              onChange={(event) => setDraftField('cache', event.target.value)}
-              placeholder="0.0000"
-              step="0.0001"
-            />
+            <div style={{ display: 'grid', gap: 8 }}>
+              <Input
+                label={`${t('usage_stats.model_price_cache')} ($/1M)`}
+                className={styles.compactInput}
+                type="number"
+                value={draft.cache}
+                onChange={(event) => setDraftField('cache', event.target.value)}
+                placeholder="0.0000"
+                step="0.0001"
+              />
+              <Input
+                label={`${t('usage_stats.model_price_cache_read')} ($/1M)`}
+                className={styles.compactInput}
+                type="number"
+                value={draft.cacheRead}
+                onChange={(event) => setDraftField('cacheRead', event.target.value)}
+                placeholder={t('model_prices.optional_price_placeholder')}
+                step="0.0001"
+              />
+              <Input
+                label={`${t('usage_stats.model_price_cache_creation')} ($/1M)`}
+                className={styles.compactInput}
+                type="number"
+                value={draft.cacheCreation}
+                onChange={(event) => setDraftField('cacheCreation', event.target.value)}
+                placeholder={t('model_prices.optional_price_placeholder')}
+                step="0.0001"
+              />
+            </div>
             <div className={styles.compactEditorActions}>
               <Button
                 size="xs"
@@ -357,6 +377,8 @@ export function ModelPricesPage() {
                   <th>{t('usage_stats.model_price_prompt')}</th>
                   <th>{t('usage_stats.model_price_completion')}</th>
                   <th>{t('usage_stats.model_price_cache')}</th>
+                  <th>{t('usage_stats.model_price_cache_read')}</th>
+                  <th>{t('usage_stats.model_price_cache_creation')}</th>
                   <th>{t('model_prices.source')}</th>
                   <th>{t('common.action')}</th>
                 </tr>
@@ -388,6 +410,8 @@ export function ModelPricesPage() {
                       <td>{formatPriceUnit(row.price?.prompt)}</td>
                       <td>{formatPriceUnit(row.price?.completion)}</td>
                       <td>{formatPriceUnit(row.price?.cache)}</td>
+                      <td>{formatPriceUnit(row.price?.cacheRead)}</td>
+                      <td>{formatPriceUnit(row.price?.cacheCreation)}</td>
                       <td className={styles.sourceCell}>
                         {row.price ? (
                           <div className={styles.sourceContent}>

--- a/apps/web/src/features/monitoring/model/modelPricesPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/modelPricesPageModel.test.ts
@@ -118,12 +118,40 @@ describe('modelPricesPageModel', () => {
         prompt: '1',
         completion: '2',
         cache: '',
+        cacheRead: '',
+        cacheCreation: '',
       })
     ).toMatchObject({
       prompt: 1,
       completion: 2,
       cache: 1,
+      promptConfigured: true,
+      completionConfigured: true,
+      cacheReadConfigured: false,
+      cacheCreationConfigured: false,
       source: 'manual',
+    });
+  });
+
+  it('distinguishes blank cache prices from explicitly configured zero prices', () => {
+    expect(
+      buildPriceFromDraft({
+        model: 'gpt-5.6-sol',
+        prompt: '0',
+        completion: '0',
+        cache: '',
+        cacheRead: '0',
+        cacheCreation: '0',
+      })
+    ).toMatchObject({
+      prompt: 0,
+      completion: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+      promptConfigured: true,
+      completionConfigured: true,
+      cacheReadConfigured: true,
+      cacheCreationConfigured: true,
     });
   });
 });

--- a/apps/web/src/features/monitoring/model/modelPricesPageModel.ts
+++ b/apps/web/src/features/monitoring/model/modelPricesPageModel.ts
@@ -12,6 +12,8 @@ export type PriceDraft = {
   prompt: string;
   completion: string;
   cache: string;
+  cacheRead: string;
+  cacheCreation: string;
 };
 
 export type ModelPriceRow = {
@@ -36,13 +38,26 @@ export const createEmptyPriceDraft = (): PriceDraft => ({
   prompt: '',
   completion: '',
   cache: '',
+  cacheRead: '',
+  cacheCreation: '',
 });
+
+const createConfiguredDraftValue = (value: number | undefined, configured?: boolean): string =>
+  configured || Number(value) > 0 ? String(Number(value) || 0) : '';
 
 export const createPriceDraft = (model: string, price?: ModelPrice): PriceDraft => ({
   model,
-  prompt: price ? String(price.prompt) : '',
-  completion: price ? String(price.completion) : '',
+  prompt: price ? createConfiguredDraftValue(price.prompt, price.promptConfigured) : '',
+  completion: price
+    ? createConfiguredDraftValue(price.completion, price.completionConfigured)
+    : '',
   cache: price ? String(price.cache) : '',
+  cacheRead: price
+    ? createConfiguredDraftValue(price.cacheRead, price.cacheReadConfigured)
+    : '',
+  cacheCreation: price
+    ? createConfiguredDraftValue(price.cacheCreation, price.cacheCreationConfigured)
+    : '',
 });
 
 export const parsePriceValue = (value: string) => {
@@ -56,7 +71,18 @@ export const buildPriceFromDraft = (draft: PriceDraft): ModelPrice | null => {
   const prompt = parsePriceValue(draft.prompt);
   const completion = parsePriceValue(draft.completion);
   const cache = draft.cache.trim() === '' ? prompt : parsePriceValue(draft.cache);
-  return { prompt, completion, cache, source: 'manual' };
+  return {
+    prompt,
+    completion,
+    cache,
+    cacheRead: parsePriceValue(draft.cacheRead),
+    cacheCreation: parsePriceValue(draft.cacheCreation),
+    promptConfigured: draft.prompt.trim() !== '',
+    completionConfigured: draft.completion.trim() !== '',
+    cacheReadConfigured: draft.cacheRead.trim() !== '',
+    cacheCreationConfigured: draft.cacheCreation.trim() !== '',
+    source: 'manual',
+  };
 };
 
 export const applyCandidatePrice = (

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1440,6 +1440,7 @@
     "candidate_confirmed": "Candidate price confirmed",
     "add_manual": "Add manually",
     "unmatched_title": "Unmatched models",
+    "optional_price_placeholder": "Auto when blank",
     "empty": "No matching model prices"
   },
   "usage_stats": {
@@ -1516,6 +1517,8 @@
     "model_price_prompt": "Prompt price",
     "model_price_completion": "Completion price",
     "model_price_cache": "Cache price",
+    "model_price_cache_read": "Cache read price",
+    "model_price_cache_creation": "Cache creation price",
     "model_price_save": "Save Price",
     "model_price_empty": "No model prices set",
     "model_price_model": "Model",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -1440,6 +1440,7 @@
     "candidate_confirmed": "Цена подтверждена",
     "add_manual": "Добавить вручную",
     "unmatched_title": "Модели без совпадений",
+    "optional_price_placeholder": "Автоматически, если пусто",
     "empty": "Подходящих цен моделей нет"
   },
   "usage_stats": {
@@ -1516,6 +1517,8 @@
     "model_price_prompt": "Цена prompt",
     "model_price_completion": "Цена completion",
     "model_price_cache": "Цена кэша",
+    "model_price_cache_read": "Цена чтения кэша",
+    "model_price_cache_creation": "Цена создания кэша",
     "model_price_save": "Сохранить цену",
     "model_price_empty": "Цена для моделей не задана",
     "model_price_model": "Модель",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -1440,6 +1440,7 @@
     "candidate_confirmed": "价格已确认",
     "add_manual": "手动添加",
     "unmatched_title": "未匹配模型",
+    "optional_price_placeholder": "留空时自动计算",
     "empty": "没有符合条件的模型价格"
   },
   "usage_stats": {
@@ -1516,6 +1517,8 @@
     "model_price_prompt": "提示价格",
     "model_price_completion": "补全价格",
     "model_price_cache": "缓存价格",
+    "model_price_cache_read": "缓存读取价格",
+    "model_price_cache_creation": "缓存创建价格",
     "model_price_save": "保存价格",
     "model_price_empty": "暂未设置任何模型价格",
     "model_price_model": "模型",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -1440,6 +1440,7 @@
     "candidate_confirmed": "價格已確認",
     "add_manual": "手動新增",
     "unmatched_title": "未匹配模型",
+    "optional_price_placeholder": "留空時自動計算",
     "empty": "沒有符合條件的模型價格"
   },
   "usage_stats": {
@@ -1516,6 +1517,8 @@
     "model_price_prompt": "提示定價",
     "model_price_completion": "補全定價",
     "model_price_cache": "快取定價",
+    "model_price_cache_read": "快取讀取定價",
+    "model_price_cache_creation": "快取建立定價",
     "model_price_save": "儲存定價",
     "model_price_empty": "尚未設定任何模型定價",
     "model_price_model": "模型",

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -376,7 +376,7 @@ describe('calculateCost model price preference', () => {
     expect(cost).toBeCloseTo(50);
   });
 
-  it('applies the tier multiplier to the requested price fallback', () => {
+  it('keeps resolved model tier behavior when using a requested price fallback', () => {
     const cost = calculateCost(
       {
         tokens: { input_tokens: 1_000_000, output_tokens: 0 },
@@ -387,7 +387,7 @@ describe('calculateCost model price preference', () => {
       prices
     );
 
-    expect(cost).toBeCloseTo(100);
+    expect(cost).toBeCloseTo(50);
   });
 
   it('charges cached input tokens only at the cache price', () => {
@@ -488,6 +488,155 @@ describe('calculateCost model price preference', () => {
     ).toBeCloseTo(2.5);
   });
 
+  it('uses official gpt-5.6 prices when the current price book has no entry', () => {
+    const cost = calculateCost(
+      {
+        tokens: {
+          input_tokens: 200_000,
+          output_tokens: 20_000,
+          cached_tokens: 20_000,
+          cache_read_tokens: 40_000,
+          cache_creation_tokens: 20_000,
+        },
+        __modelName: 'openai/gpt-5.6-sol',
+      },
+      {}
+    );
+
+    expect(cost).toBeCloseTo(1.355);
+  });
+
+  it('prefers configured gpt-5.6 base prices over the official fallback', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 100_000 },
+        __modelName: 'gpt-5.6-sol',
+      },
+      {
+        'gpt-5.6-sol': { prompt: 9, completion: 18, cache: 0 },
+      }
+    );
+
+    expect(cost).toBeCloseTo(0.9);
+  });
+
+  it('applies gpt-5.6 long-context multipliers above 272K', () => {
+    const cost = calculateCost(
+      {
+        tokens: {
+          input_tokens: 1_000_000,
+          output_tokens: 100_000,
+          cache_read_tokens: 200_000,
+          cache_creation_tokens: 100_000,
+        },
+        __modelName: 'gpt-5.6-sol',
+      },
+      {}
+    );
+
+    expect(cost).toBeCloseTo(12.95);
+  });
+
+  it('keeps exactly 272K of gpt-5.6 input at standard rates', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 272_000, output_tokens: 100_000 },
+        __modelName: 'gpt-5.6-luna',
+      },
+      {}
+    );
+
+    expect(cost).toBeCloseTo(0.872);
+  });
+
+  it('uses resolved gpt-5.6 behavior with a configured alias price', () => {
+    const cost = calculateCost(
+      {
+        tokens: {
+          input_tokens: 200_000,
+          cache_read_tokens: 40_000,
+          cache_creation_tokens: 20_000,
+        },
+        __modelName: 'internal-fast',
+        __resolvedModel: 'openai/gpt-5.6-luna',
+      },
+      {
+        'internal-fast': { prompt: 2, completion: 4, cache: 0 },
+      }
+    );
+
+    expect(cost).toBeCloseTo(0.338);
+  });
+
+  it('ignores the legacy cache price when gpt-5.6 cache-read pricing is missing', () => {
+    const cost = calculateCost(
+      {
+        tokens: {
+          input_tokens: 200_000,
+          cache_read_tokens: 40_000,
+          cache_creation_tokens: 20_000,
+        },
+        __modelName: 'gpt-5.6-terra',
+      },
+      {
+        'gpt-5.6-terra': {
+          prompt: 10,
+          completion: 20,
+          cache: 10,
+          promptConfigured: true,
+          completionConfigured: true,
+        },
+      }
+    );
+
+    expect(cost).toBeCloseTo(1.69);
+  });
+
+  it('respects explicitly configured zero prices for gpt-5.6', () => {
+    const cost = calculateCost(
+      {
+        tokens: {
+          input_tokens: 1_000_000,
+          output_tokens: 100_000,
+          cache_read_tokens: 200_000,
+          cache_creation_tokens: 100_000,
+        },
+        __modelName: 'gpt-5.6-sol',
+      },
+      {
+        'gpt-5.6-sol': {
+          prompt: 0,
+          completion: 0,
+          cache: 0,
+          cacheRead: 0,
+          cacheCreation: 0,
+          promptConfigured: true,
+          completionConfigured: true,
+          cacheReadConfigured: true,
+          cacheCreationConfigured: true,
+        },
+      }
+    );
+
+    expect(cost).toBe(0);
+  });
+
+  it('keeps resolved non-gpt behavior when the requested alias is gpt-5.6', () => {
+    const cost = calculateCost(
+      {
+        tokens: { input_tokens: 1_000_000 },
+        __modelName: 'gpt-5.6-sol',
+        __resolvedModel: 'resolved-other',
+        service_tier: 'priority',
+      },
+      {
+        'resolved-other': { prompt: 2, completion: 4, cache: 0 },
+      }
+    );
+
+    expect(cost).toBeCloseTo(2);
+  });
+
   it('does not guess priority multiplier for unknown models', () => {
     const cost = calculateCost(
       {
@@ -507,6 +656,7 @@ describe('calculateCost model price preference', () => {
 describe('getServiceTierMultiplier', () => {
   it('matches backend priority tier rules', () => {
     expect(getServiceTierMultiplier('gpt-5.4', 'default')).toBe(1);
+    expect(getServiceTierMultiplier('openai/gpt-5.6-sol', 'priority')).toBe(2);
     expect(getServiceTierMultiplier('gpt-5.4', 'priority')).toBe(2);
     expect(getServiceTierMultiplier('gpt-5.4', 'fast')).toBe(2);
     expect(getServiceTierMultiplier('gpt-5.4-mini', 'priority')).toBe(2);

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -11,6 +11,10 @@ export interface ModelPrice {
   cache: number;
   cacheRead?: number;
   cacheCreation?: number;
+  promptConfigured?: boolean;
+  completionConfigured?: boolean;
+  cacheReadConfigured?: boolean;
+  cacheCreationConfigured?: boolean;
   source?: string;
   sourceModelId?: string;
   rawJson?: string;
@@ -30,6 +34,8 @@ export interface UsageTokens {
   cache_creation_tokens?: number;
   cache_creation_input_tokens?: number;
   cacheCreationInputTokens?: number;
+  cache_write_tokens?: number;
+  cacheWriteTokens?: number;
   cache_write_input_tokens?: number;
   cacheWriteInputTokens?: number;
   total_tokens?: number;
@@ -196,6 +202,8 @@ const CACHE_CREATION_TOKEN_KEYS = [
   'cacheCreationTokens',
   'cache_creation_input_tokens',
   'cacheCreationInputTokens',
+  'cache_write_tokens',
+  'cacheWriteTokens',
   'cache_write_input_tokens',
   'cacheWriteInputTokens',
 ] as const;
@@ -238,8 +246,68 @@ const readDetailString = (value: unknown): string | undefined => {
 const readResponseHeaderMetadata = (value: unknown): UsageResponseHeaderMetadata | undefined =>
   isRecord(value) ? (value as UsageResponseHeaderMetadata) : undefined;
 
-const isModelFamily = (modelName: string, family: string): boolean =>
-  modelName === family || modelName.startsWith(`${family}-`);
+const normalizedModelSlug = (modelName: string): string => {
+  const normalized = String(modelName ?? '')
+    .trim()
+    .toLowerCase();
+  const separator = normalized.lastIndexOf('/');
+  return separator >= 0 ? normalized.slice(separator + 1) : normalized;
+};
+
+const isModelFamily = (modelName: string, family: string): boolean => {
+  const slug = normalizedModelSlug(modelName);
+  return slug === family || slug.startsWith(`${family}-`);
+};
+
+const isGpt56Model = (modelName: string): boolean => isModelFamily(modelName, 'gpt-5.6');
+
+const isConfiguredPriceValue = (value: unknown, configured?: boolean): boolean => {
+  const parsed = Number(value);
+  return configured === true || (Number.isFinite(parsed) && parsed > 0);
+};
+
+const getOfficialGpt56Price = (modelName: string): ModelPrice | undefined => {
+  if (isModelFamily(modelName, 'gpt-5.6-sol')) {
+    return {
+      prompt: 5,
+      completion: 30,
+      cache: 0.5,
+      cacheRead: 0.5,
+      cacheCreation: 6.25,
+      promptConfigured: true,
+      completionConfigured: true,
+      cacheReadConfigured: true,
+      cacheCreationConfigured: true,
+    };
+  }
+  if (isModelFamily(modelName, 'gpt-5.6-terra')) {
+    return {
+      prompt: 2.5,
+      completion: 15,
+      cache: 0.25,
+      cacheRead: 0.25,
+      cacheCreation: 3.125,
+      promptConfigured: true,
+      completionConfigured: true,
+      cacheReadConfigured: true,
+      cacheCreationConfigured: true,
+    };
+  }
+  if (isModelFamily(modelName, 'gpt-5.6-luna')) {
+    return {
+      prompt: 1,
+      completion: 6,
+      cache: 0.1,
+      cacheRead: 0.1,
+      cacheCreation: 1.25,
+      promptConfigured: true,
+      completionConfigured: true,
+      cacheReadConfigured: true,
+      cacheCreationConfigured: true,
+    };
+  }
+  return undefined;
+};
 
 export function getServiceTierMultiplier(modelName: string, serviceTier?: string): number {
   const tier = String(serviceTier ?? '')
@@ -253,6 +321,7 @@ export function getServiceTierMultiplier(modelName: string, serviceTier?: string
   // OpenAI Priority pricing currently publishes tier multipliers for these
   // model families. Keep this as a compatibility layer until model prices can
   // be represented per tier, such as standard, priority, flex, and batch.
+  if (isModelFamily(normalizedModel, 'gpt-5.6')) return 2;
   if (isModelFamily(normalizedModel, 'gpt-5.5')) return 2.5;
   if (isModelFamily(normalizedModel, 'gpt-5.4-mini')) return 2;
   if (isModelFamily(normalizedModel, 'gpt-5.4')) return 2;
@@ -736,8 +805,28 @@ export function calculateCost(
   const requestedModel = detail.__modelName || '';
   const resolvedPrice = resolvedModel ? modelPrices[resolvedModel] : undefined;
   const requestedPrice = requestedModel ? modelPrices[requestedModel] : undefined;
-  const price = resolvedPrice || requestedPrice;
-  const pricedModel = resolvedPrice ? resolvedModel : requestedPrice ? requestedModel : '';
+  const behaviorModel = resolvedModel || requestedModel;
+  const behaviorFallback = getOfficialGpt56Price(behaviorModel);
+  const officialCandidatePrice =
+    getOfficialGpt56Price(resolvedModel) || getOfficialGpt56Price(requestedModel);
+  const configuredPrice = resolvedPrice || requestedPrice;
+  const price = configuredPrice
+    ? {
+        ...configuredPrice,
+        prompt: isConfiguredPriceValue(
+          configuredPrice.prompt,
+          configuredPrice.promptConfigured
+        )
+          ? Number(configuredPrice.prompt)
+          : (behaviorFallback?.prompt ?? 0),
+        completion: isConfiguredPriceValue(
+          configuredPrice.completion,
+          configuredPrice.completionConfigured
+        )
+          ? Number(configuredPrice.completion)
+          : (behaviorFallback?.completion ?? 0),
+      }
+    : officialCandidatePrice;
   if (!price) return 0;
 
   const inputTokens = Math.max(toFiniteNumber(detail.tokens.input_tokens), 0);
@@ -751,7 +840,33 @@ export function calculateCost(
   const promptPrice = Number(price.prompt) || 0;
   const completionPrice = Number(price.completion) || 0;
   let standardCost = 0;
-  if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
+  if (isGpt56Model(behaviorModel)) {
+    const configuredCacheReadPrice = Number(price.cacheRead) || 0;
+    const cacheReadPrice = isConfiguredPriceValue(
+      configuredCacheReadPrice,
+      price.cacheReadConfigured
+    )
+      ? configuredCacheReadPrice
+      : promptPrice * 0.1;
+    const configuredCacheCreationPrice = Number(price.cacheCreation) || 0;
+    const cacheCreationPrice = isConfiguredPriceValue(
+      configuredCacheCreationPrice,
+      price.cacheCreationConfigured
+    )
+      ? configuredCacheCreationPrice
+      : promptPrice * 1.25;
+    const readTokens = cachedTokens + cacheReadTokens;
+    const promptTokens = Math.max(inputTokens - readTokens - cacheCreationTokens, 0);
+    const longContext = inputTokens > 272_000;
+    const inputMultiplier = longContext ? 2 : 1;
+    const outputMultiplier = longContext ? 1.5 : 1;
+    standardCost =
+      ((promptTokens / TOKENS_PER_PRICE_UNIT) * promptPrice +
+        (readTokens / TOKENS_PER_PRICE_UNIT) * cacheReadPrice +
+        (cacheCreationTokens / TOKENS_PER_PRICE_UNIT) * cacheCreationPrice) *
+        inputMultiplier +
+      (completionTokens / TOKENS_PER_PRICE_UNIT) * completionPrice * outputMultiplier;
+  } else if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
     const cacheReadPrice = Number(price.cacheRead) || Number(price.cache) || 0;
     const cacheCreationPrice = Number(price.cacheCreation) || promptPrice;
     const promptTokens = Math.max(inputTokens - cachedTokens, 0);
@@ -770,7 +885,7 @@ export function calculateCost(
   }
 
   const serviceTier = detail.service_tier ?? detail.serviceTier;
-  const multiplier = getServiceTierMultiplier(pricedModel, serviceTier);
+  const multiplier = getServiceTierMultiplier(behaviorModel, serviceTier);
   const total = standardCost * multiplier;
   return Number.isFinite(total) && total > 0 ? total : 0;
 }


### PR DESCRIPTION
## Summary
Add GPT-5.6 Sol, Terra, and Luna pricing support across Manager Server analytics and frontend realtime estimates.
Account for cache creation, long-context pricing, and Priority processing while preserving configured prices and resolved-model billing behavior.

## Scope
- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Parse cache-creation usage fields and preserve per-request long-context token buckets through analytics and rollups.
- Apply GPT-5.6 official fallback prices, cache read/write ratios, long-context multipliers, and Priority tier pricing.
- Keep resolved/upstream models authoritative for billing behavior while retaining requested aliases as price fallbacks.
- Persist whether individual model-price fields were configured so explicit zero-cost prices remain valid.
- Extend manual model pricing with cache-read and cache-creation values and align frontend realtime calculations.
- Make rollup schema upgrades and derived-data rebuilds atomic and retryable.

## User Impact
GPT-5.6 usage now reports more accurate estimated costs, including cache creation, long contexts, and Priority processing. Users can also configure cache-read and cache-creation prices explicitly, including zero-cost values.

## Compatibility / Runtime Notes
- CPA panel mode: Realtime event estimates use the same GPT-5.6 behavior and configured-price semantics as Manager Server analytics.
- Manager Server mode: Startup migration adds pricing metadata and long-context rollup columns, then rebuilds derived rollups from retained usage events.
- Full Docker / native packages: Migration runs automatically on startup; no configuration changes are required.

## Data / Security Notes
The migration clears only derived account-history and dashboard rollups and resets their checkpoints so they can be rebuilt from `usage_events`. Raw usage events and security-sensitive configuration are not removed or exposed.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Revert the feature commits to restore the previous calculation paths. The additive SQLite columns can remain safely because older code ignores them.
- Derived rollups can be regenerated from retained usage events after rollback if needed.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test                         # 86 files, 728 tests
npm run manager-server:test
npm run build
npm --workspace apps/web run build:bundle
npm run check:demo-isolation
git diff --check origin/main..HEAD
```

## Screenshots / Recordings
N/A. The visible change is limited to additional numeric cache-price fields and table columns; no screenshot was captured.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
