### PR TITLE
perf(manager-server): accelerate usage analytics with hourly rollups

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -62,6 +62,7 @@ const zhSidebar: DefaultTheme.Sidebar = [
     text: '运维',
     items: [
       { text: 'Manager Server 指南', link: '/operations/manager-server' },
+      { text: '性能优化报告（2026-07-10）', link: '/operations/performance-optimization-2026-07-10' },
       { text: '配置与数据目录', link: '/operations/configuration' },
       { text: '备份与恢复', link: '/operations/backup' },
       { text: '重置管理员密钥', link: '/operations/reset-admin-key' },
@@ -138,6 +139,7 @@ const enSidebar: DefaultTheme.Sidebar = [
     text: 'Operations',
     items: [
       { text: 'Manager Server Guide', link: '/en/operations/manager-server' },
+      { text: 'Performance Report (2026-07-10)', link: '/en/operations/performance-optimization-2026-07-10' },
       { text: 'Configuration And Data Directory', link: '/en/operations/configuration' },
       { text: 'Backup And Restore', link: '/en/operations/backup' },
       { text: 'Reset Admin Key', link: '/en/operations/reset-admin-key' },

--- a/apps/docs/en/operations/manager-server.md
+++ b/apps/docs/en/operations/manager-server.md
@@ -195,7 +195,7 @@ Saving CPAMP configuration does not rewrite the full CPA `config.yaml`.
 | `USAGE_BATCH_SIZE` | `100` | Max records per batch. |
 | `USAGE_POLL_INTERVAL_MS` | `500` | Idle poll interval. |
 | `USAGE_QUERY_LIMIT` | `50000` | Max recent usage events. |
-| `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED` | `true` | Enable the Dashboard hourly rollup worker and query path. Temporarily set it to `false` when diagnosing SQLite write contention or rollup failures; Dashboard falls back to raw events. |
+| `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED` | `true` | Enable the hourly rollup worker plus the Dashboard and strictly unfiltered Usage Analytics query paths. Temporarily set it to `false` when diagnosing SQLite write contention or rollup failures; queries fall back to raw events. |
 | `USAGE_CORS_ORIGINS` | `*` | CORS origins for compatibility endpoints. |
 | `USAGE_RESP_TLS_SKIP_VERIFY` | `false` | Skip TLS verification for RESP connection. |
 | `USAGE_QUOTA_COOLDOWN_ENABLED` | `false` | Enable the Codex usage-limit cooldown worker. |
@@ -218,13 +218,15 @@ go tool pprof http://127.0.0.1:6060/debug/pprof/heap
 
 The equivalent config-file field is `pprofAddr`. The service is disabled by default and should not be exposed through Docker port mappings or a reverse proxy.
 
-Dashboard hourly rollup is enabled by default. The worker catches up historical events in bounded batches. While its checkpoint is pending, or if a rollup read fails, Dashboard automatically falls back to raw events and records the reason through rate-limited logs. To stop background rollup temporarily, set:
+Hourly rollup is enabled by default. The worker catches up historical events in bounded batches. Dashboard and strictly unfiltered Usage Analytics long-window core metrics reuse complete hourly data; searches and dimension, status, latency, or cache filters continue to read raw events. If the checkpoint is pending, the requested timezone cannot be represented losslessly by UTC hourly buckets, or a rollup read fails, the affected query falls back to raw events. Runtime failures are recorded through rate-limited logs. To stop background rollup temporarily, set:
 
 ```bash
 USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 ```
 
-Restart Manager Server after changing it. Dashboard will always use raw events while disabled, and existing rollup tables are left intact.
+Restart Manager Server after changing it. Dashboard and Usage Analytics will always use raw events while disabled, and existing rollup tables are left intact. This runtime switch is not exposed in the UI.
+
+See the [July 10, 2026 Performance Optimization Report](./performance-optimization-2026-07-10.md) for the causes, delivery stages, and complete 100k benchmark evidence.
 
 When `USAGE_QUOTA_COOLDOWN_ENABLED`, `USAGE_ACCOUNT_ACTIONS_ENABLED`, or `USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE` is set through the environment, the matching panel switch is shown as environment-sourced and locked. Remove the environment variable and restart Manager Server if you want the setting to be editable from the panel.
 

--- a/apps/docs/en/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/en/operations/performance-optimization-2026-07-10.md
@@ -1,0 +1,276 @@
+# Performance Optimization Report — July 10, 2026
+
+This report documents the Manager Server, Dashboard, Request Monitoring, Usage Analytics, and Model Prices performance work completed on July 10, 2026. It covers the causes, implementation strategy, benchmark methodology, and measured results.
+
+## Executive Summary
+
+The work was delivered in four stages:
+
+1. PR #319 bounded memory, request, and SQLite connection resources.
+2. PR #320 moved Dashboard core metrics to incremental hourly rollups.
+3. PR #323 scoped Usage Analytics requests to the active tab.
+4. Usage Analytics Hourly Rollup Phase 2B reused hourly rollups for strictly unfiltered long-window core metrics.
+
+Using the effective work required to open Usage Analytics Overview on a 100,000-event dataset:
+
+| Metric | Legacy path | Current path | Combined change |
+|---|---:|---:|---:|
+| Request time | about 7.00s | about 2.48s | about 65% lower |
+| Allocation per operation | about 215MB | about 20.24MB | about 91% lower |
+
+The legacy path requested every tab and the complete filter dataset. The current path executes only the queries required by Overview. This comparison represents the user-visible Overview workload rather than two identical SQL workloads.
+
+## Benchmark Interpretation
+
+- `ns/op` or duration is the execution time for one benchmark operation.
+- `B/op` is total allocation during one operation; it is not the final process RSS.
+- `allocs/op` is the number of allocations during one operation.
+- pprof `inuse_space` shows heap objects still alive after GC and is more useful for identifying retained event slices or leaks.
+- Core benchmarks use 100,000 synthetic usage events across 12 models, multiple accounts and API keys, successes and failures, tokens, and latency samples.
+
+## Stage 1: Memory Pressure Controls
+
+### Cause
+
+The growth from a small initial RSS to hundreds of megabytes was not traced to one classic leak. It came from several linear or unbounded resource paths being exercised together:
+
+- Usage import and export built complete datasets in memory.
+- Monitoring retained a continuously growing event array.
+- Multiple presentation snapshots could indirectly retain event-derived data.
+- SQLite had no maximum open connection limit, allowing per-connection caches to multiply.
+- Model Prices downloaded the full usage payload only to count model calls.
+- Duplicate or stale Analytics requests continued running.
+- Latency percentile calculation retained large sample windows in the Go heap.
+
+### Changes
+
+| Area | Before | After |
+|---|---|---|
+| Usage export | Build the complete response | Stream rows from a fixed database snapshot |
+| Usage import | Parse the complete payload before persistence | Commit batches of 256 events |
+| SQLite pool | Unlimited maximum open connections | 4 open, 2 idle, 5-minute idle lifetime |
+| Monitoring events | Could continue growing | Retain at most 2,000 events |
+| Monitoring page size | Wide results accumulated | 500 events per page |
+| Presentation snapshots | Derived state could retain rows | At most 4 snapshots without event rows |
+| Auto refresh | Could continue while hidden | 30-second default and pause while hidden |
+| Analytics requests | Duplicate and stale work could continue | Abort, throttle, and in-flight deduplication |
+| Model Prices | Download up to 50,000 complete events | Return model-level usage summaries |
+| Summary P95 | Retain a full Go sample window | Calculate with a SQLite window query |
+
+### Why Memory Improved
+
+The import working set changed from `O(total events)` to `O(256)`. Frontend events, presentation snapshots, and SQLite connections now have explicit limits. Complete JSON payloads, full event arrays, and an expanding set of connection caches no longer amplify RSS after large operations.
+
+On the current 100,000-event benchmark dataset with 12 models, the Model Prices result shape changes from up to 50,000 complete event rows to about 12 model summary rows—roughly 4,167 times fewer rows. This stage did not preserve one unified end-to-end before/after benchmark, so the report does not claim an unsupported fixed RSS reduction.
+
+## Stage 2: Dashboard Hourly Rollup
+
+### Cause
+
+Each Dashboard refresh repeatedly scanned the same `usage_events` window for:
+
+```text
+aggregate
++ model stats
++ top models
++ hourly timeline
+```
+
+The cost was approximately `query count × raw event count`, so CPU, SQLite I/O, and page latency grew with retained history.
+
+### Changes
+
+A UTC hourly rollup stores stable metrics by:
+
+```text
+hour + model + billing model + service tier
+```
+
+It contains calls, success/failure, token categories, latency sum/count, and zero-token calls. Reads use:
+
+```text
+raw leading edge
++ complete hourly rollups
++ raw trailing edge
+```
+
+Cost is calculated from current model prices at read time. Pending checkpoints, disabled rollups, or read errors safely fall back to raw events.
+
+### 100k Results
+
+| Path | Duration | Change |
+|---|---:|---:|
+| Raw events | about 774ms | baseline |
+| Hourly rollup | about 2.66ms | about 291 times faster |
+| Latency reduction |  | about 99.7% |
+
+Twenty consecutive rollup runs remained near 2.66ms/op and 556KB/op. The ending heap profile showed about 2.9MB in use with no retained 100,000-event slice.
+
+## Stage 3: Active-Tab Usage Analytics Requests
+
+### Cause
+
+Before this change, opening Overview, Trends, Models, API Keys, Credentials, or Heatmap requested nearly the complete Analytics dataset and full filter options. SQL for hidden tabs still executed.
+
+### Changes
+
+- Each tab sends the minimum include matrix required by its UI.
+- Filter selectors are loaded independently from the main Analytics request.
+- The selector path only reads distinct model, API key, provider, and auth file values.
+- Switching tabs does not reload stable selectors.
+- Selector failure does not block the main content.
+- Compatibility flags preserve behavior with older Manager Server versions.
+
+### 100k Results
+
+| Request | Duration | Allocation |
+|---|---:|---:|
+| Legacy full | about 7.00s | about 215MB |
+| Overview initial | about 3.63s | about 34MB |
+| Specialized tabs | about 2.34–3.10s | not recorded separately |
+| Filter selectors | about 402ms | about 25KB |
+
+Overview time decreased by about 48% and allocation by about 84%. Specialized tab time decreased by approximately 56%–67%.
+
+## Stage 4: Usage Analytics Hourly Rollup Phase 2B
+
+### Cause
+
+After active-tab query shaping, Overview and related pages still scanned raw events for current-period and previous-period aggregates, model stats, and timelines. These core queries continued to scale with total history.
+
+### Changes
+
+A shared Dashboard and Monitoring hourly reader now owns:
+
+- Checkpoint and latest-event completeness checks.
+- Complete UTC hour reads.
+- Raw leading and trailing edge compensation.
+- Aggregate, model-stat, and timeline merging.
+- Rate-limited fallback diagnostics.
+
+Only strictly unfiltered requests use rollups:
+
+- No search query or API key search.
+- No model, provider, account, auth file, API key, project, source, or header filters.
+- Both successful and failed events are included.
+- No latency or cache-status filter.
+
+Rollup-backed metrics:
+
+- Current-period and previous-period aggregates.
+- Model stats and cost calculated with current prices.
+- Losslessly representable hour/day timelines.
+- Average latency.
+
+Metrics intentionally left on raw events:
+
+- P95 latency and P95 TTFT.
+- Rolling 30-minute RPM/TPM.
+- Task buckets, active days, and zero-token models.
+- API key, credential, channel, account, and heatmap dimensions.
+- Every searched or filtered request.
+
+### Timezone Correctness
+
+Raw Analytics and the rollup reader use one shared timezone bucket rule. Every complete UTC hour is checked to ensure its first and last millisecond map to the same target bucket:
+
+- UTC, whole-hour offsets, and normal DST boundaries can use rollups.
+- Half-hour or 45-minute zones fall back to raw timelines when a UTC hour cannot be represented losslessly.
+- Timeline fallback does not prevent Summary and Model Stats from using safe rollup data.
+
+Tests cover UTC, Asia/Shanghai, Asia/Kolkata, America/New_York DST spring/fall, partial hours, price changes, pending checkpoints, disabled rollups, and empty-model semantics.
+
+### 100k Overview — Three Runs
+
+| Path | Average duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| Raw | about 3.21s | 34.43MB | about 2.69 million |
+| Rollup | about 2.48s | 20.24MB | about 0.97 million |
+| Change | about 23% lower | about 41% lower | about 64% lower |
+
+### 100k Rollup-Owned Core Path — Three Runs
+
+This scope includes only the aggregate, model-stat, and timeline work owned by Phase 2B:
+
+| Path | Average duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| Raw | about 777ms | 23.70MB | about 1.86 million |
+| Rollup | about 39ms | 9.51MB | about 142 thousand |
+| Change | about 20 times faster | about 60% lower | about 92% lower |
+
+The rollup-owned path is about 20 times faster, while the complete Overview request is about 23% faster because P95, TTFT, task, active-day, API key, and channel queries remain on raw events and now dominate the remaining time.
+
+## Memory And Stability Validation
+
+- Ten-run and 200-run 100k rollup benchmarks remained stable.
+- The 200-run benchmark stayed near 38–40ms/op.
+- The final heap profile showed about 5MB in use.
+- No CPAMP hourly reader or complete event slice appeared in the in-use top.
+- No retained heap growth was observed as the request count increased.
+
+`B/op` measures cumulative request allocation and does not mean the memory remains resident. The pprof in-use result is the more relevant leak signal.
+
+## Why The Combined System Is Faster
+
+The main cost previously resembled:
+
+```text
+all tab datasets × multiple queries × all raw events
+```
+
+It now resembles:
+
+```text
+active-tab data
+×
+complete hourly rollup rows
++
+small raw edges
++
+specialized metrics that cannot be rolled up safely
+```
+
+The architectural changes are:
+
+- `O(all events)` retained memory became `O(fixed batch/fixed limit)`.
+- All-tab queries became active-tab queries.
+- Repeated raw scans became hourly-rollup reads.
+- Complete event responses became aggregate responses.
+- Unlimited connections and caches became explicit resource budgets.
+- Stale work became cancel, throttle, and deduplication.
+
+## Verification
+
+The final implementation passed:
+
+- The complete Manager Server test suite.
+- The complete Go race suite.
+- `go vet ./...`.
+- 86 Vitest files and 719 tests.
+- The VitePress documentation build.
+- Timezone, DST, fallback, and price-change tests.
+- Multiple code-review passes with no blocking findings remaining.
+
+## Runtime And Rollback
+
+Hourly rollup is enabled by default. To disable it temporarily:
+
+```bash
+USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
+```
+
+Restart Manager Server after changing the variable. Dashboard and Usage Analytics will use raw events while disabled, and existing rollup tables remain intact. The switch is intentionally not exposed in the UI.
+
+See the [Manager Server Guide](./manager-server.md) for the full runtime reference.
+
+## Recommended Next Step
+
+The remaining time is concentrated in raw-only Summary metrics:
+
+- P95 latency and P95 TTFT.
+- Task buckets.
+- Active days.
+- Zero-token models.
+- Overview API key and channel dimensions.
+
+The next optimization should evaluate a Compact Summary Profile so tabs that do not need full diagnostic metrics stop executing these raw queries. A bounded recent-event cache should only proceed if new pprof evidence shows short-window SQLite reads are still the dominant bottleneck.

--- a/apps/docs/operations/manager-server.md
+++ b/apps/docs/operations/manager-server.md
@@ -193,7 +193,7 @@ Manager Server 管理：
 | `USAGE_BATCH_SIZE` | `100` | 单批最大记录数。 |
 | `USAGE_POLL_INTERVAL_MS` | `500` | 空闲轮询间隔。 |
 | `USAGE_QUERY_LIMIT` | `50000` | 最近 usage events 返回上限。 |
-| `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED` | `true` | 启用 Dashboard 小时汇总 worker 和 rollup 查询；排查 SQLite 写竞争或汇总异常时可临时设为 `false`，Dashboard 会回退 raw events。 |
+| `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED` | `true` | 启用小时汇总 worker，以及 Dashboard 和严格无筛选 Usage Analytics 的 rollup 查询；排查 SQLite 写竞争或汇总异常时可临时设为 `false`，查询会回退 raw events。 |
 | `USAGE_CORS_ORIGINS` | `*` | 兼容接口 CORS origin。 |
 | `USAGE_RESP_TLS_SKIP_VERIFY` | `false` | RESP 跳过 TLS 校验。 |
 | `USAGE_QUOTA_COOLDOWN_ENABLED` | `false` | 启用 Codex usage-limit cooldown worker。 |
@@ -216,13 +216,15 @@ go tool pprof http://127.0.0.1:6060/debug/pprof/heap
 
 配置文件中的等价字段是 `pprofAddr`。该服务默认关闭，不应通过 Docker 端口映射或反向代理暴露。
 
-Dashboard 小时汇总默认启用。服务会分批追平历史事件；如果 checkpoint 尚未追平或 rollup 读取失败，Dashboard 会自动回退 raw events，并以限频日志记录原因。需要临时停止后台汇总时，可设置：
+小时汇总默认启用。服务会分批追平历史事件，Dashboard 和严格无筛选的 Usage Analytics 长窗口核心统计会复用完整小时数据；带搜索或维度、状态、延迟、缓存条件的分析仍读取 raw events。如果 checkpoint 尚未追平、目标时区无法由 UTC 小时桶无损表达或 rollup 读取失败，相关查询会自动回退 raw events，并以限频日志记录运行异常。需要临时停止后台汇总时，可设置：
 
 ```bash
 USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 ```
 
-关闭后需重启 Manager Server，Dashboard 将始终读取 raw events，已有 rollup 表不会被删除。
+关闭后需重启 Manager Server，Dashboard 和 Usage Analytics 将始终读取 raw events，已有 rollup 表不会被删除。该运行期开关不接入 UI。
+
+完整的优化原因、实现阶段和 100k benchmark 数据见 [2026-07-10 性能优化报告](./performance-optimization-2026-07-10.md)。
 
 如果 `USAGE_QUOTA_COOLDOWN_ENABLED`、`USAGE_ACCOUNT_ACTIONS_ENABLED` 或 `USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE` 由环境变量设置，面板中的对应开关会显示为环境变量来源并被锁定。要改成面板可编辑，需要移除环境变量并重启 Manager Server。
 

--- a/apps/docs/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/operations/performance-optimization-2026-07-10.md
@@ -1,0 +1,276 @@
+# 2026-07-10 性能优化报告
+
+本文记录 2026-07-10 完成的 Manager Server、Dashboard、请求监控、Usage Analytics 和 Model Prices 性能优化，包括问题原因、实现方式、测试口径和实测结果。
+
+## 执行摘要
+
+本轮优化分为四个阶段：
+
+1. PR #319：限制无界内存、请求和 SQLite 连接资源。
+2. PR #320：Dashboard 核心统计改用增量小时汇总。
+3. PR #323：Usage Analytics 按当前 Tab 请求最小数据集。
+4. Usage Analytics Hourly Rollup Phase 2B：严格无筛选的长窗口核心统计复用小时汇总。
+
+在 100,000 条测试事件下，以打开 Usage Analytics Overview 的有效工作量为口径：
+
+| 指标 | 优化前 legacy 路径 | 当前路径 | 综合变化 |
+|---|---:|---:|---:|
+| 请求耗时 | 约 7.00s | 约 2.48s | 降低约 65% |
+| 单次内存分配 | 约 215MB | 约 20.24MB | 降低约 91% |
+
+legacy 路径会请求全部 Tab 和完整筛选数据；当前路径只执行 Overview 实际需要的查询。因此该结果代表用户打开 Overview 时的有效工作量变化，而不是两组完全相同 SQL 的对比。
+
+## 测试口径说明
+
+- `ns/op` 或耗时：一次 benchmark 操作的执行时间。
+- `B/op`：一次操作期间累计分配的字节数，不等于进程最终 RSS。
+- `allocs/op`：一次操作产生的分配次数。
+- pprof `inuse_space`：GC 后仍然存活的堆对象，更适合判断是否存在 retained heap 或事件切片泄漏。
+- 所有核心 benchmark 使用 100,000 条合成 usage events，覆盖 12 个模型、多个账号/API Key、成功/失败、Token 和延迟数据。
+
+## 阶段一：内存压力治理
+
+### 问题原因
+
+程序从较低初始 RSS 增长到数百 MB，未定位到单一经典内存泄漏点。主要问题是多个线性或无界资源路径叠加：
+
+- Usage 导入、导出一次性构建完整数据集。
+- Monitoring 长时间保留持续增长的事件数组。
+- 多份展示快照可能间接保留事件数据。
+- SQLite 最大连接数不受限，每个连接可能持有独立缓存。
+- Model Prices 下载完整 usage payload，只为统计模型调用次数。
+- 重复或已过期的 Analytics 请求继续执行。
+- 延迟百分位计算在 Go 堆中保留较大的样本窗口。
+
+### 优化内容
+
+| 优化项 | 优化前 | 优化后 |
+|---|---|---|
+| Usage 导出 | 完整结果构建后返回 | 从固定数据库快照逐行写入 |
+| Usage 导入 | 完整 payload 解析后写入 | 每 256 条提交一批 |
+| SQLite 连接 | 最大连接数不受限 | 最多 4 个 open、2 个 idle，5 分钟 idle lifetime |
+| Monitoring 事件 | 可持续增长 | 最多保留 2,000 条 |
+| Monitoring 分页 | 宽结果持续累积 | 每页 500 条 |
+| 展示快照 | 多份派生状态可能保留事件 | 最多 4 份，快照不保存事件行 |
+| 自动刷新 | 页面不可见时仍可能继续 | 默认 30 秒，页面隐藏时暂停 |
+| Analytics 请求 | 重复或旧请求可能继续 | Abort、节流和 in-flight 去重 |
+| Model Prices | 最多下载 50,000 条完整事件 | 返回按模型聚合的轻量统计 |
+| P95 Summary | Go 堆保留完整样本 | SQLite window query 计算 |
+
+### 为什么会降低内存
+
+导入工作集由 `O(总事件数)` 变为 `O(256)`；前端事件、展示快照和 SQLite 连接都有明确上限。大请求结束后，不再有完整 JSON、全部事件数组或多连接缓存持续放大 RSS。
+
+在当前 100,000 条测试数据包含 12 个模型的情况下，Model Prices 的结果规模从最多 50,000 条完整事件降为约 12 条模型统计行，返回行数约缩小 4,167 倍。该阶段没有保存统一的端到端前后耗时 benchmark，因此不对整体 RSS 给出不准确的固定下降数字。
+
+## 阶段二：Dashboard Hourly Rollup
+
+### 问题原因
+
+Dashboard 每次刷新会针对同一个时间窗口重复扫描 `usage_events`：
+
+```text
+aggregate
++ model stats
++ top models
++ hourly timeline
+```
+
+查询成本近似为 `查询数量 × 原始事件数量`，数据增长后 CPU、SQLite I/O 和页面延迟同步增长。
+
+### 优化内容
+
+新增 UTC 小时汇总，按以下维度保存稳定统计：
+
+```text
+hour + model + billing model + service tier
+```
+
+汇总字段包括调用数、成功/失败、各类 Token、延迟 sum/count 和 zero-token calls。读取策略为：
+
+```text
+raw leading edge
++ complete hourly rollups
++ raw trailing edge
+```
+
+价格不会写入 rollup，而是在读取时使用当前 Model Prices 重新计算。checkpoint 未追平、rollup 关闭或读取异常时，查询自动回退 raw events。
+
+### 100k 测试结果
+
+| 路径 | 耗时 | 变化 |
+|---|---:|---:|
+| Raw events | 约 774ms | 基线 |
+| Hourly rollup | 约 2.66ms | 约快 291 倍 |
+| 延迟降幅 |  | 约 99.7% |
+
+连续 20 次 rollup benchmark 稳定在约 2.66ms/op、556KB/op。heap profile 结束时 in-use 约 2.9MB，未发现 100,000 条事件切片被长期保留。
+
+## 阶段三：Usage Analytics 按 Tab 裁剪
+
+### 问题原因
+
+优化前，无论用户打开 Overview、Trends、Models、API Keys、Credentials 还是 Heatmap，前端都会请求几乎完整的 Analytics 数据集和筛选选项。隐藏 Tab 的 SQL 仍会执行。
+
+### 优化内容
+
+- 每个 Tab 只发送实际需要的 include 矩阵。
+- Filter selectors 从主 Analytics 请求中拆分。
+- Selector 只读取 model、API key、provider 和 auth file 的 distinct 值。
+- Tab 切换不重复加载稳定 selectors。
+- Selector 失败不阻塞主内容。
+- 同时发送兼容标志，旧 Manager Server 仍可返回完整 filter options。
+
+### 100k 测试结果
+
+| 请求类型 | 耗时 | 单次分配 |
+|---|---:|---:|
+| Legacy full | 约 7.00s | 约 215MB |
+| Overview initial | 约 3.63s | 约 34MB |
+| 专项 Tab | 约 2.34～3.10s | 未单独记录 |
+| Filter selectors | 约 402ms | 约 25KB |
+
+Overview 耗时降低约 48%，分配降低约 84%。专项 Tab 耗时降低约 56%～67%。
+
+## 阶段四：Usage Analytics Hourly Rollup Phase 2B
+
+### 问题原因
+
+按 Tab 裁剪后，Overview 等页面仍需要对 raw events 执行当前周期、上一周期、model stats 和 timeline 扫描。这些核心查询仍随历史事件总量增长。
+
+### 优化内容
+
+新增 Dashboard 和 Monitoring 共用的 hourly reader，统一处理：
+
+- checkpoint 和 latest event 完整性检查。
+- 完整 UTC 小时读取。
+- 首尾 raw edge 补偿。
+- Aggregate、model stats 和 timeline 合并。
+- 限频 fallback 诊断。
+
+只有严格无筛选请求使用 rollup：
+
+- 无 search query 或 API key search。
+- 无 model、provider、account、auth file、API key、project、source 或 header filters。
+- 包含成功与失败事件。
+- 无 latency/cache status 条件。
+
+以下统计使用 rollup：
+
+- 当前和上一周期 aggregate。
+- Model stats 和按当前价格计算的 cost。
+- 可无损表达的 hour/day timeline。
+- Average latency。
+
+以下统计继续读取 raw events：
+
+- P95 latency 和 P95 TTFT。
+- Rolling 30m RPM/TPM。
+- Task buckets、active days 和 zero-token models。
+- API Key、Credential、Channel、Account 和 Heatmap 等高维统计。
+- 所有搜索或筛选请求。
+
+### 时区正确性
+
+Raw analytics 与 rollup reader 共用同一个时区 bucket 规则。每个 UTC 小时会检查区间首尾是否映射到同一目标 bucket：
+
+- UTC、整小时时区和通常的 DST 边界可使用 rollup。
+- 半小时或 45 分钟时区无法无损表达时，timeline 自动回退 raw。
+- Timeline 回退不会阻止 Summary 和 Model Stats 使用安全的 rollup 数据。
+
+测试覆盖 UTC、Asia/Shanghai、Asia/Kolkata、America/New_York DST spring/fall、partial hour、price change、checkpoint pending、disabled 和空模型语义。
+
+### 100k Overview 三次测试
+
+| 路径 | 平均耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| Raw | 约 3.21s | 34.43MB | 约 269 万 |
+| Rollup | 约 2.48s | 20.24MB | 约 97 万 |
+| 变化 | 降低约 23% | 降低约 41% | 降低约 64% |
+
+### 100k 核心路径三次测试
+
+该口径只包含 Phase 2B 实际负责的 aggregate、model stats 和 timeline：
+
+| 路径 | 平均耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| Raw | 约 777ms | 23.70MB | 约 186 万 |
+| Rollup | 约 39ms | 9.51MB | 约 14.2 万 |
+| 变化 | 约快 20 倍 | 降低约 60% | 降低约 92% |
+
+核心路径约快 20 倍，但 Overview 整体只快约 23%，是因为 P95、TTFT、task、active days、API Key 和 Channel 等保留的 raw 查询已经成为主要耗时来源。
+
+## 内存与稳定性验证
+
+- 10 次和 200 次连续 100k rollup benchmark 保持稳定。
+- 200 次测试约 38～40ms/op。
+- 最终 heap profile in-use 约 5MB。
+- in-use top 中没有 CPAMP hourly reader 或完整事件切片。
+- 未观察到随请求次数持续增长的 retained heap。
+
+`B/op` 表示请求期间累计分配，不代表这些内存会持续保留。pprof in-use 结果更接近是否存在泄漏的判断依据。
+
+## 整体性能为什么提升
+
+优化前的主要成本近似为：
+
+```text
+全部 Tab 数据 × 多组查询 × 全部原始事件
+```
+
+优化后变为：
+
+```text
+当前 Tab 所需数据
+×
+完整小时汇总行
++
+首尾少量 raw events
++
+无法汇总的专项指标
+```
+
+复杂度变化可以概括为：
+
+- `O(全部事件)` 内存保留变为 `O(固定批次/固定上限)`。
+- 全 Tab 查询变为当前 Tab 查询。
+- 重复 raw scan 变为小时 rollup。
+- 完整事件响应变为聚合响应。
+- 无界连接和缓存变为明确资源预算。
+- stale 请求继续执行变为 cancel、throttle 和 dedupe。
+
+## 验证结果
+
+最终通过：
+
+- Manager Server 全量测试。
+- Go race 全量测试。
+- `go vet ./...`。
+- 86 个 Vitest 文件、719 个测试。
+- VitePress 文档构建。
+- 多时区、DST、fallback 和价格变更测试。
+- 多轮代码审查，最终无阻断发现。
+
+## 运行与回滚
+
+小时汇总默认开启。临时关闭时设置：
+
+```bash
+USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
+```
+
+修改后重启 Manager Server。Dashboard 和 Usage Analytics 会回退 raw events，已有 rollup 表不会删除。该开关不接入 UI。
+
+更多配置见 [Manager Server 指南](./manager-server.md)。
+
+## 后续方向
+
+当前剩余耗时主要集中在 Summary 的 raw-only 指标：
+
+- P95 latency 和 P95 TTFT。
+- Task buckets。
+- Active days。
+- Zero-token models。
+- Overview 的 API Key 和 Channel 高维聚合。
+
+下一阶段应优先评估 Compact Summary Profile，让不需要完整诊断指标的 Tab 不再重复执行这些 raw 查询。只有新的 pprof 证据显示短窗口 SQLite 查询仍是瓶颈时，才应继续考虑 bounded recent event cache。

--- a/apps/manager-server/internal/app/context.go
+++ b/apps/manager-server/internal/app/context.go
@@ -85,7 +85,7 @@ func FromExisting(
 		UsageService:                   usagesvc.New(st),
 		DashboardService:               dashboardsvc.New(st, cfg.DashboardHourlyRollupEnabled),
 		CodexInspectionService:         codexinspectionsvc.New(st, managerConfigService),
-		MonitoringService:              monitoringsvc.New(st),
+		MonitoringService:              monitoringsvc.New(st, cfg.DashboardHourlyRollupEnabled),
 		ModelPriceService:              modelpricesvc.NewMultiSource(st, modelPriceSyncURL, openRouterModelPriceSyncURL, managerConfigService),
 		APIKeyAliasService:             apikeyaliassvc.New(st),
 		AccountActionService:           accountactionsvc.New(st, managerConfigService),

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -525,17 +525,6 @@ order by max(t.model_calls) desc, f.model, calls desc`
 	return stats, rows.Err()
 }
 
-func resolveBucketMS(timestampMS int64, granularity string, location *time.Location) int64 {
-	if location == nil {
-		location = time.UTC
-	}
-	tm := time.UnixMilli(timestampMS).In(location)
-	if granularity == "day" {
-		return time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, location).UnixMilli()
-	}
-	return time.Date(tm.Year(), tm.Month(), tm.Day(), tm.Hour(), 0, 0, 0, location).UnixMilli()
-}
-
 func (r *repository) TimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]TimelinePoint, error) {
 	where, args := analyticsWhere(filter)
 	query := fmt.Sprintf(`select
@@ -600,7 +589,7 @@ order by timestamp_ms, model`, where)
 			return nil, err
 		}
 		mapKey := key{
-			bucketMS:     resolveBucketMS(timestampMS, granularity, location),
+			bucketMS:     usage.AnalyticsBucketMS(timestampMS, granularity, location),
 			model:        model,
 			billingModel: billingModel,
 			serviceTier:  serviceTier,
@@ -692,7 +681,7 @@ order by timestamp_ms`, where)
 		if err := rows.Scan(&timestampMS, &latency, &ttft); err != nil {
 			return nil, err
 		}
-		bucketMS := resolveBucketMS(timestampMS, granularity, location)
+		bucketMS := usage.AnalyticsBucketMS(timestampMS, granularity, location)
 		if !hasCurrentBucket || bucketMS != currentBucketMS {
 			flushBucket()
 			currentBucketMS = bucketMS
@@ -1375,7 +1364,7 @@ order by timestamp_ms, credential_id, model`, where)
 		); err != nil {
 			return nil, err
 		}
-		bucketMS := resolveBucketMS(timestampMS, granularity, location)
+		bucketMS := usage.AnalyticsBucketMS(timestampMS, granularity, location)
 		mapKey := key{
 			id:               point.ID,
 			authFileSnapshot: point.AuthFileSnapshot,

--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -3,33 +3,29 @@ package dashboard
 import (
 	"context"
 	"errors"
-	"fmt"
-	"log"
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usagehourly"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
 
 const (
-	defaultTopModels            = 5
-	defaultRecentFailures       = 5
-	defaultHealthRows           = 5
-	rollingWindowMinutes        = 30
-	rollingWindowMs             = rollingWindowMinutes * 60 * 1000
-	hourWindowMs                = 60 * 60 * 1000
-	healthTimelineBucketMs      = 10 * 60 * 1000
-	healthTimelineBuckets       = 24 * 6
-	rollupFallbackLogIntervalMS = int64(5 * time.Minute / time.Millisecond)
+	defaultTopModels       = 5
+	defaultRecentFailures  = 5
+	defaultHealthRows      = 5
+	rollingWindowMinutes   = 30
+	rollingWindowMs        = rollingWindowMinutes * 60 * 1000
+	hourWindowMs           = 60 * 60 * 1000
+	healthTimelineBucketMs = 10 * 60 * 1000
+	healthTimelineBuckets  = 24 * 6
 )
 
 type Service struct {
-	store                   *store.Store
-	hourlyRollupEnabled     bool
-	lastRollupFallbackLogMS atomic.Int64
+	store        *store.Store
+	hourlyReader *usagehourly.Reader
 }
 
 func New(store *store.Store, hourlyRollupEnabled ...bool) *Service {
@@ -37,7 +33,10 @@ func New(store *store.Store, hourlyRollupEnabled ...bool) *Service {
 	if len(hourlyRollupEnabled) > 0 {
 		enabled = hourlyRollupEnabled[0]
 	}
-	return &Service{store: store, hourlyRollupEnabled: enabled}
+	return &Service{
+		store:        store,
+		hourlyReader: usagehourly.New(store, enabled, "dashboard-rollup"),
+	}
 }
 
 type SummaryParams struct {
@@ -321,259 +320,15 @@ func (s *Service) loadTodayMetrics(ctx context.Context, fromMS, toMS int64, topL
 }
 
 func (s *Service) loadTodayMetricsFromRollup(ctx context.Context, fromMS, toMS int64) (store.Aggregate, []store.ModelStat, []store.TimelinePoint, bool) {
-	if !s.hourlyRollupEnabled {
+	snapshot, ok := s.hourlyReader.Load(ctx, fromMS, toMS)
+	if !ok {
 		return store.Aggregate{}, nil, nil, false
 	}
-	if fromMS >= toMS {
-		return store.Aggregate{}, []store.ModelStat{}, []store.TimelinePoint{}, true
-	}
-	checkpoint, err := s.store.DashboardHourlyRollupCheckpoint(ctx)
-	if err != nil {
-		s.logRollupFallback(fmt.Sprintf("checkpoint query failed: %v", err))
+	timeline, ok := s.hourlyReader.DashboardTimeline(ctx, snapshot, fromMS, toMS)
+	if !ok {
 		return store.Aggregate{}, nil, nil, false
 	}
-	latestID, err := s.store.LatestUsageEventID(ctx)
-	if err != nil {
-		s.logRollupFallback(fmt.Sprintf("latest event query failed: %v", err))
-		return store.Aggregate{}, nil, nil, false
-	}
-	if checkpoint.LastEventID < latestID {
-		s.logRollupFallback(fmt.Sprintf("checkpoint pending: last_event_id=%d latest_event_id=%d", checkpoint.LastEventID, latestID))
-		return store.Aggregate{}, nil, nil, false
-	}
-
-	fullStartMS := ceilHourMS(fromMS)
-	fullEndMS := floorHourMS(toMS)
-	if fullStartMS >= fullEndMS {
-		return store.Aggregate{}, nil, nil, false
-	}
-	rows, err := s.store.DashboardHourlyRollupRows(ctx, fullStartMS, fullEndMS)
-	if err != nil {
-		s.logRollupFallback(fmt.Sprintf("hourly rows query failed: %v", err))
-		return store.Aggregate{}, nil, nil, false
-	}
-
-	agg, modelStats, timeline := dashboardMetricsFromHourlyRows(rows)
-	for _, edge := range dashboardRawEdges(fromMS, toMS, fullStartMS, fullEndMS) {
-		edgeAgg, err := s.store.AggregateBetween(ctx, edge.fromMS, edge.toMS)
-		if err != nil {
-			s.logRollupFallback(fmt.Sprintf("raw edge aggregate failed: %v", err))
-			return store.Aggregate{}, nil, nil, false
-		}
-		edgeModels, err := s.store.ModelStatsBetween(ctx, edge.fromMS, edge.toMS)
-		if err != nil {
-			s.logRollupFallback(fmt.Sprintf("raw edge model query failed: %v", err))
-			return store.Aggregate{}, nil, nil, false
-		}
-		agg = mergeDashboardAggregates(agg, edgeAgg)
-		modelStats = mergeDashboardModelStats(modelStats, edgeModels)
-	}
-
-	if fromMS%hourWindowMs != 0 {
-		timeline, err = s.store.HourlyTimelineBetween(ctx, fromMS, toMS)
-		if err != nil {
-			s.logRollupFallback(fmt.Sprintf("offset timeline query failed: %v", err))
-			return store.Aggregate{}, nil, nil, false
-		}
-	} else if fullEndMS < toMS {
-		edgeTimeline, err := s.store.HourlyTimelineBetween(ctx, fullEndMS, toMS)
-		if err != nil {
-			s.logRollupFallback(fmt.Sprintf("raw edge timeline query failed: %v", err))
-			return store.Aggregate{}, nil, nil, false
-		}
-		timeline = mergeDashboardTimeline(timeline, edgeTimeline)
-	}
-
-	return agg, modelStats, timeline, true
-}
-
-func (s *Service) logRollupFallback(reason string) {
-	nowMS := time.Now().UnixMilli()
-	for {
-		lastMS := s.lastRollupFallbackLogMS.Load()
-		if lastMS > 0 && nowMS-lastMS < rollupFallbackLogIntervalMS {
-			return
-		}
-		if s.lastRollupFallbackLogMS.CompareAndSwap(lastMS, nowMS) {
-			log.Printf("[dashboard-rollup] falling back to raw usage events: %s", reason)
-			return
-		}
-	}
-}
-
-type dashboardTimeRange struct {
-	fromMS int64
-	toMS   int64
-}
-
-func dashboardRawEdges(fromMS, toMS, fullStartMS, fullEndMS int64) []dashboardTimeRange {
-	ranges := make([]dashboardTimeRange, 0, 2)
-	if fromMS < fullStartMS {
-		ranges = append(ranges, dashboardTimeRange{fromMS: fromMS, toMS: min(fullStartMS, toMS)})
-	}
-	if fullEndMS < toMS {
-		ranges = append(ranges, dashboardTimeRange{fromMS: max(fullEndMS, fromMS), toMS: toMS})
-	}
-	return ranges
-}
-
-func ceilHourMS(value int64) int64 {
-	if value%hourWindowMs == 0 {
-		return value
-	}
-	return value - value%hourWindowMs + hourWindowMs
-}
-
-func floorHourMS(value int64) int64 {
-	return value - value%hourWindowMs
-}
-
-func dashboardMetricsFromHourlyRows(rows []store.DashboardHourlyRollupRow) (store.Aggregate, []store.ModelStat, []store.TimelinePoint) {
-	agg := store.Aggregate{}
-	modelStats := make([]store.ModelStat, 0, len(rows))
-	timelineByBucket := make(map[int64]*store.TimelinePoint)
-	var latencySum int64
-	for _, row := range rows {
-		agg.TotalCalls += row.Calls
-		agg.SuccessCalls += row.SuccessCalls
-		agg.FailureCalls += row.FailureCalls
-		agg.InputTokens += row.InputTokens
-		agg.OutputTokens += row.OutputTokens
-		agg.ReasoningTokens += row.ReasoningTokens
-		agg.CachedTokens += row.CachedTokens
-		agg.CacheReadTokens += row.CacheReadTokens
-		agg.CacheCreationTokens += row.CacheCreationTokens
-		agg.LongInputTokens += row.LongInputTokens
-		agg.LongOutputTokens += row.LongOutputTokens
-		agg.LongCachedTokens += row.LongCachedTokens
-		agg.LongCacheReadTokens += row.LongCacheReadTokens
-		agg.LongCacheCreationTokens += row.LongCacheCreationTokens
-		agg.TotalTokens += row.TotalTokens
-		agg.LatencySamples += row.LatencySamples
-		agg.ZeroTokenCalls += row.ZeroTokenCalls
-		latencySum += row.LatencySumMS
-		modelStats = append(modelStats, store.ModelStat{
-			Model:               row.Model,
-			BillingModel:        row.BillingModel,
-			ServiceTier:         row.ServiceTier,
-			Calls:               row.Calls,
-			SuccessCalls:        row.SuccessCalls,
-			InputTokens:         row.InputTokens,
-			OutputTokens:        row.OutputTokens,
-			ReasoningTokens:     row.ReasoningTokens,
-			CachedTokens:        row.CachedTokens,
-			CacheReadTokens:     row.CacheReadTokens,
-			CacheCreationTokens: row.CacheCreationTokens,
-			LongContextTokens:   row.LongContextTokens,
-			TotalTokens:         row.TotalTokens,
-		})
-		point := timelineByBucket[row.BucketMS]
-		if point == nil {
-			point = &store.TimelinePoint{BucketMS: row.BucketMS}
-			timelineByBucket[row.BucketMS] = point
-		}
-		point.Calls += row.Calls
-		point.Tokens += row.TotalTokens
-		point.Success += row.SuccessCalls
-		point.Failure += row.FailureCalls
-	}
-	if agg.LatencySamples > 0 {
-		agg.AvgLatencyMS.Valid = true
-		agg.AvgLatencyMS.Float64 = float64(latencySum) / float64(agg.LatencySamples)
-	}
-	timeline := make([]store.TimelinePoint, 0, len(timelineByBucket))
-	for _, point := range timelineByBucket {
-		timeline = append(timeline, *point)
-	}
-	sort.Slice(timeline, func(i, j int) bool { return timeline[i].BucketMS < timeline[j].BucketMS })
-	return agg, modelStats, timeline
-}
-
-func mergeDashboardAggregates(left, right store.Aggregate) store.Aggregate {
-	latencySum := left.AvgLatencyMS.Float64*float64(left.LatencySamples) + right.AvgLatencyMS.Float64*float64(right.LatencySamples)
-	left.TotalCalls += right.TotalCalls
-	left.SuccessCalls += right.SuccessCalls
-	left.FailureCalls += right.FailureCalls
-	left.InputTokens += right.InputTokens
-	left.OutputTokens += right.OutputTokens
-	left.ReasoningTokens += right.ReasoningTokens
-	left.CachedTokens += right.CachedTokens
-	left.CacheReadTokens += right.CacheReadTokens
-	left.CacheCreationTokens += right.CacheCreationTokens
-	left.LongInputTokens += right.LongInputTokens
-	left.LongOutputTokens += right.LongOutputTokens
-	left.LongCachedTokens += right.LongCachedTokens
-	left.LongCacheReadTokens += right.LongCacheReadTokens
-	left.LongCacheCreationTokens += right.LongCacheCreationTokens
-	left.TotalTokens += right.TotalTokens
-	left.LatencySamples += right.LatencySamples
-	left.ZeroTokenCalls += right.ZeroTokenCalls
-	left.AvgLatencyMS.Valid = left.LatencySamples > 0
-	if left.AvgLatencyMS.Valid {
-		left.AvgLatencyMS.Float64 = latencySum / float64(left.LatencySamples)
-	}
-	return left
-}
-
-func mergeDashboardModelStats(left, right []store.ModelStat) []store.ModelStat {
-	type key struct {
-		model        string
-		billingModel string
-		serviceTier  string
-	}
-	grouped := make(map[key]*store.ModelStat, len(left)+len(right))
-	order := make([]key, 0, len(left)+len(right))
-	for _, stat := range append(append([]store.ModelStat{}, left...), right...) {
-		mapKey := key{model: stat.Model, billingModel: stat.BillingModel, serviceTier: stat.ServiceTier}
-		entry := grouped[mapKey]
-		if entry == nil {
-			copy := stat
-			grouped[mapKey] = &copy
-			order = append(order, mapKey)
-			continue
-		}
-		entry.Calls += stat.Calls
-		entry.SuccessCalls += stat.SuccessCalls
-		entry.InputTokens += stat.InputTokens
-		entry.OutputTokens += stat.OutputTokens
-		entry.ReasoningTokens += stat.ReasoningTokens
-		entry.CachedTokens += stat.CachedTokens
-		entry.CacheReadTokens += stat.CacheReadTokens
-		entry.CacheCreationTokens += stat.CacheCreationTokens
-		entry.LongInputTokens += stat.LongInputTokens
-		entry.LongOutputTokens += stat.LongOutputTokens
-		entry.LongCachedTokens += stat.LongCachedTokens
-		entry.LongCacheReadTokens += stat.LongCacheReadTokens
-		entry.LongCacheCreationTokens += stat.LongCacheCreationTokens
-		entry.TotalTokens += stat.TotalTokens
-	}
-	result := make([]store.ModelStat, 0, len(order))
-	for _, mapKey := range order {
-		result = append(result, *grouped[mapKey])
-	}
-	return result
-}
-
-func mergeDashboardTimeline(left, right []store.TimelinePoint) []store.TimelinePoint {
-	grouped := make(map[int64]*store.TimelinePoint, len(left)+len(right))
-	for _, point := range append(append([]store.TimelinePoint{}, left...), right...) {
-		entry := grouped[point.BucketMS]
-		if entry == nil {
-			copy := point
-			grouped[point.BucketMS] = &copy
-			continue
-		}
-		entry.Calls += point.Calls
-		entry.Tokens += point.Tokens
-		entry.Success += point.Success
-		entry.Failure += point.Failure
-	}
-	result := make([]store.TimelinePoint, 0, len(grouped))
-	for _, point := range grouped {
-		result = append(result, *point)
-	}
-	sort.Slice(result, func(i, j int) bool { return result[i].BucketMS < result[j].BucketMS })
-	return result
+	return snapshot.Aggregate, snapshot.ModelStats, timeline, true
 }
 
 func selectTopModelStats(stats []store.ModelStat, limit int) []store.ModelStat {

--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -497,19 +497,6 @@ func TestSummaryDashboardHourlyRollupCanBeDisabled(t *testing.T) {
 	}
 }
 
-func TestDashboardRollupFallbackLogIsRateLimited(t *testing.T) {
-	service := New(newDashboardTestStore(t))
-	service.logRollupFallback("first")
-	first := service.lastRollupFallbackLogMS.Load()
-	if first <= 0 {
-		t.Fatalf("first log timestamp = %d", first)
-	}
-	service.logRollupFallback("second")
-	if got := service.lastRollupFallbackLogMS.Load(); got != first {
-		t.Fatalf("fallback log was not rate limited: first=%d got=%d", first, got)
-	}
-}
-
 func catchUpDashboardHourlyForTest(t *testing.T, ctx context.Context, db *store.Store) {
 	t.Helper()
 	for {

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usagehourly"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -28,11 +29,19 @@ const (
 )
 
 type Service struct {
-	store *store.Store
+	store        *store.Store
+	hourlyReader *usagehourly.Reader
 }
 
-func New(store *store.Store) *Service {
-	return &Service{store: store}
+func New(store *store.Store, hourlyRollupEnabled ...bool) *Service {
+	enabled := false
+	if len(hourlyRollupEnabled) > 0 {
+		enabled = hourlyRollupEnabled[0]
+	}
+	return &Service{
+		store:        store,
+		hourlyReader: usagehourly.New(store, enabled, "monitoring-rollup"),
+	}
 }
 
 type Request struct {
@@ -645,13 +654,27 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 	// (summary and events use the exact same filter).
 	var summaryTotalCalls int64
 	summaryComputed := false
+	rollupEligible := analyticsHourlyRollupEligible(filter)
+	needsHourlyAggregates := req.Include.Summary || req.Include.ModelShare || req.Include.ModelStats
+	needsHourlyTimeline := req.Include.Timeline || req.Include.AnomalyPoints
+	hourlyTimelineRepresentable := rollupEligible && needsHourlyTimeline && s.hourlyReader.CanRepresentAnalyticsTimeline(req.FromMS, req.ToMS, granularity, location)
+	needsHourlyCore := needsHourlyAggregates || hourlyTimelineRepresentable
+	var hourlySnapshot usagehourly.Snapshot
+	hourlySnapshotAvailable := false
+	if rollupEligible && needsHourlyCore {
+		hourlySnapshot, hourlySnapshotAvailable = s.hourlyReader.Load(ctx, req.FromMS, req.ToMS)
+	}
 
 	var modelStats []store.ModelStat
 	needsModelStats := req.Include.Summary || req.Include.ModelShare || req.Include.ModelStats
 	if needsModelStats {
-		modelStats, err = s.store.ModelStatsWithFilter(ctx, filter, 0)
-		if err != nil {
-			return Response{}, err
+		if hourlySnapshotAvailable {
+			modelStats = hourlySnapshot.ModelStats
+		} else {
+			modelStats, err = s.store.ModelStatsWithFilter(ctx, filter, 0)
+			if err != nil {
+				return Response{}, err
+			}
 		}
 	}
 
@@ -664,9 +687,14 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 	}
 
 	if req.Include.Summary {
-		agg, err := s.store.AggregateWithFilter(ctx, filter)
-		if err != nil {
-			return Response{}, err
+		var agg store.Aggregate
+		if hourlySnapshotAvailable {
+			agg = hourlySnapshot.Aggregate
+		} else {
+			agg, err = s.store.AggregateWithFilter(ctx, filter)
+			if err != nil {
+				return Response{}, err
+			}
 		}
 		latencySummary, err := s.store.LatencySummaryWithFilter(ctx, filter)
 		if err != nil {
@@ -700,13 +728,25 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 				prevFilter := filter
 				prevFilter.FromMS = prevFrom
 				prevFilter.ToMS = req.FromMS
-				prevAgg, err := s.store.AggregateWithFilter(ctx, prevFilter)
-				if err != nil {
-					return Response{}, err
+				var prevAgg store.Aggregate
+				var prevModelStats []store.ModelStat
+				var prevSnapshot usagehourly.Snapshot
+				prevSnapshotAvailable := false
+				if rollupEligible {
+					prevSnapshot, prevSnapshotAvailable = s.hourlyReader.Load(ctx, prevFrom, req.FromMS)
 				}
-				prevModelStats, err := s.store.ModelStatsWithFilter(ctx, prevFilter, 0)
-				if err != nil {
-					return Response{}, err
+				if prevSnapshotAvailable {
+					prevAgg = prevSnapshot.Aggregate
+					prevModelStats = prevSnapshot.ModelStats
+				} else {
+					prevAgg, err = s.store.AggregateWithFilter(ctx, prevFilter)
+					if err != nil {
+						return Response{}, err
+					}
+					prevModelStats, err = s.store.ModelStatsWithFilter(ctx, prevFilter, 0)
+					if err != nil {
+						return Response{}, err
+					}
 				}
 				response.SummaryComparison = &SummaryComparison{
 					FromMS:       prevFrom,
@@ -723,9 +763,16 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 	}
 	var timeline []TimelinePoint
 	if req.Include.Timeline || req.Include.AnomalyPoints {
-		points, err := s.store.TimelineWithFilter(ctx, filter, granularity, location)
-		if err != nil {
-			return Response{}, err
+		var points []store.TimelinePoint
+		pointsAvailable := false
+		if hourlySnapshotAvailable && hourlyTimelineRepresentable {
+			points, pointsAvailable = s.hourlyReader.AnalyticsTimeline(ctx, hourlySnapshot, granularity, location)
+		}
+		if !pointsAvailable {
+			points, err = s.store.TimelineWithFilter(ctx, filter, granularity, location)
+			if err != nil {
+				return Response{}, err
+			}
 		}
 		percentiles, err := s.store.LatencyPercentilesWithFilter(ctx, filter, granularity, location)
 		if err != nil {
@@ -1037,6 +1084,28 @@ func buildFilter(req Request) store.AnalyticsFilter {
 		MinLatencyMS:     req.Filters.MinLatencyMS,
 		CacheStatus:      req.Filters.CacheStatus,
 	}
+}
+
+func analyticsHourlyRollupEligible(filter store.AnalyticsFilter) bool {
+	return strings.TrimSpace(filter.SearchQuery) == "" &&
+		strings.TrimSpace(filter.SearchAPIKeyHash) == "" &&
+		len(filter.Models) == 0 &&
+		len(filter.Providers) == 0 &&
+		len(filter.Accounts) == 0 &&
+		len(filter.AuthFiles) == 0 &&
+		len(filter.AuthIndices) == 0 &&
+		len(filter.APIKeyHashes) == 0 &&
+		len(filter.SourceHashes) == 0 &&
+		len(filter.ProjectIDs) == 0 &&
+		len(filter.RequestTypes) == 0 &&
+		len(filter.HeaderErrorKinds) == 0 &&
+		len(filter.HeaderErrorCodes) == 0 &&
+		len(filter.HeaderQuotaPlans) == 0 &&
+		len(filter.HeaderTraceIDs) == 0 &&
+		filter.IncludeFailed &&
+		!filter.FailedOnly &&
+		filter.MinLatencyMS == 0 &&
+		strings.TrimSpace(filter.CacheStatus) == ""
 }
 
 func (s *Service) filterOptions(ctx context.Context, filter store.AnalyticsFilter, prices map[string]store.ModelPrice) (*FilterOptions, error) {

--- a/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usagehourly"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -21,7 +23,17 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 	fromMS := int64(1_800_000_000_000)
 	toMS := fromMS + 30*24*60*60*1000
 	insertMonitoringBenchmarkEvents(b, ctx, db, fromMS, toMS, 100_000)
-	service := New(db)
+	for {
+		result, err := db.CatchUpDashboardHourlyRollups(ctx, 5_000, toMS)
+		if err != nil {
+			b.Fatalf("catch up hourly rollup: %v", err)
+		}
+		if !result.Pending {
+			break
+		}
+	}
+	rawService := New(db, false)
+	rollupService := New(db, true)
 
 	request := func(include Include) Request {
 		return Request{
@@ -35,10 +47,12 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 	selectors := request(Include{FilterOptions: true, FilterSelectors: true})
 	profiles := []struct {
 		name     string
+		service  *Service
 		requests []Request
 	}{
 		{
-			name: "legacy_full",
+			name:    "legacy_full",
+			service: rollupService,
 			requests: []Request{request(Include{
 				Summary:            true,
 				SummaryComparison:  true,
@@ -55,7 +69,8 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			})},
 		},
 		{
-			name: "overview_initial",
+			name:    "overview_initial",
+			service: rollupService,
 			requests: []Request{
 				request(Include{
 					Summary:           true,
@@ -71,7 +86,8 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			},
 		},
 		{
-			name: "overview_tab_request",
+			name:    "overview_tab_raw",
+			service: rawService,
 			requests: []Request{request(Include{
 				Summary:           true,
 				SummaryComparison: true,
@@ -84,7 +100,44 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			})},
 		},
 		{
-			name: "trends_tab_request",
+			name:    "overview_tab_rollup",
+			service: rollupService,
+			requests: []Request{request(Include{
+				Summary:           true,
+				SummaryComparison: true,
+				Timeline:          true,
+				ModelStats:        true,
+				ChannelShare:      true,
+				APIKeyStats:       true,
+				AnomalyPoints:     true,
+				Granularity:       "day",
+			})},
+		},
+		{
+			name:    "analytics_core_raw",
+			service: rawService,
+			requests: []Request{request(Include{
+				Summary:           true,
+				SummaryComparison: true,
+				Timeline:          true,
+				ModelStats:        true,
+				Granularity:       "day",
+			})},
+		},
+		{
+			name:    "analytics_core_rollup",
+			service: rollupService,
+			requests: []Request{request(Include{
+				Summary:           true,
+				SummaryComparison: true,
+				Timeline:          true,
+				ModelStats:        true,
+				Granularity:       "day",
+			})},
+		},
+		{
+			name:    "trends_tab_request",
+			service: rollupService,
 			requests: []Request{request(Include{
 				Summary:           true,
 				SummaryComparison: true,
@@ -96,7 +149,8 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			})},
 		},
 		{
-			name: "models_tab_request",
+			name:    "models_tab_request",
+			service: rollupService,
 			requests: []Request{request(Include{
 				Summary:     true,
 				Timeline:    true,
@@ -106,7 +160,8 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			})},
 		},
 		{
-			name: "api_keys_tab_request",
+			name:    "api_keys_tab_request",
+			service: rollupService,
 			requests: []Request{request(Include{
 				Summary:     true,
 				APIKeyStats: true,
@@ -114,7 +169,8 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			})},
 		},
 		{
-			name: "credentials_tab_request",
+			name:    "credentials_tab_request",
+			service: rollupService,
 			requests: []Request{request(Include{
 				Summary:            true,
 				CredentialStats:    true,
@@ -123,14 +179,15 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			})},
 		},
 		{
-			name: "heatmap_tab_request",
+			name:    "heatmap_tab_request",
+			service: rollupService,
 			requests: []Request{request(Include{
 				Summary:     true,
 				Heatmap:     true,
 				Granularity: "day",
 			})},
 		},
-		{name: "filter_selectors", requests: []Request{selectors}},
+		{name: "filter_selectors", service: rollupService, requests: []Request{selectors}},
 	}
 
 	for _, profile := range profiles {
@@ -138,13 +195,65 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				for _, req := range profile.requests {
-					if _, err := service.Analytics(ctx, req); err != nil {
+					if _, err := profile.service.Analytics(ctx, req); err != nil {
 						b.Fatalf("analytics: %v", err)
 					}
 				}
 			}
 		})
 	}
+}
+
+func BenchmarkUsageAnalyticsHourlyCorePaths(b *testing.B) {
+	db, err := store.Open(filepath.Join(b.TempDir(), "usage.sqlite"))
+	if err != nil {
+		b.Fatalf("open store: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	fromMS := int64(1_800_000_000_000)
+	toMS := fromMS + 30*24*60*60*1000
+	insertMonitoringBenchmarkEvents(b, ctx, db, fromMS, toMS, 100_000)
+	for {
+		result, err := db.CatchUpDashboardHourlyRollups(ctx, 5_000, toMS)
+		if err != nil {
+			b.Fatalf("catch up hourly rollup: %v", err)
+		}
+		if !result.Pending {
+			break
+		}
+	}
+	filter := store.AnalyticsFilter{FromMS: fromMS, ToMS: toMS, IncludeFailed: true}
+	reader := usagehourly.New(db, true)
+
+	b.Run("raw", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			if _, err := db.AggregateWithFilter(ctx, filter); err != nil {
+				b.Fatalf("aggregate: %v", err)
+			}
+			if _, err := db.ModelStatsWithFilter(ctx, filter, 0); err != nil {
+				b.Fatalf("model stats: %v", err)
+			}
+			if _, err := db.TimelineWithFilter(ctx, filter, "day", time.UTC); err != nil {
+				b.Fatalf("timeline: %v", err)
+			}
+		}
+	})
+
+	b.Run("rollup", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			snapshot, ok := reader.Load(ctx, fromMS, toMS)
+			if !ok {
+				b.Fatal("rollup unavailable")
+			}
+			if _, ok := reader.AnalyticsTimeline(ctx, snapshot, "day", time.UTC); !ok {
+				b.Fatal("rollup timeline unavailable")
+			}
+		}
+	})
 }
 
 func insertMonitoringBenchmarkEvents(b *testing.B, ctx context.Context, db *store.Store, fromMS, toMS int64, count int) {

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -1582,6 +1583,252 @@ func TestAccountHistoryEmptyTargetDoesNotMatchAnonymousBucket(t *testing.T) {
 	}
 	if resp.Items[0].Matched || resp.Items[0].AccountKey != "" || resp.Items[0].SyncStatus != "empty" {
 		t.Fatalf("empty target matched anonymous bucket: %#v", resp.Items[0])
+	}
+}
+
+func TestAnalyticsHourlyRollupMatchesRawCoreComparisonAndTimeline(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	windowMS := int64(48 * time.Hour / time.Millisecond)
+	fromMS := int64(1_800_000_000_000)
+	toMS := fromMS + windowMS
+	latency100 := int64(100)
+	latency400 := int64(400)
+	ttft50 := int64(50)
+
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"resolved-a": {Prompt: 2, Completion: 4},
+		"model-b":    {Prompt: 1, Completion: 3},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	events := []usage.Event{
+		monitoringEvent("rollup-prev-a", fromMS-windowMS+10*time.Minute.Milliseconds(), "alias-a", "auth-a", "source-a", false, 1_000_000, 100, 0, 0, 1_000_100, &latency100),
+		monitoringEvent("rollup-prev-b", fromMS-time.Hour.Milliseconds(), "model-b", "auth-b", "source-b", true, 200, 300, 0, 0, 500, &latency400),
+		monitoringEvent("rollup-current-a", fromMS+10*time.Minute.Milliseconds(), "alias-a", "auth-a", "source-a", false, 500_000, 250_000, 20, 30, 750_020, &latency100),
+		monitoringEvent("rollup-current-b", fromMS+25*time.Hour.Milliseconds(), "model-b", "auth-b", "source-b", true, 400, 500, 0, 0, 900, &latency400),
+		monitoringEvent("rollup-current-zero", toMS-10*time.Minute.Milliseconds(), "model-b", "auth-b", "source-b", false, 0, 0, 0, 0, 0, nil),
+	}
+	for index := range events {
+		events[index].RequestID = fmt.Sprintf("rollup-request-%d", index)
+		events[index].TTFTMS = &ttft50
+	}
+	events[0].ResolvedModel = "resolved-a"
+	events[2].ResolvedModel = "resolved-a"
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	req := Request{
+		FromMS:   fromMS,
+		ToMS:     toMS,
+		NowMS:    toMS,
+		TimeZone: "UTC",
+		Include: Include{
+			Summary:           true,
+			SummaryComparison: true,
+			Timeline:          true,
+			ModelStats:        true,
+			AnomalyPoints:     true,
+			Granularity:       "day",
+		},
+	}
+	raw, err := New(db, false).Analytics(ctx, req)
+	if err != nil {
+		t.Fatalf("raw analytics: %v", err)
+	}
+	catchUpMonitoringHourlyRollup(t, ctx, db)
+	rolled, err := New(db, true).Analytics(ctx, req)
+	if err != nil {
+		t.Fatalf("rollup analytics: %v", err)
+	}
+	raw.GeneratedAtMS = rolled.GeneratedAtMS
+	if !reflect.DeepEqual(rolled, raw) {
+		t.Fatalf("analytics mismatch\nrollup=%#v\nraw=%#v", rolled, raw)
+	}
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"resolved-a": {Prompt: 4, Completion: 8},
+		"model-b":    {Prompt: 2, Completion: 6},
+	}); err != nil {
+		t.Fatalf("update prices: %v", err)
+	}
+	repricedRaw, err := New(db, false).Analytics(ctx, req)
+	if err != nil {
+		t.Fatalf("repriced raw analytics: %v", err)
+	}
+	repricedRollup, err := New(db, true).Analytics(ctx, req)
+	if err != nil {
+		t.Fatalf("repriced rollup analytics: %v", err)
+	}
+	repricedRaw.GeneratedAtMS = repricedRollup.GeneratedAtMS
+	if !reflect.DeepEqual(repricedRollup, repricedRaw) {
+		t.Fatalf("repriced analytics mismatch\nrollup=%#v\nraw=%#v", repricedRollup, repricedRaw)
+	}
+	if repricedRollup.Summary == nil || rolled.Summary == nil || repricedRollup.Summary.TotalCost != rolled.Summary.TotalCost*2 {
+		t.Fatalf("repriced summary = %#v, original = %#v", repricedRollup.Summary, rolled.Summary)
+	}
+}
+
+func TestAnalyticsHourlyRollupTimelineMatchesRawAcrossDST(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := time.Date(2026, time.March, 7, 0, 0, 0, 0, time.UTC).UnixMilli()
+	toMS := time.Date(2026, time.March, 10, 0, 0, 0, 0, time.UTC).UnixMilli()
+	latency := int64(250)
+	events := make([]usage.Event, 0, 18)
+	for index := 0; index < 18; index++ {
+		timestampMS := fromMS + int64(index)*4*time.Hour.Milliseconds() + 10*time.Minute.Milliseconds()
+		events = append(events, monitoringEvent(
+			fmt.Sprintf("dst-%02d", index),
+			timestampMS,
+			fmt.Sprintf("model-%d", index%2),
+			"auth-a",
+			"source-a",
+			index%5 == 0,
+			int64(100+index),
+			int64(50+index),
+			0,
+			0,
+			int64(150+2*index),
+			&latency,
+		))
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	catchUpMonitoringHourlyRollup(t, ctx, db)
+
+	for _, timeZone := range []string{"America/New_York", "Asia/Shanghai", "Asia/Kolkata"} {
+		for _, granularity := range []string{"hour", "day"} {
+			t.Run(timeZone+"/"+granularity, func(t *testing.T) {
+				req := Request{
+					FromMS:   fromMS,
+					ToMS:     toMS,
+					NowMS:    toMS,
+					TimeZone: timeZone,
+					Include: Include{
+						Timeline:    true,
+						Granularity: granularity,
+					},
+				}
+				raw, err := New(db, false).Analytics(ctx, req)
+				if err != nil {
+					t.Fatalf("raw analytics: %v", err)
+				}
+				rolled, err := New(db, true).Analytics(ctx, req)
+				if err != nil {
+					t.Fatalf("rollup analytics: %v", err)
+				}
+				if !reflect.DeepEqual(rolled.Timeline, raw.Timeline) {
+					t.Fatalf("timeline mismatch\nrollup=%#v\nraw=%#v", rolled.Timeline, raw.Timeline)
+				}
+			})
+		}
+	}
+}
+
+func TestAnalyticsHourlyRollupTimelineMatchesRawAcrossDSTFallBack(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := time.Date(2026, time.October, 31, 0, 0, 0, 0, time.UTC).UnixMilli()
+	toMS := time.Date(2026, time.November, 3, 0, 0, 0, 0, time.UTC).UnixMilli()
+	latency := int64(180)
+	events := make([]usage.Event, 0, 24)
+	for index := 0; index < 24; index++ {
+		timestampMS := fromMS + int64(index)*3*time.Hour.Milliseconds() + 15*time.Minute.Milliseconds()
+		events = append(events, monitoringEvent(
+			fmt.Sprintf("dst-fall-%02d", index),
+			timestampMS,
+			fmt.Sprintf("model-%d", index%3),
+			"auth-a",
+			"source-a",
+			index%7 == 0,
+			int64(90+index),
+			int64(40+index),
+			0,
+			0,
+			int64(130+2*index),
+			&latency,
+		))
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	catchUpMonitoringHourlyRollup(t, ctx, db)
+	req := Request{
+		FromMS:   fromMS,
+		ToMS:     toMS,
+		NowMS:    toMS,
+		TimeZone: "America/New_York",
+		Include: Include{
+			Timeline:    true,
+			Granularity: "hour",
+		},
+	}
+	raw, err := New(db, false).Analytics(ctx, req)
+	if err != nil {
+		t.Fatalf("raw analytics: %v", err)
+	}
+	rolled, err := New(db, true).Analytics(ctx, req)
+	if err != nil {
+		t.Fatalf("rollup analytics: %v", err)
+	}
+	if !reflect.DeepEqual(rolled.Timeline, raw.Timeline) {
+		t.Fatalf("timeline mismatch\nrollup=%#v\nraw=%#v", rolled.Timeline, raw.Timeline)
+	}
+}
+
+func TestAnalyticsHourlyRollupEligibilityIsStrict(t *testing.T) {
+	base := store.AnalyticsFilter{IncludeFailed: true}
+	if !analyticsHourlyRollupEligible(base) {
+		t.Fatal("unfiltered analytics should be rollup eligible")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*store.AnalyticsFilter)
+	}{
+		{name: "search", mutate: func(filter *store.AnalyticsFilter) { filter.SearchQuery = "model" }},
+		{name: "search api key", mutate: func(filter *store.AnalyticsFilter) { filter.SearchAPIKeyHash = "key" }},
+		{name: "models", mutate: func(filter *store.AnalyticsFilter) { filter.Models = []string{"model-a"} }},
+		{name: "providers", mutate: func(filter *store.AnalyticsFilter) { filter.Providers = []string{"codex"} }},
+		{name: "accounts", mutate: func(filter *store.AnalyticsFilter) { filter.Accounts = []string{"account"} }},
+		{name: "auth files", mutate: func(filter *store.AnalyticsFilter) { filter.AuthFiles = []string{"account.json"} }},
+		{name: "auth indices", mutate: func(filter *store.AnalyticsFilter) { filter.AuthIndices = []string{"auth-a"} }},
+		{name: "api keys", mutate: func(filter *store.AnalyticsFilter) { filter.APIKeyHashes = []string{"key"} }},
+		{name: "source hashes", mutate: func(filter *store.AnalyticsFilter) { filter.SourceHashes = []string{"source"} }},
+		{name: "projects", mutate: func(filter *store.AnalyticsFilter) { filter.ProjectIDs = []string{"project"} }},
+		{name: "request types", mutate: func(filter *store.AnalyticsFilter) { filter.RequestTypes = []string{"chat"} }},
+		{name: "header error kinds", mutate: func(filter *store.AnalyticsFilter) { filter.HeaderErrorKinds = []string{"quota"} }},
+		{name: "header error codes", mutate: func(filter *store.AnalyticsFilter) { filter.HeaderErrorCodes = []string{"429"} }},
+		{name: "header quota plans", mutate: func(filter *store.AnalyticsFilter) { filter.HeaderQuotaPlans = []string{"pro"} }},
+		{name: "header trace ids", mutate: func(filter *store.AnalyticsFilter) { filter.HeaderTraceIDs = []string{"trace"} }},
+		{name: "exclude failed", mutate: func(filter *store.AnalyticsFilter) { filter.IncludeFailed = false }},
+		{name: "failed only", mutate: func(filter *store.AnalyticsFilter) { filter.FailedOnly = true }},
+		{name: "minimum latency", mutate: func(filter *store.AnalyticsFilter) { filter.MinLatencyMS = 100 }},
+		{name: "cache status", mutate: func(filter *store.AnalyticsFilter) { filter.CacheStatus = "hit" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter := base
+			test.mutate(&filter)
+			if analyticsHourlyRollupEligible(filter) {
+				t.Fatalf("filter unexpectedly eligible: %#v", filter)
+			}
+		})
+	}
+}
+
+func catchUpMonitoringHourlyRollup(t *testing.T, ctx context.Context, db *store.Store) {
+	t.Helper()
+	for {
+		result, err := db.CatchUpDashboardHourlyRollups(ctx, 100, time.Now().UnixMilli())
+		if err != nil {
+			t.Fatalf("catch up hourly rollup: %v", err)
+		}
+		if !result.Pending {
+			return
+		}
 	}
 }
 

--- a/apps/manager-server/internal/service/usagehourly/reader.go
+++ b/apps/manager-server/internal/service/usagehourly/reader.go
@@ -1,0 +1,525 @@
+package usagehourly
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+const (
+	hourMS                    = int64(time.Hour / time.Millisecond)
+	fallbackLogIntervalMS     = int64(5 * time.Minute / time.Millisecond)
+	defaultFallbackLogContext = "usage-hourly-rollup"
+)
+
+type Reader struct {
+	store              *store.Store
+	enabled            bool
+	lastFallbackLogMS  atomic.Int64
+	fallbackLogContext string
+}
+
+type Snapshot struct {
+	Aggregate  store.Aggregate
+	ModelStats []store.ModelStat
+
+	rows        []store.DashboardHourlyRollupRow
+	edges       []timeRange
+	fullStartMS int64
+	fullEndMS   int64
+}
+
+type timeRange struct {
+	fromMS int64
+	toMS   int64
+}
+
+type modelStatKey struct {
+	model        string
+	billingModel string
+	serviceTier  string
+}
+
+type analyticsTimelineKey struct {
+	bucketMS     int64
+	model        string
+	billingModel string
+	serviceTier  string
+}
+
+func New(store *store.Store, enabled bool, logContext ...string) *Reader {
+	contextName := defaultFallbackLogContext
+	if len(logContext) > 0 && logContext[0] != "" {
+		contextName = logContext[0]
+	}
+	return &Reader{
+		store:              store,
+		enabled:            enabled,
+		fallbackLogContext: contextName,
+	}
+}
+
+func (r *Reader) Load(ctx context.Context, fromMS, toMS int64) (Snapshot, bool) {
+	if !r.enabled {
+		return Snapshot{}, false
+	}
+	if fromMS >= toMS {
+		return Snapshot{
+			ModelStats: []store.ModelStat{},
+		}, true
+	}
+	fullStartMS := ceilHourMS(fromMS)
+	fullEndMS := floorHourMS(toMS)
+	if fullStartMS >= fullEndMS {
+		return Snapshot{}, false
+	}
+
+	checkpoint, err := r.store.DashboardHourlyRollupCheckpoint(ctx)
+	if err != nil {
+		r.logFallback(fmt.Sprintf("checkpoint query failed: %v", err))
+		return Snapshot{}, false
+	}
+	latestID, err := r.store.LatestUsageEventID(ctx)
+	if err != nil {
+		r.logFallback(fmt.Sprintf("latest event query failed: %v", err))
+		return Snapshot{}, false
+	}
+	if checkpoint.LastEventID < latestID {
+		r.logFallback(fmt.Sprintf("checkpoint pending: last_event_id=%d latest_event_id=%d", checkpoint.LastEventID, latestID))
+		return Snapshot{}, false
+	}
+
+	rows, err := r.store.DashboardHourlyRollupRows(ctx, fullStartMS, fullEndMS)
+	if err != nil {
+		r.logFallback(fmt.Sprintf("hourly rows query failed: %v", err))
+		return Snapshot{}, false
+	}
+	for _, row := range rows {
+		if row.Model == "-" {
+			r.logFallback("hourly rows contain a normalized empty model")
+			return Snapshot{}, false
+		}
+	}
+
+	agg, modelStats := coreFromRows(rows)
+	edges := rawEdges(fromMS, toMS, fullStartMS, fullEndMS)
+	for _, edge := range edges {
+		edgeAgg, err := r.store.AggregateBetween(ctx, edge.fromMS, edge.toMS)
+		if err != nil {
+			r.logFallback(fmt.Sprintf("raw edge aggregate failed: %v", err))
+			return Snapshot{}, false
+		}
+		edgeModels, err := r.store.ModelStatsBetween(ctx, edge.fromMS, edge.toMS)
+		if err != nil {
+			r.logFallback(fmt.Sprintf("raw edge model query failed: %v", err))
+			return Snapshot{}, false
+		}
+		agg = mergeAggregates(agg, edgeAgg)
+		modelStats = mergeModelStats(modelStats, edgeModels)
+	}
+
+	return Snapshot{
+		Aggregate:   agg,
+		ModelStats:  modelStats,
+		rows:        rows,
+		edges:       edges,
+		fullStartMS: fullStartMS,
+		fullEndMS:   fullEndMS,
+	}, true
+}
+
+func (r *Reader) DashboardTimeline(ctx context.Context, snapshot Snapshot, fromMS, toMS int64) ([]store.TimelinePoint, bool) {
+	if fromMS%hourMS != 0 {
+		timeline, err := r.store.HourlyTimelineBetween(ctx, fromMS, toMS)
+		if err != nil {
+			r.logFallback(fmt.Sprintf("offset timeline query failed: %v", err))
+			return nil, false
+		}
+		return timeline, true
+	}
+
+	timeline := dashboardTimelineFromRows(snapshot.rows)
+	if snapshot.fullEndMS < toMS {
+		edgeTimeline, err := r.store.HourlyTimelineBetween(ctx, snapshot.fullEndMS, toMS)
+		if err != nil {
+			r.logFallback(fmt.Sprintf("raw edge timeline query failed: %v", err))
+			return nil, false
+		}
+		timeline = mergeDashboardTimeline(timeline, edgeTimeline)
+	}
+	return timeline, true
+}
+
+func (r *Reader) AnalyticsTimeline(
+	ctx context.Context,
+	snapshot Snapshot,
+	granularity string,
+	location *time.Location,
+) ([]store.TimelinePoint, bool) {
+	if location == nil {
+		location = time.UTC
+	}
+	if granularity != "day" {
+		granularity = "hour"
+	}
+	if !bucketsRepresentable(snapshot.fullStartMS, snapshot.fullEndMS, granularity, location) {
+		return nil, false
+	}
+
+	timeline := analyticsTimelineFromRows(snapshot.rows, granularity, location)
+	for _, edge := range snapshot.edges {
+		filter := store.AnalyticsFilter{
+			FromMS:        edge.fromMS,
+			ToMS:          edge.toMS,
+			IncludeFailed: true,
+		}
+		edgeTimeline, err := r.store.TimelineWithFilter(ctx, filter, granularity, location)
+		if err != nil {
+			r.logFallback(fmt.Sprintf("analytics raw edge timeline query failed: %v", err))
+			return nil, false
+		}
+		timeline = mergeAnalyticsTimeline(timeline, edgeTimeline)
+	}
+	return timeline, true
+}
+
+// CanRepresentAnalyticsTimeline reports whether complete UTC hourly rows can
+// be mapped to the requested local buckets without splitting an hourly row.
+func (r *Reader) CanRepresentAnalyticsTimeline(fromMS, toMS int64, granularity string, location *time.Location) bool {
+	if !r.enabled {
+		return false
+	}
+	if location == nil {
+		location = time.UTC
+	}
+	if granularity != "day" {
+		granularity = "hour"
+	}
+	fullStartMS := ceilHourMS(fromMS)
+	fullEndMS := floorHourMS(toMS)
+	return fullStartMS < fullEndMS && bucketsRepresentable(fullStartMS, fullEndMS, granularity, location)
+}
+
+func rawEdges(fromMS, toMS, fullStartMS, fullEndMS int64) []timeRange {
+	ranges := make([]timeRange, 0, 2)
+	if fromMS < fullStartMS {
+		ranges = append(ranges, timeRange{fromMS: fromMS, toMS: min(fullStartMS, toMS)})
+	}
+	if fullEndMS < toMS {
+		ranges = append(ranges, timeRange{fromMS: max(fullEndMS, fromMS), toMS: toMS})
+	}
+	return ranges
+}
+
+func ceilHourMS(value int64) int64 {
+	if value%hourMS == 0 {
+		return value
+	}
+	return value - value%hourMS + hourMS
+}
+
+func floorHourMS(value int64) int64 {
+	return value - value%hourMS
+}
+
+func coreFromRows(rows []store.DashboardHourlyRollupRow) (store.Aggregate, []store.ModelStat) {
+	agg := store.Aggregate{}
+	modelStats := make(map[modelStatKey]*store.ModelStat)
+	var latencySum int64
+	for _, row := range rows {
+		agg.TotalCalls += row.Calls
+		agg.SuccessCalls += row.SuccessCalls
+		agg.FailureCalls += row.FailureCalls
+		agg.InputTokens += row.InputTokens
+		agg.OutputTokens += row.OutputTokens
+		agg.ReasoningTokens += row.ReasoningTokens
+		agg.CachedTokens += row.CachedTokens
+		agg.CacheReadTokens += row.CacheReadTokens
+		agg.CacheCreationTokens += row.CacheCreationTokens
+		agg.LongInputTokens += row.LongInputTokens
+		agg.LongOutputTokens += row.LongOutputTokens
+		agg.LongCachedTokens += row.LongCachedTokens
+		agg.LongCacheReadTokens += row.LongCacheReadTokens
+		agg.LongCacheCreationTokens += row.LongCacheCreationTokens
+		agg.TotalTokens += row.TotalTokens
+		agg.LatencySamples += row.LatencySamples
+		agg.ZeroTokenCalls += row.ZeroTokenCalls
+		latencySum += row.LatencySumMS
+		addModelStat(modelStats, store.ModelStat{
+			Model:               row.Model,
+			BillingModel:        row.BillingModel,
+			ServiceTier:         row.ServiceTier,
+			Calls:               row.Calls,
+			SuccessCalls:        row.SuccessCalls,
+			InputTokens:         row.InputTokens,
+			OutputTokens:        row.OutputTokens,
+			ReasoningTokens:     row.ReasoningTokens,
+			CachedTokens:        row.CachedTokens,
+			CacheReadTokens:     row.CacheReadTokens,
+			CacheCreationTokens: row.CacheCreationTokens,
+			LongContextTokens:   row.LongContextTokens,
+			TotalTokens:         row.TotalTokens,
+		})
+	}
+	if agg.LatencySamples > 0 {
+		agg.AvgLatencyMS.Valid = true
+		agg.AvgLatencyMS.Float64 = float64(latencySum) / float64(agg.LatencySamples)
+	}
+	return agg, sortedModelStats(modelStats)
+}
+
+func mergeAggregates(left, right store.Aggregate) store.Aggregate {
+	latencySum := left.AvgLatencyMS.Float64*float64(left.LatencySamples) + right.AvgLatencyMS.Float64*float64(right.LatencySamples)
+	left.TotalCalls += right.TotalCalls
+	left.SuccessCalls += right.SuccessCalls
+	left.FailureCalls += right.FailureCalls
+	left.InputTokens += right.InputTokens
+	left.OutputTokens += right.OutputTokens
+	left.ReasoningTokens += right.ReasoningTokens
+	left.CachedTokens += right.CachedTokens
+	left.CacheReadTokens += right.CacheReadTokens
+	left.CacheCreationTokens += right.CacheCreationTokens
+	left.LongInputTokens += right.LongInputTokens
+	left.LongOutputTokens += right.LongOutputTokens
+	left.LongCachedTokens += right.LongCachedTokens
+	left.LongCacheReadTokens += right.LongCacheReadTokens
+	left.LongCacheCreationTokens += right.LongCacheCreationTokens
+	left.TotalTokens += right.TotalTokens
+	left.LatencySamples += right.LatencySamples
+	left.ZeroTokenCalls += right.ZeroTokenCalls
+	left.AvgLatencyMS.Valid = left.LatencySamples > 0
+	if left.AvgLatencyMS.Valid {
+		left.AvgLatencyMS.Float64 = latencySum / float64(left.LatencySamples)
+	}
+	return left
+}
+
+func mergeModelStats(left, right []store.ModelStat) []store.ModelStat {
+	grouped := make(map[modelStatKey]*store.ModelStat, len(left)+len(right))
+	for _, stat := range left {
+		addModelStat(grouped, stat)
+	}
+	for _, stat := range right {
+		addModelStat(grouped, stat)
+	}
+	return sortedModelStats(grouped)
+}
+
+func addModelStat(grouped map[modelStatKey]*store.ModelStat, stat store.ModelStat) {
+	mapKey := modelStatKey{model: stat.Model, billingModel: stat.BillingModel, serviceTier: stat.ServiceTier}
+	entry := grouped[mapKey]
+	if entry == nil {
+		copy := stat
+		grouped[mapKey] = &copy
+		return
+	}
+	entry.Calls += stat.Calls
+	entry.SuccessCalls += stat.SuccessCalls
+	entry.InputTokens += stat.InputTokens
+	entry.OutputTokens += stat.OutputTokens
+	entry.ReasoningTokens += stat.ReasoningTokens
+	entry.CachedTokens += stat.CachedTokens
+	entry.CacheReadTokens += stat.CacheReadTokens
+	entry.CacheCreationTokens += stat.CacheCreationTokens
+	entry.LongInputTokens += stat.LongInputTokens
+	entry.LongOutputTokens += stat.LongOutputTokens
+	entry.LongCachedTokens += stat.LongCachedTokens
+	entry.LongCacheReadTokens += stat.LongCacheReadTokens
+	entry.LongCacheCreationTokens += stat.LongCacheCreationTokens
+	entry.TotalTokens += stat.TotalTokens
+}
+
+func sortedModelStats(grouped map[modelStatKey]*store.ModelStat) []store.ModelStat {
+	result := make([]store.ModelStat, 0, len(grouped))
+	for _, stat := range grouped {
+		result = append(result, *stat)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Calls != result[j].Calls {
+			return result[i].Calls > result[j].Calls
+		}
+		if result[i].Model != result[j].Model {
+			return result[i].Model < result[j].Model
+		}
+		if result[i].BillingModel != result[j].BillingModel {
+			return result[i].BillingModel < result[j].BillingModel
+		}
+		return result[i].ServiceTier < result[j].ServiceTier
+	})
+	return result
+}
+
+func dashboardTimelineFromRows(rows []store.DashboardHourlyRollupRow) []store.TimelinePoint {
+	grouped := make(map[int64]*store.TimelinePoint)
+	for _, row := range rows {
+		point := grouped[row.BucketMS]
+		if point == nil {
+			point = &store.TimelinePoint{BucketMS: row.BucketMS}
+			grouped[row.BucketMS] = point
+		}
+		point.Calls += row.Calls
+		point.Tokens += row.TotalTokens
+		point.Success += row.SuccessCalls
+		point.Failure += row.FailureCalls
+	}
+	result := make([]store.TimelinePoint, 0, len(grouped))
+	for _, point := range grouped {
+		result = append(result, *point)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].BucketMS < result[j].BucketMS })
+	return result
+}
+
+func mergeDashboardTimeline(left, right []store.TimelinePoint) []store.TimelinePoint {
+	grouped := make(map[int64]*store.TimelinePoint, len(left)+len(right))
+	add := func(point store.TimelinePoint) {
+		entry := grouped[point.BucketMS]
+		if entry == nil {
+			copy := point
+			grouped[point.BucketMS] = &copy
+			return
+		}
+		entry.Calls += point.Calls
+		entry.Tokens += point.Tokens
+		entry.Success += point.Success
+		entry.Failure += point.Failure
+	}
+	for _, point := range left {
+		add(point)
+	}
+	for _, point := range right {
+		add(point)
+	}
+	result := make([]store.TimelinePoint, 0, len(grouped))
+	for _, point := range grouped {
+		result = append(result, *point)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].BucketMS < result[j].BucketMS })
+	return result
+}
+
+func analyticsTimelineFromRows(rows []store.DashboardHourlyRollupRow, granularity string, location *time.Location) []store.TimelinePoint {
+	grouped := make(map[analyticsTimelineKey]*store.TimelinePoint)
+	for _, row := range rows {
+		point := store.TimelinePoint{
+			LongContextTokens:   row.LongContextTokens,
+			BucketMS:            usage.AnalyticsBucketMS(row.BucketMS, granularity, location),
+			Model:               row.Model,
+			BillingModel:        row.BillingModel,
+			ServiceTier:         row.ServiceTier,
+			Calls:               row.Calls,
+			Tokens:              row.TotalTokens,
+			Success:             row.SuccessCalls,
+			Failure:             row.FailureCalls,
+			InputTokens:         row.InputTokens,
+			OutputTokens:        row.OutputTokens,
+			ReasoningTokens:     row.ReasoningTokens,
+			CachedTokens:        row.CachedTokens,
+			CacheReadTokens:     row.CacheReadTokens,
+			CacheCreationTokens: row.CacheCreationTokens,
+			LatencySamples:      row.LatencySamples,
+		}
+		if row.LatencySamples > 0 {
+			point.AvgLatencyMS.Valid = true
+			point.AvgLatencyMS.Float64 = float64(row.LatencySumMS) / float64(row.LatencySamples)
+		}
+		addAnalyticsTimelinePoint(grouped, point)
+	}
+	return sortedAnalyticsTimeline(grouped)
+}
+
+func mergeAnalyticsTimeline(left, right []store.TimelinePoint) []store.TimelinePoint {
+	grouped := make(map[analyticsTimelineKey]*store.TimelinePoint, len(left)+len(right))
+	for _, point := range left {
+		addAnalyticsTimelinePoint(grouped, point)
+	}
+	for _, point := range right {
+		addAnalyticsTimelinePoint(grouped, point)
+	}
+	return sortedAnalyticsTimeline(grouped)
+}
+
+func addAnalyticsTimelinePoint(grouped map[analyticsTimelineKey]*store.TimelinePoint, point store.TimelinePoint) {
+	mapKey := analyticsTimelineKey{
+		bucketMS:     point.BucketMS,
+		model:        point.Model,
+		billingModel: point.BillingModel,
+		serviceTier:  point.ServiceTier,
+	}
+	entry := grouped[mapKey]
+	if entry == nil {
+		copy := point
+		grouped[mapKey] = &copy
+		return
+	}
+	latencyTotal := entry.AvgLatencyMS.Float64*float64(entry.LatencySamples) + point.AvgLatencyMS.Float64*float64(point.LatencySamples)
+	entry.Calls += point.Calls
+	entry.Tokens += point.Tokens
+	entry.Success += point.Success
+	entry.Failure += point.Failure
+	entry.InputTokens += point.InputTokens
+	entry.OutputTokens += point.OutputTokens
+	entry.ReasoningTokens += point.ReasoningTokens
+	entry.CachedTokens += point.CachedTokens
+	entry.CacheReadTokens += point.CacheReadTokens
+	entry.CacheCreationTokens += point.CacheCreationTokens
+	entry.LongInputTokens += point.LongInputTokens
+	entry.LongOutputTokens += point.LongOutputTokens
+	entry.LongCachedTokens += point.LongCachedTokens
+	entry.LongCacheReadTokens += point.LongCacheReadTokens
+	entry.LongCacheCreationTokens += point.LongCacheCreationTokens
+	entry.LatencySamples += point.LatencySamples
+	entry.AvgLatencyMS.Valid = entry.LatencySamples > 0
+	if entry.AvgLatencyMS.Valid {
+		entry.AvgLatencyMS.Float64 = latencyTotal / float64(entry.LatencySamples)
+	}
+}
+
+func sortedAnalyticsTimeline(grouped map[analyticsTimelineKey]*store.TimelinePoint) []store.TimelinePoint {
+	result := make([]store.TimelinePoint, 0, len(grouped))
+	for _, point := range grouped {
+		result = append(result, *point)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].BucketMS != result[j].BucketMS {
+			return result[i].BucketMS < result[j].BucketMS
+		}
+		if result[i].Model != result[j].Model {
+			return result[i].Model < result[j].Model
+		}
+		if result[i].BillingModel != result[j].BillingModel {
+			return result[i].BillingModel < result[j].BillingModel
+		}
+		return result[i].ServiceTier < result[j].ServiceTier
+	})
+	return result
+}
+
+func bucketsRepresentable(fromMS, toMS int64, granularity string, location *time.Location) bool {
+	for bucketMS := fromMS; bucketMS < toMS; bucketMS += hourMS {
+		if usage.AnalyticsBucketMS(bucketMS, granularity, location) != usage.AnalyticsBucketMS(bucketMS+hourMS-1, granularity, location) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *Reader) logFallback(reason string) {
+	nowMS := time.Now().UnixMilli()
+	for {
+		lastMS := r.lastFallbackLogMS.Load()
+		if lastMS > 0 && nowMS-lastMS < fallbackLogIntervalMS {
+			return
+		}
+		if r.lastFallbackLogMS.CompareAndSwap(lastMS, nowMS) {
+			log.Printf("[%s] falling back to raw usage events: %s", r.fallbackLogContext, reason)
+			return
+		}
+	}
+}

--- a/apps/manager-server/internal/service/usagehourly/reader_test.go
+++ b/apps/manager-server/internal/service/usagehourly/reader_test.go
@@ -1,0 +1,188 @@
+package usagehourly
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestReaderMatchesRawCoreAndTimelines(t *testing.T) {
+	db := newReaderTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_000_000_000) + 15*60*1000
+	toMS := fromMS + 3*hourMS + 20*60*1000
+	latency100 := int64(100)
+	latency300 := int64(300)
+
+	first := readerEvent("reader-first", fromMS+10*60*1000, "alias-a", false, 100, 20, &latency100)
+	first.ResolvedModel = "resolved-a"
+	first.ServiceTier = "priority"
+	second := readerEvent("reader-second", fromMS+hourMS+5*60*1000, "alias-a", true, 300_000, 30, &latency300)
+	second.ResolvedModel = "resolved-a"
+	second.ServiceTier = "priority"
+	third := readerEvent("reader-third", toMS-5*60*1000, "model-b", false, 300, 40, nil)
+	if _, err := db.InsertEvents(ctx, []usage.Event{first, second, third}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	rawAggregate, err := db.AggregateBetween(ctx, fromMS, toMS)
+	if err != nil {
+		t.Fatalf("raw aggregate: %v", err)
+	}
+	rawModels, err := db.ModelStatsBetween(ctx, fromMS, toMS)
+	if err != nil {
+		t.Fatalf("raw models: %v", err)
+	}
+	rawDashboardTimeline, err := db.HourlyTimelineBetween(ctx, fromMS, toMS)
+	if err != nil {
+		t.Fatalf("raw dashboard timeline: %v", err)
+	}
+	filter := store.AnalyticsFilter{FromMS: fromMS, ToMS: toMS, IncludeFailed: true}
+	rawAnalyticsTimeline, err := db.TimelineWithFilter(ctx, filter, "day", time.UTC)
+	if err != nil {
+		t.Fatalf("raw analytics timeline: %v", err)
+	}
+
+	catchUpReaderRollup(t, ctx, db)
+	reader := New(db, true)
+	snapshot, ok := reader.Load(ctx, fromMS, toMS)
+	if !ok {
+		t.Fatal("reader did not use rollup")
+	}
+	if !reflect.DeepEqual(snapshot.Aggregate, rawAggregate) {
+		t.Fatalf("aggregate mismatch\nrollup=%#v\nraw=%#v", snapshot.Aggregate, rawAggregate)
+	}
+	if snapshot.Aggregate.LongInputTokens != second.InputTokens {
+		t.Fatalf("long input tokens = %d, want %d", snapshot.Aggregate.LongInputTokens, second.InputTokens)
+	}
+	if !reflect.DeepEqual(snapshot.ModelStats, rawModels) {
+		t.Fatalf("model stats mismatch\nrollup=%#v\nraw=%#v", snapshot.ModelStats, rawModels)
+	}
+	dashboardTimeline, ok := reader.DashboardTimeline(ctx, snapshot, fromMS, toMS)
+	if !ok || !reflect.DeepEqual(dashboardTimeline, rawDashboardTimeline) {
+		t.Fatalf("dashboard timeline mismatch\nrollup=%#v\nraw=%#v", dashboardTimeline, rawDashboardTimeline)
+	}
+	analyticsTimeline, ok := reader.AnalyticsTimeline(ctx, snapshot, "day", time.UTC)
+	if !ok || !reflect.DeepEqual(analyticsTimeline, rawAnalyticsTimeline) {
+		t.Fatalf("analytics timeline mismatch\nrollup=%#v\nraw=%#v", analyticsTimeline, rawAnalyticsTimeline)
+	}
+}
+
+func TestReaderAnalyticsTimelineFallsBackForHalfHourBuckets(t *testing.T) {
+	db := newReaderTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_000_000_000)
+	toMS := fromMS + 3*hourMS
+	if _, err := db.InsertEvents(ctx, []usage.Event{
+		readerEvent("half-hour-zone", fromMS+10*60*1000, "model-a", false, 1, 2, nil),
+	}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	catchUpReaderRollup(t, ctx, db)
+	snapshot, ok := New(db, true).Load(ctx, fromMS, toMS)
+	if !ok {
+		t.Fatal("reader did not load rollup")
+	}
+	location, err := time.LoadLocation("Asia/Kolkata")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	reader := New(db, true)
+	if reader.CanRepresentAnalyticsTimeline(fromMS, toMS, "hour", location) {
+		t.Fatal("half-hour timeline unexpectedly reported as representable")
+	}
+	if _, ok := reader.AnalyticsTimeline(ctx, snapshot, "hour", location); ok {
+		t.Fatal("half-hour timeline unexpectedly used UTC hourly rollup")
+	}
+}
+
+func TestReaderFallsBackForNormalizedEmptyModel(t *testing.T) {
+	db := newReaderTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_000_000_000)
+	toMS := fromMS + 2*hourMS
+	if _, err := db.InsertEvents(ctx, []usage.Event{
+		readerEvent("empty-model", fromMS+1_000, "", false, 1, 2, nil),
+	}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	catchUpReaderRollup(t, ctx, db)
+	if _, ok := New(db, true).Load(ctx, fromMS, toMS); ok {
+		t.Fatal("normalized empty model used rollup instead of preserving raw model semantics")
+	}
+}
+
+func TestReaderFallsBackWhenDisabledOrPending(t *testing.T) {
+	db := newReaderTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_000_000_000)
+	toMS := fromMS + 2*hourMS
+	if _, err := db.InsertEvents(ctx, []usage.Event{
+		readerEvent("pending", fromMS+1_000, "model-a", false, 1, 2, nil),
+	}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	if _, ok := New(db, false).Load(ctx, fromMS, toMS); ok {
+		t.Fatal("disabled reader used rollup")
+	}
+	if _, ok := New(db, true).Load(ctx, fromMS, toMS); ok {
+		t.Fatal("pending checkpoint used rollup")
+	}
+}
+
+func TestReaderFallbackLogIsRateLimited(t *testing.T) {
+	reader := New(newReaderTestStore(t), true)
+	reader.logFallback("first")
+	first := reader.lastFallbackLogMS.Load()
+	if first <= 0 {
+		t.Fatalf("first log timestamp = %d", first)
+	}
+	reader.logFallback("second")
+	if got := reader.lastFallbackLogMS.Load(); got != first {
+		t.Fatalf("fallback log was not rate limited: first=%d got=%d", first, got)
+	}
+}
+
+func catchUpReaderRollup(t *testing.T, ctx context.Context, db *store.Store) {
+	t.Helper()
+	for {
+		result, err := db.CatchUpDashboardHourlyRollups(ctx, 100, time.Now().UnixMilli())
+		if err != nil {
+			t.Fatalf("catch up rollup: %v", err)
+		}
+		if !result.Pending {
+			return
+		}
+	}
+}
+
+func newReaderTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	db, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func readerEvent(hash string, timestampMS int64, model string, failed bool, inputTokens, outputTokens int64, latencyMS *int64) usage.Event {
+	return usage.Event{
+		EventHash:    hash,
+		TimestampMS:  timestampMS,
+		Timestamp:    time.UnixMilli(timestampMS).UTC().Format(time.RFC3339Nano),
+		Model:        model,
+		Endpoint:     "POST /v1/chat/completions",
+		Method:       "POST",
+		Path:         "/v1/chat/completions",
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  inputTokens + outputTokens,
+		LatencyMS:    latencyMS,
+		Failed:       failed,
+	}
+}

--- a/apps/manager-server/internal/usage/analytics_bucket.go
+++ b/apps/manager-server/internal/usage/analytics_bucket.go
@@ -1,0 +1,16 @@
+package usage
+
+import "time"
+
+// AnalyticsBucketMS resolves an event timestamp to the start of its local
+// analytics hour or day bucket.
+func AnalyticsBucketMS(timestampMS int64, granularity string, location *time.Location) int64 {
+	if location == nil {
+		location = time.UTC
+	}
+	tm := time.UnixMilli(timestampMS).In(location)
+	if granularity == "day" {
+		return time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, location).UnixMilli()
+	}
+	return time.Date(tm.Year(), tm.Month(), tm.Day(), tm.Hour(), 0, 0, 0, location).UnixMilli()
+}

--- a/apps/manager-server/internal/usage/analytics_bucket_test.go
+++ b/apps/manager-server/internal/usage/analytics_bucket_test.go
@@ -1,0 +1,45 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAnalyticsBucketMSAcrossDST(t *testing.T) {
+	location, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	tests := []struct {
+		name        string
+		timestampMS int64
+		granularity string
+		wantMS      int64
+	}{
+		{
+			name:        "hour before spring transition",
+			timestampMS: time.Date(2026, time.March, 8, 6, 30, 0, 0, time.UTC).UnixMilli(),
+			granularity: "hour",
+			wantMS:      time.Date(2026, time.March, 8, 6, 0, 0, 0, time.UTC).UnixMilli(),
+		},
+		{
+			name:        "hour after spring transition",
+			timestampMS: time.Date(2026, time.March, 8, 7, 30, 0, 0, time.UTC).UnixMilli(),
+			granularity: "hour",
+			wantMS:      time.Date(2026, time.March, 8, 7, 0, 0, 0, time.UTC).UnixMilli(),
+		},
+		{
+			name:        "local day",
+			timestampMS: time.Date(2026, time.March, 8, 18, 0, 0, 0, time.UTC).UnixMilli(),
+			granularity: "day",
+			wantMS:      time.Date(2026, time.March, 8, 5, 0, 0, 0, time.UTC).UnixMilli(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := AnalyticsBucketMS(test.timestampMS, test.granularity, location); got != test.wantMS {
+				t.Fatalf("bucket = %d, want %d", got, test.wantMS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reuse complete hourly rollups for eligible unfiltered Usage Analytics queries while preserving raw-event fallbacks for filters, percentiles, unsupported timezones, and incomplete checkpoints.
This reduces the 100k-event rollup-owned core from 777 ms / 23.70 MB to 39 ms / 9.51 MB, and publishes a bilingual report for the July 10 performance work.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add a shared hourly-rollup reader and migrate Dashboard plus strictly unfiltered Usage Analytics core metrics to it.
- Preserve raw-event parity for edge buckets, filtered or high-dimensional queries, P95/TTFT metrics, DST behavior, and unsupported timezone buckets.
- Add parity, fallback, stability, race, and benchmark coverage plus bilingual performance documentation.

## User Impact

Long-window Usage Analytics overview queries use materially less CPU time and memory when the hourly rollup is current. Filtered analytics behavior and API response semantics remain unchanged.

## Compatibility / Runtime Notes

- CPA panel mode: No behavior change.
- Manager Server mode: Hourly rollup remains enabled by default and now serves eligible Dashboard and Usage Analytics reads.
- Full Docker / native packages: No deployment change. Set `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false` and restart Manager Server to force raw-event reads.

## Data / Security Notes

No schema change and no new sensitive-data exposure. Existing rollup tables and sanitized API behavior are unchanged.

## Risk / Rollback

Risk level: Medium

Rollback notes:

- Set `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false` and restart Manager Server.
- The service will fall back to raw events without deleting existing rollup data.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test                       # 86 files, 728 tests
npm --workspace apps/web run build:bundle
npm run check:demo-isolation
npm run docs:build
npm run manager-server:test
cd apps/manager-server && go test -race ./...
cd apps/manager-server && go vet ./...
git diff --check origin/main...HEAD
```

Benchmark evidence:

- Overview: 3.21 s / 34.43 MB -> 2.48 s / 20.24 MB (~23% faster, ~41% lower B/op, ~64% fewer allocations).
- Rollup-owned core: 777 ms / 23.70 MB -> 39 ms / 9.51 MB (~20x faster, ~60% lower B/op, ~92% fewer allocations).
- Final heap profile: approximately 5 MB in use with no retained CPAMP reader/event slice; 200 iterations remained stable near 38-40 ms/op.

## Screenshots / Recordings

N/A — backend and documentation changes only.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

N/A