### PR TITLE
docs(release): add v1.11.0 release notes

### DIFF
--- a/docs/release-notes/v1.11.0-en.md
+++ b/docs/release-notes/v1.11.0-en.md
@@ -1,0 +1,60 @@
+# CPA Manager Plus v1.11.0
+
+> 51 commits · 194 files changed · +12966 / -1862
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.0/docs/release-notes/v1.11.0-zh.md)
+
+## Overview
+
+This release focuses on performance and long-running stability across Manager Server, Dashboard, Usage Analytics, and Request Monitoring. It also adds GPT-5.6 pricing and long-context billing, automatic cooldown handling for exhausted xAI free usage, and fixes for cache-hit metrics, model costs, concurrent configuration saves, plugin configuration, and OAuth compatibility.
+
+## Highlights
+
+### Features
+
+- Add official GPT-5.6 pricing, long-context multipliers, cache read/write and cache creation billing, with model-alias and service-tier support (`manager-server/pricing`, `web/model-prices`).
+- Handle xAI `free-usage-exhausted` signals with a controlled 24-hour cooldown, automatically recover CPAMP-owned disables, and expose the state in Auth Files and automation settings (`manager-server/quota-cooldown`, `web/auth-files`).
+- Align auth-files OAuth compatibility with upstream v1.18 and harden plugin trust, configuration updates, and concurrent provider saves (`web/auth-files`, `web/plugins`, `web/providers`).
+- Add a loopback-only pprof service for controlled production memory and CPU diagnostics (`manager-server/pprof`).
+
+### Performance
+
+- Scope Usage Analytics requests to the active tab so hidden views no longer execute unnecessary statistics queries (`web/usage-analytics`).
+- Serve Dashboard and strictly unfiltered Usage Analytics queries from incremental hourly rollups instead of repeatedly scanning historical `usage_events` (`manager-server/dashboard`, `manager-server/monitoring`).
+- Stream and batch usage import/export work, and bound Monitoring events, presentation snapshots, and SQLite connections (`manager-server/usage`, `web/monitoring`, `sqlite`).
+- With 100,000 synthetic events, the effective Usage Analytics Overview workload decreased from about 7.00s to 2.48s, a reduction of about 65%; per-operation allocation decreased from about 215MB to 20.24MB, about 91% lower.
+- The rollup-owned Usage Analytics core decreased from about 777ms to 39ms, roughly 20x faster; Dashboard core statistics decreased from about 774ms to 2.66ms, roughly 291x faster.
+- Two hundred consecutive core benchmark iterations remained near 38-40ms/op, with a final heap profile near 5MB in use and no retained full-event slice.
+
+### Fixes
+
+- Normalize cache-hit, cache read/write, input-token, and cost semantics across providers and GPT-5.6 (`manager-server/usage`, `web/monitoring`).
+- Clarify and correct cache metrics in Monitoring account and model aggregation (`manager-server/monitoring`, `web/monitoring`).
+- Prevent concurrent Provider, configuration-center, and quota-state saves from overwriting one another (`web/providers`, `web/config`, `web/quota`).
+- Harden plugin trust and configuration update boundaries, and distinguish Dashboard model-price loading failures (`web/plugins`, `web/dashboard`).
+- Prevent Codex header quota matches across workspaces and synchronize missing CPA configuration fields (`web/quota`, `web/config`).
+
+### Docs And CI
+
+- Add bilingual performance reports covering the memory investigation, optimization phases, benchmarks, and rollback procedures (`docs/performance`).
+- Refresh README product positioning and documentation entry points (`docs/readme`).
+- Slim PR demo and documentation checks to avoid duplicate builds (`ci`).
+
+## Upgrade Notes
+
+- This release automatically creates the Dashboard hourly-rollup SQLite structures and applies required pricing and cache-accounting migrations. No manual migration is required.
+- Back up the SQLite files and `data.key` before upgrading.
+- The first startup catches up historical hourly rollups in the background. Queries fall back to raw events while catch-up is pending, so the full performance improvement may not be immediate.
+- Hourly rollups are enabled by default. For diagnostics, set `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false` and restart Manager Server.
+- pprof is disabled by default. Bind it only to a loopback address and do not expose it through public ports or a reverse proxy.
+- GPT-5.6 and cache-accounting corrections may change historical cost or cache-hit values shown by the UI; the new results better match provider billing semantics.
+- Benchmark results use synthetic data. Actual improvements depend on data volume, filters, storage, and runtime environment.
+- This release includes visible Provider automation guidance, xAI cooldown states, and cache metrics. Consider adding screenshots for those areas and a before/after chart for the performance work.
+
+## Acknowledgements
+
+- [@lost9999](https://github.com/lost9999) - Contributed xAI free-usage cooldown handling, provider alias normalization, and Auth Files cooldown-state visibility.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.5...v1.11.0

--- a/docs/release-notes/v1.11.0-zh.md
+++ b/docs/release-notes/v1.11.0-zh.md
@@ -1,0 +1,60 @@
+# CPA Manager Plus v1.11.0
+
+> 51 commits · 194 files changed · +12966 / -1862
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.0/docs/release-notes/v1.11.0-en.md)
+
+## Overview
+
+本次发布集中提升 Manager Server、Dashboard、Usage Analytics 和 Request Monitoring 的性能与长期运行稳定性，并新增 GPT-5.6 定价、长上下文计费和 xAI 免费额度耗尽后的自动冷却支持。同时修复缓存命中率、模型成本、并发配置保存、插件配置和 OAuth 兼容性问题。
+
+## Highlights
+
+### Features
+
+- 新增 GPT-5.6 官方定价、长上下文倍率、cache read/write 和 cache creation 成本计算，并支持模型别名与 service tier（`manager-server/pricing`、`web/model-prices`）。
+- xAI `free-usage-exhausted` 事件可触发受控的 24 小时自动冷却，恢复后自动解除 CPAMP 管理的禁用状态，并在 Auth Files 与自动化配置中展示对应状态（`manager-server/quota-cooldown`、`web/auth-files`）。
+- 对齐上游 v1.18 auth-files OAuth 兼容行为，并加固插件信任、配置更新和 provider 并发保存（`web/auth-files`、`web/plugins`、`web/providers`）。
+- 新增 loopback-only pprof 服务，为生产环境内存和 CPU 问题提供受控诊断入口（`manager-server/pprof`）。
+
+### Performance
+
+- Usage Analytics 根据当前 Tab 请求最小数据集，避免执行不可见页面的统计查询（`web/usage-analytics`）。
+- Dashboard 和严格无筛选的 Usage Analytics 使用增量小时汇总，减少重复扫描历史 `usage_events`（`manager-server/dashboard`、`manager-server/monitoring`）。
+- Usage 导入导出改为流式与分批处理，并限制 Monitoring 事件、展示快照和 SQLite 连接数量（`manager-server/usage`、`web/monitoring`、`sqlite`）。
+- 在 100,000 条测试事件下，Usage Analytics Overview 有效工作量耗时由约 7.00s 降至 2.48s，降低约 65%；单次内存分配由约 215MB 降至 20.24MB，降低约 91%。
+- Usage Analytics rollup-owned 核心统计由约 777ms 降至 39ms，约快 20 倍；Dashboard 核心统计由约 774ms 降至 2.66ms，约快 291 倍。
+- 连续 200 次核心 benchmark 保持约 38～40ms/op，最终 heap profile 约 5MB in-use，未发现完整事件切片持续保留。
+
+### Fixes
+
+- 统一不同 Provider 和 GPT-5.6 的缓存命中、cache read/write、输入 Token 与成本统计口径（`manager-server/usage`、`web/monitoring`）。
+- 修复 Monitoring 账号与模型聚合中缓存指标含义不清或计算不一致的问题（`manager-server/monitoring`、`web/monitoring`）。
+- 修复 Provider、配置中心和 quota 状态并发保存时可能互相覆盖的问题（`web/providers`、`web/config`、`web/quota`）。
+- 修复插件信任与配置更新边界，以及 Dashboard 模型价格加载失败提示（`web/plugins`、`web/dashboard`）。
+- 修复 Codex header quota 跨 workspace 错配和 CPA 配置字段覆盖不完整的问题（`web/quota`、`web/config`）。
+
+### Docs And CI
+
+- 新增中英文性能优化报告，记录内存问题原因、优化阶段、benchmark 和回滚方式（`docs/performance`）。
+- 更新 README 产品定位和文档入口（`docs/readme`）。
+- 精简 PR demo/docs 检查，避免重复构建（`ci`）。
+
+## Upgrade Notes
+
+- 本版本会自动创建 Dashboard 小时汇总相关 SQLite 结构，并执行必要的定价和缓存统计迁移；无需手工迁移。
+- 建议升级前备份 SQLite 文件和 `data.key`。
+- 首次启动会在后台追平历史小时汇总。追平期间查询会自动回退 raw events，性能提升可能不会立即完全体现。
+- 小时汇总默认开启。需要排查时可设置 `USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false`，修改后重启 Manager Server。
+- pprof 默认关闭，仅建议绑定 loopback 地址，不应通过公网端口或反向代理暴露。
+- GPT-5.6 和缓存统计口径修正后，部分历史页面展示的成本或缓存命中率可能与旧版本不同，新结果更接近 Provider 实际计费语义。
+- benchmark 数据来自合成测试环境，实际效果取决于数据量、筛选条件、磁盘和运行环境。
+- 本版本包含 Provider 自动化提示、xAI 冷却状态和缓存指标等可视变化，建议在 GitHub Release 补充相关截图；性能改进可使用优化前后对比图展示。
+
+## Acknowledgements
+
+- [@lost9999](https://github.com/lost9999) - 贡献 xAI 免费额度耗尽自动冷却、Provider 别名处理和 Auth Files 冷却状态展示。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.10.5...v1.11.0


### PR DESCRIPTION
## Summary

Add the curated Chinese and English release notes for CPA Manager Plus v1.11.0.
The notes cover the performance and memory work, GPT-5.6 pricing, xAI cooldown automation, cache-accounting fixes, upstream compatibility updates, and upgrade guidance included since v1.10.5.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `docs/release-notes/v1.11.0-zh.md` as the authored Chinese release body.
- Add `docs/release-notes/v1.11.0-en.md` with matching structure, statistics, upgrade notes, and acknowledgements.
- Use tag-pinned language links and a `v1.10.5...v1.11.0` full changelog link.

## User Impact

No runtime behavior change in this PR. After the v1.11.0 tag is pushed, the release workflow will use the curated Chinese notes as the GitHub Release body and package the matching native, web, and container artifacts.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; documentation-only PR.
- Manager Server mode: N/A; documentation-only PR.
- Full Docker / native packages: The notes document automatic SQLite migrations, hourly-rollup catch-up, pprof exposure boundaries, and rollback configuration for the v1.11.0 artifacts.

## Data / Security Notes

No data or security behavior changes in this PR. The release notes remind operators to back up SQLite files and `data.key`, and to keep pprof loopback-only.

## Risk / Rollback

Risk level: Low

Rollback notes:

- Close or revert this documentation-only PR before tagging if the release scope changes.
- Do not push `v1.11.0` until these notes are merged to `main`.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
main == origin/main == 23f7df5a99c43f93abf879306f2b9aed5df30e73
previous tag: v1.10.5
planned tag: v1.11.0 (not present)
release range: 51 commits, 194 files, +12966 / -1862
release branch created from main
language links pin to v1.11.0 under docs/release-notes/
full changelog links v1.10.5...v1.11.0
```

## Screenshots / Recordings

N/A — release-notes-only PR.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related

N/A