### PR TITLE
✨ feat(quota): support Claude model-scoped weekly limits

### DIFF
--- a/apps/web/src/components/quota/quotaConfigs.test.ts
+++ b/apps/web/src/components/quota/quotaConfigs.test.ts
@@ -1,6 +1,14 @@
+import React from 'react';
+import type { TFunction } from 'i18next';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { describe, expect, it } from 'vitest';
-import type { CodexQuotaState } from '@/types';
-import { getSortedCodexResetCreditExpiries, resolveQuotaDisplayState } from './quotaConfigs';
+import type { ClaudeQuotaState, CodexQuotaState } from '@/types';
+import type { QuotaRenderHelpers } from './QuotaCard';
+import {
+  CLAUDE_CONFIG,
+  getSortedCodexResetCreditExpiries,
+  resolveQuotaDisplayState,
+} from './quotaConfigs';
 
 type TestQuotaState = {
   status: 'idle' | 'loading' | 'success' | 'error';
@@ -48,6 +56,49 @@ describe('getSortedCodexResetCreditExpiries', () => {
       new Date('2026-07-18T08:31:33Z').getTime(),
       new Date('2026-07-19T00:42:09Z').getTime(),
     ]);
+  });
+});
+
+describe('CLAUDE_CONFIG.renderQuotaItems', () => {
+  it('renders scoped model quota windows with their dynamic labels', () => {
+    const quota: ClaudeQuotaState = {
+      status: 'success',
+      windows: [
+        {
+          id: 'weekly-scoped-fable%205%20max',
+          label: 'Fable 5 Max',
+          usedPercent: 100,
+          resetLabel: '07/08 21:00',
+        },
+      ],
+    };
+    const helpers: QuotaRenderHelpers = {
+      styles: new Proxy(
+        {},
+        {
+          get: (_target, property) => String(property),
+        }
+      ) as QuotaRenderHelpers['styles'],
+      QuotaProgressBar: ({ percent }) =>
+        React.createElement('div', { className: 'progress', 'data-percent': percent }),
+    };
+    let renderer!: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        React.createElement(
+          React.Fragment,
+          null,
+          CLAUDE_CONFIG.renderQuotaItems(quota, ((key: string) => key) as TFunction, helpers)
+        )
+      );
+    });
+
+    const output = JSON.stringify(renderer.toJSON());
+    expect(output).toContain('Fable 5 Max');
+    expect(output).toContain('0%');
+    expect(output).toContain('07/08 21:00');
+    expect(output).toContain('"data-percent":0');
   });
 });
 

--- a/apps/web/src/features/demo/demoFixtures.quota.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.quota.test.ts
@@ -4,21 +4,31 @@ import { getDemoApiCallResult } from './demoFixtures';
 const CLAUDE_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
 
 describe('Claude quota demo fixtures', () => {
-  it('provides multiple model-scoped weekly limits for the team account', () => {
+  it('provides limits-only base quotas plus multiple fictional scoped models', () => {
     const result = getDemoApiCallResult({
       authIndex: 'claude-team-01',
       url: CLAUDE_USAGE_URL,
     });
 
     expect(result.body).toMatchObject({
-      five_hour: { utilization: 44 },
-      seven_day: { utilization: 31 },
       limits: [
+        {
+          kind: 'session',
+          group: 'session',
+          percent: 44,
+          scope: null,
+        },
+        {
+          kind: 'weekly_all',
+          group: 'weekly',
+          percent: 31,
+          scope: null,
+        },
         {
           kind: 'weekly_scoped',
           group: 'weekly',
           percent: 78,
-          scope: { model: { display_name: 'Fable 5 Max' } },
+          scope: { model: { display_name: 'Demo Model A' } },
         },
         {
           kind: 'model_scoped',
@@ -28,6 +38,8 @@ describe('Claude quota demo fixtures', () => {
         },
       ],
     });
+    expect(result.body).not.toHaveProperty('five_hour');
+    expect(result.body).not.toHaveProperty('seven_day');
   });
 
   it('keeps the research account on the legacy payload without limits', () => {

--- a/apps/web/src/features/demo/demoFixtures.quota.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.quota.test.ts
@@ -33,6 +33,13 @@ describe('Claude quota demo fixtures', () => {
         {
           kind: 'model_scoped',
           group: 'weekly',
+          percent: 12,
+          scope: { model: { displayName: 'Demo Model B' } },
+          is_active: false,
+        },
+        {
+          kind: 'model_scoped',
+          group: 'weekly',
           percent: 42,
           scope: { model: { displayName: 'Demo Model B' } },
           is_active: false,

--- a/apps/web/src/features/demo/demoFixtures.quota.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.quota.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getDemoApiCallResult } from './demoFixtures';
+
+const CLAUDE_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+
+describe('Claude quota demo fixtures', () => {
+  it('provides multiple model-scoped weekly limits for the team account', () => {
+    const result = getDemoApiCallResult({
+      authIndex: 'claude-team-01',
+      url: CLAUDE_USAGE_URL,
+    });
+
+    expect(result.body).toMatchObject({
+      five_hour: { utilization: 44 },
+      seven_day: { utilization: 31 },
+      limits: [
+        {
+          kind: 'weekly_scoped',
+          group: 'weekly',
+          percent: 78,
+          scope: { model: { display_name: 'Fable 5 Max' } },
+        },
+        {
+          kind: 'model_scoped',
+          group: 'weekly',
+          percent: 42,
+          scope: { model: { displayName: 'Demo Model B' } },
+        },
+      ],
+    });
+  });
+
+  it('keeps the research account on the legacy payload without limits', () => {
+    const result = getDemoApiCallResult({
+      authIndex: 'claude-research-02',
+      url: CLAUDE_USAGE_URL,
+    });
+
+    expect(result.body).toMatchObject({
+      five_hour: { utilization: 18 },
+      seven_day: { utilization: 22 },
+    });
+    expect(result.body).not.toHaveProperty('limits');
+  });
+});

--- a/apps/web/src/features/demo/demoFixtures.quota.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.quota.test.ts
@@ -35,6 +35,7 @@ describe('Claude quota demo fixtures', () => {
           group: 'weekly',
           percent: 42,
           scope: { model: { displayName: 'Demo Model B' } },
+          is_active: false,
         },
       ],
     });

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -2869,6 +2869,14 @@ export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
               {
                 kind: 'model_scoped',
                 group: 'weekly',
+                percent: 12,
+                resets_at: new Date(now() + 4 * day).toISOString(),
+                scope: { model: { displayName: 'Demo Model B' } },
+                is_active: false,
+              },
+              {
+                kind: 'model_scoped',
+                group: 'weekly',
                 percent: 42,
                 resets_at: new Date(now() + 5 * day).toISOString(),
                 scope: { model: { displayName: 'Demo Model B' } },

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -2841,15 +2841,29 @@ export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
     body =
       authIndex === 'claude-team-01'
         ? {
-            five_hour: fiveHour,
-            seven_day: sevenDay,
             limits: [
+              {
+                kind: 'session',
+                group: 'session',
+                percent: fiveHour.utilization,
+                resets_at: fiveHour.resets_at,
+                scope: null,
+                is_active: true,
+              },
+              {
+                kind: 'weekly_all',
+                group: 'weekly',
+                percent: sevenDay.utilization,
+                resets_at: sevenDay.resets_at,
+                scope: null,
+                is_active: true,
+              },
               {
                 kind: 'weekly_scoped',
                 group: 'weekly',
                 percent: 78,
                 resets_at: new Date(now() + 4 * day).toISOString(),
-                scope: { model: { display_name: 'Fable 5 Max' } },
+                scope: { model: { display_name: 'Demo Model A' } },
                 is_active: true,
               },
               {

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -2770,6 +2770,7 @@ export const getDemoConfigYaml = () =>
 
 export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
   const requestUrl = String(payload.url || '');
+  const authIndex = String(payload.authIndex || '');
   let body: unknown = { data: demoProviderModels.map((model) => ({ id: model.name })) };
 
   if (requestUrl.includes('/wham/usage')) {
@@ -2822,15 +2823,49 @@ export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
       ],
     };
   } else if (requestUrl.includes('anthropic.com/api/oauth/profile')) {
-    body = { email: 'research@example.com', organization_name: 'Research Team' };
+    body =
+      authIndex === 'claude-team-01'
+        ? { account: { has_claude_max: true } }
+        : authIndex === 'claude-research-02'
+          ? { account: { has_claude_pro: true } }
+          : { email: 'research@example.com', organization_name: 'Research Team' };
   } else if (requestUrl.includes('anthropic.com/api/oauth/usage')) {
-    body = {
-      plan_type: 'pro',
-      usage: {
-        five_hour: { utilization: 0.44, resets_at: new Date(now() + 2 * hour).toISOString() },
-        seven_day: { utilization: 0.31, resets_at: new Date(now() + 3 * day).toISOString() },
-      },
+    const fiveHour = {
+      utilization: authIndex === 'claude-team-01' ? 44 : 18,
+      resets_at: new Date(now() + 2 * hour).toISOString(),
     };
+    const sevenDay = {
+      utilization: authIndex === 'claude-team-01' ? 31 : 22,
+      resets_at: new Date(now() + 3 * day).toISOString(),
+    };
+    body =
+      authIndex === 'claude-team-01'
+        ? {
+            five_hour: fiveHour,
+            seven_day: sevenDay,
+            limits: [
+              {
+                kind: 'weekly_scoped',
+                group: 'weekly',
+                percent: 78,
+                resets_at: new Date(now() + 4 * day).toISOString(),
+                scope: { model: { display_name: 'Fable 5 Max' } },
+                is_active: true,
+              },
+              {
+                kind: 'model_scoped',
+                group: 'weekly',
+                percent: 42,
+                resets_at: new Date(now() + 5 * day).toISOString(),
+                scope: { model: { displayName: 'Demo Model B' } },
+                is_active: true,
+              },
+            ],
+          }
+        : {
+            five_hour: fiveHour,
+            seven_day: sevenDay,
+          };
   } else if (requestUrl.includes('api.kimi.com')) {
     body = {
       items: [

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -2872,7 +2872,7 @@ export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
                 percent: 42,
                 resets_at: new Date(now() + 5 * day).toISOString(),
                 scope: { model: { displayName: 'Demo Model B' } },
-                is_active: true,
+                is_active: false,
               },
             ],
           }

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -259,6 +259,12 @@ describe('monitoringCenterPageModel account quota', () => {
           usedPercent: 40,
           resetLabel: '05/20 12:00',
         },
+        {
+          id: 'weekly-scoped-fable%205%20max',
+          label: 'Fable 5 Max',
+          usedPercent: 100,
+          resetLabel: '05/27 12:00',
+        },
       ],
       planType: 'plan_pro',
       extraUsage: {
@@ -281,6 +287,12 @@ describe('monitoringCenterPageModel account quota', () => {
           label: '5-hour limit',
           remainingPercent: 60,
           resetLabel: '05/20 12:00',
+        },
+        {
+          id: 'weekly-scoped-fable%205%20max',
+          label: 'Fable 5 Max',
+          remainingPercent: 0,
+          resetLabel: '05/27 12:00',
         },
       ],
     });

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -227,6 +227,19 @@ export interface ClaudeExtraUsage {
   utilization: number | null;
 }
 
+export interface ClaudeUsageLimit {
+  kind?: unknown;
+  group?: unknown;
+  percent?: unknown;
+  resets_at?: unknown;
+  resetsAt?: unknown;
+  reset_at?: unknown;
+  resetAt?: unknown;
+  scope?: unknown;
+  is_active?: unknown;
+  isActive?: unknown;
+}
+
 export interface ClaudeUsagePayload {
   five_hour?: ClaudeUsageWindow | null;
   seven_day?: ClaudeUsageWindow | null;
@@ -235,6 +248,7 @@ export interface ClaudeUsagePayload {
   seven_day_sonnet?: ClaudeUsageWindow | null;
   seven_day_cowork?: ClaudeUsageWindow | null;
   iguana_necktie?: ClaudeUsageWindow | null;
+  limits?: ClaudeUsageLimit[] | null;
   extra_usage?: ClaudeExtraUsage | null;
 }
 

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -278,6 +278,286 @@ describe('fetchClaudeQuota', () => {
     });
   });
 
+  it('restores base windows from a limits-only response before scoped weekly rows', async () => {
+    const sessionResetAt = '2026-07-01T10:00:00Z';
+    const weeklyResetAt = '2026-07-07T10:00:00Z';
+    const scopedResetAt = '2026-07-08T21:00:00+00:00';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              percent: '18',
+              resets_at: sessionResetAt,
+              is_active: true,
+            },
+            {
+              kind: 'weekly_all',
+              group: 'weekly',
+              percent: 125,
+              resetsAt: weeklyResetAt,
+              scope: null,
+              isActive: true,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 42,
+              reset_at: scopedResetAt,
+              scope: { model: { display_name: 'Fable 5 Max' } },
+              is_active: true,
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'five-hour',
+        label: 'claude_quota.five_hour',
+        labelKey: 'claude_quota.five_hour',
+        usedPercent: 18,
+        resetLabel: formatQuotaResetTime(sessionResetAt),
+      },
+      {
+        id: 'seven-day',
+        label: 'claude_quota.seven_day',
+        labelKey: 'claude_quota.seven_day',
+        usedPercent: 125,
+        resetLabel: formatQuotaResetTime(weeklyResetAt),
+      },
+      {
+        id: 'weekly-scoped-fable%205%20max',
+        label: 'Fable 5 Max',
+        usedPercent: 42,
+        resetLabel: formatQuotaResetTime(scopedResetAt),
+      },
+    ]);
+  });
+
+  it('fills only a missing base window and keeps top-level values authoritative', async () => {
+    const topLevelResetAt = '2026-07-01T10:00:00Z';
+    const fallbackResetAt = '2026-07-07T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 9,
+            resets_at: topLevelResetAt,
+          },
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              percent: 99,
+              resets_at: '2026-07-02T10:00:00Z',
+              scope: null,
+            },
+            {
+              kind: 'weekly',
+              group: 'weekly',
+              percent: 41,
+              resets_at: fallbackResetAt,
+            },
+            {
+              kind: 'weekly_all',
+              group: 'weekly',
+              percent: 88,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: null,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {},
+      });
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'five-hour',
+        label: 'claude_quota.five_hour',
+        labelKey: 'claude_quota.five_hour',
+        usedPercent: 9,
+        resetLabel: formatQuotaResetTime(topLevelResetAt),
+      },
+      {
+        id: 'seven-day',
+        label: 'claude_quota.seven_day',
+        labelKey: 'claude_quota.seven_day',
+        usedPercent: 41,
+        resetLabel: formatQuotaResetTime(fallbackResetAt),
+      },
+    ]);
+  });
+
+  it('uses valid limits fallbacks when top-level windows contain no displayable data', async () => {
+    const sessionResetAt = '2026-07-01T10:00:00Z';
+    const weeklyResetAt = '2026-07-07T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 'bad',
+            resets_at: 'not-a-date',
+          },
+          seven_day: {
+            utilization: null,
+            resets_at: '',
+          },
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              percent: 17,
+              resets_at: sessionResetAt,
+              scope: null,
+            },
+            {
+              kind: 'weekly_all',
+              group: 'weekly',
+              percent: 29,
+              resets_at: weeklyResetAt,
+              scope: null,
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'five-hour',
+        label: 'claude_quota.five_hour',
+        labelKey: 'claude_quota.five_hour',
+        usedPercent: 17,
+        resetLabel: formatQuotaResetTime(sessionResetAt),
+      },
+      {
+        id: 'seven-day',
+        label: 'claude_quota.seven_day',
+        labelKey: 'claude_quota.seven_day',
+        usedPercent: 29,
+        resetLabel: formatQuotaResetTime(weeklyResetAt),
+      },
+    ]);
+  });
+
+  it('skips unsafe base fallback candidates without losing valid scoped limits', async () => {
+    const scopedResetAt = '2026-07-08T21:00:00+00:00';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              percent: 10,
+              resets_at: '2026-07-01T10:00:00Z',
+              scope: { model: { display_name: 'Scoped session' } },
+            },
+            {
+              kind: 'session',
+              group: 'session',
+              percent: 20,
+              resets_at: '2026-07-01T10:00:00Z',
+              is_active: false,
+            },
+            {
+              kind: 'weekly_all',
+              group: 'weekly',
+              percent: null,
+              resets_at: 'not-a-date',
+              scope: null,
+            },
+            {
+              kind: 'monthly',
+              group: 'monthly',
+              percent: 30,
+              resets_at: '2026-08-01T10:00:00Z',
+              scope: null,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 42,
+              resets_at: scopedResetAt,
+              scope: { model: { display_name: 'Healthy scoped model' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'weekly-scoped-healthy%20scoped%20model',
+        label: 'Healthy scoped model',
+        usedPercent: 42,
+        resetLabel: formatQuotaResetTime(scopedResetAt),
+      },
+    ]);
+  });
+
   it('preserves over-limit scoped percentages for the renderer to clamp', async () => {
     mocks.request
       .mockResolvedValueOnce({
@@ -346,6 +626,13 @@ describe('fetchClaudeQuota', () => {
               group: 'weekly',
               percent: 34,
               resets_at: '2026-07-07T10:00:00Z',
+              scope: null,
+            },
+            {
+              kind: 'weekly_all',
+              group: 'weekly',
+              percent: 35,
+              resets_at: '2026-07-08T10:00:00Z',
               scope: null,
             },
             {

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -26,11 +26,14 @@ import {
   ANTIGRAVITY_AVAILABLE_MODELS_URLS,
   ANTIGRAVITY_QUOTA_SUMMARY_URLS,
   ANTIGRAVITY_USER_AGENT,
+  CLAUDE_PROFILE_URL,
+  CLAUDE_USAGE_URL,
   CODEX_RATE_LIMIT_RESET_CREDITS_URL,
   CODEX_USAGE_URL,
   XAI_BILLING_MONTHLY_URL,
   XAI_BILLING_WEEKLY_URL,
 } from './constants';
+import { formatQuotaResetTime } from './formatters';
 import {
   buildXaiBillingSummary,
   fetchXaiQuota,
@@ -197,7 +200,8 @@ describe('fetchCodexQuota', () => {
 });
 
 describe('fetchClaudeQuota', () => {
-  it('keeps usage quota data when profile lookup fails', async () => {
+  it('adds model-scoped weekly limits from the existing usage request', async () => {
+    const resetAt = '2026-07-08T21:00:00+00:00';
     mocks.request
       .mockResolvedValueOnce({
         statusCode: 200,
@@ -209,6 +213,404 @@ describe('fetchClaudeQuota', () => {
             utilization: 12,
             resets_at: '2026-07-01T10:00:00Z',
           },
+          seven_day: {
+            utilization: 34,
+            resets_at: '2026-07-07T10:00:00Z',
+          },
+          iguana_necktie: {
+            utilization: 56,
+            resets_at: '2026-07-09T10:00:00Z',
+          },
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 100,
+              resets_at: resetAt,
+              scope: {
+                model: {
+                  id: null,
+                  display_name: 'Fable 5 Max',
+                },
+              },
+              is_active: true,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {},
+      });
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    expect(mocks.request.mock.calls.map(([request]) => request.url)).toEqual([
+      CLAUDE_USAGE_URL,
+      CLAUDE_PROFILE_URL,
+    ]);
+    expect(result.windows.map((window) => window.id)).toEqual([
+      'five-hour',
+      'seven-day',
+      'weekly-scoped-fable%205%20max',
+      'iguana-necktie',
+    ]);
+    expect(result.windows[2]).toEqual({
+      id: 'weekly-scoped-fable%205%20max',
+      label: 'Fable 5 Max',
+      usedPercent: 100,
+      resetLabel: formatQuotaResetTime(resetAt),
+    });
+    expect(result.windows[3]).toMatchObject({
+      id: 'iguana-necktie',
+      labelKey: 'claude_quota.iguana_necktie',
+    });
+  });
+
+  it('preserves over-limit scoped percentages for the renderer to clamp', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 125,
+              scope: { model: { display_name: 'Over Limit' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'weekly-scoped-over%20limit',
+        label: 'Over Limit',
+        usedPercent: 125,
+        resetLabel: '-',
+      },
+    ]);
+  });
+
+  it('ignores unscoped duplicates, unrelated kinds, and malformed scoped limits', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 12,
+            resets_at: '2026-07-01T10:00:00Z',
+          },
+          seven_day: {
+            utilization: 34,
+            resets_at: '2026-07-07T10:00:00Z',
+          },
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              percent: 12,
+              resets_at: '2026-07-01T10:00:00Z',
+              scope: null,
+            },
+            {
+              kind: 'weekly',
+              group: 'weekly',
+              percent: 34,
+              resets_at: '2026-07-07T10:00:00Z',
+              scope: null,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 50,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: { display_name: '   ' } },
+            },
+            {
+              kind: 'monthly_scoped',
+              group: 'monthly',
+              percent: 50,
+              resets_at: '2026-08-01T10:00:00Z',
+              scope: { model: { display_name: 'Unrelated' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: null,
+              resets_at: 'not-a-date',
+              scope: { model: { display_name: 'Broken' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 25,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: { display_name: 123 } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 25,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: { display_name: 'Inactive' } },
+              is_active: false,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 25,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: null,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 25,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: 'invalid',
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 25,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: null },
+            },
+            null,
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows.map((window) => window.id)).toEqual(['five-hour', 'seven-day']);
+  });
+
+  it('sorts and deduplicates multiple model-scoped weekly limits', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 10,
+            resets_at: '2026-07-01T10:00:00Z',
+          },
+          seven_day: {
+            utilization: 20,
+            resets_at: '2026-07-07T10:00:00Z',
+          },
+          seven_day_oauth_apps: {
+            utilization: 30,
+            resets_at: '2026-07-07T11:00:00Z',
+          },
+          limits: [
+            {
+              kind: 'modelScoped',
+              group: 'weekly',
+              percent: 70,
+              resetsAt: '2026-07-10T10:00:00Z',
+              scope: { model: { id: 'model-z', displayName: 'Zulu' } },
+            },
+            {
+              kind: 'weekly-scoped',
+              group: 'weekly',
+              percent: 40,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: { id: 'model-a1', details: { display_name: 'Alpha' } } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 50,
+              resets_at: '2026-07-09T10:00:00Z',
+              scope: { model: { id: 'model-a2', display_name: 'Alpha' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 90,
+              resets_at: '2026-07-11T10:00:00Z',
+              scope: { model: { id: 'model-z', display_name: 'Zulu renamed' } },
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {},
+      });
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows.map((window) => [window.id, window.label, window.usedPercent])).toEqual([
+      ['five-hour', 'claude_quota.five_hour', 10],
+      ['seven-day', 'claude_quota.seven_day', 20],
+      ['weekly-scoped-id-model-a1', 'Alpha', 40],
+      ['weekly-scoped-id-model-a2', 'Alpha', 50],
+      ['weekly-scoped-id-model-z', 'Zulu', 70],
+      ['seven-day-oauth-apps', 'claude_quota.seven_day_oauth_apps', 30],
+    ]);
+  });
+
+  it('isolates malformed Unicode labels instead of failing the whole refresh', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 10,
+            resets_at: '2026-07-01T10:00:00Z',
+          },
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 25,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: { display_name: '\ud800' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 50,
+              resets_at: '2026-07-09T10:00:00Z',
+              scope: { model: { display_name: 'Healthy' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows.map((window) => window.id)).toEqual([
+      'five-hour',
+      'weekly-scoped-healthy',
+      'weekly-scoped-utf16-d800',
+    ]);
+  });
+
+  it('preserves legacy Claude window output when limits are absent', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 12,
+            resets_at: '2026-07-01T10:00:00Z',
+          },
+          seven_day: {
+            utilization: 34,
+            resets_at: '2026-07-07T10:00:00Z',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {},
+      });
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows.map((window) => window.id)).toEqual(['five-hour', 'seven-day']);
+    expect(result.windows.every((window) => window.labelKey)).toBe(true);
+  });
+
+  it('keeps usage quota data when profile lookup fails', async () => {
+    const scopedResetAt = '2026-07-08T21:00:00+00:00';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          five_hour: {
+            utilization: 12,
+            resets_at: '2026-07-01T10:00:00Z',
+          },
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 100,
+              resets_at: scopedResetAt,
+              scope: { model: { display_name: 'Fable 5 Max' } },
+            },
+          ],
         },
       })
       .mockRejectedValueOnce(new Error('profile unavailable'));
@@ -223,10 +625,16 @@ describe('fetchClaudeQuota', () => {
     );
 
     expect(result.planType).toBeNull();
-    expect(result.windows).toHaveLength(1);
+    expect(result.windows).toHaveLength(2);
     expect(result.windows[0]).toMatchObject({
       id: 'five-hour',
       usedPercent: 12,
+    });
+    expect(result.windows[1]).toEqual({
+      id: 'weekly-scoped-fable%205%20max',
+      label: 'Fable 5 Max',
+      usedPercent: 100,
+      resetLabel: formatQuotaResetTime(scopedResetAt),
     });
   });
 });

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -683,6 +683,99 @@ describe('fetchClaudeQuota', () => {
     ]);
   });
 
+  it('prefers fresher quota values for same-rank scoped duplicates', async () => {
+    const percentResetAt = '2026-07-09T10:00:00Z';
+    const newerResetAt = '2026-07-10T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 10,
+              resets_at: '2026-07-08T10:00:00Z',
+              scope: { model: { id: 'model-percent', display_name: 'Old percent' } },
+              is_active: false,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 80,
+              resets_at: percentResetAt,
+              scope: { model: { id: 'model-percent', display_name: 'Fresh percent' } },
+              is_active: false,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 50,
+              resets_at: '2026-07-08T12:00:00Z',
+              scope: { model: { id: 'model-reset', display_name: 'Old reset' } },
+              is_active: true,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 50,
+              resets_at: newerResetAt,
+              scope: { model: { id: 'model-reset', display_name: 'Fresh reset' } },
+              is_active: true,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 90,
+              resets_at: '2026-07-08T14:00:00Z',
+              scope: { model: { id: 'model-conservative', display_name: 'Higher usage' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 20,
+              resets_at: '2026-07-11T14:00:00Z',
+              scope: { model: { id: 'model-conservative', display_name: 'Later reset' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'weekly-scoped-id-model-percent',
+        label: 'Fresh percent',
+        usedPercent: 80,
+        resetLabel: formatQuotaResetTime(percentResetAt),
+      },
+      {
+        id: 'weekly-scoped-id-model-reset',
+        label: 'Fresh reset',
+        usedPercent: 50,
+        resetLabel: formatQuotaResetTime(newerResetAt),
+      },
+      {
+        id: 'weekly-scoped-id-model-conservative',
+        label: 'Higher usage',
+        usedPercent: 90,
+        resetLabel: formatQuotaResetTime('2026-07-08T14:00:00Z'),
+      },
+    ]);
+  });
+
   it('ignores unscoped duplicates, unrelated kinds, and malformed scoped limits', async () => {
     mocks.request
       .mockResolvedValueOnce({
@@ -870,7 +963,7 @@ describe('fetchClaudeQuota', () => {
       ['seven-day', 'claude_quota.seven_day', 20],
       ['weekly-scoped-id-model-a1', 'Alpha', 40],
       ['weekly-scoped-id-model-a2', 'Alpha', 50],
-      ['weekly-scoped-id-model-z', 'Zulu', 70],
+      ['weekly-scoped-id-model-z', 'Zulu renamed', 90],
       ['seven-day-oauth-apps', 'claude_quota.seven_day_oauth_apps', 30],
     ]);
   });

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -597,6 +597,92 @@ describe('fetchClaudeQuota', () => {
     ]);
   });
 
+  it('keeps inactive scoped weekly limits visible and prefers an active duplicate', async () => {
+    const dormantResetAt = '2026-07-08T10:00:00Z';
+    const activeResetAt = '2026-07-10T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 35,
+              resets_at: dormantResetAt,
+              scope: { model: { id: 'model-dormant', display_name: 'Dormant model' } },
+              is_active: false,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 10,
+              resets_at: '2026-07-09T10:00:00Z',
+              scope: { model: { id: 'model-shared', display_name: 'Shared inactive' } },
+              is_active: false,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 80,
+              resets_at: activeResetAt,
+              scope: { model: { id: 'model-shared', display_name: 'Shared active' } },
+              is_active: true,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 15,
+              resets_at: '2026-07-09T12:00:00Z',
+              scope: { model: { id: 'model-unknown', display_name: 'Unknown inactive' } },
+              is_active: false,
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 55,
+              resets_at: '2026-07-10T12:00:00Z',
+              scope: { model: { id: 'model-unknown', display_name: 'Unknown preferred' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      {
+        name: 'claude.json',
+        type: 'claude',
+        authIndex: 'claude-1',
+      },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'weekly-scoped-id-model-dormant',
+        label: 'Dormant model',
+        usedPercent: 35,
+        resetLabel: formatQuotaResetTime(dormantResetAt),
+      },
+      {
+        id: 'weekly-scoped-id-model-shared',
+        label: 'Shared active',
+        usedPercent: 80,
+        resetLabel: formatQuotaResetTime(activeResetAt),
+      },
+      {
+        id: 'weekly-scoped-id-model-unknown',
+        label: 'Unknown preferred',
+        usedPercent: 55,
+        resetLabel: formatQuotaResetTime('2026-07-10T12:00:00Z'),
+      },
+    ]);
+  });
+
   it('ignores unscoped duplicates, unrelated kinds, and malformed scoped limits', async () => {
     mocks.request
       .mockResolvedValueOnce({
@@ -666,8 +752,8 @@ describe('fetchClaudeQuota', () => {
             {
               kind: 'weekly_scoped',
               group: 'weekly',
-              percent: 25,
-              resets_at: '2026-07-08T10:00:00Z',
+              percent: null,
+              resets_at: 'not-a-date',
               scope: { model: { display_name: 'Inactive' } },
               is_active: false,
             },

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -418,8 +418,8 @@ describe('fetchClaudeQuota', () => {
         id: 'seven-day',
         label: 'claude_quota.seven_day',
         labelKey: 'claude_quota.seven_day',
-        usedPercent: 41,
-        resetLabel: formatQuotaResetTime(fallbackResetAt),
+        usedPercent: 88,
+        resetLabel: formatQuotaResetTime('2026-07-08T10:00:00Z'),
       },
     ]);
   });
@@ -484,6 +484,173 @@ describe('fetchClaudeQuota', () => {
         label: 'claude_quota.seven_day',
         labelKey: 'claude_quota.seven_day',
         usedPercent: 29,
+        resetLabel: formatQuotaResetTime(weeklyResetAt),
+      },
+    ]);
+  });
+
+  it('selects complete current base candidates and prefers weekly_all independent of order', async () => {
+    const sessionResetAt = '2026-07-02T10:00:00Z';
+    const weeklyResetAt = '2026-07-08T10:00:00Z';
+    const createUsageBody = (weeklyLimits: Array<Record<string, unknown>>) => ({
+      limits: [
+        {
+          kind: 'session',
+          group: 'session',
+          percent: null,
+          resets_at: sessionResetAt,
+          scope: null,
+          is_active: true,
+        },
+        {
+          kind: 'session',
+          group: 'session',
+          percent: 90,
+          resets_at: '2026-07-01T12:00:00Z',
+          scope: null,
+          is_active: true,
+        },
+        {
+          kind: 'session',
+          group: 'session',
+          percent: 20,
+          resets_at: sessionResetAt,
+          scope: null,
+          is_active: true,
+        },
+        ...weeklyLimits,
+      ],
+    });
+    const weekly = {
+      kind: 'weekly',
+      group: 'weekly',
+      percent: 30,
+      resets_at: weeklyResetAt,
+      scope: null,
+      is_active: true,
+    };
+    const weeklyAll = {
+      kind: 'weekly_all',
+      group: 'weekly',
+      percent: 40,
+      resets_at: weeklyResetAt,
+      scope: null,
+      is_active: true,
+    };
+
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: createUsageBody([weekly, weeklyAll]),
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'))
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: createUsageBody([weeklyAll, weekly]),
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const first = await fetchClaudeQuota(
+      { name: 'claude-a.json', type: 'claude', authIndex: 'claude-a' },
+      t
+    );
+    const reversed = await fetchClaudeQuota(
+      { name: 'claude-b.json', type: 'claude', authIndex: 'claude-b' },
+      t
+    );
+
+    const expectedWindows = [
+      {
+        id: 'five-hour',
+        label: 'claude_quota.five_hour',
+        labelKey: 'claude_quota.five_hour',
+        usedPercent: 20,
+        resetLabel: formatQuotaResetTime(sessionResetAt),
+      },
+      {
+        id: 'seven-day',
+        label: 'claude_quota.seven_day',
+        labelKey: 'claude_quota.seven_day',
+        usedPercent: 40,
+        resetLabel: formatQuotaResetTime(weeklyResetAt),
+      },
+    ];
+    expect(first.windows).toEqual(expectedWindows);
+    expect(reversed.windows).toEqual(expectedWindows);
+  });
+
+  it('orders base candidates by freshness, completeness, then kind precedence', async () => {
+    const currentSessionResetAt = '2026-07-02T10:00:00Z';
+    const weeklyResetAt = '2026-07-08T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'session',
+              group: 'session',
+              percent: 90,
+              resets_at: '2026-07-01T10:00:00Z',
+              scope: null,
+              is_active: true,
+            },
+            {
+              kind: 'session',
+              group: 'session',
+              percent: null,
+              resets_at: currentSessionResetAt,
+              scope: null,
+              is_active: true,
+            },
+            {
+              kind: 'weekly_all',
+              group: 'weekly',
+              percent: null,
+              resets_at: weeklyResetAt,
+              scope: null,
+              is_active: true,
+            },
+            {
+              kind: 'weekly',
+              group: 'weekly',
+              percent: 30,
+              resets_at: weeklyResetAt,
+              scope: null,
+              is_active: true,
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      { name: 'claude.json', type: 'claude', authIndex: 'claude-1' },
+      t
+    );
+
+    expect(result.windows).toEqual([
+      {
+        id: 'five-hour',
+        label: 'claude_quota.five_hour',
+        labelKey: 'claude_quota.five_hour',
+        usedPercent: null,
+        resetLabel: formatQuotaResetTime(currentSessionResetAt),
+      },
+      {
+        id: 'seven-day',
+        label: 'claude_quota.seven_day',
+        labelKey: 'claude_quota.seven_day',
+        usedPercent: 30,
         resetLabel: formatQuotaResetTime(weeklyResetAt),
       },
     ]);
@@ -619,15 +786,15 @@ describe('fetchClaudeQuota', () => {
             {
               kind: 'weekly_scoped',
               group: 'weekly',
-              percent: 10,
-              resets_at: '2026-07-09T10:00:00Z',
+              percent: 95,
+              resets_at: activeResetAt,
               scope: { model: { id: 'model-shared', display_name: 'Shared inactive' } },
               is_active: false,
             },
             {
               kind: 'weekly_scoped',
               group: 'weekly',
-              percent: 80,
+              percent: 20,
               resets_at: activeResetAt,
               scope: { model: { id: 'model-shared', display_name: 'Shared active' } },
               is_active: true,
@@ -635,15 +802,15 @@ describe('fetchClaudeQuota', () => {
             {
               kind: 'weekly_scoped',
               group: 'weekly',
-              percent: 15,
-              resets_at: '2026-07-09T12:00:00Z',
+              percent: 95,
+              resets_at: '2026-07-10T12:00:00Z',
               scope: { model: { id: 'model-unknown', display_name: 'Unknown inactive' } },
               is_active: false,
             },
             {
               kind: 'weekly_scoped',
               group: 'weekly',
-              percent: 55,
+              percent: 20,
               resets_at: '2026-07-10T12:00:00Z',
               scope: { model: { id: 'model-unknown', display_name: 'Unknown preferred' } },
             },
@@ -671,19 +838,19 @@ describe('fetchClaudeQuota', () => {
       {
         id: 'weekly-scoped-id-model-shared',
         label: 'Shared active',
-        usedPercent: 80,
+        usedPercent: 20,
         resetLabel: formatQuotaResetTime(activeResetAt),
       },
       {
         id: 'weekly-scoped-id-model-unknown',
         label: 'Unknown preferred',
-        usedPercent: 55,
+        usedPercent: 20,
         resetLabel: formatQuotaResetTime('2026-07-10T12:00:00Z'),
       },
     ]);
   });
 
-  it('prefers fresher quota values for same-rank scoped duplicates', async () => {
+  it('prefers the current reset period before activity and usage for scoped duplicates', async () => {
     const percentResetAt = '2026-07-09T10:00:00Z';
     const newerResetAt = '2026-07-10T10:00:00Z';
     mocks.request
@@ -698,7 +865,7 @@ describe('fetchClaudeQuota', () => {
               kind: 'weekly_scoped',
               group: 'weekly',
               percent: 10,
-              resets_at: '2026-07-08T10:00:00Z',
+              resets_at: percentResetAt,
               scope: { model: { id: 'model-percent', display_name: 'Old percent' } },
               is_active: false,
             },
@@ -732,6 +899,7 @@ describe('fetchClaudeQuota', () => {
               percent: 90,
               resets_at: '2026-07-08T14:00:00Z',
               scope: { model: { id: 'model-conservative', display_name: 'Higher usage' } },
+              is_active: true,
             },
             {
               kind: 'weekly_scoped',
@@ -739,6 +907,7 @@ describe('fetchClaudeQuota', () => {
               percent: 20,
               resets_at: '2026-07-11T14:00:00Z',
               scope: { model: { id: 'model-conservative', display_name: 'Later reset' } },
+              is_active: false,
             },
           ],
         },
@@ -769,9 +938,9 @@ describe('fetchClaudeQuota', () => {
       },
       {
         id: 'weekly-scoped-id-model-conservative',
-        label: 'Higher usage',
-        usedPercent: 90,
-        resetLabel: formatQuotaResetTime('2026-07-08T14:00:00Z'),
+        label: 'Later reset',
+        usedPercent: 20,
+        resetLabel: formatQuotaResetTime('2026-07-11T14:00:00Z'),
       },
     ]);
   });
@@ -965,6 +1134,112 @@ describe('fetchClaudeQuota', () => {
       ['weekly-scoped-id-model-a2', 'Alpha', 50],
       ['weekly-scoped-id-model-z', 'Zulu renamed', 90],
       ['seven-day-oauth-apps', 'claude_quota.seven_day_oauth_apps', 30],
+    ]);
+  });
+
+  it('deduplicates the same scoped model with and without an id in both orders', async () => {
+    const resetAt = '2026-07-10T10:00:00Z';
+    const withId = {
+      kind: 'weekly_scoped',
+      group: 'weekly',
+      percent: 40,
+      resets_at: resetAt,
+      scope: { model: { id: 'model-shared', display_name: 'Shared Model' } },
+      is_active: true,
+    };
+    const withoutId = {
+      kind: 'weekly_scoped',
+      group: 'weekly',
+      percent: 20,
+      resets_at: '2026-07-09T10:00:00Z',
+      scope: { model: { id: null, display_name: 'Shared Model' } },
+      is_active: true,
+    };
+
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: { limits: [withoutId, withId] },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'))
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: { limits: [withId, withoutId] },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const withoutIdFirst = await fetchClaudeQuota(
+      { name: 'claude-a.json', type: 'claude', authIndex: 'claude-a' },
+      t
+    );
+    const withIdFirst = await fetchClaudeQuota(
+      { name: 'claude-b.json', type: 'claude', authIndex: 'claude-b' },
+      t
+    );
+
+    const expectedWindows = [
+      {
+        id: 'weekly-scoped-id-model-shared',
+        label: 'Shared Model',
+        usedPercent: 40,
+        resetLabel: formatQuotaResetTime(resetAt),
+      },
+    ];
+    expect(withoutIdFirst.windows).toEqual(expectedWindows);
+    expect(withIdFirst.windows).toEqual(expectedWindows);
+  });
+
+  it('keeps a label-only scoped entry separate when the label maps to multiple ids', async () => {
+    const resetAt = '2026-07-10T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 40,
+              resets_at: resetAt,
+              scope: { model: { id: 'model-a', display_name: 'Shared Model' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 50,
+              resets_at: resetAt,
+              scope: { model: { id: 'model-b', display_name: 'Shared Model' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 60,
+              resets_at: '2026-07-11T10:00:00Z',
+              scope: { model: { id: null, display_name: 'Shared Model' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      { name: 'claude.json', type: 'claude', authIndex: 'claude-1' },
+      t
+    );
+
+    expect(result.windows.map((window) => [window.id, window.usedPercent])).toEqual([
+      ['weekly-scoped-id-model-a', 40],
+      ['weekly-scoped-id-model-b', 50],
+      ['weekly-scoped-shared%20model', 60],
     ]);
   });
 

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -21,6 +21,7 @@ import type {
   XaiProductUsageSummary,
 } from '@/types';
 import { apiCallApi, getApiCallErrorMessage } from '@/services/api/apiCall';
+import { isRecord } from '@/utils/helpers';
 import {
   antigravitySubscriptionApi,
   type AntigravitySubscriptionSummary,
@@ -456,25 +457,154 @@ const resolveClaudePlanType = (profile: ClaudeProfileResponse | null): string | 
   return null;
 };
 
+const normalizeClaudeLimitToken = (value: unknown): string | null => {
+  const normalized = normalizeStringValue(value);
+  if (!normalized) return null;
+  return normalized
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+};
+
+const isClaudeWeeklyScopedLimit = (limit: Record<string, unknown>): boolean => {
+  const kind = normalizeClaudeLimitToken(limit.kind);
+  const group = normalizeClaudeLimitToken(limit.group);
+  if (group && group !== 'weekly') return false;
+  if (kind === 'weekly_scoped' || kind === 'weekly_model_scoped') return true;
+  return kind === 'model_scoped' && group === 'weekly';
+};
+
+const findClaudeModelDisplayName = (value: unknown, depth = 0): string | null => {
+  if (!isRecord(value)) return null;
+
+  const rawDisplayName = value.display_name ?? value.displayName;
+  if (typeof rawDisplayName === 'string') {
+    const direct = rawDisplayName.trim().replace(/\s+/g, ' ');
+    if (direct) return direct;
+  }
+  if (depth >= 1) return null;
+
+  for (const nested of Object.values(value)) {
+    const label = findClaudeModelDisplayName(nested, depth + 1);
+    if (label) return label;
+  }
+  return null;
+};
+
+const normalizeClaudeIdentityText = (value: string): string => {
+  try {
+    return value.normalize('NFKC');
+  } catch {
+    return value;
+  }
+};
+
+const encodeClaudeWindowIdPart = (value: string): string => {
+  try {
+    return encodeURIComponent(value);
+  } catch {
+    const codeUnits = Array.from({ length: value.length }, (_, index) =>
+      value.charCodeAt(index).toString(16).padStart(4, '0')
+    );
+    return `utf16-${codeUnits.join('-')}`;
+  }
+};
+
+type ClaudeScopedWeeklyWindowEntry = {
+  identityKey: string;
+  sortLabel: string;
+  window: ClaudeQuotaWindow;
+};
+
+const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuotaWindow[] => {
+  if (!Array.isArray(payload.limits)) return [];
+
+  const windowsByModel = new Map<string, ClaudeScopedWeeklyWindowEntry>();
+  for (const rawLimit of payload.limits) {
+    try {
+      if (!isRecord(rawLimit) || !isClaudeWeeklyScopedLimit(rawLimit)) continue;
+      if (normalizeFlagValue(rawLimit.is_active ?? rawLimit.isActive) === false) continue;
+
+      const scope = isRecord(rawLimit.scope) ? rawLimit.scope : null;
+      const model = isRecord(scope?.model) ? scope.model : null;
+      if (!model) continue;
+      const label = findClaudeModelDisplayName(model);
+      if (!label) continue;
+
+      const rawPercent = normalizeNumberValue(rawLimit.percent);
+      const usedPercent = rawPercent !== null && rawPercent >= 0 ? rawPercent : null;
+      const rawResetAt =
+        rawLimit.resets_at ?? rawLimit.resetsAt ?? rawLimit.reset_at ?? rawLimit.resetAt;
+      const resetAt = typeof rawResetAt === 'string' ? rawResetAt.trim() : '';
+      const resetLabel = formatQuotaResetTime(resetAt || undefined);
+      if (usedPercent === null && resetLabel === '-') continue;
+
+      const rawModelId = model.id ?? model.model_id ?? model.modelId;
+      const modelId =
+        typeof rawModelId === 'string' && rawModelId.trim()
+          ? normalizeClaudeIdentityText(rawModelId.trim())
+          : null;
+      const labelKey = normalizeClaudeIdentityText(label).toLowerCase();
+      const identityKey = modelId ? `id:${modelId}` : `label:${labelKey}`;
+      if (windowsByModel.has(identityKey)) continue;
+
+      const idPart = modelId
+        ? `id-${encodeClaudeWindowIdPart(modelId)}`
+        : encodeClaudeWindowIdPart(labelKey);
+      windowsByModel.set(identityKey, {
+        identityKey,
+        sortLabel: labelKey,
+        window: {
+          id: `weekly-scoped-${idPart}`,
+          label,
+          usedPercent,
+          resetLabel,
+        },
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return [...windowsByModel.values()]
+    .sort((left, right) => {
+      if (left.sortLabel !== right.sortLabel) {
+        return left.sortLabel < right.sortLabel ? -1 : 1;
+      }
+      return left.identityKey < right.identityKey
+        ? -1
+        : left.identityKey > right.identityKey
+          ? 1
+          : 0;
+    })
+    .map(({ window }) => window);
+};
+
 const buildClaudeQuotaWindows = (
   payload: ClaudeUsagePayload,
   t: TFunction
 ): ClaudeQuotaWindow[] => {
   const windows: ClaudeQuotaWindow[] = [];
+  const scopedWeeklyWindows = buildClaudeScopedWeeklyWindows(payload);
 
   for (const { key, id, labelKey } of CLAUDE_USAGE_WINDOW_KEYS) {
     const window = payload[key as keyof ClaudeUsagePayload];
-    if (!window || typeof window !== 'object' || !('utilization' in window)) continue;
-    const typedWindow = window as { utilization: number; resets_at: string };
-    const usedPercent = normalizeNumberValue(typedWindow.utilization);
-    const resetLabel = formatQuotaResetTime(typedWindow.resets_at);
-    windows.push({
-      id,
-      label: t(labelKey),
-      labelKey,
-      usedPercent,
-      resetLabel,
-    });
+    if (window && typeof window === 'object' && 'utilization' in window) {
+      const typedWindow = window as { utilization: number; resets_at: string };
+      const usedPercent = normalizeNumberValue(typedWindow.utilization);
+      const resetLabel = formatQuotaResetTime(typedWindow.resets_at);
+      windows.push({
+        id,
+        label: t(labelKey),
+        labelKey,
+        usedPercent,
+        resetLabel,
+      });
+    }
+    if (key === 'seven_day') {
+      windows.push(...scopedWeeklyWindows);
+    }
   }
 
   return windows;

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -475,6 +475,38 @@ const isClaudeWeeklyScopedLimit = (limit: Record<string, unknown>): boolean => {
   return kind === 'model_scoped' && group === 'weekly';
 };
 
+type ClaudeBaseLimitWindowId = 'five-hour' | 'seven-day';
+
+const resolveClaudeBaseLimitWindowId = (
+  limit: Record<string, unknown>
+): ClaudeBaseLimitWindowId | null => {
+  const kind = normalizeClaudeLimitToken(limit.kind);
+  const group = normalizeClaudeLimitToken(limit.group);
+
+  if (kind === 'session' && (!group || group === 'session')) return 'five-hour';
+  if (
+    (kind === 'weekly' || kind === 'weekly_all') &&
+    (!group || group === 'weekly' || group === 'weekly_all')
+  ) {
+    return 'seven-day';
+  }
+  return null;
+};
+
+type ClaudeLimitWindowValues = Pick<ClaudeQuotaWindow, 'usedPercent' | 'resetLabel'>;
+
+const parseClaudeLimitWindowValues = (
+  limit: Record<string, unknown>
+): ClaudeLimitWindowValues | null => {
+  const rawPercent = normalizeNumberValue(limit.percent);
+  const usedPercent = rawPercent !== null && rawPercent >= 0 ? rawPercent : null;
+  const rawResetAt = limit.resets_at ?? limit.resetsAt ?? limit.reset_at ?? limit.resetAt;
+  const resetAt = typeof rawResetAt === 'string' ? rawResetAt.trim() : '';
+  const resetLabel = formatQuotaResetTime(resetAt || undefined);
+  if (usedPercent === null && resetLabel === '-') return null;
+  return { usedPercent, resetLabel };
+};
+
 const findClaudeModelDisplayName = (value: unknown, depth = 0): string | null => {
   if (!isRecord(value)) return null;
 
@@ -517,6 +549,31 @@ type ClaudeScopedWeeklyWindowEntry = {
   window: ClaudeQuotaWindow;
 };
 
+const buildClaudeBaseLimitFallbacks = (
+  payload: ClaudeUsagePayload
+): Map<ClaudeBaseLimitWindowId, ClaudeLimitWindowValues> => {
+  const fallbacks = new Map<ClaudeBaseLimitWindowId, ClaudeLimitWindowValues>();
+  if (!Array.isArray(payload.limits)) return fallbacks;
+
+  for (const rawLimit of payload.limits) {
+    try {
+      if (!isRecord(rawLimit)) continue;
+      if (normalizeFlagValue(rawLimit.is_active ?? rawLimit.isActive) === false) continue;
+      if (rawLimit.scope !== undefined && rawLimit.scope !== null) continue;
+
+      const windowId = resolveClaudeBaseLimitWindowId(rawLimit);
+      if (!windowId || fallbacks.has(windowId)) continue;
+      const values = parseClaudeLimitWindowValues(rawLimit);
+      if (!values) continue;
+      fallbacks.set(windowId, values);
+    } catch {
+      continue;
+    }
+  }
+
+  return fallbacks;
+};
+
 const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuotaWindow[] => {
   if (!Array.isArray(payload.limits)) return [];
 
@@ -532,13 +589,8 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
       const label = findClaudeModelDisplayName(model);
       if (!label) continue;
 
-      const rawPercent = normalizeNumberValue(rawLimit.percent);
-      const usedPercent = rawPercent !== null && rawPercent >= 0 ? rawPercent : null;
-      const rawResetAt =
-        rawLimit.resets_at ?? rawLimit.resetsAt ?? rawLimit.reset_at ?? rawLimit.resetAt;
-      const resetAt = typeof rawResetAt === 'string' ? rawResetAt.trim() : '';
-      const resetLabel = formatQuotaResetTime(resetAt || undefined);
-      if (usedPercent === null && resetLabel === '-') continue;
+      const values = parseClaudeLimitWindowValues(rawLimit);
+      if (!values) continue;
 
       const rawModelId = model.id ?? model.model_id ?? model.modelId;
       const modelId =
@@ -558,8 +610,7 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
         window: {
           id: `weekly-scoped-${idPart}`,
           label,
-          usedPercent,
-          resetLabel,
+          ...values,
         },
       });
     } catch {
@@ -586,21 +637,37 @@ const buildClaudeQuotaWindows = (
   t: TFunction
 ): ClaudeQuotaWindow[] => {
   const windows: ClaudeQuotaWindow[] = [];
+  const baseLimitFallbacks = buildClaudeBaseLimitFallbacks(payload);
   const scopedWeeklyWindows = buildClaudeScopedWeeklyWindows(payload);
 
   for (const { key, id, labelKey } of CLAUDE_USAGE_WINDOW_KEYS) {
     const window = payload[key as keyof ClaudeUsagePayload];
+    let renderedTopLevelWindow = false;
     if (window && typeof window === 'object' && 'utilization' in window) {
       const typedWindow = window as { utilization: number; resets_at: string };
       const usedPercent = normalizeNumberValue(typedWindow.utilization);
       const resetLabel = formatQuotaResetTime(typedWindow.resets_at);
-      windows.push({
-        id,
-        label: t(labelKey),
-        labelKey,
-        usedPercent,
-        resetLabel,
-      });
+      if (usedPercent !== null || resetLabel !== '-') {
+        windows.push({
+          id,
+          label: t(labelKey),
+          labelKey,
+          usedPercent,
+          resetLabel,
+        });
+        renderedTopLevelWindow = true;
+      }
+    }
+    if (!renderedTopLevelWindow && (id === 'five-hour' || id === 'seven-day')) {
+      const fallback = baseLimitFallbacks.get(id);
+      if (fallback) {
+        windows.push({
+          id,
+          label: t(labelKey),
+          labelKey,
+          ...fallback,
+        });
+      }
     }
     if (key === 'seven_day') {
       windows.push(...scopedWeeklyWindows);

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -495,13 +495,17 @@ const resolveClaudeBaseLimitWindowId = (
 
 type ClaudeLimitWindowValues = Pick<ClaudeQuotaWindow, 'usedPercent' | 'resetLabel'>;
 
+const resolveClaudeLimitResetAt = (limit: Record<string, unknown>): string => {
+  const rawResetAt = limit.resets_at ?? limit.resetsAt ?? limit.reset_at ?? limit.resetAt;
+  return typeof rawResetAt === 'string' ? rawResetAt.trim() : '';
+};
+
 const parseClaudeLimitWindowValues = (
   limit: Record<string, unknown>
 ): ClaudeLimitWindowValues | null => {
   const rawPercent = normalizeNumberValue(limit.percent);
   const usedPercent = rawPercent !== null && rawPercent >= 0 ? rawPercent : null;
-  const rawResetAt = limit.resets_at ?? limit.resetsAt ?? limit.reset_at ?? limit.resetAt;
-  const resetAt = typeof rawResetAt === 'string' ? rawResetAt.trim() : '';
+  const resetAt = resolveClaudeLimitResetAt(limit);
   const resetLabel = formatQuotaResetTime(resetAt || undefined);
   if (usedPercent === null && resetLabel === '-') return null;
   return { usedPercent, resetLabel };
@@ -546,8 +550,23 @@ const encodeClaudeWindowIdPart = (value: string): string => {
 type ClaudeScopedWeeklyWindowEntry = {
   activityRank: number;
   identityKey: string;
+  resetAtRank: number;
   sortLabel: string;
+  usedPercentRank: number;
   window: ClaudeQuotaWindow;
+};
+
+const shouldReplaceClaudeScopedWindow = (
+  existing: ClaudeScopedWeeklyWindowEntry,
+  candidate: ClaudeScopedWeeklyWindowEntry
+): boolean => {
+  if (candidate.activityRank !== existing.activityRank) {
+    return candidate.activityRank > existing.activityRank;
+  }
+  if (candidate.usedPercentRank !== existing.usedPercentRank) {
+    return candidate.usedPercentRank > existing.usedPercentRank;
+  }
+  return candidate.resetAtRank > existing.resetAtRank;
 };
 
 const buildClaudeBaseLimitFallbacks = (
@@ -601,22 +620,26 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
       const identityKey = modelId ? `id:${modelId}` : `label:${labelKey}`;
       const activeFlag = normalizeFlagValue(rawLimit.is_active ?? rawLimit.isActive);
       const activityRank = activeFlag === true ? 2 : activeFlag === undefined ? 1 : 0;
-      const existing = windowsByModel.get(identityKey);
-      if (existing && existing.activityRank >= activityRank) continue;
+      const resetTimestamp = Date.parse(resolveClaudeLimitResetAt(rawLimit));
 
       const idPart = modelId
         ? `id-${encodeClaudeWindowIdPart(modelId)}`
         : encodeClaudeWindowIdPart(labelKey);
-      windowsByModel.set(identityKey, {
+      const candidate: ClaudeScopedWeeklyWindowEntry = {
         activityRank,
         identityKey,
+        resetAtRank: Number.isFinite(resetTimestamp) ? resetTimestamp : -1,
         sortLabel: labelKey,
+        usedPercentRank: values.usedPercent ?? -1,
         window: {
           id: `weekly-scoped-${idPart}`,
           label,
           ...values,
         },
-      });
+      };
+      const existing = windowsByModel.get(identityKey);
+      if (existing && !shouldReplaceClaudeScopedWindow(existing, candidate)) continue;
+      windowsByModel.set(identityKey, candidate);
     } catch {
       continue;
     }

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -544,6 +544,7 @@ const encodeClaudeWindowIdPart = (value: string): string => {
 };
 
 type ClaudeScopedWeeklyWindowEntry = {
+  activityRank: number;
   identityKey: string;
   sortLabel: string;
   window: ClaudeQuotaWindow;
@@ -581,7 +582,6 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
   for (const rawLimit of payload.limits) {
     try {
       if (!isRecord(rawLimit) || !isClaudeWeeklyScopedLimit(rawLimit)) continue;
-      if (normalizeFlagValue(rawLimit.is_active ?? rawLimit.isActive) === false) continue;
 
       const scope = isRecord(rawLimit.scope) ? rawLimit.scope : null;
       const model = isRecord(scope?.model) ? scope.model : null;
@@ -599,12 +599,16 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
           : null;
       const labelKey = normalizeClaudeIdentityText(label).toLowerCase();
       const identityKey = modelId ? `id:${modelId}` : `label:${labelKey}`;
-      if (windowsByModel.has(identityKey)) continue;
+      const activeFlag = normalizeFlagValue(rawLimit.is_active ?? rawLimit.isActive);
+      const activityRank = activeFlag === true ? 2 : activeFlag === undefined ? 1 : 0;
+      const existing = windowsByModel.get(identityKey);
+      if (existing && existing.activityRank >= activityRank) continue;
 
       const idPart = modelId
         ? `id-${encodeClaudeWindowIdPart(modelId)}`
         : encodeClaudeWindowIdPart(labelKey);
       windowsByModel.set(identityKey, {
+        activityRank,
         identityKey,
         sortLabel: labelKey,
         window: {

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -500,6 +500,11 @@ const resolveClaudeLimitResetAt = (limit: Record<string, unknown>): string => {
   return typeof rawResetAt === 'string' ? rawResetAt.trim() : '';
 };
 
+const resolveClaudeLimitResetRank = (limit: Record<string, unknown>): number => {
+  const resetTimestamp = Date.parse(resolveClaudeLimitResetAt(limit));
+  return Number.isFinite(resetTimestamp) ? resetTimestamp : -1;
+};
+
 const parseClaudeLimitWindowValues = (
   limit: Record<string, unknown>
 ): ClaudeLimitWindowValues | null => {
@@ -560,20 +565,44 @@ const shouldReplaceClaudeScopedWindow = (
   existing: ClaudeScopedWeeklyWindowEntry,
   candidate: ClaudeScopedWeeklyWindowEntry
 ): boolean => {
+  if (candidate.resetAtRank !== existing.resetAtRank) {
+    return candidate.resetAtRank > existing.resetAtRank;
+  }
   if (candidate.activityRank !== existing.activityRank) {
     return candidate.activityRank > existing.activityRank;
   }
-  if (candidate.usedPercentRank !== existing.usedPercentRank) {
-    return candidate.usedPercentRank > existing.usedPercentRank;
+  return candidate.usedPercentRank > existing.usedPercentRank;
+};
+
+type ClaudeBaseLimitCandidate = {
+  completenessRank: number;
+  kindRank: number;
+  resetAtRank: number;
+  usedPercentRank: number;
+  values: ClaudeLimitWindowValues;
+};
+
+const shouldReplaceClaudeBaseLimit = (
+  existing: ClaudeBaseLimitCandidate,
+  candidate: ClaudeBaseLimitCandidate
+): boolean => {
+  if (candidate.resetAtRank !== existing.resetAtRank) {
+    return candidate.resetAtRank > existing.resetAtRank;
   }
-  return candidate.resetAtRank > existing.resetAtRank;
+  if (candidate.completenessRank !== existing.completenessRank) {
+    return candidate.completenessRank > existing.completenessRank;
+  }
+  if (candidate.kindRank !== existing.kindRank) {
+    return candidate.kindRank > existing.kindRank;
+  }
+  return candidate.usedPercentRank > existing.usedPercentRank;
 };
 
 const buildClaudeBaseLimitFallbacks = (
   payload: ClaudeUsagePayload
 ): Map<ClaudeBaseLimitWindowId, ClaudeLimitWindowValues> => {
-  const fallbacks = new Map<ClaudeBaseLimitWindowId, ClaudeLimitWindowValues>();
-  if (!Array.isArray(payload.limits)) return fallbacks;
+  const candidates = new Map<ClaudeBaseLimitWindowId, ClaudeBaseLimitCandidate>();
+  if (!Array.isArray(payload.limits)) return new Map();
 
   for (const rawLimit of payload.limits) {
     try {
@@ -582,22 +611,37 @@ const buildClaudeBaseLimitFallbacks = (
       if (rawLimit.scope !== undefined && rawLimit.scope !== null) continue;
 
       const windowId = resolveClaudeBaseLimitWindowId(rawLimit);
-      if (!windowId || fallbacks.has(windowId)) continue;
+      if (!windowId) continue;
       const values = parseClaudeLimitWindowValues(rawLimit);
       if (!values) continue;
-      fallbacks.set(windowId, values);
+      const kind = normalizeClaudeLimitToken(rawLimit.kind);
+      const candidate: ClaudeBaseLimitCandidate = {
+        completenessRank:
+          (values.usedPercent !== null ? 1 : 0) + (values.resetLabel !== '-' ? 1 : 0),
+        kindRank: windowId === 'seven-day' && kind === 'weekly_all' ? 1 : 0,
+        resetAtRank: resolveClaudeLimitResetRank(rawLimit),
+        usedPercentRank: values.usedPercent ?? -1,
+        values,
+      };
+      const existing = candidates.get(windowId);
+      if (existing && !shouldReplaceClaudeBaseLimit(existing, candidate)) continue;
+      candidates.set(windowId, candidate);
     } catch {
       continue;
     }
   }
 
-  return fallbacks;
+  return new Map(
+    [...candidates.entries()].map(([windowId, candidate]) => [windowId, candidate.values])
+  );
 };
 
 const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuotaWindow[] => {
   if (!Array.isArray(payload.limits)) return [];
 
-  const windowsByModel = new Map<string, ClaudeScopedWeeklyWindowEntry>();
+  const idWindowsByModel = new Map<string, ClaudeScopedWeeklyWindowEntry>();
+  const labelOnlyWindowsByModel = new Map<string, ClaudeScopedWeeklyWindowEntry>();
+  const idKeysByLabel = new Map<string, Set<string>>();
   for (const rawLimit of payload.limits) {
     try {
       if (!isRecord(rawLimit) || !isClaudeWeeklyScopedLimit(rawLimit)) continue;
@@ -620,7 +664,6 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
       const identityKey = modelId ? `id:${modelId}` : `label:${labelKey}`;
       const activeFlag = normalizeFlagValue(rawLimit.is_active ?? rawLimit.isActive);
       const activityRank = activeFlag === true ? 2 : activeFlag === undefined ? 1 : 0;
-      const resetTimestamp = Date.parse(resolveClaudeLimitResetAt(rawLimit));
 
       const idPart = modelId
         ? `id-${encodeClaudeWindowIdPart(modelId)}`
@@ -628,7 +671,7 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
       const candidate: ClaudeScopedWeeklyWindowEntry = {
         activityRank,
         identityKey,
-        resetAtRank: Number.isFinite(resetTimestamp) ? resetTimestamp : -1,
+        resetAtRank: resolveClaudeLimitResetRank(rawLimit),
         sortLabel: labelKey,
         usedPercentRank: values.usedPercent ?? -1,
         window: {
@@ -637,15 +680,41 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
           ...values,
         },
       };
-      const existing = windowsByModel.get(identityKey);
+      const targetMap = modelId ? idWindowsByModel : labelOnlyWindowsByModel;
+      if (modelId) {
+        const idKeys = idKeysByLabel.get(labelKey) ?? new Set<string>();
+        idKeys.add(identityKey);
+        idKeysByLabel.set(labelKey, idKeys);
+      }
+      const existing = targetMap.get(identityKey);
       if (existing && !shouldReplaceClaudeScopedWindow(existing, candidate)) continue;
-      windowsByModel.set(identityKey, candidate);
+      targetMap.set(identityKey, candidate);
     } catch {
       continue;
     }
   }
 
-  return [...windowsByModel.values()]
+  for (const labelEntry of labelOnlyWindowsByModel.values()) {
+    const matchingIdKeys = idKeysByLabel.get(labelEntry.sortLabel);
+    if (matchingIdKeys?.size !== 1) continue;
+    const identityKey = matchingIdKeys.values().next().value;
+    if (!identityKey) continue;
+    const idEntry = idWindowsByModel.get(identityKey);
+    if (!idEntry) continue;
+    if (shouldReplaceClaudeScopedWindow(idEntry, labelEntry)) {
+      idWindowsByModel.set(identityKey, {
+        ...labelEntry,
+        identityKey,
+        window: {
+          ...labelEntry.window,
+          id: idEntry.window.id,
+        },
+      });
+    }
+    labelOnlyWindowsByModel.delete(labelEntry.identityKey);
+  }
+
+  return [...idWindowsByModel.values(), ...labelOnlyWindowsByModel.values()]
     .sort((left, right) => {
       if (left.sortLabel !== right.sortLabel) {
         return left.sortLabel < right.sortLabel ? -1 : 1;


### PR DESCRIPTION
## Summary
Add generic Claude model-scoped weekly quota rows from the existing `/api/oauth/usage` `limits[]` response, and preserve the base five-hour/all-model weekly quotas when Claude returns them only in `limits[]`. Labels remain dynamic, malformed or unrelated entries are isolated, and legacy payloads continue to render unchanged.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Parse explicit `weekly_scoped` limits, plus weekly `model_scoped` entries, from the existing Claude usage response; resolve model labels from `scope.model.display_name` / `displayName`; keep stable sorting immediately after the account seven-day quota.
- Deduplicate scoped rows by model ID, and conservatively merge a label-only row into an ID-backed row only when the normalized label maps to exactly one model ID. Distinct IDs sharing a label remain separate.
- Resolve scoped duplicates by current reset period first, then activity and usage within the same period. Valid inactive rows remain visible, finite over-limit percentages are preserved, and exact ties retain the first valid item.
- When a displayable top-level window is unavailable, map active unscoped `session` to the five-hour row and active unscoped `weekly` / `weekly_all` to the seven-day row. Top-level windows remain authoritative and each base row falls back independently.
- Select base fallback candidates deterministically by reset freshness, data completeness, `weekly_all` precedence over `weekly` for equal seven-day candidates, then usage; malformed or unrelated entries remain isolated.
- Add regression coverage for limits-only responses, partial fallback, all comparator conflicts, both weekly orderings, ID/label aliases in both orders, ambiguous same-label IDs, malformed entries, legacy payloads, profile failures, unchanged request count, rendering, monitoring mapping, and safe demo evidence.

## User Impact
Claude quota cards can show dynamically named model-level weekly limits while still retaining the account five-hour and all-model weekly quotas across both known response shapes. Accounts without supported `limits[]` entries look exactly as before.

## Compatibility / Runtime Notes
- CPA panel mode: The frontend uses the existing `/v0/management/api-call` request directly against CPA.
- Full Docker mode: The same frontend adapter calls the same path on Manager Server; the existing proxy preserves the path/body and replaces Authorization with the saved CPA Management Key. `api-call` is already allowlisted and its targeted proxy test passes.
- Request behavior: The existing parallel usage/profile pair is unchanged; no additional upstream or management request is introduced.
- Duplicate rule: A displayable top-level `five_hour` / `seven_day` row always wins. `limits[]` only fills the corresponding missing or unusable base row, so the same account quota is never rendered from both sources.
- Stable fallback: Base candidates are independent of upstream array order unless all displayed ranking fields are exactly tied. Scoped duplicates prefer the current reset period, then activity and usage; ID/label aliases merge only when unambiguous.
- Full Docker / native packages: No Go, configuration, packaging, migration, or deployment changes.

## Data / Security Notes
No new storage, logging, credentials, tokens, account identifiers, or outbound destinations are introduced. Malformed `limits[]` items are isolated and skipped per entry. Screenshot fixtures use only fictional model labels.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the PR's frontend quota commits to restore the previous Claude quota adapter and demo fixture behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test
  98 files, 921 tests passed
npm --workspace apps/web run type-check
npm --workspace apps/web run lint -- --max-warnings=0
npm --workspace apps/web run build
npm --workspace apps/web run build:demo
GOCACHE=/tmp/cpamp-go-build-cache go test ./internal/service/proxy -run TestIsManagementPath
git diff --check

Browser smoke: headed Chromium at 1440x1100 and 390x844; no console warnings/errors and no horizontal overflow.
Independent review: code reviewer APPROVE; architecture CLEAR.
External final gate: claude-fable-5, effort max — APPROVE, no Blocker/High findings; all three final correctness requirements covered; ready to push.
```

## Screenshots / Recordings
Sanitized synthetic demo data only; no real account identifiers, tokens, or credentials are shown.

### Desktop quota page
![Desktop quota page](https://raw.githubusercontent.com/bc19sam-afk/CPA-Manager-Plus/f3196f37/pr-evidence/344/desktop-limits-fallback-main.png)

### Desktop Claude quota cards
The left card uses the legacy top-level payload. The right card uses a limits-only payload and shows recovered five-hour/seven-day rows followed by two fictional scoped models.

![Desktop Claude quota cards](https://raw.githubusercontent.com/bc19sam-afk/CPA-Manager-Plus/c1a889a0/pr-evidence/344/desktop-maintainer-three-fixes.png)

### Narrow viewport — legacy payload
![Narrow legacy card](https://raw.githubusercontent.com/bc19sam-afk/CPA-Manager-Plus/f3196f37/pr-evidence/344/narrow-legacy-no-limits-card.png)

### Narrow viewport — limits-only plus scoped models
![Narrow limits-only scoped card](https://raw.githubusercontent.com/bc19sam-afk/CPA-Manager-Plus/c1a889a0/pr-evidence/344/narrow-maintainer-three-fixes.png)

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Refs: https://github.com/seakee/CPA-Manager-Plus/pull/344#issuecomment-4978824953
