### PR TITLE
perf(usage-analytics): preaggregate credential timeline in SQLite

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -1290,6 +1290,42 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 }
 
 func (r *repository) CredentialTimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]CredentialTimelinePoint, error) {
+	coreFromMS, coreToMS := usage.AnalyticsFullUTCHourRange(filter.FromMS, filter.ToMS)
+	if coreFromMS >= coreToMS || !usage.CanMapUTCWholeHours(coreFromMS, coreToMS, granularity, location) {
+		return r.credentialTimelineRawWithFilter(ctx, filter, granularity, location)
+	}
+
+	parts := make([][]CredentialTimelinePoint, 0, 3)
+	if filter.FromMS < coreFromMS {
+		edgeFilter := filter
+		edgeFilter.ToMS = coreFromMS
+		points, err := r.credentialTimelineRawWithFilter(ctx, edgeFilter, granularity, location)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, points)
+	}
+	coreFilter := filter
+	coreFilter.FromMS = coreFromMS
+	coreFilter.ToMS = coreToMS
+	core, err := r.credentialTimelineHourlyWithFilter(ctx, coreFilter, granularity, location)
+	if err != nil {
+		return nil, err
+	}
+	parts = append(parts, core)
+	if coreToMS < filter.ToMS {
+		edgeFilter := filter
+		edgeFilter.FromMS = coreToMS
+		points, err := r.credentialTimelineRawWithFilter(ctx, edgeFilter, granularity, location)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, points)
+	}
+	return mergeCredentialTimelineParts(parts), nil
+}
+
+func (r *repository) credentialTimelineRawWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]CredentialTimelinePoint, error) {
 	where, args := analyticsWhere(filter)
 	query := fmt.Sprintf(`select
 	timestamp_ms,
@@ -1429,6 +1465,222 @@ order by timestamp_ms, credential_id, model`, where)
 		points = append(points, *point)
 	}
 	return points, nil
+}
+
+func (r *repository) credentialTimelineHourlyWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]CredentialTimelinePoint, error) {
+	where, args := analyticsWhere(filter)
+	const hourBucketExpr = "(timestamp_ms / 3600000) * 3600000"
+	const credentialIDExpr = "coalesce(nullif(auth_file_snapshot, ''), nullif(auth_index, ''), nullif(source_hash, ''), nullif(source, ''), '-')"
+	queryPrefix := ""
+	queryFrom := "from usage_events\n"
+	bucketExpr := "bucket_map.bucket_ms"
+	queryArgs := args
+	if offsetMS, ok := analyticsConstantOffsetMS(filter.FromMS, filter.ToMS, location); ok {
+		bucketSizeMS := int64(time.Hour / time.Millisecond)
+		if granularity == "day" {
+			bucketSizeMS = int64(24 * time.Hour / time.Millisecond)
+		}
+		bucketExpr = fmt.Sprintf("((timestamp_ms + %d) / %d) * %d - %d", offsetMS, bucketSizeMS, bucketSizeMS, offsetMS)
+	} else {
+		mapSQL, mapArgs, ok := credentialBucketMapSQL(filter.FromMS, filter.ToMS, granularity, location)
+		if !ok {
+			return r.credentialTimelineRawWithFilter(ctx, filter, granularity, location)
+		}
+		queryPrefix = "with bucket_map(hour_bucket, bucket_ms) as (values " + mapSQL + ")\n"
+		queryFrom += "join bucket_map on " + hourBucketExpr + " = bucket_map.hour_bucket\n"
+		queryArgs = append(mapArgs, args...)
+	}
+	query := queryPrefix + `select
+	` + bucketExpr + `,
+	` + credentialIDExpr + ` as credential_id,
+	coalesce(auth_file_snapshot, ''),
+	coalesce(auth_index, ''),
+	coalesce(source, ''),
+	coalesce(source_hash, ''),
+	coalesce(account_snapshot, ''),
+	coalesce(auth_label_snapshot, ''),
+	coalesce(nullif(auth_provider_snapshot, ''), provider, ''),
+	coalesce(auth_project_id_snapshot, ''),
+	model,
+	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
+	count(*),
+	coalesce(sum(total_tokens), 0),
+	sum(case when failed = 0 then 1 else 0 end),
+	sum(case when failed = 1 then 1 else 0 end),
+	coalesce(sum(` + normalizedInputExpr + `), 0),
+	coalesce(sum(output_tokens), 0),
+	coalesce(sum(reasoning_tokens), 0),
+	coalesce(sum(` + compatCachedExpr + `), 0),
+	coalesce(sum(cache_read_tokens), 0),
+	coalesce(sum(cache_creation_tokens), 0),
+	coalesce(sum(` + longInputExpr + `), 0),
+	coalesce(sum(` + longOutputExpr + `), 0),
+	coalesce(sum(` + longCachedExpr + `), 0),
+	coalesce(sum(` + longCacheReadExpr + `), 0),
+	coalesce(sum(` + longCacheCreationExpr + `), 0),
+	avg(case when latency_ms > 0 then latency_ms end),
+	count(case when latency_ms > 0 then 1 end)
+` + queryFrom + where + `
+group by ` + bucketExpr + `, credential_id,
+	coalesce(auth_file_snapshot, ''), coalesce(auth_index, ''), coalesce(source, ''), coalesce(source_hash, ''),
+	coalesce(account_snapshot, ''), coalesce(auth_label_snapshot, ''),
+	coalesce(nullif(auth_provider_snapshot, ''), provider, ''), coalesce(auth_project_id_snapshot, ''),
+	model, billing_model, service_tier
+order by min(timestamp_ms), credential_id, model`
+	rows, err := r.db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	points := make([]CredentialTimelinePoint, 0)
+	for rows.Next() {
+		var point CredentialTimelinePoint
+		if err := rows.Scan(
+			&point.BucketMS,
+			&point.ID,
+			&point.AuthFileSnapshot,
+			&point.AuthIndex,
+			&point.Source,
+			&point.SourceHash,
+			&point.AccountSnapshot,
+			&point.AuthLabelSnapshot,
+			&point.AuthProviderSnapshot,
+			&point.AuthProjectIDSnapshot,
+			&point.Model,
+			&point.BillingModel,
+			&point.ServiceTier,
+			&point.Calls,
+			&point.Tokens,
+			&point.Success,
+			&point.Failure,
+			&point.InputTokens,
+			&point.OutputTokens,
+			&point.ReasoningTokens,
+			&point.CachedTokens,
+			&point.CacheReadTokens,
+			&point.CacheCreationTokens,
+			&point.LongInputTokens,
+			&point.LongOutputTokens,
+			&point.LongCachedTokens,
+			&point.LongCacheReadTokens,
+			&point.LongCacheCreationTokens,
+			&point.AvgLatencyMS,
+			&point.LatencySamples,
+		); err != nil {
+			return nil, err
+		}
+		points = append(points, point)
+	}
+	return points, rows.Err()
+}
+
+const maxAnalyticsBucketMapHours = 4_000
+
+func analyticsConstantOffsetMS(fromMS, toMS int64, location *time.Location) (int64, bool) {
+	const hourMS = int64(time.Hour / time.Millisecond)
+	if fromMS >= toMS {
+		return 0, false
+	}
+	if location == nil {
+		location = time.UTC
+	}
+	_, firstOffsetSeconds := time.UnixMilli(fromMS).In(location).Zone()
+	for timestampMS := fromMS; timestampMS < toMS; timestampMS += hourMS {
+		_, offsetSeconds := time.UnixMilli(timestampMS).In(location).Zone()
+		if offsetSeconds != firstOffsetSeconds {
+			return 0, false
+		}
+	}
+	_, lastOffsetSeconds := time.UnixMilli(toMS - 1).In(location).Zone()
+	if lastOffsetSeconds != firstOffsetSeconds {
+		return 0, false
+	}
+	return int64(firstOffsetSeconds) * 1000, true
+}
+
+func credentialBucketMapSQL(fromMS, toMS int64, granularity string, location *time.Location) (string, []any, bool) {
+	const hourMS = int64(time.Hour / time.Millisecond)
+	hours := (toMS - fromMS) / hourMS
+	if hours <= 0 || hours > maxAnalyticsBucketMapHours {
+		return "", nil, false
+	}
+	placeholders := make([]string, 0, hours)
+	args := make([]any, 0, hours*2)
+	for hourBucketMS := fromMS; hourBucketMS < toMS; hourBucketMS += hourMS {
+		placeholders = append(placeholders, "(?, ?)")
+		args = append(args, hourBucketMS, usage.AnalyticsBucketMS(hourBucketMS, granularity, location))
+	}
+	return strings.Join(placeholders, ", "), args, true
+}
+
+func mergeCredentialTimelineParts(parts [][]CredentialTimelinePoint) []CredentialTimelinePoint {
+	type key struct {
+		id               string
+		authFileSnapshot string
+		authIndex        string
+		sourceHash       string
+		bucketMS         int64
+		model            string
+		billingModel     string
+		serviceTier      string
+	}
+	grouped := make(map[key]*CredentialTimelinePoint)
+	order := make([]key, 0)
+	for _, points := range parts {
+		for _, point := range points {
+			mapKey := key{point.ID, point.AuthFileSnapshot, point.AuthIndex, point.SourceHash, point.BucketMS, point.Model, point.BillingModel, point.ServiceTier}
+			entry := grouped[mapKey]
+			if entry == nil {
+				next := point
+				grouped[mapKey] = &next
+				order = append(order, mapKey)
+				continue
+			}
+			if entry.Source == "" {
+				entry.Source = point.Source
+			}
+			if entry.AccountSnapshot == "" {
+				entry.AccountSnapshot = point.AccountSnapshot
+			}
+			if entry.AuthLabelSnapshot == "" {
+				entry.AuthLabelSnapshot = point.AuthLabelSnapshot
+			}
+			if entry.AuthProviderSnapshot == "" {
+				entry.AuthProviderSnapshot = point.AuthProviderSnapshot
+			}
+			if entry.AuthProjectIDSnapshot == "" {
+				entry.AuthProjectIDSnapshot = point.AuthProjectIDSnapshot
+			}
+			latencySum := entry.AvgLatencyMS.Float64*float64(entry.LatencySamples) + point.AvgLatencyMS.Float64*float64(point.LatencySamples)
+			entry.Calls += point.Calls
+			entry.Tokens += point.Tokens
+			entry.Success += point.Success
+			entry.Failure += point.Failure
+			entry.InputTokens += point.InputTokens
+			entry.OutputTokens += point.OutputTokens
+			entry.ReasoningTokens += point.ReasoningTokens
+			entry.CachedTokens += point.CachedTokens
+			entry.CacheReadTokens += point.CacheReadTokens
+			entry.CacheCreationTokens += point.CacheCreationTokens
+			entry.LongInputTokens += point.LongInputTokens
+			entry.LongOutputTokens += point.LongOutputTokens
+			entry.LongCachedTokens += point.LongCachedTokens
+			entry.LongCacheReadTokens += point.LongCacheReadTokens
+			entry.LongCacheCreationTokens += point.LongCacheCreationTokens
+			entry.LatencySamples += point.LatencySamples
+			entry.AvgLatencyMS.Valid = entry.LatencySamples > 0
+			if entry.AvgLatencyMS.Valid {
+				entry.AvgLatencyMS.Float64 = latencySum / float64(entry.LatencySamples)
+			}
+		}
+	}
+	result := make([]CredentialTimelinePoint, 0, len(order))
+	for _, mapKey := range order {
+		result = append(result, *grouped[mapKey])
+	}
+	return result
 }
 
 func (r *repository) APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error) {

--- a/apps/manager-server/internal/repository/usageevent/analytics_preaggregation_test.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics_preaggregation_test.go
@@ -1,0 +1,140 @@
+package usageevent
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+)
+
+func TestCredentialTimelineHourlyPreaggregationMatchesRaw(t *testing.T) {
+	repo := newAnalyticsPreaggregationRepo(t)
+	ctx := context.Background()
+	base := time.Date(2026, time.March, 8, 5, 0, 0, 0, time.UTC)
+	insertAnalyticsPreaggregationEvents(t, ctx, repo, base)
+	location, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	filter := AnalyticsFilter{
+		FromMS:        base.Add(15 * time.Minute).UnixMilli(),
+		ToMS:          base.Add(4*time.Hour + 45*time.Minute).UnixMilli(),
+		IncludeFailed: true,
+	}
+
+	for _, granularity := range []string{"hour", "day"} {
+		raw, err := repo.credentialTimelineRawWithFilter(ctx, filter, granularity, location)
+		if err != nil {
+			t.Fatalf("raw %s: %v", granularity, err)
+		}
+		got, err := repo.CredentialTimelineWithFilter(ctx, filter, granularity, location)
+		if err != nil {
+			t.Fatalf("preaggregate %s: %v", granularity, err)
+		}
+		sortCredentialTimelinePoints(raw)
+		sortCredentialTimelinePoints(got)
+		if !reflect.DeepEqual(got, raw) {
+			t.Fatalf("%s mismatch\npreaggregate=%#v\nraw=%#v", granularity, got, raw)
+		}
+	}
+}
+
+func TestCredentialTimelinePreaggregationFallsBackForFractionalOffset(t *testing.T) {
+	repo := newAnalyticsPreaggregationRepo(t)
+	ctx := context.Background()
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	insertAnalyticsPreaggregationEvents(t, ctx, repo, base)
+	filter := AnalyticsFilter{FromMS: base.UnixMilli(), ToMS: base.Add(5 * time.Hour).UnixMilli(), IncludeFailed: true}
+
+	for _, name := range []string{"Asia/Kolkata", "Australia/Eucla"} {
+		location, err := time.LoadLocation(name)
+		if err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+		rawCredentials, err := repo.credentialTimelineRawWithFilter(ctx, filter, "hour", location)
+		if err != nil {
+			t.Fatalf("raw credentials %s: %v", name, err)
+		}
+		gotCredentials, err := repo.CredentialTimelineWithFilter(ctx, filter, "hour", location)
+		if err != nil {
+			t.Fatalf("credentials %s: %v", name, err)
+		}
+		if !reflect.DeepEqual(gotCredentials, rawCredentials) {
+			t.Fatalf("credentials %s did not preserve raw fallback", name)
+		}
+	}
+}
+
+func newAnalyticsPreaggregationRepo(t *testing.T) *repository {
+	t.Helper()
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return &repository{db: db}
+}
+
+func insertAnalyticsPreaggregationEvents(t *testing.T, ctx context.Context, repo *repository, base time.Time) {
+	t.Helper()
+	latencies := []int64{100, 0, -200, 500, 700, 900}
+	events := make([]usage.Event, 0, len(latencies))
+	for index, latency := range latencies {
+		timestamp := base.Add(time.Duration(index)*time.Hour + 20*time.Minute)
+		event := usage.Event{
+			EventHash:             "analytics-preaggregate-" + timestamp.Format("20060102T150405Z"),
+			TimestampMS:           timestamp.UnixMilli(),
+			Timestamp:             timestamp.Format(time.RFC3339Nano),
+			Provider:              "fallback-provider",
+			Model:                 "gpt-test",
+			ResolvedModel:         "gpt-test-billing",
+			ServiceTier:           "priority",
+			AuthIndex:             "auth-1",
+			Source:                "source-a",
+			SourceHash:            "source-hash-a",
+			APIKeyHash:            "api-key-a",
+			AuthFileSnapshot:      "credential-a.json",
+			AccountSnapshot:       "account-a",
+			AuthLabelSnapshot:     "label-a",
+			AuthProviderSnapshot:  "openai",
+			AuthProjectIDSnapshot: "project-a",
+			InputTokens:           int64(100_000 + index*100_000),
+			OutputTokens:          int64(10 + index),
+			ReasoningTokens:       int64(index),
+			CachedTokens:          int64(index * 3),
+			CacheReadTokens:       int64(index),
+			CacheCreationTokens:   int64(index),
+			TotalTokens:           int64(100_010 + index*100_001),
+			Failed:                index%3 == 1,
+			CreatedAtMS:           timestamp.UnixMilli(),
+		}
+		if latency != 0 {
+			event.LatencyMS = &latencies[index]
+		}
+		if index == 3 {
+			event.AccountSnapshot = ""
+			event.AuthLabelSnapshot = ""
+		}
+		events = append(events, event)
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+}
+
+func sortCredentialTimelinePoints(points []CredentialTimelinePoint) {
+	sort.Slice(points, func(i, j int) bool {
+		if points[i].BucketMS != points[j].BucketMS {
+			return points[i].BucketMS < points[j].BucketMS
+		}
+		if points[i].ID != points[j].ID {
+			return points[i].ID < points[j].ID
+		}
+		return points[i].Model < points[j].Model
+	})
+}

--- a/apps/manager-server/internal/service/usagehourly/reader.go
+++ b/apps/manager-server/internal/service/usagehourly/reader.go
@@ -168,7 +168,7 @@ func (r *Reader) AnalyticsTimeline(
 	if granularity != "day" {
 		granularity = "hour"
 	}
-	if !bucketsRepresentable(snapshot.fullStartMS, snapshot.fullEndMS, granularity, location) {
+	if !usage.CanMapUTCWholeHours(snapshot.fullStartMS, snapshot.fullEndMS, granularity, location) {
 		return nil, false
 	}
 
@@ -203,7 +203,7 @@ func (r *Reader) CanRepresentAnalyticsTimeline(fromMS, toMS int64, granularity s
 	}
 	fullStartMS := ceilHourMS(fromMS)
 	fullEndMS := floorHourMS(toMS)
-	return fullStartMS < fullEndMS && bucketsRepresentable(fullStartMS, fullEndMS, granularity, location)
+	return fullStartMS < fullEndMS && usage.CanMapUTCWholeHours(fullStartMS, fullEndMS, granularity, location)
 }
 
 func rawEdges(fromMS, toMS, fullStartMS, fullEndMS int64) []timeRange {
@@ -499,15 +499,6 @@ func sortedAnalyticsTimeline(grouped map[analyticsTimelineKey]*store.TimelinePoi
 		return result[i].ServiceTier < result[j].ServiceTier
 	})
 	return result
-}
-
-func bucketsRepresentable(fromMS, toMS int64, granularity string, location *time.Location) bool {
-	for bucketMS := fromMS; bucketMS < toMS; bucketMS += hourMS {
-		if usage.AnalyticsBucketMS(bucketMS, granularity, location) != usage.AnalyticsBucketMS(bucketMS+hourMS-1, granularity, location) {
-			return false
-		}
-	}
-	return true
 }
 
 func (r *Reader) logFallback(reason string) {

--- a/apps/manager-server/internal/usage/analytics_bucket.go
+++ b/apps/manager-server/internal/usage/analytics_bucket.go
@@ -2,6 +2,8 @@ package usage
 
 import "time"
 
+const analyticsHourMS = int64(time.Hour / time.Millisecond)
+
 // AnalyticsBucketMS resolves an event timestamp to the start of its local
 // analytics hour or day bucket.
 func AnalyticsBucketMS(timestampMS int64, granularity string, location *time.Location) int64 {
@@ -13,4 +15,35 @@ func AnalyticsBucketMS(timestampMS int64, granularity string, location *time.Loc
 		return time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, location).UnixMilli()
 	}
 	return time.Date(tm.Year(), tm.Month(), tm.Day(), tm.Hour(), 0, 0, 0, location).UnixMilli()
+}
+
+// AnalyticsFullUTCHourRange returns the complete UTC hours contained by the
+// half-open analytics range [fromMS, toMS).
+func AnalyticsFullUTCHourRange(fromMS, toMS int64) (int64, int64) {
+	startMS := fromMS - fromMS%analyticsHourMS
+	if fromMS%analyticsHourMS != 0 {
+		startMS += analyticsHourMS
+	}
+	endMS := toMS - toMS%analyticsHourMS
+	return startMS, endMS
+}
+
+// CanMapUTCWholeHours reports whether every complete UTC hour in the supplied
+// aligned range maps to one local analytics bucket without being split.
+func CanMapUTCWholeHours(fromMS, toMS int64, granularity string, location *time.Location) bool {
+	if fromMS >= toMS || fromMS%analyticsHourMS != 0 || toMS%analyticsHourMS != 0 {
+		return false
+	}
+	if location == nil {
+		location = time.UTC
+	}
+	if granularity != "day" {
+		granularity = "hour"
+	}
+	for hourMS := fromMS; hourMS < toMS; hourMS += analyticsHourMS {
+		if AnalyticsBucketMS(hourMS, granularity, location) != AnalyticsBucketMS(hourMS+analyticsHourMS-1, granularity, location) {
+			return false
+		}
+	}
+	return true
 }

--- a/apps/manager-server/internal/usage/analytics_bucket_test.go
+++ b/apps/manager-server/internal/usage/analytics_bucket_test.go
@@ -43,3 +43,49 @@ func TestAnalyticsBucketMSAcrossDST(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalyticsFullUTCHourRange(t *testing.T) {
+	hourMS := int64(time.Hour / time.Millisecond)
+	fromMS := int64(1_800_000_000_000) + 15*60*1000
+	toMS := fromMS + 3*hourMS + 20*60*1000
+	startMS, endMS := AnalyticsFullUTCHourRange(fromMS, toMS)
+	if startMS%hourMS != 0 || endMS%hourMS != 0 {
+		t.Fatalf("range = [%d, %d), want UTC-hour alignment", startMS, endMS)
+	}
+	if startMS < fromMS || startMS-fromMS >= hourMS {
+		t.Fatalf("start = %d, from = %d", startMS, fromMS)
+	}
+	if endMS > toMS || toMS-endMS >= hourMS {
+		t.Fatalf("end = %d, to = %d", endMS, toMS)
+	}
+}
+
+func TestCanMapUTCWholeHours(t *testing.T) {
+	hourMS := int64(time.Hour / time.Millisecond)
+	fromMS := time.Date(2026, time.March, 7, 0, 0, 0, 0, time.UTC).UnixMilli()
+	toMS := fromMS + 72*hourMS
+
+	for _, name := range []string{"UTC", "Asia/Shanghai", "America/New_York"} {
+		location, err := time.LoadLocation(name)
+		if err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+		if !CanMapUTCWholeHours(fromMS, toMS, "hour", location) {
+			t.Fatalf("%s unexpectedly not representable", name)
+		}
+	}
+
+	for _, name := range []string{"Asia/Kolkata", "Australia/Eucla"} {
+		location, err := time.LoadLocation(name)
+		if err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+		if CanMapUTCWholeHours(fromMS, toMS, "hour", location) {
+			t.Fatalf("%s unexpectedly representable", name)
+		}
+	}
+
+	if CanMapUTCWholeHours(fromMS+1, toMS, "hour", time.UTC) {
+		t.Fatal("unaligned range unexpectedly representable")
+	}
+}


### PR DESCRIPTION
## Summary
Preaggregate Credential Timeline data in SQLite instead of loading every matching usage event into Go.
Preserve existing response semantics with raw partial-range edges and timezone-safe fallback behavior.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Group complete UTC-hour Credential Timeline ranges in SQLite and merge partial raw edges.
- Share UTC-hour bucket representability checks with the existing hourly rollup reader.
- Preserve raw fallback for fractional-offset time zones and add raw-versus-SQL parity coverage.

## User Impact
No user-facing behavior or response contract change. The 100k-event Credentials tab benchmark reduces allocations from approximately 106 MB to 50 MB and from 3.33 million allocations to 466 thousand allocations.

## Compatibility / Runtime Notes
- CPA panel mode: Credential analytics use the optimized Manager Server query path with existing authentication and API behavior.
- Manager Server mode: No configuration or endpoint changes; unsupported timezone mappings retain the raw query path.
- Full Docker / native packages: No packaging or runtime configuration changes.

## Data / Security Notes
No SQLite schema or persisted data changes. Queries continue to use the existing filtered usage event data, and no raw event fields are newly exposed.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Revert the commit to restore the previous per-event Go aggregation path.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
cd apps/manager-server && go test ./...
cd apps/manager-server && go test -race ./internal/repository/usageevent ./internal/service/monitoring ./internal/service/usagehourly ./internal/usage
cd apps/manager-server && go test -run '^$' -bench '^BenchmarkUsageAnalyticsIncludeProfiles/(credentials_tab_request|heatmap_tab_request)$' -benchmem -benchtime=1x -count=1 ./internal/service/monitoring

Credentials: ~1.24s / 50.34MB / 466k allocs
Heatmap:    ~0.59s / 102.99MB / 2.37M allocs (unchanged raw path)
```

## Screenshots / Recordings
N/A. Backend-only performance change with no visible UI changes.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A