### PR TITLE
perf(usage-analytics): load selected credential timeline on demand

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -28,6 +28,7 @@ var (
 	longCachedFExpr         = "case when " + normalizedInputFExpr + " > " + longContextThresholdSQL + " then " + compatCachedFExpr + " else 0 end"
 	longCacheReadFExpr      = "case when " + normalizedInputFExpr + " > " + longContextThresholdSQL + " then f.cache_read_tokens else 0 end"
 	longCacheCreationFExpr  = "case when " + normalizedInputFExpr + " > " + longContextThresholdSQL + " then f.cache_creation_tokens else 0 end"
+	credentialIDExpr        = "coalesce(nullif(auth_file_snapshot, ''), nullif(auth_index, ''), nullif(source_hash, ''), nullif(source, ''), '-')"
 )
 
 type AnalyticsFilter struct {
@@ -38,6 +39,7 @@ type AnalyticsFilter struct {
 	Models           []string
 	Providers        []string
 	Accounts         []string
+	CredentialIDs    []string
 	AuthFiles        []string
 	AuthIndices      []string
 	APIKeyHashes     []string
@@ -1211,7 +1213,7 @@ order by max(timestamp_ms) desc, count(*) desc`, args...)
 func (r *repository) CredentialModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]CredentialModelStat, error) {
 	where, args := analyticsWhere(filter)
 	rows, err := r.db.QueryContext(ctx, `select
-	coalesce(nullif(auth_file_snapshot, ''), nullif(auth_index, ''), nullif(source_hash, ''), nullif(source, ''), '-') as credential_id,
+	`+credentialIDExpr+` as credential_id,
 	coalesce(auth_file_snapshot, ''),
 	coalesce(auth_index, ''),
 	coalesce(max(source), ''),
@@ -1329,7 +1331,7 @@ func (r *repository) credentialTimelineRawWithFilter(ctx context.Context, filter
 	where, args := analyticsWhere(filter)
 	query := fmt.Sprintf(`select
 	timestamp_ms,
-	coalesce(nullif(auth_file_snapshot, ''), nullif(auth_index, ''), nullif(source_hash, ''), nullif(source, ''), '-') as credential_id,
+	`+credentialIDExpr+` as credential_id,
 	coalesce(auth_file_snapshot, ''),
 	coalesce(auth_index, ''),
 	coalesce(source, ''),
@@ -1470,7 +1472,6 @@ order by timestamp_ms, credential_id, model`, where)
 func (r *repository) credentialTimelineHourlyWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]CredentialTimelinePoint, error) {
 	where, args := analyticsWhere(filter)
 	const hourBucketExpr = "(timestamp_ms / 3600000) * 3600000"
-	const credentialIDExpr = "coalesce(nullif(auth_file_snapshot, ''), nullif(auth_index, ''), nullif(source_hash, ''), nullif(source, ''), '-')"
 	queryPrefix := ""
 	queryFrom := "from usage_events\n"
 	bucketExpr := "bucket_map.bucket_ms"
@@ -2249,6 +2250,7 @@ func analyticsWhere(filter AnalyticsFilter) (string, []any) {
 	addInCondition("model", filter.Models)
 	addProviderCondition(filter.Providers, &conditions, &args)
 	addAccountCondition(filter.Accounts, &conditions, &args)
+	addInCondition(credentialIDExpr, filter.CredentialIDs)
 	addInCondition("auth_file_snapshot", filter.AuthFiles)
 	addInCondition("auth_index", filter.AuthIndices)
 	addInCondition("api_key_hash", filter.APIKeyHashes)

--- a/apps/manager-server/internal/repository/usageevent/analytics_preaggregation_test.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics_preaggregation_test.go
@@ -70,6 +70,71 @@ func TestCredentialTimelinePreaggregationFallsBackForFractionalOffset(t *testing
 	}
 }
 
+func TestCredentialIDFilterMatchesAllIdentityFallbacks(t *testing.T) {
+	repo := newAnalyticsPreaggregationRepo(t)
+	ctx := context.Background()
+	base := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	identities := []struct {
+		name       string
+		id         string
+		authFile   string
+		authIndex  string
+		sourceHash string
+		source     string
+	}{
+		{name: "auth file", id: "credential.json", authFile: "credential.json", authIndex: "auth-file", sourceHash: "hash-file", source: "source-file"},
+		{name: "auth index", id: "auth-index", authIndex: "auth-index", sourceHash: "hash-index", source: "source-index"},
+		{name: "source hash", id: "hash-only", sourceHash: "hash-only", source: "source-hash"},
+		{name: "source", id: "source-only", source: "source-only"},
+	}
+	events := make([]usage.Event, 0, len(identities))
+	for index, identity := range identities {
+		timestamp := base.Add(time.Duration(index) * time.Hour)
+		events = append(events, usage.Event{
+			EventHash:        "credential-filter-" + identity.name,
+			TimestampMS:      timestamp.UnixMilli(),
+			Timestamp:        timestamp.Format(time.RFC3339Nano),
+			Model:            "gpt-test",
+			AuthFileSnapshot: identity.authFile,
+			AuthIndex:        identity.authIndex,
+			SourceHash:       identity.sourceHash,
+			Source:           identity.source,
+			InputTokens:      10,
+			OutputTokens:     5,
+			TotalTokens:      15,
+			CreatedAtMS:      timestamp.UnixMilli(),
+		})
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	for _, identity := range identities {
+		t.Run(identity.name, func(t *testing.T) {
+			filter := AnalyticsFilter{
+				FromMS:        base.UnixMilli(),
+				ToMS:          base.Add(5 * time.Hour).UnixMilli(),
+				CredentialIDs: []string{identity.id},
+				IncludeFailed: true,
+			}
+			stats, err := repo.CredentialModelStatsWithFilter(ctx, filter)
+			if err != nil {
+				t.Fatalf("credential stats: %v", err)
+			}
+			if len(stats) != 1 || stats[0].ID != identity.id {
+				t.Fatalf("credential stats = %#v", stats)
+			}
+			points, err := repo.CredentialTimelineWithFilter(ctx, filter, "hour", time.UTC)
+			if err != nil {
+				t.Fatalf("credential timeline: %v", err)
+			}
+			if len(points) != 1 || points[0].ID != identity.id {
+				t.Fatalf("credential timeline = %#v", points)
+			}
+		})
+	}
+}
+
 func newAnalyticsPreaggregationRepo(t *testing.T) *repository {
 	t.Helper()
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -59,6 +59,7 @@ type Filters struct {
 	Models           []string `json:"models"`
 	Providers        []string `json:"providers"`
 	Accounts         []string `json:"accounts"`
+	CredentialIDs    []string `json:"credential_ids"`
 	AuthFiles        []string `json:"auth_files"`
 	AuthIndices      []string `json:"auth_indices"`
 	APIKeyHashes     []string `json:"api_key_hashes"`
@@ -1095,6 +1096,7 @@ func buildFilter(req Request) store.AnalyticsFilter {
 		Models:           req.Filters.Models,
 		Providers:        req.Filters.Providers,
 		Accounts:         req.Filters.Accounts,
+		CredentialIDs:    req.Filters.CredentialIDs,
 		AuthFiles:        req.Filters.AuthFiles,
 		AuthIndices:      req.Filters.AuthIndices,
 		APIKeyHashes:     req.Filters.APIKeyHashes,
@@ -1118,6 +1120,7 @@ func analyticsHourlyRollupEligible(filter store.AnalyticsFilter) bool {
 		len(filter.Models) == 0 &&
 		len(filter.Providers) == 0 &&
 		len(filter.Accounts) == 0 &&
+		len(filter.CredentialIDs) == 0 &&
 		len(filter.AuthFiles) == 0 &&
 		len(filter.AuthIndices) == 0 &&
 		len(filter.APIKeyHashes) == 0 &&
@@ -1192,6 +1195,7 @@ func filterOptionsBaseFilter(filter store.AnalyticsFilter) store.AnalyticsFilter
 	optionFilter.Models = nil
 	optionFilter.Providers = nil
 	optionFilter.Accounts = nil
+	optionFilter.CredentialIDs = nil
 	optionFilter.AuthFiles = nil
 	optionFilter.AuthIndices = nil
 	optionFilter.APIKeyHashes = nil

--- a/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
@@ -45,6 +45,11 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 		}
 	}
 	selectors := request(Include{FilterOptions: true, FilterSelectors: true})
+	selectedCredentialTimeline := request(Include{
+		CredentialTimeline: true,
+		Granularity:        "day",
+	})
+	selectedCredentialTimeline.Filters.CredentialIDs = []string{"account-000.json"}
 	profiles := []struct {
 		name     string
 		service  *Service
@@ -244,12 +249,29 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 			name:    "credentials_tab_request",
 			service: rollupService,
 			requests: []Request{request(Include{
-				Summary:            true,
-				SummaryProfile:     "compact",
-				CredentialStats:    true,
-				CredentialTimeline: true,
-				Granularity:        "day",
+				Summary:         true,
+				SummaryProfile:  "compact",
+				CredentialStats: true,
+				Granularity:     "day",
 			})},
+		},
+		{
+			name:     "selected_credential_timeline_request",
+			service:  rollupService,
+			requests: []Request{selectedCredentialTimeline},
+		},
+		{
+			name:    "credentials_tab_two_stage",
+			service: rollupService,
+			requests: []Request{
+				request(Include{
+					Summary:         true,
+					SummaryProfile:  "compact",
+					CredentialStats: true,
+					Granularity:     "day",
+				}),
+				selectedCredentialTimeline,
+			},
 		},
 		{
 			name:    "heatmap_tab_request",

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -942,6 +942,19 @@ func TestAnalyticsAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestBuildFilterIncludesCredentialIDs(t *testing.T) {
+	filter := buildFilter(Request{
+		FromMS: 100,
+		ToMS:   200,
+		Filters: Filters{
+			CredentialIDs: []string{"credential-a"},
+		},
+	})
+	if !reflect.DeepEqual(filter.CredentialIDs, []string{"credential-a"}) {
+		t.Fatalf("credential ids = %#v", filter.CredentialIDs)
+	}
+}
+
 func TestAnalyticsAccountAndAPIKeyStatsUseFullFilteredScope(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()
@@ -1958,6 +1971,7 @@ func TestAnalyticsHourlyRollupEligibilityIsStrict(t *testing.T) {
 		{name: "models", mutate: func(filter *store.AnalyticsFilter) { filter.Models = []string{"model-a"} }},
 		{name: "providers", mutate: func(filter *store.AnalyticsFilter) { filter.Providers = []string{"codex"} }},
 		{name: "accounts", mutate: func(filter *store.AnalyticsFilter) { filter.Accounts = []string{"account"} }},
+		{name: "credential ids", mutate: func(filter *store.AnalyticsFilter) { filter.CredentialIDs = []string{"credential"} }},
 		{name: "auth files", mutate: func(filter *store.AnalyticsFilter) { filter.AuthFiles = []string{"account.json"} }},
 		{name: "auth indices", mutate: func(filter *store.AnalyticsFilter) { filter.AuthIndices = []string{"auth-a"} }},
 		{name: "api keys", mutate: func(filter *store.AnalyticsFilter) { filter.APIKeyHashes = []string{"key"} }},

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
@@ -380,6 +380,8 @@ const createUsageState = (overrides: Record<string, unknown> = {}) => {
         points: [{ bucketMs: point.bucketMs, label: point.label, value: 8 }],
       },
     ],
+    credentialTrendLoading: false,
+    credentialTrendError: '',
     keyAnomalies: [
       {
         id: 'abcdef1234567890',
@@ -828,6 +830,24 @@ describe('UsageAnalyticsPage', () => {
     expect(mocks.navigate).toHaveBeenCalledWith(
       '/monitoring?from_ms=1780000000000&to_ms=1780003600000&auth_file=auth.json&project_id=project-1&search=req-42&min_latency_ms=10000&cache_status=miss'
     );
+  });
+
+  it('renders selected credential timeline loading and error states', () => {
+    mocks.usageState = createUsageState({
+      activeTab: 'credentials',
+      credentialTrendLoading: true,
+    });
+    let renderer = renderPage();
+    expect(getText(renderer.root)).toContain('common.loading');
+
+    mocks.usageState = createUsageState({
+      activeTab: 'credentials',
+      credentialTrendError: 'timeline failed',
+    });
+    renderer = renderPage();
+    const text = getText(renderer.root);
+    expect(text).toContain('usage_analytics.error_title');
+    expect(text).toContain('timeline failed');
   });
 
   it('renders the heatmap tab as a focused time-window workspace', () => {

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -1938,10 +1938,14 @@ function EntityTrendChart({
   metric,
   series,
   highlightId,
+  loading = false,
+  error = '',
 }: {
   metric: UsageTrendMetricKey;
   series: UsageEntityTrendSeries[];
   highlightId?: string;
+  loading?: boolean;
+  error?: string;
 }) {
   const { t } = useTranslation();
   const chartTheme = useUsageChartTheme();
@@ -2024,6 +2028,25 @@ function EntityTrendChart({
     }),
     [chartTheme, hasHighlight, highlightId, metric, series]
   );
+
+  if (loading) {
+    return (
+      <div className={styles.chartEmptyInline}>
+        <IconRefreshCw size={24} />
+        <span>{t('common.loading')}</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.chartEmptyInline}>
+        <IconX size={24} />
+        <span>{t('usage_analytics.error_title')}</span>
+        <span>{error}</span>
+      </div>
+    );
+  }
 
   if (series.length === 0) {
     return (
@@ -3288,7 +3311,12 @@ function UsageAnalyticsPageInner() {
                   ))}
                 </div>
               </div>
-              <EntityTrendChart series={usage.credentialTrendSeries} metric={usage.trendMetric} />
+              <EntityTrendChart
+                series={usage.credentialTrendSeries}
+                metric={usage.trendMetric}
+                loading={usage.credentialTrendLoading}
+                error={usage.credentialTrendError}
+              />
             </div>
             {usage.selectedCredential ? (
               <DetailPanel

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -142,7 +142,6 @@ describe('usage analytics request model', () => {
       summary: true,
       summary_profile: 'compact',
       credential_stats: true,
-      credential_timeline: true,
       granularity: 'day',
     });
     expect(

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -756,7 +756,6 @@ export const buildUsageAnalyticsInclude = (
       break;
     case 'credentials':
       include.credential_stats = true;
-      include.credential_timeline = true;
       break;
     case 'heatmap':
       include.heatmap = true;

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -38,6 +38,8 @@ describe('useUsageAnalytics request orchestration', () => {
   let renderer: ReactTestRenderer | null = null;
   let latestResult: ReturnType<typeof useUsageAnalytics> | null = null;
   let selectorError = '';
+  let credentialTimelineError = '';
+  let credentialTimelineLoading = false;
   const mainRefresh = vi.fn();
   const selectorRefresh = vi.fn();
   const auxiliaryRefresh = vi.fn();
@@ -45,10 +47,35 @@ describe('useUsageAnalytics request orchestration', () => {
   const resultFor = (params: UseMonitoringAnalyticsParams): UseMonitoringAnalyticsReturn => {
     const selectors = Boolean(params.include?.filter_selectors);
     const main = Boolean(params.include?.summary);
+    const credentialTimeline = Boolean(params.include?.credential_timeline);
+    const mainData = params.include?.credential_stats
+      ? {
+          ...emptyAnalyticsResponse,
+          credential_stats: [
+            {
+              id: 'credential-a.json',
+              auth_file_snapshot: 'credential-a.json',
+              calls: 10,
+              success_calls: 9,
+              failure_calls: 1,
+              success_rate: 0.9,
+              input_tokens: 100,
+              output_tokens: 50,
+              cached_tokens: 0,
+              cache_read_tokens: 0,
+              cache_creation_tokens: 0,
+              total_tokens: 150,
+              cost: 1,
+              average_latency_ms: 100,
+              last_seen_ms: 1,
+            },
+          ],
+        }
+      : emptyAnalyticsResponse;
     return {
       enabled: Boolean(params.fromMs && params.toMs),
-      loading: false,
-      error: selectors ? selectorError : '',
+      loading: credentialTimeline ? credentialTimelineLoading : false,
+      error: selectors ? selectorError : credentialTimeline ? credentialTimelineError : '',
       data: selectors
         ? selectorError
           ? null
@@ -62,8 +89,23 @@ describe('useUsageAnalytics request orchestration', () => {
               },
             }
         : main
-          ? emptyAnalyticsResponse
-          : null,
+          ? mainData
+          : credentialTimeline && !credentialTimelineError && !credentialTimelineLoading
+            ? {
+                ...emptyAnalyticsResponse,
+                credential_timeline: [
+                  {
+                    id: 'credential-a.json',
+                    auth_file_snapshot: 'credential-a.json',
+                    bucket_ms: 1,
+                    calls: 10,
+                    tokens: 150,
+                    success: 9,
+                    failure: 1,
+                  },
+                ],
+              }
+            : null,
       dataStale: false,
       lastRefreshedAt: null,
       serviceBase: 'http://manager.local',
@@ -87,6 +129,8 @@ describe('useUsageAnalytics request orchestration', () => {
 
   beforeEach(() => {
     selectorError = '';
+    credentialTimelineError = '';
+    credentialTimelineLoading = false;
     latestResult = null;
     mainRefresh.mockReset();
     selectorRefresh.mockReset();
@@ -165,5 +209,57 @@ describe('useUsageAnalytics request orchestration', () => {
     });
     expect(mainRefresh).toHaveBeenCalledTimes(1);
     expect(selectorRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads only the selected credential timeline after the credential ranking', async () => {
+    await renderHook();
+
+    await act(async () => {
+      latestResult?.setActiveTab('credentials');
+      await Promise.resolve();
+    });
+
+    const credentials = lastParams((params) => Boolean(params.include?.credential_stats));
+    expect(credentials?.include).toEqual({
+      summary: true,
+      summary_profile: 'compact',
+      credential_stats: true,
+      granularity: 'hour',
+    });
+
+    const timeline = lastParams((params) => Boolean(params.include?.credential_timeline));
+    expect(timeline?.include).toEqual({ granularity: 'hour', credential_timeline: true });
+    expect(timeline?.filters).toMatchObject({ credential_ids: ['credential-a.json'] });
+    expect(JSON.parse(timeline?.dataScopeKey ?? '{}')).toMatchObject({
+      activeTab: 'credentials',
+      selectedCredentialID: 'credential-a.json',
+    });
+    expect(latestResult?.credentialTrendSeries).toHaveLength(1);
+  });
+
+  it('exposes selected credential timeline loading and error states', async () => {
+    credentialTimelineLoading = true;
+    await renderHook();
+
+    await act(async () => {
+      latestResult?.setActiveTab('credentials');
+      await Promise.resolve();
+    });
+    expect(latestResult?.credentialTrendLoading).toBe(true);
+    expect(latestResult?.credentialTrendError).toBe('');
+
+    credentialTimelineLoading = false;
+    credentialTimelineError = 'timeline failed';
+    await act(async () => {
+      renderer?.update(
+        <MemoryRouter initialEntries={['/usage-analytics']}>
+          <Harness />
+        </MemoryRouter>
+      );
+      await Promise.resolve();
+    });
+    expect(latestResult?.credentialTrendLoading).toBe(false);
+    expect(latestResult?.credentialTrendError).toBe('timeline failed');
+    expect(latestResult?.credentialRows).toHaveLength(1);
   });
 });

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -28,6 +28,7 @@ import {
   buildUsageHeatmapRangeContext,
   buildUsageMatrix,
   buildUsageSummaryDelta,
+  buildUsageCredentialTimeline,
   buildUsageAnalyticsFilters,
   buildUsageAnalyticsFilterSelectorsInclude,
   buildUsageAnalyticsInclude,
@@ -461,14 +462,83 @@ export function useUsageAnalytics() {
     () => buildSelectedApiKeyTrendSeries(selectedApiKey, selectedApiKeyTimeline, trendMetric),
     [selectedApiKey, selectedApiKeyTimeline, trendMetric]
   );
+  const selectedCredentialFilterID = selectedCredential?.id || '';
+  const selectedCredentialTimelineFilters = useMemo(
+    () =>
+      selectedCredentialFilterID
+        ? { ...analyticsFilters, credential_ids: [selectedCredentialFilterID] }
+        : analyticsFilters,
+    [analyticsFilters, selectedCredentialFilterID]
+  );
+  const selectedCredentialTimelineInclude = useMemo(
+    () => ({
+      granularity: resolvedGranularity,
+      credential_timeline: true,
+    }),
+    [resolvedGranularity]
+  );
+  const selectedCredentialTimelineDataScopeKey = useMemo(
+    () =>
+      JSON.stringify({
+        activeTab: activeTabState,
+        bounds,
+        filters: selectedCredentialTimelineFilters,
+        granularity: resolvedGranularity,
+        searchQuery: debouncedSearchQuery,
+        selectedCredentialID: selectedCredentialFilterID,
+      }),
+    [
+      activeTabState,
+      bounds,
+      debouncedSearchQuery,
+      resolvedGranularity,
+      selectedCredentialFilterID,
+      selectedCredentialTimelineFilters,
+    ]
+  );
+  const selectedCredentialTimelineAnalytics = useMonitoringAnalytics({
+    fromMs:
+      activeTabState === 'credentials' && selectedCredentialFilterID ? bounds?.fromMs : undefined,
+    toMs:
+      activeTabState === 'credentials' && selectedCredentialFilterID ? bounds?.toMs : undefined,
+    nowMs,
+    dataScopeKey: selectedCredentialTimelineDataScopeKey,
+    searchQuery: debouncedSearchQuery,
+    filters: selectedCredentialTimelineFilters,
+    include: selectedCredentialTimelineInclude,
+    throttleMs: 0,
+  });
+  const selectedCredentialTimelineData = selectedCredentialTimelineAnalytics.dataStale
+    ? null
+    : selectedCredentialTimelineAnalytics.data;
+  const credentialTrendLoading = Boolean(
+    activeTabState === 'credentials' &&
+      selectedCredentialFilterID &&
+      (selectedCredentialTimelineAnalytics.loading ||
+        selectedCredentialTimelineAnalytics.dataStale ||
+        (!selectedCredentialTimelineAnalytics.data && !selectedCredentialTimelineAnalytics.error))
+  );
+  const credentialTrendError =
+    activeTabState === 'credentials' && selectedCredentialFilterID
+      ? selectedCredentialTimelineAnalytics.error
+      : '';
+  const selectedCredentialTimeline = useMemo(
+    () =>
+      buildUsageCredentialTimeline(
+        selectedCredentialTimelineData?.credential_timeline ?? [],
+        resolvedGranularity,
+        credentialDisplayContext
+      ),
+    [credentialDisplayContext, resolvedGranularity, selectedCredentialTimelineData]
+  );
   const credentialTrendSeries = useMemo(
     () =>
       buildSelectedCredentialTrendSeries(
         selectedCredential,
-        adapted.credentialTimeline,
+        selectedCredentialTimeline,
         trendMetric
       ),
-    [adapted.credentialTimeline, selectedCredential, trendMetric]
+    [selectedCredential, selectedCredentialTimeline, trendMetric]
   );
   const heatmapDetail = useMemo(
     () => buildUsageHeatmapCellDetail(heatmapDetailSource, selectedHeatmapCell, heatmapMetric),
@@ -569,6 +639,9 @@ export function useUsageAnalytics() {
     if (selectedApiKeyTimelineAnalytics.enabled) {
       void selectedApiKeyTimelineAnalytics.refresh({ force: true });
     }
+    if (selectedCredentialTimelineAnalytics.enabled) {
+      void selectedCredentialTimelineAnalytics.refresh({ force: true });
+    }
     if (selectedHeatmapDate) {
       void heatmapDateAnalytics.refresh({ force: true });
     }
@@ -579,6 +652,7 @@ export function useUsageAnalytics() {
     loadApiKeyAliases,
     loadMonitoringMeta,
     selectedApiKeyTimelineAnalytics,
+    selectedCredentialTimelineAnalytics,
     selectedHeatmapDate,
   ]);
 
@@ -632,6 +706,8 @@ export function useUsageAnalytics() {
     apiKeyTrendSeries,
     selectedApiKeyTrendSeries,
     credentialTrendSeries,
+    credentialTrendLoading,
+    credentialTrendError,
     keyAnomalies,
     credentialAnomalies,
     credentialQuotaRows,

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -594,6 +594,7 @@ export interface MonitoringAnalyticsFilters {
   models?: string[];
   providers?: string[];
   accounts?: string[];
+  credential_ids?: string[];
   auth_files?: string[];
   auth_indices?: string[];
   api_key_hashes?: string[];


### PR DESCRIPTION
## Summary
Load Credential Timeline data only for the currently selected credential instead of returning timelines for every credential in the initial Credentials tab request.

This reduces the 100k-event two-stage allocation from approximately 50.34 MB to 12.20 MB while preserving existing filters, identity fallback behavior, and response contracts.

## Scope
- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add an exact `credential_ids` analytics filter using the shared credential identity fallback expression.
- Split the Credentials tab into a ranking request and a selected-credential timeline request.
- Add explicit loading and error states for the auxiliary timeline request, plus backend, frontend, and benchmark coverage.

## User Impact
The Credentials tab loads with substantially lower transient memory usage. Ranking data remains available if the selected credential timeline request fails, and the trend panel now shows explicit loading and error feedback.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the existing Manager Server analytics endpoint and CPA-key-compatible authentication path.
- Manager Server mode: Adds an optional backward-compatible filter field; existing clients and requests are unchanged.
- Full Docker / native packages: No configuration, packaging, or runtime topology changes.

## Data / Security Notes
No SQLite schema or persisted-data changes. Credential IDs are used only as server-side query filters, and no credential contents, raw usage fields, or secrets are newly exposed.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Restore `credential_timeline` to the main Credentials include request and remove the selected-credential auxiliary request.
- The optional backend `credential_ids` filter can remain without affecting existing clients.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test
npm run manager-server:test
cd apps/manager-server && go test -run '^$' -bench '^BenchmarkUsageAnalyticsIncludeProfiles/(credentials_tab_request|selected_credential_timeline_request|credentials_tab_two_stage)$' -benchmem -benchtime=1x -count=1 ./internal/service/monitoring

Frontend: 93 test files / 770 tests passed
Manager Server: go test ./... passed
Credentials main request: ~11.86 MB/op / 550 ms/op
Selected credential timeline: ~0.34 MB/op / 49 ms/op
Two-stage total: ~12.20 MB/op / 585 ms/op
Previous PR #347 path: ~50.34 MB/op / 1.19 s/op
```

## Screenshots / Recordings
N/A. The visible change is limited to transient loading and error feedback for the selected credential trend and is covered by component tests.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A