### PR TITLE
perf(usage-analytics): project hourly rollup reads

### DIFF
--- a/apps/manager-server/internal/repository/usagerollup/dashboard.go
+++ b/apps/manager-server/internal/repository/usagerollup/dashboard.go
@@ -189,6 +189,110 @@ order by bucket_ms, model, billing_model, service_tier`, fromMS, toMS)
 	return result, rows.Err()
 }
 
+func (r *repository) DashboardHourlyModelRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRow, error) {
+	return r.dashboardProjectedRows(ctx, `select
+	? as bucket_ms,
+	model,
+	billing_model,
+	service_tier,
+	sum(calls),
+	sum(success_calls),
+	sum(failure_calls),
+	sum(input_tokens),
+	sum(output_tokens),
+	sum(reasoning_tokens),
+	sum(cached_tokens),
+	sum(cache_read_tokens),
+	sum(cache_creation_tokens),
+	sum(long_input_tokens),
+	sum(long_output_tokens),
+	sum(long_cached_tokens),
+	sum(long_cache_read_tokens),
+	sum(long_cache_creation_tokens),
+	sum(total_tokens),
+	sum(latency_sum_ms),
+	sum(latency_samples),
+	sum(zero_token_calls),
+	max(updated_at_ms)
+from usage_dashboard_hourly_rollups
+where bucket_ms >= ? and bucket_ms < ?
+group by model, billing_model, service_tier
+order by model, billing_model, service_tier`, fromMS, fromMS, toMS)
+}
+
+func (r *repository) DashboardDailyRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRow, error) {
+	return r.dashboardProjectedRows(ctx, `select
+	(bucket_ms / ?) * ? as projected_bucket_ms,
+	model,
+	billing_model,
+	service_tier,
+	sum(calls),
+	sum(success_calls),
+	sum(failure_calls),
+	sum(input_tokens),
+	sum(output_tokens),
+	sum(reasoning_tokens),
+	sum(cached_tokens),
+	sum(cache_read_tokens),
+	sum(cache_creation_tokens),
+	sum(long_input_tokens),
+	sum(long_output_tokens),
+	sum(long_cached_tokens),
+	sum(long_cache_read_tokens),
+	sum(long_cache_creation_tokens),
+	sum(total_tokens),
+	sum(latency_sum_ms),
+	sum(latency_samples),
+	sum(zero_token_calls),
+	max(updated_at_ms)
+from usage_dashboard_hourly_rollups
+where bucket_ms >= ? and bucket_ms < ?
+group by projected_bucket_ms, model, billing_model, service_tier
+order by projected_bucket_ms, model, billing_model, service_tier`, int64(24)*dashboardHourMS, int64(24)*dashboardHourMS, fromMS, toMS)
+}
+
+func (r *repository) dashboardProjectedRows(ctx context.Context, query string, args ...any) ([]DashboardHourlyRow, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make([]DashboardHourlyRow, 0)
+	for rows.Next() {
+		var row DashboardHourlyRow
+		if err := rows.Scan(
+			&row.BucketMS,
+			&row.Model,
+			&row.BillingModel,
+			&row.ServiceTier,
+			&row.Calls,
+			&row.SuccessCalls,
+			&row.FailureCalls,
+			&row.InputTokens,
+			&row.OutputTokens,
+			&row.ReasoningTokens,
+			&row.CachedTokens,
+			&row.CacheReadTokens,
+			&row.CacheCreationTokens,
+			&row.LongInputTokens,
+			&row.LongOutputTokens,
+			&row.LongCachedTokens,
+			&row.LongCacheReadTokens,
+			&row.LongCacheCreationTokens,
+			&row.TotalTokens,
+			&row.LatencySumMS,
+			&row.LatencySamples,
+			&row.ZeroTokenCalls,
+			&row.UpdatedAtMS,
+		); err != nil {
+			return nil, err
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
 func dashboardEventsAfterCheckpoint(ctx context.Context, tx *sql.Tx, lastEventID int64, limit int) ([]dashboardEventRow, error) {
 	rows, err := tx.QueryContext(ctx, `select
 	id,

--- a/apps/manager-server/internal/repository/usagerollup/dashboard_test.go
+++ b/apps/manager-server/internal/repository/usagerollup/dashboard_test.go
@@ -73,6 +73,23 @@ func TestCatchUpDashboardHourlyAggregatesByCheckpoint(t *testing.T) {
 		t.Fatalf("priority row = %#v", rows[1])
 	}
 
+	modelRows, err := repo.DashboardHourlyModelRows(ctx, firstHour, firstHour+2*dashboardHourMS)
+	if err != nil {
+		t.Fatalf("query model projection: %v", err)
+	}
+	if len(modelRows) != 2 || modelRows[0].BucketMS != firstHour || modelRows[0].Calls != 3 || modelRows[1].Calls != 1 {
+		t.Fatalf("model projection = %#v", modelRows)
+	}
+
+	dailyRows, err := repo.DashboardDailyRows(ctx, firstHour, firstHour+2*dashboardHourMS)
+	if err != nil {
+		t.Fatalf("query daily projection: %v", err)
+	}
+	dayMS := int64(24) * dashboardHourMS
+	if len(dailyRows) != 2 || dailyRows[0].BucketMS != firstHour-firstHour%dayMS || dailyRows[0].Calls != 3 || dailyRows[1].Calls != 1 {
+		t.Fatalf("daily projection = %#v", dailyRows)
+	}
+
 	checkpoint, err := repo.Checkpoint(ctx, DashboardHourlyCheckpointName)
 	if err != nil {
 		t.Fatalf("checkpoint: %v", err)

--- a/apps/manager-server/internal/repository/usagerollup/repository.go
+++ b/apps/manager-server/internal/repository/usagerollup/repository.go
@@ -19,6 +19,8 @@ type Repository interface {
 	LatestEventID(ctx context.Context) (int64, error)
 	AccountHistoryRows(ctx context.Context, accountKeys []string) ([]AccountHistoryRow, error)
 	DashboardHourlyRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRow, error)
+	DashboardHourlyModelRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRow, error)
+	DashboardDailyRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRow, error)
 }
 
 type Checkpoint struct {

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -674,7 +674,14 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 	var hourlySnapshot usagehourly.Snapshot
 	hourlySnapshotAvailable := false
 	if rollupEligible && needsHourlyCore {
-		hourlySnapshot, hourlySnapshotAvailable = s.hourlyReader.Load(ctx, req.FromMS, req.ToMS)
+		hourlySnapshot, hourlySnapshotAvailable = s.hourlyReader.LoadAnalytics(
+			ctx,
+			req.FromMS,
+			req.ToMS,
+			granularity,
+			location,
+			hourlyTimelineRepresentable,
+		)
 	}
 
 	var modelStats []store.ModelStat
@@ -760,7 +767,14 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 				var prevSnapshot usagehourly.Snapshot
 				prevSnapshotAvailable := false
 				if rollupEligible {
-					prevSnapshot, prevSnapshotAvailable = s.hourlyReader.Load(ctx, prevFrom, req.FromMS)
+					prevSnapshot, prevSnapshotAvailable = s.hourlyReader.LoadAnalytics(
+						ctx,
+						prevFrom,
+						req.FromMS,
+						granularity,
+						location,
+						false,
+					)
 				}
 				if prevSnapshotAvailable {
 					prevAgg = prevSnapshot.Aggregate

--- a/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
@@ -341,7 +341,7 @@ func BenchmarkUsageAnalyticsHourlyCorePaths(b *testing.B) {
 	b.Run("rollup", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
-			snapshot, ok := reader.Load(ctx, fromMS, toMS)
+			snapshot, ok := reader.LoadAnalytics(ctx, fromMS, toMS, "day", time.UTC, true)
 			if !ok {
 				b.Fatal("rollup unavailable")
 			}

--- a/apps/manager-server/internal/service/usagehourly/reader.go
+++ b/apps/manager-server/internal/service/usagehourly/reader.go
@@ -29,10 +29,12 @@ type Snapshot struct {
 	Aggregate  store.Aggregate
 	ModelStats []store.ModelStat
 
-	rows        []store.DashboardHourlyRollupRow
-	edges       []timeRange
-	fullStartMS int64
-	fullEndMS   int64
+	rows                   []store.DashboardHourlyRollupRow
+	edges                  []timeRange
+	fullStartMS            int64
+	fullEndMS              int64
+	dashboardTimelineReady bool
+	analyticsTimelineReady bool
 }
 
 type timeRange struct {
@@ -66,6 +68,36 @@ func New(store *store.Store, enabled bool, logContext ...string) *Reader {
 }
 
 func (r *Reader) Load(ctx context.Context, fromMS, toMS int64) (Snapshot, bool) {
+	return r.loadRows(ctx, fromMS, toMS, r.store.DashboardHourlyRollupRows, true, true)
+}
+
+func (r *Reader) LoadAnalytics(
+	ctx context.Context,
+	fromMS int64,
+	toMS int64,
+	granularity string,
+	location *time.Location,
+	needsTimeline bool,
+) (Snapshot, bool) {
+	if needsTimeline {
+		if granularity != "day" || location == nil || location.String() != "UTC" {
+			return r.Load(ctx, fromMS, toMS)
+		}
+		return r.loadRows(ctx, fromMS, toMS, r.store.DashboardDailyRollupRows, false, true)
+	}
+	return r.loadRows(ctx, fromMS, toMS, r.store.DashboardHourlyRollupModelRows, false, false)
+}
+
+type rowLoader func(context.Context, int64, int64) ([]store.DashboardHourlyRollupRow, error)
+
+func (r *Reader) loadRows(
+	ctx context.Context,
+	fromMS int64,
+	toMS int64,
+	load rowLoader,
+	dashboardTimelineReady bool,
+	analyticsTimelineReady bool,
+) (Snapshot, bool) {
 	if !r.enabled {
 		return Snapshot{}, false
 	}
@@ -95,7 +127,7 @@ func (r *Reader) Load(ctx context.Context, fromMS, toMS int64) (Snapshot, bool) 
 		return Snapshot{}, false
 	}
 
-	rows, err := r.store.DashboardHourlyRollupRows(ctx, fullStartMS, fullEndMS)
+	rows, err := load(ctx, fullStartMS, fullEndMS)
 	if err != nil {
 		r.logFallback(fmt.Sprintf("hourly rows query failed: %v", err))
 		return Snapshot{}, false
@@ -125,16 +157,21 @@ func (r *Reader) Load(ctx context.Context, fromMS, toMS int64) (Snapshot, bool) 
 	}
 
 	return Snapshot{
-		Aggregate:   agg,
-		ModelStats:  modelStats,
-		rows:        rows,
-		edges:       edges,
-		fullStartMS: fullStartMS,
-		fullEndMS:   fullEndMS,
+		Aggregate:              agg,
+		ModelStats:             modelStats,
+		rows:                   rows,
+		edges:                  edges,
+		fullStartMS:            fullStartMS,
+		fullEndMS:              fullEndMS,
+		dashboardTimelineReady: dashboardTimelineReady,
+		analyticsTimelineReady: analyticsTimelineReady,
 	}, true
 }
 
 func (r *Reader) DashboardTimeline(ctx context.Context, snapshot Snapshot, fromMS, toMS int64) ([]store.TimelinePoint, bool) {
+	if !snapshot.dashboardTimelineReady {
+		return nil, false
+	}
 	if fromMS%hourMS != 0 {
 		timeline, err := r.store.HourlyTimelineBetween(ctx, fromMS, toMS)
 		if err != nil {
@@ -162,6 +199,9 @@ func (r *Reader) AnalyticsTimeline(
 	granularity string,
 	location *time.Location,
 ) ([]store.TimelinePoint, bool) {
+	if !snapshot.analyticsTimelineReady {
+		return nil, false
+	}
 	if location == nil {
 		location = time.UTC
 	}

--- a/apps/manager-server/internal/service/usagehourly/reader_test.go
+++ b/apps/manager-server/internal/service/usagehourly/reader_test.go
@@ -70,6 +70,29 @@ func TestReaderMatchesRawCoreAndTimelines(t *testing.T) {
 	if !ok || !reflect.DeepEqual(analyticsTimeline, rawAnalyticsTimeline) {
 		t.Fatalf("analytics timeline mismatch\nrollup=%#v\nraw=%#v", analyticsTimeline, rawAnalyticsTimeline)
 	}
+
+	projected, ok := reader.LoadAnalytics(ctx, fromMS, toMS, "day", time.UTC, true)
+	if !ok {
+		t.Fatal("analytics reader did not use daily projection")
+	}
+	if !reflect.DeepEqual(projected.Aggregate, rawAggregate) || !reflect.DeepEqual(projected.ModelStats, rawModels) {
+		t.Fatalf("projected core mismatch\nrollup=%#v %#v\nraw=%#v %#v", projected.Aggregate, projected.ModelStats, rawAggregate, rawModels)
+	}
+	projectedTimeline, ok := reader.AnalyticsTimeline(ctx, projected, "day", time.UTC)
+	if !ok || !reflect.DeepEqual(projectedTimeline, rawAnalyticsTimeline) {
+		t.Fatalf("projected timeline mismatch\nrollup=%#v\nraw=%#v", projectedTimeline, rawAnalyticsTimeline)
+	}
+	if _, ok := reader.DashboardTimeline(ctx, projected, fromMS, toMS); ok {
+		t.Fatal("daily analytics projection unexpectedly exposed dashboard timeline")
+	}
+
+	modelOnly, ok := reader.LoadAnalytics(ctx, fromMS, toMS, "day", time.UTC, false)
+	if !ok || !reflect.DeepEqual(modelOnly.Aggregate, rawAggregate) || !reflect.DeepEqual(modelOnly.ModelStats, rawModels) {
+		t.Fatalf("model-only projection mismatch\nrollup=%#v %#v\nraw=%#v %#v", modelOnly.Aggregate, modelOnly.ModelStats, rawAggregate, rawModels)
+	}
+	if _, ok := reader.AnalyticsTimeline(ctx, modelOnly, "day", time.UTC); ok {
+		t.Fatal("model-only projection unexpectedly exposed analytics timeline")
+	}
 }
 
 func TestReaderAnalyticsTimelineFallsBackForHalfHourBuckets(t *testing.T) {

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -292,6 +292,14 @@ func (s *Store) DashboardHourlyRollupRows(ctx context.Context, fromMS, toMS int6
 	return s.UsageRollups.DashboardHourlyRows(ctx, fromMS, toMS)
 }
 
+func (s *Store) DashboardHourlyRollupModelRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRollupRow, error) {
+	return s.UsageRollups.DashboardHourlyModelRows(ctx, fromMS, toMS)
+}
+
+func (s *Store) DashboardDailyRollupRows(ctx context.Context, fromMS, toMS int64) ([]DashboardHourlyRollupRow, error) {
+	return s.UsageRollups.DashboardDailyRows(ctx, fromMS, toMS)
+}
+
 func AccountHistoryKey(accountSnapshot, authLabelSnapshot, source, authIndex string) string {
 	return usagerollup.AccountKey(accountSnapshot, authLabelSnapshot, source, authIndex)
 }


### PR DESCRIPTION
## Summary
Use query-specific hourly rollup projections for Usage Analytics instead of loading every wide hourly row into Go.

This reduces allocations for common analytics tabs while preserving API contracts, raw edge compensation, checkpoint guards, and timezone fallbacks.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add model-only and UTC daily projection queries over existing hourly rollups.
- Select compact analytics snapshots based on timeline and timezone requirements.
- Add repository and reader parity coverage plus projected-path benchmarks.

## User Impact
No user-facing behavior change. Usage Analytics uses substantially less transient memory when loading Overview, Trends, Models, API Keys, and Credentials data.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the same Manager Server analytics endpoint and authentication path.
- Manager Server mode: Response contracts and raw fallback behavior are unchanged.
- Full Docker / native packages: No configuration, schema, packaging, or runtime topology changes.

## Data / Security Notes
No SQLite schema or persisted-data changes. Queries read the existing hourly rollup table and do not expose new usage fields, raw payloads, failure bodies, or credentials.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Restore Usage Analytics to the generic hourly rollup reader.
- The projection repository methods can be removed independently because they do not modify persisted data.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run manager-server:test
cd apps/manager-server && go test -race ./internal/repository/usagerollup ./internal/service/usagehourly ./internal/service/monitoring
cd apps/manager-server && go test -run '^$' -bench 'BenchmarkUsageAnalyticsIncludeProfiles/.*|BenchmarkUsageAnalyticsHourlyCorePaths/.*' -benchmem -benchtime=1x -count=1 ./internal/service/monitoring

Hourly rollup core: ~11.27 MB/op -> ~0.61 MB/op (-94.6%)
Trends / Models: ~17.85 MB/op -> ~7.20 MB/op (-59.7%)
API Keys: ~11.80 MB/op -> ~0.79 MB/op
Credentials two-stage: ~12.20 MB/op -> ~1.18 MB/op
```

## Screenshots / Recordings
N/A. This is a backend-only performance optimization with no visible UI changes.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A