### PR TITLE
perf(dashboard): parallelize refresh queries

### DIFF
--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
@@ -236,40 +237,84 @@ func (s *Service) Summary(ctx context.Context, p SummaryParams) (SummaryResponse
 		recentLimit = defaultRecentFailures
 	}
 
-	todayAgg, modelStats, topStats, timeline, err := s.loadTodayMetrics(ctx, p.TodayStartMS, nowMS, topLimit)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
 	rollingStartMS := nowMS - rollingWindowMs
-	rollingAgg, err := s.store.AggregateBetween(ctx, rollingStartMS, nowMS)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	recentFailures, err := s.store.RecentFailuresBetween(ctx, p.TodayStartMS, nowMS, recentLimit)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	prices, err := s.store.LoadModelPrices(ctx)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
 	filter := store.AnalyticsFilter{
 		FromMS:        p.TodayStartMS,
 		ToMS:          nowMS,
 		IncludeFailed: true,
 	}
 	healthTimelineToMS := p.TodayStartMS + int64(healthTimelineBuckets)*healthTimelineBucketMs
-	healthTimelinePoints, err := s.store.BucketTimelineBetween(ctx, p.TodayStartMS, nowMS, healthTimelineBucketMs)
-	if err != nil {
-		return SummaryResponse{}, err
+
+	queryCtx, cancelQueries := context.WithCancel(ctx)
+	defer cancelQueries()
+
+	var (
+		todayAgg             store.Aggregate
+		modelStats           []store.ModelStat
+		topStats             []store.ModelStat
+		timeline             []store.TimelinePoint
+		rollingAgg           store.Aggregate
+		recentFailures       []store.RecentFailure
+		prices               map[string]store.ModelPrice
+		healthTimelinePoints []store.TimelinePoint
+		channelStats         []store.ChannelModelStat
+		failureSources       []store.FailureSourceStat
+	)
+	var waitGroup sync.WaitGroup
+	var firstError error
+	var errorOnce sync.Once
+	runQuery := func(query func() error) {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			if err := query(); err != nil {
+				errorOnce.Do(func() {
+					firstError = err
+					cancelQueries()
+				})
+			}
+		}()
 	}
-	channelStats, err := s.store.ChannelModelStatsWithFilter(ctx, filter)
-	if err != nil {
-		return SummaryResponse{}, err
-	}
-	failureSources, err := s.store.FailureSourcesWithFilter(ctx, filter)
-	if err != nil {
-		return SummaryResponse{}, err
+
+	runQuery(func() error {
+		var err error
+		todayAgg, modelStats, topStats, timeline, err = s.loadTodayMetrics(queryCtx, p.TodayStartMS, nowMS, topLimit)
+		return err
+	})
+	runQuery(func() error {
+		var err error
+		rollingAgg, err = s.store.AggregateBetween(queryCtx, rollingStartMS, nowMS)
+		return err
+	})
+	runQuery(func() error {
+		var err error
+		recentFailures, err = s.store.RecentFailuresBetween(queryCtx, p.TodayStartMS, nowMS, recentLimit)
+		return err
+	})
+	runQuery(func() error {
+		var err error
+		prices, err = s.store.LoadModelPrices(queryCtx)
+		return err
+	})
+	runQuery(func() error {
+		var err error
+		healthTimelinePoints, err = s.store.BucketTimelineBetween(queryCtx, p.TodayStartMS, nowMS, healthTimelineBucketMs)
+		return err
+	})
+	runQuery(func() error {
+		var err error
+		channelStats, err = s.store.ChannelModelStatsWithFilter(queryCtx, filter)
+		return err
+	})
+	runQuery(func() error {
+		var err error
+		failureSources, err = s.store.FailureSourcesWithFilter(queryCtx, filter)
+		return err
+	})
+
+	waitGroup.Wait()
+	if firstError != nil {
+		return SummaryResponse{}, firstError
 	}
 	today := buildTodaySummary(todayAgg, modelStats, prices)
 	trafficTimeline := buildTrafficTimeline(p.TodayStartMS, nowMS, timeline)

--- a/apps/manager-server/internal/service/dashboard/service_benchmark_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	monitoringsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/monitoring"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -80,6 +81,195 @@ func insertDashboardBenchmarkEvents(b *testing.B, ctx context.Context, db *store
 			}
 			if index%7 == 0 {
 				event.ServiceTier = "priority"
+			}
+			events = append(events, event)
+		}
+		if _, err := db.InsertEvents(ctx, events); err != nil {
+			b.Fatalf("insert benchmark events: %v", err)
+		}
+	}
+}
+
+func BenchmarkDashboardMonitoringRefreshPaths(b *testing.B) {
+	for _, count := range []int{10_000, 100_000, 1_000_000} {
+		b.Run(fmt.Sprintf("events_%dk", count/1_000), func(b *testing.B) {
+			db, err := store.Open(filepath.Join(b.TempDir(), "usage.sqlite"))
+			if err != nil {
+				b.Fatalf("open store: %v", err)
+			}
+			b.Cleanup(func() { _ = db.Close() })
+
+			ctx := context.Background()
+			todayStartMS := int64(1_800_000_000_000)
+			nowMS := todayStartMS + 24*hourWindowMs
+			insertDashboardRecentBenchmarkEvents(b, ctx, db, todayStartMS, nowMS, count)
+			for {
+				result, err := db.CatchUpDashboardHourlyRollups(ctx, 10_000, nowMS)
+				if err != nil {
+					b.Fatalf("catch up dashboard rollup: %v", err)
+				}
+				if !result.Pending {
+					break
+				}
+			}
+
+			dashboardService := New(db)
+			monitoringService := monitoringsvc.New(db, true)
+			todayFilter := store.AnalyticsFilter{FromMS: todayStartMS, ToMS: nowMS, IncludeFailed: true}
+			recentFromMS := nowMS - rollingWindowMs
+			recentFilter := store.AnalyticsFilter{FromMS: recentFromMS, ToMS: nowMS, IncludeFailed: true}
+
+			benchmarks := []struct {
+				name string
+				run  func() error
+			}{
+				{
+					name: "dashboard_full_refresh",
+					run: func() error {
+						_, err := dashboardService.Summary(ctx, SummaryParams{
+							TodayStartMS:   todayStartMS,
+							NowMS:          nowMS,
+							TopModels:      5,
+							RecentFailures: 5,
+						})
+						return err
+					},
+				},
+				{
+					name: "rolling_30m",
+					run: func() error {
+						_, err := db.AggregateBetween(ctx, recentFromMS, nowMS)
+						return err
+					},
+				},
+				{
+					name: "health_timeline_5m",
+					run: func() error {
+						_, err := db.BucketTimelineBetween(ctx, todayStartMS, nowMS, 5*60*1000)
+						return err
+					},
+				},
+				{
+					name: "health_timeline_10m",
+					run: func() error {
+						_, err := db.BucketTimelineBetween(ctx, todayStartMS, nowMS, healthTimelineBucketMs)
+						return err
+					},
+				},
+				{
+					name: "recent_failures",
+					run: func() error {
+						_, err := db.RecentFailuresBetween(ctx, todayStartMS, nowMS, 5)
+						return err
+					},
+				},
+				{
+					name: "channel_stats",
+					run: func() error {
+						_, err := db.ChannelModelStatsWithFilter(ctx, todayFilter)
+						return err
+					},
+				},
+				{
+					name: "failure_sources",
+					run: func() error {
+						_, err := db.FailureSourcesWithFilter(ctx, todayFilter)
+						return err
+					},
+				},
+				{
+					name: "recent_query_combo",
+					run: func() error {
+						if _, err := db.AggregateWithFilter(ctx, recentFilter); err != nil {
+							return err
+						}
+						if _, err := db.BucketTimelineBetween(ctx, recentFromMS, nowMS, 5*60*1000); err != nil {
+							return err
+						}
+						if _, err := db.RecentFailuresWithFilter(ctx, recentFilter, 8); err != nil {
+							return err
+						}
+						if _, err := db.ChannelModelStatsWithFilter(ctx, recentFilter); err != nil {
+							return err
+						}
+						_, err := db.FailureSourcesWithFilter(ctx, recentFilter)
+						return err
+					},
+				},
+				{
+					name: "monitoring_recent_refresh",
+					run: func() error {
+						_, err := monitoringService.Analytics(ctx, monitoringsvc.Request{
+							FromMS:   recentFromMS,
+							ToMS:     nowMS,
+							NowMS:    nowMS,
+							TimeZone: "UTC",
+							Include: monitoringsvc.Include{
+								Summary:        true,
+								Timeline:       true,
+								ChannelShare:   true,
+								FailureSources: true,
+								RecentFailures: 8,
+								EventsPage:     &monitoringsvc.EventsPage{Limit: 50},
+								Granularity:    "hour",
+							},
+						})
+						return err
+					},
+				},
+			}
+
+			for _, benchmark := range benchmarks {
+				b.Run(benchmark.name, func(b *testing.B) {
+					b.ReportAllocs()
+					for range b.N {
+						if err := benchmark.run(); err != nil {
+							b.Fatalf("%s: %v", benchmark.name, err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func insertDashboardRecentBenchmarkEvents(b *testing.B, ctx context.Context, db *store.Store, fromMS, toMS int64, count int) {
+	b.Helper()
+	const batchSize = 1_000
+	stepMS := max(int64(1), (toMS-fromMS)/int64(count))
+	for start := 0; start < count; start += batchSize {
+		end := min(start+batchSize, count)
+		events := make([]usage.Event, 0, end-start)
+		for index := start; index < end; index++ {
+			timestampMS := fromMS + int64(index)*stepMS
+			latencyMS := int64(50 + index%2_000)
+			model := fmt.Sprintf("benchmark-model-%02d", index%12)
+			event := dashboardEvent(
+				fmt.Sprintf("dashboard-recent-benchmark-%07d", index),
+				timestampMS,
+				model,
+				index%20 == 0,
+				int64(100+index%1_000),
+				int64(50+index%500),
+				int64(index%100),
+				int64(index%200),
+				int64(index%50),
+				int64(200+index%2_000),
+				&latencyMS,
+			)
+			event.ResolvedModel = model
+			event.ServiceTier = []string{"", "default", "priority"}[index%3]
+			event.AuthIndex = fmt.Sprintf("auth-%03d", index%200)
+			event.Source = fmt.Sprintf("source-%03d", index%200)
+			event.SourceHash = fmt.Sprintf("source-hash-%03d", index%200)
+			event.APIKeyHash = fmt.Sprintf("api-key-%03d", index%100)
+			event.AccountSnapshot = fmt.Sprintf("account-%03d@example.com", index%200)
+			event.AuthLabelSnapshot = fmt.Sprintf("Account %03d", index%200)
+			event.AuthProviderSnapshot = []string{"codex", "claude", "gemini"}[index%3]
+			event.AuthProjectIDSnapshot = fmt.Sprintf("project-%02d", index%20)
+			event.Endpoint = "/v1/responses"
+			if event.Failed {
+				event.FailSummary = fmt.Sprintf("benchmark failure %d", index%10)
 			}
 			events = append(events, event)
 		}

--- a/apps/manager-server/internal/service/dashboard/service_test.go
+++ b/apps/manager-server/internal/service/dashboard/service_test.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"errors"
 	"math"
 	"path/filepath"
 	"reflect"
@@ -11,6 +12,20 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
+
+func TestSummaryReturnsContextCancellation(t *testing.T) {
+	db := newDashboardTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := New(db).Summary(ctx, SummaryParams{
+		TodayStartMS: 1_778_000_000_000,
+		NowMS:        1_778_000_060_000,
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("summary error = %v, want context canceled", err)
+	}
+}
 
 func TestSummaryEmptyStore(t *testing.T) {
 	db := newDashboardTestStore(t)


### PR DESCRIPTION
## Summary
Reduce Dashboard refresh latency by running independent read-only summary queries concurrently on the existing bounded SQLite connection pool.
Profiling showed current-day channel, failure-source, and health aggregations were the dominant cost; recent-event caching was not justified by the measured recent-window cost.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Execute independent Dashboard summary reads concurrently with shared context cancellation and first-error propagation.
- Keep the existing four-connection SQLite pool as the concurrency bound.
- Add cancellation coverage and reproducible 10k, 100k, and 1m refresh benchmarks covering rolling windows, health timelines, recent failures, channel stats, failure sources, and monitoring combinations.

## User Impact
No response-contract or visible behavior changes. Dashboard refreshes complete substantially faster as usage history grows.

## Compatibility / Runtime Notes
- CPA panel mode: No authentication, routing, or response changes.
- Manager Server mode: Uses the existing SQLite pool and raw/rollup fallback behavior.
- Full Docker / native packages: No configuration, schema, or packaging changes.

## Data / Security Notes
No event cache was added. Queries retain the existing privacy boundaries and do not introduce storage or exposure of raw_json, fail_body, full metadata, keys, or credentials.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the commit to restore sequential Dashboard queries.
- At 1m events, measured maximum RSS increased from about 38.2 MB to 55.5 MB while refresh latency fell by about 50%; repeated runs showed bounded memory rather than growth.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
go test ./internal/service/dashboard -count=1
go test -race ./internal/service/dashboard -count=1
go vet ./...
npm run manager-server:test
cd apps/manager-server && go test -race ./...
go test ./internal/service/dashboard -run '^$' -bench BenchmarkDashboardMonitoringRefreshPaths -benchmem

10k full refresh: about 65.7 ms -> 41.2 ms
100k full refresh: about 717.7 ms -> 402.4 ms
1m full refresh: about 8.62 s -> 4.27 s
100k rolling 30m: about 2.3 ms
100k recent failures: about 0.16 ms
```

## Screenshots / Recordings
N/A — backend-only performance change with no visible UI changes.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A