### PR TITLE
fix(manager-server): support Windows SQLite file URIs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -70,6 +70,24 @@ jobs:
         working-directory: apps/manager-server
         run: go test ./...
 
+  manager-server-windows-sqlite:
+    name: Manager Server SQLite (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+          cache-dependency-path: apps/manager-server/go.sum
+
+      - name: Test SQLite repository
+        working-directory: apps/manager-server
+        run: go test ./internal/repository/sqlite
+
   native-control:
     name: Native Control (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/apps/manager-server/internal/repository/sqlite/db.go
+++ b/apps/manager-server/internal/repository/sqlite/db.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -14,10 +15,14 @@ func Open(path string) (*sql.DB, error) {
 }
 
 func OpenWithOptions(options Options) (*sql.DB, error) {
-	if err := os.MkdirAll(filepath.Dir(options.Path), 0o755); err != nil {
+	dbPath, err := filepath.Abs(options.Path)
+	if err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite", dataSourceName(options.Path))
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", dataSourceName(dbPath))
 	if err != nil {
 		return nil, err
 	}
@@ -32,9 +37,13 @@ func OpenWithOptions(options Options) (*sql.DB, error) {
 }
 
 func dataSourceName(path string) string {
+	uriPath := filepath.ToSlash(path)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
 	dsn := &url.URL{
 		Scheme: "file",
-		Path:   filepath.ToSlash(path),
+		Path:   uriPath,
 	}
 	query := dsn.Query()
 	query.Add("_pragma", "busy_timeout(5000)")

--- a/apps/manager-server/internal/repository/sqlite/db_test.go
+++ b/apps/manager-server/internal/repository/sqlite/db_test.go
@@ -51,7 +51,7 @@ func TestOpenWithOptionsSupportsRelativePath(t *testing.T) {
 }
 
 func TestOpenWithOptionsAppliesConnectionDefaults(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "usage ? #.sqlite")
+	dbPath := filepath.Join(t.TempDir(), "usage #.sqlite")
 	db, err := OpenWithOptions(Options{Path: dbPath})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)

--- a/apps/manager-server/internal/repository/sqlite/db_test.go
+++ b/apps/manager-server/internal/repository/sqlite/db_test.go
@@ -3,9 +3,52 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"net/url"
+	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
+
+func TestDataSourceNameEncodesWindowsDrivePath(t *testing.T) {
+	dsn := dataSourceName("C:/CPA Manager/data/usage ? #.sqlite")
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse data source name: %v", err)
+	}
+	if parsed.Scheme != "file" {
+		t.Fatalf("scheme = %q, want file", parsed.Scheme)
+	}
+	if parsed.Host != "" {
+		t.Fatalf("host = %q, want empty", parsed.Host)
+	}
+	if want := "/C:/CPA Manager/data/usage ? #.sqlite"; parsed.Path != want {
+		t.Fatalf("path = %q, want %q", parsed.Path, want)
+	}
+	wantPragmas := []string{
+		"busy_timeout(5000)",
+		"foreign_keys(1)",
+		"synchronous(FULL)",
+	}
+	if pragmas := parsed.Query()["_pragma"]; !slices.Equal(pragmas, wantPragmas) {
+		t.Fatalf("pragmas = %q, want %q", pragmas, wantPragmas)
+	}
+}
+
+func TestOpenWithOptionsSupportsRelativePath(t *testing.T) {
+	t.Chdir(t.TempDir())
+	dbPath := filepath.Join("data", "usage.sqlite")
+	db, err := OpenWithOptions(Options{Path: dbPath})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("stat sqlite database: %v", err)
+	}
+}
 
 func TestOpenWithOptionsAppliesConnectionDefaults(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "usage ? #.sqlite")


### PR DESCRIPTION
## Summary

Fix Windows native packages failing to start when opening SQLite databases with drive-letter paths.

The SQLite DSN now preserves an empty URI authority and produces paths such as `file:///C:/data/usage.sqlite`.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Resolve SQLite database paths to absolute paths before constructing the DSN.
- Encode Windows drive-letter paths as file URI paths rather than URI authorities.
- Add drive-letter and relative-path regression tests plus focused Windows CI coverage.

## User Impact

Windows native packages can initialize and open SQLite databases normally instead of exiting with `SQL logic error: out of memory (1)`.

## Compatibility / Runtime Notes

- CPA panel mode: No frontend behavior change.
- Manager Server mode: SQLite paths are normalized before opening the database.
- Full Docker / native packages: Docker, Linux, and macOS behavior is unchanged; Windows native startup is fixed.

## Data / Security Notes

No schema, migration, encryption, or stored-data changes. Existing SQLite databases and `data.key` files continue to be used unchanged.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert the two commits to restore the previous DSN construction and CI configuration.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
go test ./internal/repository/sqlite
go test ./...
GOOS=windows GOARCH=amd64 go test -c ./internal/repository/sqlite
GOOS=windows GOARCH=arm64 go test -c ./internal/repository/sqlite
npm run build
Windows amd64 native package startup verified in a virtual machine.
```

## Screenshots / Recordings

N/A — backend/native startup fix.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related

Fixes #345