### PR TITLE
fix(usage-analytics): show fine-grained cache tokens

### DIFF
--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -63,11 +63,11 @@ const splitTokens = (totalTokens: number) => {
   const cachedTokens = Math.round(totalTokens * 0.13);
   const cacheReadTokens = Math.round(cachedTokens * 0.78);
   const cacheCreationTokens = cachedTokens - cacheReadTokens;
-  const reasoningTokens = Math.max(0, totalTokens - inputTokens - outputTokens - cachedTokens);
+  const reasoningTokens = Math.max(0, totalTokens - inputTokens - outputTokens);
   return {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
-    cached_tokens: cachedTokens,
+    cached_tokens: 0,
     cache_read_tokens: cacheReadTokens,
     cache_creation_tokens: cacheCreationTokens,
     reasoning_tokens: reasoningTokens,
@@ -1958,11 +1958,12 @@ const buildMonitoringAnalytics = (
     const profile = eventProfiles[index % eventProfiles.length];
     const failed = index % 9 === 0 || index % 22 === 0;
     const quotaFailure = failed && index % 2 === 0;
-    const inputTokens = 620 + ((index * 113) % 2600);
+    const uncachedInputTokens = 620 + ((index * 113) % 2600);
     const outputTokens = 210 + ((index * 71) % 980);
     const cachedTokens = index % 3 === 0 ? 180 + ((index * 17) % 520) : 0;
+    const inputTokens = uncachedInputTokens + cachedTokens;
     const reasoningTokens = index % 4 === 0 ? 80 + ((index * 13) % 360) : 0;
-    const totalTokens = inputTokens + outputTokens + cachedTokens + reasoningTokens;
+    const totalTokens = inputTokens + outputTokens + reasoningTokens;
     const timestampMs = analyticsNow - (index * 5 + (index % 4)) * minute;
     return {
       request_id: `demo-request-${String(index + 1).padStart(3, '0')}`,
@@ -1990,7 +1991,7 @@ const buildMonitoringAnalytics = (
       executor_type: profile.executor,
       input_tokens: inputTokens,
       output_tokens: outputTokens,
-      cached_tokens: cachedTokens,
+      cached_tokens: 0,
       cache_read_tokens: Math.round(cachedTokens * 0.78),
       cache_creation_tokens: Math.round(cachedTokens * 0.22),
       reasoning_tokens: reasoningTokens,
@@ -2376,9 +2377,9 @@ const buildMonitoringAnalytics = (
         auth_index: 'codex-team-01',
         models: ['gpt-4.1-mini', 'gpt-4.1'],
         endpoints: ['/v1/chat/completions', '/v1/responses'],
-        input_tokens: 1_260_000,
+        input_tokens: 1_520_000,
         output_tokens: 540_000,
-        cached_tokens: 260_000,
+        cached_tokens: 0,
         cache_read_tokens: 210_000,
         cache_creation_tokens: 50_000,
         total_tokens: 2_060_000,
@@ -2397,9 +2398,9 @@ const buildMonitoringAnalytics = (
         auth_index: 'claude-team-01',
         models: ['claude-sonnet-4-5'],
         endpoints: ['/v1/messages'],
-        input_tokens: 1_480_000,
+        input_tokens: 1_660_000,
         output_tokens: 620_000,
-        cached_tokens: 180_000,
+        cached_tokens: 0,
         cache_read_tokens: 150_000,
         cache_creation_tokens: 30_000,
         total_tokens: 2_280_000,

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
@@ -1,6 +1,7 @@
 import { act } from 'react';
 import { create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EChartsView } from '@/components/charts/EChartsView';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import {
@@ -534,6 +535,52 @@ describe('UsageAnalyticsPage', () => {
     expect(text).not.toContain('usage_analytics.model_overview_title');
     expect(text).not.toContain('usage_analytics.api_key_overview_title');
     expect(text).not.toContain('usage_analytics.drilldown_preview_title');
+  });
+
+  it('renders fine-grained cache buckets in token charts', () => {
+    const point = createTimelinePoint({
+      cachedTokens: 0,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+    });
+    mocks.usageState = createUsageState({
+      activeTab: 'trends',
+      timeline: [point],
+      anomalyAnalysis: null,
+      selectedBucket: null,
+    });
+
+    const renderer = renderPage();
+    const cacheSeries = renderer.root
+      .findAllByType(EChartsView)
+      .flatMap(
+        (node) => (node.props.option?.series ?? []) as Array<{ data?: number[]; name?: string }>
+      )
+      .find((series) => series.name === 'usage_analytics.metric_cached_tokens');
+
+    expect(cacheSeries?.data).toEqual([100]);
+  });
+
+  it('renders fine-grained cache buckets in rank tables', () => {
+    const modelRow = createRankRow({
+      cachedTokens: 0,
+      cacheReadTokens: 80,
+      cacheCreationTokens: 20,
+    });
+    mocks.usageState = createUsageState({
+      activeTab: 'models',
+      modelRows: [modelRow],
+      selectedModel: modelRow,
+    });
+
+    const renderer = renderPage();
+    const cells = renderer.root
+      .findAllByType('tr')
+      .map((row) => row.findAllByType('td'))
+      .find((rowCells) => rowCells.length >= 10 && getText(rowCells[1]).includes('gpt-4o'));
+
+    expect(cells).toBeDefined();
+    expect(getText(cells![6])).toBe('100');
   });
 
   it('shows empty and error states from the analytics hook', () => {

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -45,6 +45,7 @@ import {
   formatHeatmapMetricValue,
   formatLocalDateTime,
   formatMetricValue,
+  getUsageCacheTokens,
   hasUsageData,
   maskApiKeyHash,
   parseDateTimeLocalValue,
@@ -471,7 +472,8 @@ const getApiKeyContributorDisplayLabel = (row: UsageHeatmapContributor) => {
   return label && label.toLowerCase() !== row.key.toLowerCase() ? label : maskApiKeyHash(row.key);
 };
 
-const metricValue = (point: UsageTimelinePoint, key: UsageMetricKey) => point[key];
+const metricValue = (point: UsageTimelinePoint, key: UsageMetricKey) =>
+  key === 'cachedTokens' ? getUsageCacheTokens(point) : point[key];
 
 const getMetricAxisIndex = (axis: (typeof USAGE_METRICS)[number]['axis']) =>
   usageChartAxisKeys[axis];
@@ -1896,7 +1898,7 @@ function TokenStructureChart({ timeline }: { timeline: UsageTimelinePoint[] }) {
         },
         {
           barMaxWidth: 22,
-          data: timeline.map((point) => point.cachedTokens),
+          data: timeline.map((point) => getUsageCacheTokens(point)),
           itemStyle: tokenBarItemStyle,
           name: t('usage_analytics.metric_cached_tokens'),
           stack: 'tokens',
@@ -3706,7 +3708,7 @@ function RankTable({
                 <td>{compactNumber(row.totalTokens)}</td>
                 <td>{compactNumber(row.inputTokens)}</td>
                 <td>{compactNumber(row.outputTokens)}</td>
-                <td>{compactNumber(row.cachedTokens)}</td>
+                <td>{compactNumber(getUsageCacheTokens(row))}</td>
                 {type !== 'credential' ? (
                   <td>{formatPercent(computeRowCacheHitRate(row))}</td>
                 ) : null}

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -29,6 +29,7 @@ import {
   computeCacheHitRate,
   computeRowAverageCostPerCall,
   computeRowCacheHitRate,
+  getUsageCacheTokens,
   getUsageRangeBounds,
   maskApiKeyHash,
   resolveUsageGranularity,
@@ -396,6 +397,23 @@ describe('usage analytics adapters', () => {
       successRate: 2 / 3,
       averageLatencyMs: 250,
     });
+  });
+
+  it('combines compatible, cache-read, and cache-creation buckets for display', () => {
+    expect(
+      getUsageCacheTokens({
+        cachedTokens: 0,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+      })
+    ).toBe(100);
+    expect(
+      getUsageCacheTokens({
+        cachedTokens: 5,
+        cacheReadTokens: 4,
+        cacheCreationTokens: 1,
+      })
+    ).toBe(10);
   });
 
   it('builds selected credential trend series from backend credential timeline buckets', () => {
@@ -1266,10 +1284,7 @@ describe('model rank derivations', () => {
       cacheHitRate: 151_000 / 152_600,
     });
     expect(computeRowCacheHitRate(row)).toBeCloseTo(151_000 / 152_600, 6);
-    expect(computeRowCacheHitRate(rankRow({ models: [row] }))).toBeCloseTo(
-      151_000 / 152_600,
-      6
-    );
+    expect(computeRowCacheHitRate(rankRow({ models: [row] }))).toBeCloseTo(151_000 / 152_600, 6);
   });
 
   it('builds the reverse key distribution for a model from API key breakdowns', () => {
@@ -1373,6 +1388,41 @@ describe('usage anomaly drilldown', () => {
         averageTokensPerRequest: 0,
       })
     ).toEqual(['usage_analytics.cause_request_drop', 'usage_analytics.cause_cost_drop']);
+  });
+
+  it('detects cache growth from fine-grained cache buckets', () => {
+    const timeline = buildUsageTimeline(
+      [
+        {
+          bucket_ms: NOW_MS,
+          label: '',
+          calls: 1,
+          tokens: 100,
+          success: 1,
+          failure: 0,
+          input_tokens: 100,
+          cache_read_tokens: 10,
+          cache_creation_tokens: 0,
+        },
+        {
+          bucket_ms: NOW_MS + HOUR_MS,
+          label: '',
+          calls: 1,
+          tokens: 100,
+          success: 1,
+          failure: 0,
+          input_tokens: 100,
+          cache_read_tokens: 25,
+          cache_creation_tokens: 5,
+        },
+      ],
+      'hour'
+    );
+
+    const analysis = analyzeUsageBucket(timeline, NOW_MS + HOUR_MS);
+
+    expect(analysis?.changes.cachedTokens).toBe(2);
+    expect(analysis?.causeKeys).toContain('usage_analytics.cause_cache_growth');
   });
 
   it('builds stable monitoring detail query parameters', () => {

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -819,6 +819,15 @@ export const computeCacheHitRate = (tokens: {
   return calculateCacheHitRate(tokens);
 };
 
+export const getUsageCacheTokens = (tokens: {
+  cachedTokens: unknown;
+  cacheReadTokens: unknown;
+  cacheCreationTokens: unknown;
+}): number =>
+  Math.max(toNumber(tokens.cachedTokens), 0) +
+  Math.max(toNumber(tokens.cacheReadTokens), 0) +
+  Math.max(toNumber(tokens.cacheCreationTokens), 0);
+
 const getRowCacheHitTotals = (row: UsageRankRow) => {
   const hasExplicitTotals =
     typeof row.cacheHitTokens === 'number' &&
@@ -1523,8 +1532,7 @@ const buildProviderModelsFromEntities = (
       existing.cacheReadTokens += model.cacheReadTokens;
       existing.cacheCreationTokens += model.cacheCreationTokens;
       existing.cacheHitTokens = existingCacheTotals.hitTokens + modelCacheTotals.hitTokens;
-      existing.cacheHitInputTokens =
-        existingCacheTotals.inputTokens + modelCacheTotals.inputTokens;
+      existing.cacheHitInputTokens = existingCacheTotals.inputTokens + modelCacheTotals.inputTokens;
       existing.cacheHitRate = calculateCacheHitRateFromTotals(
         existing.cacheHitTokens,
         existing.cacheHitInputTokens
@@ -2374,7 +2382,9 @@ export const analyzeUsageBucket = (
     totalTokens: previousPoint ? percentChange(point.totalTokens, previousPoint.totalTokens) : 0,
     inputTokens: previousPoint ? percentChange(point.inputTokens, previousPoint.inputTokens) : 0,
     outputTokens: previousPoint ? percentChange(point.outputTokens, previousPoint.outputTokens) : 0,
-    cachedTokens: previousPoint ? percentChange(point.cachedTokens, previousPoint.cachedTokens) : 0,
+    cachedTokens: previousPoint
+      ? percentChange(getUsageCacheTokens(point), getUsageCacheTokens(previousPoint))
+      : 0,
     cacheCreationTokens: previousPoint
       ? percentChange(point.cacheCreationTokens, previousPoint.cacheCreationTokens)
       : 0,

--- a/apps/web/src/features/usage-analytics/usageAnalyticsPresentation.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsPresentation.test.ts
@@ -7,6 +7,7 @@ import type {
   UsageTimelinePoint,
 } from './usageAnalyticsModel';
 import {
+  buildCredentialDetailCards,
   buildUsageApiKeySummaryCards,
   buildUsageEntitySummaryCards,
   buildUsageModelSummaryCards,
@@ -110,6 +111,33 @@ describe('usageAnalyticsPresentation', () => {
     });
     expect(cards[4].meta).toContain('usage_analytics.metric_reasoning_tokens');
     expect(cards[7].meta).toContain('usage_analytics.cache_read_rate');
+    expect(cards[7]).toMatchObject({ value: '8.0K', valueTitle: '8,000' });
+  });
+
+  it('shows fine-grained cache buckets in credential detail cache totals', () => {
+    const cards = buildCredentialDetailCards({
+      locale: 'en',
+      row: {
+        id: 'credential-a',
+        label: 'credential-a',
+        requestCount: 10,
+        successCount: 10,
+        failureCount: 0,
+        successRate: 1,
+        totalTokens: 1000,
+        inputTokens: 700,
+        outputTokens: 300,
+        cachedTokens: 0,
+        cacheReadTokens: 80,
+        cacheCreationTokens: 20,
+        estimatedCost: 1,
+        averageLatencyMs: 200,
+        share: 1,
+      },
+      t,
+    });
+
+    expect(cards[3].meta).toBe('usage_analytics.metric_cached_tokens 100');
   });
 
   it('builds trend summary cards from peak buckets and comparison deltas', () => {

--- a/apps/web/src/features/usage-analytics/usageAnalyticsPresentation.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsPresentation.ts
@@ -3,6 +3,7 @@ import {
   computeCacheHitRate,
   computeRowCacheHitRate,
   formatMetricValue,
+  getUsageCacheTokens,
   USAGE_MODEL_LONG_TAIL_SHARE,
   USAGE_MODEL_TOP_SHARE_THRESHOLD,
   USAGE_SUCCESS_RATE_WATCH_THRESHOLD,
@@ -164,7 +165,7 @@ export const buildUsageOverviewSummaryCards = ({
   summaryDelta,
   t,
 }: OverviewSummaryCardsInput): UsageSummaryCard[] => {
-  const cacheTokens = summary.cachedTokens + summary.cacheReadTokens + summary.cacheCreationTokens;
+  const cacheTokens = getUsageCacheTokens(summary);
   const totalTokens = Math.max(summary.totalTokens, 0);
   const p95LatencyLabel =
     summary.p95LatencyMs === null && summary.p95TtftMs !== null
@@ -610,7 +611,7 @@ export const buildCredentialDetailCards = ({
       accent: 'cyan',
       icon: 'cache',
       label: t('usage_analytics.cache_read_rate'),
-      meta: `${t('usage_analytics.metric_cached_tokens')} ${formatCompactNumber(row.cachedTokens)}`,
+      meta: `${t('usage_analytics.metric_cached_tokens')} ${formatCompactNumber(getUsageCacheTokens(row))}`,
       value: formatPercent(cacheRate),
     },
     {


### PR DESCRIPTION
## Summary
Fix usage analytics surfaces that displayed zero cached tokens when the backend reported fine-grained cache-read and cache-creation buckets.

Preserve the raw token dimensions used for pricing and cache-hit calculations while presenting a consistent combined cache-token total.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add a shared display total for compatible cached, cache-read, and cache-creation tokens.
- Use the combined value in usage trends, token structure charts, rank tables, credential details, and cache-growth analysis.
- Align demo analytics fixtures with the current backend cache-token contract.
- Add regression coverage for fine-grained cache-only responses and partial compatibility buckets.

## User Impact
Usage Analytics now shows the cache tokens already visible as CR/CW in Request Monitoring instead of incorrectly displaying zero.

Pricing, cache-hit rates, stored usage events, and API contracts are unchanged.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the existing analytics response fields; no configuration changes are required.
- Manager Server mode: No API or database changes; the frontend consumes the existing cache token dimensions.
- Full Docker / native packages: Frontend-only behavior change with no migration or rollout requirements.

## Data / Security Notes
N/A. No database schema, raw usage payload, credential, key, or logging behavior changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert commit `84447e971fb406ca50efb4075b6dd2dcd7b644b8`.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test
  93 test files passed
  775 tests passed

npm --workspace apps/web run test --   src/features/usage-analytics/usageAnalyticsModel.test.ts   src/features/usage-analytics/usageAnalyticsPresentation.test.ts   src/features/usage-analytics/UsageAnalyticsPage.test.tsx
  3 test files passed
  60 tests passed

npm --workspace apps/web run build:bundle
npm run check:demo-isolation
npm --workspace apps/web run build:demo:bundle
npm run docs:build
```

## Screenshots / Recordings
N/A — this corrects displayed numeric values without changing layout or styling.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #353
