### PR TITLE
docs(release): add v1.11.1 notes

### DIFF
--- a/docs/release-notes/v1.11.1-en.md
+++ b/docs/release-notes/v1.11.1-en.md
@@ -1,0 +1,34 @@
+# CPA Manager Plus v1.11.1
+
+> 12 commits · 30 files changed · +2035 / -144
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.1/docs/release-notes/v1.11.1-zh.md)
+
+## Overview
+
+This release improves Usage Analytics and Dashboard query efficiency for larger datasets, fixes missing fine-grained cache-token display in analytics views, and corrects SQLite database-path compatibility on Windows.
+
+## Highlights
+
+### Performance
+
+- Usage Analytics overview, trends, model/API-key, and credential views now use compact summaries to reduce browser transfer and processing work (`web/usage-analytics`, `manager-server/usage-analytics`).
+- Load credential timeline data only when it is needed, avoiding extra queries for unopened detail views (`web/usage-analytics`).
+- Preaggregate credential timelines and compact latency-percentile reads in SQLite to reduce historical usage-event scans (`manager-server/usage-analytics`).
+- Parallelize Dashboard refresh queries to shorten dashboard update waits (`manager-server/dashboard`).
+
+### Fixes
+
+- Usage Analytics trend charts, token-structure charts, rank tables, credential details, and anomaly detection consistently include compatible cached, cache-read, and cache-creation tokens (`web/usage-analytics`).
+- Correct Windows SQLite file-URI encoding and temporary test database naming to prevent database connection failures for Windows paths (`manager-server/sqlite`).
+- Add CI coverage for Windows SQLite paths to prevent regressions (`ci`).
+
+## Upgrade Notes
+
+- No manual migration or configuration change is required.
+- Native Windows-package users can upgrade directly; Manager Server will use correctly encoded SQLite file URIs.
+- For Usage Analytics users, verify cache-token charts and rankings align with Provider billing semantics.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.0...v1.11.1

--- a/docs/release-notes/v1.11.1-zh.md
+++ b/docs/release-notes/v1.11.1-zh.md
@@ -1,0 +1,34 @@
+# CPA Manager Plus v1.11.1
+
+> 12 commits · 30 files changed · +2035 / -144
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.1/docs/release-notes/v1.11.1-en.md)
+
+## Overview
+
+本次发布提升 Usage Analytics 和 Dashboard 在大规模数据下的查询效率，修复细粒度缓存 Token 在统计页面中的展示遗漏，并修复 Windows 环境下 SQLite 数据库路径兼容性。
+
+## Highlights
+
+### Performance
+
+- Usage Analytics 的概览、趋势、模型/API Key/凭据统计改为使用紧凑汇总数据，降低浏览器传输与处理开销（`web/usage-analytics`、`manager-server/usage-analytics`）。
+- 凭据趋势数据按需加载，避免在未打开明细时执行额外查询（`web/usage-analytics`）。
+- 在 SQLite 中预聚合凭据时间线和延迟分位数读取，减少历史使用事件扫描（`manager-server/usage-analytics`）。
+- Dashboard 刷新查询并行执行，缩短统计面板的刷新等待时间（`manager-server/dashboard`）。
+
+### Fixes
+
+- Usage Analytics 的趋势图、Token 结构图、排行榜、凭据详情和异常检测现统一计入兼容缓存、cache read 与 cache creation Token（`web/usage-analytics`）。
+- 修复 Windows SQLite 文件 URI 编码与临时测试数据库命名，避免带有 Windows 路径的数据库连接失败（`manager-server/sqlite`）。
+- 为 Windows SQLite 路径增加 CI 覆盖，防止兼容性回归（`ci`）。
+
+## Upgrade Notes
+
+- 无需手动迁移或配置变更。
+- Windows 原生包用户可直接升级；升级后 Manager Server 会使用正确编码的 SQLite 文件 URI。
+- 若使用 Usage Analytics，建议确认缓存 Token 图表和排行数据与 Provider 账单口径一致。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.0...v1.11.1


### PR DESCRIPTION
## Summary

Add the curated Chinese and English release notes for CPA Manager Plus v1.11.1.
The notes cover analytics performance improvements, fine-grained cache-token display fixes, and Windows SQLite path compatibility.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `docs/release-notes/v1.11.1-zh.md` as the authored release body.
- Add the matching English translation at `docs/release-notes/v1.11.1-en.md`.
- Use tag-pinned language links and the `v1.11.0...v1.11.1` changelog range.

## User Impact

No runtime behavior change from this PR. It provides the curated GitHub Release notes for v1.11.1.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; release-notes-only change.
- Manager Server mode: N/A; release-notes-only change.
- Full Docker / native packages: The tag workflow will publish v1.11.1 artifacts after this PR is merged.

## Data / Security Notes

N/A. No runtime data, credentials, keys, or security behavior are changed.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert the release-note commit before tagging if the content requires correction.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
git diff --check
main == origin/main at c039853fa5e37e19c6c334b7673c58f61e7e862a
v1.11.0..main: 12 non-merge commits, 30 files changed, +2035 / -144
Validated tag-pinned bilingual links and v1.11.0...v1.11.1 changelog URLs.
Confirmed release/v1.11.1 and v1.11.1 did not exist remotely before execution.
```

## Screenshots / Recordings

N/A. Release-notes-only change.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related

N/A
