### PR TITLE
fix(manager-server): harden streamed CPA responses

### DIFF
--- a/apps/manager-server/internal/collector/auth_snapshot.go
+++ b/apps/manager-server/internal/collector/auth_snapshot.go
@@ -3,14 +3,13 @@ package collector
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 )
 
 const authSnapshotCacheTTL = 30 * time.Second
@@ -106,43 +105,17 @@ func (r *authSnapshotResolver) lookupLocked(authIndices map[string]struct{}) map
 }
 
 func (r *authSnapshotResolver) fetch(ctx context.Context, baseURL string, managementKey string) (map[string]authSnapshot, error) {
-	endpoint, err := authFilesEndpoint(baseURL)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+managementKey)
-
 	client := r.client
 	if client == nil {
 		client = http.DefaultClient
 	}
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, 1024))
-		return nil, errors.New("auth files request failed: " + res.Status)
-	}
-
-	var payload authFilesPayload
-	decoder := json.NewDecoder(res.Body)
-	if err := decoder.Decode(&payload); err != nil {
-		return nil, err
-	}
-
 	capturedAt := time.Now().UnixMilli()
-	snapshots := make(map[string]authSnapshot, len(payload.Files))
-	for _, file := range payload.Files {
+	snapshots := make(map[string]authSnapshot)
+	err := cpaauthfiles.New(client).Visit(ctx, baseURL, managementKey, func(item cpaauthfiles.File) (bool, error) {
+		file := item.Raw
 		authIndex := readAuthFileString(file, "auth_index", "authIndex", "auth-index")
 		if authIndex == "" {
-			continue
+			return false, nil
 		}
 		account := firstSafeAccount(
 			readAuthFileString(file, "account"),
@@ -176,27 +149,12 @@ func (r *authSnapshotResolver) fetch(ctx context.Context, baseURL string, manage
 			ProjectID:    projectID,
 			CapturedAtMS: capturedAt,
 		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return snapshots, nil
-}
-
-type authFilesPayload struct {
-	Files []map[string]any `json:"files"`
-}
-
-func authFilesEndpoint(baseURL string) (string, error) {
-	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
-	if base == "" {
-		return "", errors.New("upstream URL is empty")
-	}
-	if !strings.Contains(base, "://") {
-		base = "http://" + base
-	}
-	parsed, err := url.Parse(base + "/v0/management/auth-files")
-	if err != nil {
-		return "", err
-	}
-	return parsed.String(), nil
 }
 
 func readAuthFileString(file map[string]any, keys ...string) string {

--- a/apps/manager-server/internal/collector/collector_test.go
+++ b/apps/manager-server/internal/collector/collector_test.go
@@ -23,6 +23,29 @@ func (h *recordingUsageHandler) HandleUsageEvents(_ context.Context, _ RuntimeCo
 	h.events = append(h.events, events...)
 }
 
+func TestAuthSnapshotResolverStreamsAuthFiles(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/management/auth-files" || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"files":[{"auth_index":"auth-1","account":"alice@example.com","name":"alice.json","provider":"codex","padding":"`))
+		_, _ = w.Write([]byte(strings.Repeat("x", 1024*1024)))
+		_, _ = w.Write([]byte(`"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	resolver := newAuthSnapshotResolver()
+	resolver.client = upstream.Client()
+	snapshots, err := resolver.fetch(context.Background(), upstream.URL, "management-key")
+	if err != nil {
+		t.Fatalf("fetch snapshots: %v", err)
+	}
+	if snapshot := snapshots["auth-1"]; snapshot.Account != "alice@example.com" || snapshot.FileName != "alice.json" {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
 func TestManagerConsumesHTTPUsageQueue(t *testing.T) {
 	var calls int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -25,22 +25,24 @@ import (
 )
 
 const (
-	codexUsageURL       = "https://chatgpt.com/backend-api/wham/usage"
-	codexFiveHourWindow = 18_000
-	codexWeekWindow     = 604_800
-	codexMonthWindow    = 2_592_000
-	codexMinMonthWindow = 28 * 24 * 60 * 60
-	codexMaxMonthWindow = 31 * 24 * 60 * 60
-	maxStoredBodyText   = 2048
+	codexUsageURL             = "https://chatgpt.com/backend-api/wham/usage"
+	codexFiveHourWindow       = 18_000
+	codexWeekWindow           = 604_800
+	codexMonthWindow          = 2_592_000
+	codexMinMonthWindow       = 28 * 24 * 60 * 60
+	codexMaxMonthWindow       = 31 * 24 * 60 * 60
+	maxStoredBodyText         = 2048
+	maxCPAAPICallResponseSize = 16 * 1024 * 1024
 )
 
 var (
-	ErrRunAlreadyActive    = errors.New("codex inspection is already running")
-	ErrNotConfigured       = errors.New("usage service is not configured")
-	ErrRunNotFound         = errors.New("codex inspection run not found")
-	ErrRunNotCompleted     = errors.New("codex inspection run is not completed")
-	ErrActionIDsRequired   = errors.New("codex inspection action result ids are required")
-	ErrNoActionableResults = errors.New("codex inspection has no actionable results")
+	ErrRunAlreadyActive           = errors.New("codex inspection is already running")
+	ErrNotConfigured              = errors.New("usage service is not configured")
+	ErrRunNotFound                = errors.New("codex inspection run not found")
+	ErrRunNotCompleted            = errors.New("codex inspection run is not completed")
+	ErrActionIDsRequired          = errors.New("codex inspection action result ids are required")
+	ErrNoActionableResults        = errors.New("codex inspection has no actionable results")
+	errCPAAPICallResponseTooLarge = errors.New("CPA api-call response too large")
 )
 
 type Service struct {
@@ -727,16 +729,8 @@ func (s *Service) requestCodexUsageAt(
 	}
 
 	var raw map[string]any
-	decoder := json.NewDecoder(res.Body)
-	if err := decoder.Decode(&raw); err != nil {
+	if err := decodeCPAAPICallResponse(res.Body, maxCPAAPICallResponseSize, &raw); err != nil {
 		return apiCallResponse{}, res.StatusCode, err
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return apiCallResponse{}, res.StatusCode, errors.New("api-call response contains multiple JSON values")
-		}
-		return apiCallResponse{}, res.StatusCode, fmt.Errorf("decode api-call response trailing data: %w", err)
 	}
 	statusRaw, hasStatus := firstValue(raw, "status_code", "statusCode")
 	statusCode := int(readFloat(statusRaw, 0))
@@ -748,6 +742,38 @@ func (s *Service) requestCodexUsageAt(
 		BodyText:      bodyText,
 		Body:          bodyValue,
 	}, res.StatusCode, nil
+}
+
+func decodeCPAAPICallResponse(body io.Reader, maxBytes int64, target any) error {
+	if body == nil {
+		return io.EOF
+	}
+	if maxBytes <= 0 {
+		return errors.New("CPA api-call response size limit must be positive")
+	}
+	limited := &io.LimitedReader{R: body, N: maxBytes + 1}
+	decoder := json.NewDecoder(limited)
+	if err := decoder.Decode(target); err != nil {
+		if limited.N == 0 {
+			return fmt.Errorf("%w: exceeds %d bytes", errCPAAPICallResponseTooLarge, maxBytes)
+		}
+		return err
+	}
+	if limited.N == 0 {
+		return fmt.Errorf("%w: exceeds %d bytes", errCPAAPICallResponseTooLarge, maxBytes)
+	}
+	var trailing any
+	trailingErr := decoder.Decode(&trailing)
+	if limited.N == 0 {
+		return fmt.Errorf("%w: exceeds %d bytes", errCPAAPICallResponseTooLarge, maxBytes)
+	}
+	if errors.Is(trailingErr, io.EOF) {
+		return nil
+	}
+	if trailingErr == nil {
+		return errors.New("api-call response contains multiple JSON values")
+	}
+	return fmt.Errorf("decode api-call response trailing data: %w", trailingErr)
 }
 
 func (s *Service) executeAutoActions(

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/managerconfig"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
@@ -478,37 +479,15 @@ func (s *Service) failRun(ctx context.Context, run model.CodexInspectionRun, cau
 }
 
 func (s *Service) fetchAuthFiles(ctx context.Context, setup store.Setup) ([]authFile, error) {
-	files, _, err := s.fetchAuthFilesAt(ctx, setup, "/v0/management/auth-files")
-	return files, err
-}
-
-func (s *Service) fetchAuthFilesAt(ctx context.Context, setup store.Setup, path string) ([]authFile, int, error) {
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodGet,
-		cpa.NormalizeBaseURL(setup.CPAUpstreamURL)+path,
-		nil,
-	)
+	files, err := cpaauthfiles.New(s.client).Fetch(ctx, setup.CPAUpstreamURL, setup.ManagementKey)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+setup.ManagementKey)
-	res, err := s.client.Do(req)
-	if err != nil {
-		return nil, 0, err
+	result := make([]authFile, 0, len(files))
+	for _, file := range files {
+		result = append(result, authFile(file.Raw))
 	}
-	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 8*1024*1024))
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return nil, res.StatusCode, fmt.Errorf("auth files request failed: %s %s", res.Status, truncate(string(body), maxStoredBodyText))
-	}
-	var payload struct {
-		Files []authFile `json:"files"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return nil, res.StatusCode, err
-	}
-	return payload.Files, res.StatusCode, nil
+	return result, nil
 }
 
 func (s *Service) inspectAccounts(
@@ -742,14 +721,22 @@ func (s *Service) requestCodexUsageAt(
 		return apiCallResponse{}, 0, err
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 8*1024*1024))
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, maxStoredBodyText))
 		return apiCallResponse{}, res.StatusCode, fmt.Errorf("api-call failed: %s %s", res.Status, truncate(string(body), maxStoredBodyText))
 	}
 
 	var raw map[string]any
-	if err := json.Unmarshal(body, &raw); err != nil {
+	decoder := json.NewDecoder(res.Body)
+	if err := decoder.Decode(&raw); err != nil {
 		return apiCallResponse{}, res.StatusCode, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return apiCallResponse{}, res.StatusCode, errors.New("api-call response contains multiple JSON values")
+		}
+		return apiCallResponse{}, res.StatusCode, fmt.Errorf("decode api-call response trailing data: %w", err)
 	}
 	statusRaw, hasStatus := firstValue(raw, "status_code", "statusCode")
 	statusCode := int(readFloat(statusRaw, 0))
@@ -936,15 +923,12 @@ func (s *Service) doCPAAction(req *http.Request, managementKey string) (error, i
 		return err, 0
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, maxStoredBodyText))
 		return fmt.Errorf("%s %s", res.Status, truncate(string(body), maxStoredBodyText)), res.StatusCode
 	}
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err == nil {
-		if failed, ok := payload["failed"].([]any); ok && len(failed) > 0 {
-			return fmt.Errorf("CPA action failed: %s", truncate(fmt.Sprint(failed[0]), maxStoredBodyText)), res.StatusCode
-		}
+	if err := cpaauthfiles.ValidateActionResponse(res.Body); err != nil {
+		return err, res.StatusCode
 	}
 	return nil, res.StatusCode
 }

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -84,6 +84,88 @@ func TestRunPersistsLogsResultsAndDetail(t *testing.T) {
 	}
 }
 
+func TestFetchAuthFilesStreamsResponsesLargerThanEightMiB(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/management/auth-files" || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"files":[{"name":"auth-a.json","auth_index":"auth-1","provider":"codex","padding":"`))
+		_, _ = w.Write([]byte(strings.Repeat("x", 8*1024*1024)))
+		_, _ = w.Write([]byte(`"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	svc := New(newCodexInspectionTestStore(t), nil, upstream.Client())
+	files, err := svc.fetchAuthFiles(context.Background(), store.Setup{
+		CPAUpstreamURL: upstream.URL,
+		ManagementKey:  "management-key",
+	})
+	if err != nil {
+		t.Fatalf("fetch auth files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("files = %d, want 1", len(files))
+	}
+	if name := readString(files[0], "name"); name != "auth-a.json" {
+		t.Fatalf("file name = %q, want auth-a.json", name)
+	}
+}
+
+func TestRequestCodexUsageStreamsResponsesLargerThanEightMiB(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/management/api-call" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"status_code":200,"body":{"padding":"`))
+		_, _ = w.Write([]byte(strings.Repeat("x", 8*1024*1024)))
+		_, _ = w.Write([]byte(`"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	svc := New(nil, nil, upstream.Client())
+	result, _, err := svc.requestCodexUsageAt(
+		context.Background(),
+		store.Setup{CPAUpstreamURL: upstream.URL, ManagementKey: "management-key"},
+		model.ManagerCodexInspectionConfig{},
+		account{AuthIndex: "auth-1"},
+		"/v0/management/api-call",
+	)
+	if err != nil {
+		t.Fatalf("request Codex usage: %v", err)
+	}
+	body, ok := result.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("body = %#v, want map", result.Body)
+	}
+	if padding := readString(body, "padding"); len(padding) != 8*1024*1024 {
+		t.Fatalf("padding length = %d, want %d", len(padding), 8*1024*1024)
+	}
+}
+
+func TestDoCPAActionRejectsLargeBusinessFailureResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"padding":"`))
+		_, _ = w.Write([]byte(strings.Repeat("x", 1024*1024)))
+		_, _ = w.Write([]byte(`","failed":["denied"]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, upstream.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	svc := New(nil, nil, upstream.Client())
+	actionErr, statusCode := svc.doCPAAction(req, "management-key")
+	if actionErr == nil || !strings.Contains(actionErr.Error(), "denied") {
+		t.Fatalf("action error = %v, want denied failure", actionErr)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("status code = %d, want %d", statusCode, http.StatusOK)
+	}
+}
+
 func TestRunPersistsPlanQuotaWindowsAndErrorDetail(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -3,6 +3,7 @@ package codexinspection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -141,6 +142,15 @@ func TestRequestCodexUsageStreamsResponsesLargerThanEightMiB(t *testing.T) {
 	}
 	if padding := readString(body, "padding"); len(padding) != 8*1024*1024 {
 		t.Fatalf("padding length = %d, want %d", len(padding), 8*1024*1024)
+	}
+}
+
+func TestDecodeCPAAPICallResponseRejectsOversizedBody(t *testing.T) {
+	body := `{"status_code":200,"body":{"padding":"` + strings.Repeat("x", 256) + `"}}`
+	var raw map[string]any
+	err := decodeCPAAPICallResponse(strings.NewReader(body), 128, &raw)
+	if !errors.Is(err, errCPAAPICallResponseTooLarge) {
+		t.Fatalf("decodeCPAAPICallResponse() error = %v, want errCPAAPICallResponseTooLarge", err)
 	}
 }
 

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -16,15 +16,22 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
 )
 
-const DefaultTimeout = 30 * time.Second
+const (
+	DefaultTimeout                  = 30 * time.Second
+	defaultMaxAuthFilesResponseSize = 64 * 1024 * 1024
+	maxActionResponseSize           = 4 * 1024 * 1024
+)
 
 var ErrAuthFileNotFound = errors.New("CPA auth file not found")
 
 var ErrIdentityMismatch = errors.New("CPA auth file identity mismatch")
 
+var ErrResponseTooLarge = errors.New("CPA response too large")
+
 type Client struct {
-	httpClient *http.Client
-	timeout    time.Duration
+	httpClient       *http.Client
+	timeout          time.Duration
+	maxResponseBytes int64
 }
 
 type File struct {
@@ -53,7 +60,11 @@ func New(client *http.Client, timeout ...time.Duration) *Client {
 	if len(timeout) > 0 && timeout[0] > 0 {
 		d = timeout[0]
 	}
-	return &Client{httpClient: client, timeout: d}
+	return &Client{
+		httpClient:       client,
+		timeout:          d,
+		maxResponseBytes: defaultMaxAuthFilesResponseSize,
+	}
 }
 
 const authFilesPath = "/v0/management/auth-files"
@@ -106,8 +117,15 @@ func (c *Client) Visit(ctx context.Context, baseURL string, managementKey string
 	if visit == nil {
 		return errors.New("CPA auth file visitor is required")
 	}
-	if err := scanFiles(res.Body, visit); err != nil {
+	body, limit := c.limitedAuthFilesResponse(res.Body)
+	if err := scanFiles(body, visit); err != nil {
+		if body.N == 0 {
+			return fmt.Errorf("GET %s: %w", authFilesPath, responseTooLargeError("auth-files response", limit))
+		}
 		return fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	if body.N == 0 {
+		return fmt.Errorf("GET %s: %w", authFilesPath, responseTooLargeError("auth-files response", limit))
 	}
 	return nil
 }
@@ -133,7 +151,8 @@ func (c *Client) Find(ctx context.Context, baseURL string, managementKey string,
 
 	var matched File
 	found := false
-	err = scanFiles(res.Body, func(file File) (bool, error) {
+	body, limit := c.limitedAuthFilesResponse(res.Body)
+	err = scanFiles(body, func(file File) (bool, error) {
 		if !matches(file, fileName, authIndex) {
 			return false, nil
 		}
@@ -142,9 +161,27 @@ func (c *Client) Find(ctx context.Context, baseURL string, managementKey string,
 		return true, nil
 	})
 	if err != nil {
+		if body.N == 0 {
+			return File{}, false, fmt.Errorf("GET %s: %w", authFilesPath, responseTooLargeError("auth-files response", limit))
+		}
 		return File{}, false, fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
+	if body.N == 0 {
+		return File{}, false, fmt.Errorf("GET %s: %w", authFilesPath, responseTooLargeError("auth-files response", limit))
+	}
 	return matched, found, nil
+}
+
+func (c *Client) limitedAuthFilesResponse(body io.Reader) (*io.LimitedReader, int64) {
+	limit := c.maxResponseBytes
+	if limit <= 0 {
+		limit = defaultMaxAuthFilesResponseSize
+	}
+	return &io.LimitedReader{R: body, N: limit + 1}, limit
+}
+
+func responseTooLargeError(label string, limit int64) error {
+	return fmt.Errorf("%w: %s exceeds %d bytes", ErrResponseTooLarge, label, limit)
 }
 
 func (c *Client) Verify(ctx context.Context, baseURL string, managementKey string, identity Identity) (File, error) {
@@ -493,28 +530,42 @@ func ValidateActionResponse(body io.Reader) error {
 	if body == nil {
 		return nil
 	}
-	decoder := json.NewDecoder(body)
+	limited := &io.LimitedReader{R: body, N: maxActionResponseSize + 1}
+	decoder := json.NewDecoder(limited)
 	decoder.UseNumber()
 	var payload any
 	if err := decoder.Decode(&payload); err != nil {
+		if limited.N == 0 {
+			return responseTooLargeError("action response", maxActionResponseSize)
+		}
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		return fmt.Errorf("decode CPA action response: %w", err)
 	}
+	if limited.N == 0 {
+		return responseTooLargeError("action response", maxActionResponseSize)
+	}
 	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		if err == nil {
+	trailingErr := decoder.Decode(&trailing)
+	if limited.N == 0 {
+		return responseTooLargeError("action response", maxActionResponseSize)
+	}
+	if !errors.Is(trailingErr, io.EOF) {
+		if trailingErr == nil {
 			return errors.New("decode CPA action response: multiple JSON values")
 		}
-		return fmt.Errorf("decode CPA action response trailing data: %w", err)
+		return fmt.Errorf("decode CPA action response trailing data: %w", trailingErr)
 	}
 	result, ok := payload.(map[string]any)
 	if !ok {
-		return nil
+		return errors.New("decode CPA action response: expected JSON object")
 	}
-	if failed, ok := result["failed"].([]any); ok && len(failed) > 0 {
-		return fmt.Errorf("CPA action failed: %s", strings.TrimSpace(fmt.Sprint(failed[0])))
+	if failed, exists := result["failed"]; exists && hasActionFailureValue(failed) {
+		return fmt.Errorf("CPA action failed: %s", actionFailureDetail(failed))
+	}
+	if actionErr, exists := result["error"]; exists && hasActionFailureValue(actionErr) {
+		return fmt.Errorf("CPA action failed: %s", actionFailureDetail(actionErr))
 	}
 	if success, ok := result["success"].(bool); ok && !success {
 		return errors.New("CPA action failed: success=false")
@@ -523,8 +574,39 @@ func ValidateActionResponse(body io.Reader) error {
 		return errors.New("CPA action failed: ok=false")
 	}
 	status := strings.ToLower(strings.TrimSpace(fmt.Sprint(result["status"])))
-	if status == "error" || status == "failed" {
+	if status == "error" || status == "failed" || status == "partial" {
 		return fmt.Errorf("CPA action failed: status=%s", status)
 	}
 	return nil
+}
+
+func hasActionFailureValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return typed
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case json.Number:
+		parsed, err := typed.Float64()
+		return err != nil || parsed != 0
+	case []any:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed)) != ""
+	}
+}
+
+func actionFailureDetail(value any) string {
+	if values, ok := value.([]any); ok && len(values) > 0 {
+		value = values[0]
+	}
+	detail := strings.TrimSpace(fmt.Sprint(value))
+	if detail == "" {
+		return "unknown failure"
+	}
+	return detail
 }

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -75,31 +75,41 @@ func authFilesEndpoint(baseURL string, fileName string, authIndex string) string
 }
 
 func (c *Client) Fetch(ctx context.Context, baseURL string, managementKey string) ([]File, error) {
+	files := make([]File, 0)
+	if err := c.Visit(ctx, baseURL, managementKey, func(file File) (bool, error) {
+		files = append(files, file)
+		return false, nil
+	}); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func (c *Client) Visit(ctx context.Context, baseURL string, managementKey string, visit func(File) (bool, error)) error {
 	base := cpa.NormalizeBaseURL(baseURL)
 	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+authFilesPath, nil)
 	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
+		return fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+managementKey)
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
+		return fmt.Errorf("GET %s: %w", authFilesPath, err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
-		return nil, fmt.Errorf("GET %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("GET %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
 	}
-	files := make([]File, 0)
-	if err := scanFiles(res.Body, func(file File) (bool, error) {
-		files = append(files, file)
-		return false, nil
-	}); err != nil {
-		return nil, fmt.Errorf("GET %s: %w", authFilesPath, err)
+	if visit == nil {
+		return errors.New("CPA auth file visitor is required")
 	}
-	return files, nil
+	if err := scanFiles(res.Body, visit); err != nil {
+		return fmt.Errorf("GET %s: %w", authFilesPath, err)
+	}
+	return nil
 }
 
 func (c *Client) Find(ctx context.Context, baseURL string, managementKey string, fileName string, authIndex string) (File, bool, error) {
@@ -372,10 +382,13 @@ func (c *Client) PatchDisabled(ctx context.Context, baseURL string, managementKe
 		return fmt.Errorf("PATCH %s: %w", authFilesStatusPath, err)
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
 	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		if err := ValidateActionResponse(res.Body); err != nil {
+			return fmt.Errorf("PATCH %s: %w", authFilesStatusPath, err)
+		}
 		return nil
 	}
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
 	return fmt.Errorf("PATCH %s: HTTP %d %s", authFilesStatusPath, res.StatusCode, strings.TrimSpace(string(body)))
 }
 
@@ -394,13 +407,13 @@ func (c *Client) Delete(ctx context.Context, baseURL string, managementKey strin
 		return fmt.Errorf("DELETE %s: %w", authFilesPath, err)
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
 	if res.StatusCode >= 200 && res.StatusCode < 300 {
-		if actionFailed(body) {
-			return fmt.Errorf("DELETE %s: CPA action failed", authFilesPath)
+		if err := ValidateActionResponse(res.Body); err != nil {
+			return fmt.Errorf("DELETE %s: %w", authFilesPath, err)
 		}
 		return nil
 	}
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
 	return fmt.Errorf("DELETE %s: HTTP %d %s", authFilesPath, res.StatusCode, strings.TrimSpace(string(body)))
 }
 
@@ -476,20 +489,42 @@ func stringField(file map[string]any, keys ...string) string {
 	return ""
 }
 
-func actionFailed(body []byte) bool {
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return false
+func ValidateActionResponse(body io.Reader) error {
+	if body == nil {
+		return nil
 	}
-	if failed, ok := payload["failed"].([]any); ok && len(failed) > 0 {
-		return true
+	decoder := json.NewDecoder(body)
+	decoder.UseNumber()
+	var payload any
+	if err := decoder.Decode(&payload); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return fmt.Errorf("decode CPA action response: %w", err)
 	}
-	if ok, _ := payload["success"].(bool); ok {
-		return false
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("decode CPA action response: multiple JSON values")
+		}
+		return fmt.Errorf("decode CPA action response trailing data: %w", err)
 	}
-	if ok, _ := payload["ok"].(bool); ok {
-		return false
+	result, ok := payload.(map[string]any)
+	if !ok {
+		return nil
 	}
-	status := strings.ToLower(strings.TrimSpace(fmt.Sprint(payload["status"])))
-	return status == "error" || status == "failed"
+	if failed, ok := result["failed"].([]any); ok && len(failed) > 0 {
+		return fmt.Errorf("CPA action failed: %s", strings.TrimSpace(fmt.Sprint(failed[0])))
+	}
+	if success, ok := result["success"].(bool); ok && !success {
+		return errors.New("CPA action failed: success=false")
+	}
+	if okValue, ok := result["ok"].(bool); ok && !okValue {
+		return errors.New("CPA action failed: ok=false")
+	}
+	status := strings.ToLower(strings.TrimSpace(fmt.Sprint(result["status"])))
+	if status == "error" || status == "failed" {
+		return fmt.Errorf("CPA action failed: status=%s", status)
+	}
+	return nil
 }

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -111,10 +111,17 @@ func TestValidateActionResponse(t *testing.T) {
 	}{
 		{name: "empty"},
 		{name: "success", body: `{"ok":true}`},
+		{name: "CPA status success", body: `{"status":"ok","disabled":true}`},
 		{name: "failed list", body: `{"failed":["denied"]}`, wantErr: true},
+		{name: "failed string", body: `{"failed":"denied"}`, wantErr: true},
+		{name: "error field", body: `{"error":"denied"}`, wantErr: true},
 		{name: "success false", body: `{"success":false}`, wantErr: true},
 		{name: "ok false", body: `{"ok":false}`, wantErr: true},
 		{name: "failed status", body: `{"status":"failed"}`, wantErr: true},
+		{name: "partial status", body: `{"status":"partial"}`, wantErr: true},
+		{name: "null response", body: `null`, wantErr: true},
+		{name: "boolean response", body: `false`, wantErr: true},
+		{name: "array response", body: `[]`, wantErr: true},
 		{name: "invalid json", body: `{"ok":`, wantErr: true},
 		{name: "multiple values", body: `{"ok":true}{"ok":true}`, wantErr: true},
 		{
@@ -133,6 +140,14 @@ func TestValidateActionResponse(t *testing.T) {
 	}
 }
 
+func TestValidateActionResponseRejectsOversizedBody(t *testing.T) {
+	body := `{"padding":"` + strings.Repeat("x", maxActionResponseSize) + `"}`
+	err := ValidateActionResponse(strings.NewReader(body))
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("ValidateActionResponse() error = %v, want ErrResponseTooLarge", err)
+	}
+}
+
 func TestClientActionsRejectBusinessFailureResponses(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -146,6 +161,22 @@ func TestClientActionsRejectBusinessFailureResponses(t *testing.T) {
 	}
 	if err := client.Delete(context.Background(), server.URL, "mgmt", "codex-auth.json"); err == nil {
 		t.Fatal("Delete succeeded for ok=false response")
+	}
+}
+
+func TestClientFetchRejectsOversizedAuthFilesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"files":[{"name":"auth.json","padding":"`)
+		_, _ = io.WriteString(w, strings.Repeat("x", 256))
+		_, _ = io.WriteString(w, `"}]}`)
+	}))
+	defer server.Close()
+
+	client := New(server.Client())
+	client.maxResponseBytes = 128
+	_, err := client.Fetch(context.Background(), server.URL, "mgmt")
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("Fetch() error = %v, want ErrResponseTooLarge", err)
 	}
 }
 

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -103,6 +103,52 @@ func TestClientPatchDisabledAndDelete(t *testing.T) {
 	}
 }
 
+func TestValidateActionResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{name: "empty"},
+		{name: "success", body: `{"ok":true}`},
+		{name: "failed list", body: `{"failed":["denied"]}`, wantErr: true},
+		{name: "success false", body: `{"success":false}`, wantErr: true},
+		{name: "ok false", body: `{"ok":false}`, wantErr: true},
+		{name: "failed status", body: `{"status":"failed"}`, wantErr: true},
+		{name: "invalid json", body: `{"ok":`, wantErr: true},
+		{name: "multiple values", body: `{"ok":true}{"ok":true}`, wantErr: true},
+		{
+			name:    "failure beyond old read limit",
+			body:    `{"padding":"` + strings.Repeat("x", 8192) + `","failed":["denied"]}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateActionResponse(strings.NewReader(tt.body))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateActionResponse() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClientActionsRejectBusinessFailureResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":false}`)
+	}))
+	defer server.Close()
+
+	client := New(server.Client())
+	if err := client.PatchDisabled(context.Background(), server.URL, "mgmt", "codex-auth.json", true); err == nil {
+		t.Fatal("PatchDisabled succeeded for ok=false response")
+	}
+	if err := client.Delete(context.Background(), server.URL, "mgmt", "codex-auth.json"); err == nil {
+		t.Fatal("Delete succeeded for ok=false response")
+	}
+}
+
 func TestClientFindStreamsLargeAuthFilesResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v0/management/auth-files" {


### PR DESCRIPTION
## Summary

Harden Manager Server handling of large and malformed CPA responses.
Stream auth-file data without fixed read truncation while enforcing explicit memory bounds and reliable action-result validation.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Stream CPA auth-file snapshots and Codex inspection responses without the previous fixed read truncation.
- Validate successful PATCH and DELETE response bodies for explicit CPA business failures.
- Bound auth-file, action, and api-call responses with deterministic oversized-response errors.

## User Impact

Large CPA auth-file lists and Codex inspection responses are handled more reliably. Failed CPA account actions are no longer reported as successful when the HTTP status is 2xx but the response body indicates failure.

## Compatibility / Runtime Notes

- CPA panel mode: Compatible; Manager Server CPA response handling is hardened without changing browser-side contracts.
- Manager Server mode: Auth-file responses are limited to 64 MiB, api-call responses to 16 MiB, and action responses to 4 MiB.
- Full Docker / native packages: No configuration or packaging changes; the updated Manager Server behavior applies automatically.

## Data / Security Notes

No database schema, key storage, or secret-handling changes.
Explicit response limits reduce memory-exhaustion risk, and stricter action validation prevents incorrect operational state reporting.

## Risk / Rollback

Risk level: Medium

Rollback notes:
- Revert this PR to restore the previous CPA response parsing and validation behavior.
- No data migration or cleanup is required.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
cd apps/manager-server && go test ./...
cd apps/manager-server && go test -race ./internal/service/cpaauthfiles ./internal/service/codexinspection ./internal/collector
git diff --check
```

## Screenshots / Recordings

N/A — backend-only changes.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

Fixes #331 