### PR TITLE
fix(manager-server): migrate large usage databases in background

### DIFF
--- a/apps/docs/en/operations/backup.md
+++ b/apps/docs/en/operations/backup.md
@@ -69,3 +69,41 @@ Copy-Item -Recurse .\data .\data.backup
 6. Log in and check configuration, monitoring data, and collector status.
 
 If restore produces decryption errors, first check whether `data.key` matches the SQLite database.
+
+## Move Manager Configuration Without Request History
+
+If the old `usage.sqlite` is large and request history is no longer needed, start the replacement instance with an empty data directory and use the existing Manager configuration API to move the CPA connection, collector, Codex inspection, and External Usage Service settings. This does not copy `usage_events`, rollups, inspection run history, model prices, API Key aliases, or account-processing policy.
+
+Export while the old instance is still reachable:
+
+```bash
+export OLD_CPAMP_URL='http://old-host:18317'
+export OLD_CPAMP_ADMIN_KEY='cpamp_...'
+
+curl -fsS \
+  -H "Authorization: Bearer ${OLD_CPAMP_ADMIN_KEY}" \
+  "${OLD_CPAMP_URL}/usage-service/config" \
+  | jq '{config: .config}' \
+  > manager-config.json
+chmod 600 manager-config.json
+```
+
+`manager-config.json` may contain the CPA Management Key in plaintext. Treat it as a secret, do not commit it, and do not attach it to an issue.
+
+Stop the old instance and start the new instance with an empty data directory. Record the new administrator key generated during first startup, then import the configuration:
+
+```bash
+export NEW_CPAMP_URL='http://new-host:18317'
+export NEW_CPAMP_ADMIN_KEY='cpamp_...'
+
+curl -fsS \
+  -X PUT \
+  -H "Authorization: Bearer ${NEW_CPAMP_ADMIN_KEY}" \
+  -H 'Content-Type: application/json' \
+  --data-binary @manager-config.json \
+  "${NEW_CPAMP_URL}/usage-service/config"
+```
+
+The import validates the CPA Management API. After it succeeds, verify collector status and the related settings, then securely delete the exported file.
+
+If the connection is managed through environment variables or secret files, the API reports `source` as `env` and an import cannot override the connection fields. Move `CPA_UPSTREAM_URL`, `CPA_MANAGEMENT_KEY`, or the matching secret files through the deployment environment instead. Administrator credentials are also outside the Manager configuration export; the new instance uses its newly generated or explicitly configured `CPA_MANAGER_ADMIN_KEY`.

--- a/apps/docs/en/operations/manager-server.md
+++ b/apps/docs/en/operations/manager-server.md
@@ -226,6 +226,17 @@ USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 
 Restart Manager Server after changing it. Dashboard and Usage Analytics will always use raw events while disabled, and existing rollup tables are left intact. This runtime switch is not exposed in the UI.
 
+When upgrading an existing database, Manager Server performs only fast schema changes during startup. Cache-accounting corrections that must scan historical `usage_events` begin in the background after the HTTP listener is bound, processing 1,000 rows per batch. Each data update and its checkpoint commit in the same transaction, so a restart resumes at the last successfully committed event ID instead of repeating completed batches.
+
+While the migration is running:
+
+- Newly collected events are written in the new format and are outside the legacy migration target range.
+- Account-history and dashboard-hourly rollup catch-up is paused to avoid building summaries from partially migrated data.
+- Logs report migration start, progress, retryable failures, and completion.
+- `GET /status` exposes `status`, `lastEventId`, `targetEventId`, and `processedRows` under `dataMigration`; low-level migration error text is not returned.
+
+After completion, the response-metadata backfill and both rollup workers continue automatically. Do not start a second Manager Server against the same SQLite database or CPA queue to accelerate the migration.
+
 See the [July 10, 2026 Performance Optimization Report](./performance-optimization-2026-07-10.md) for the causes, delivery stages, and complete 100k benchmark evidence.
 
 When `USAGE_QUOTA_COOLDOWN_ENABLED`, `USAGE_ACCOUNT_ACTIONS_ENABLED`, or `USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE` is set through the environment, the matching panel switch is shown as environment-sourced and locked. Remove the environment variable and restart Manager Server if you want the setting to be editable from the panel.
@@ -235,7 +246,7 @@ When `USAGE_QUOTA_COOLDOWN_ENABLED`, `USAGE_ACCOUNT_ACTIONS_ENABLED`, or `USAGE_
 | Endpoint | Purpose |
 |---|---|
 | `GET /health` | Health check. |
-| `GET /status` | Collector, SQLite, event count, and errors. |
+| `GET /status` | Collector, SQLite, event count, and background data-migration progress. |
 | `GET /usage-service/info` | Manager Server mode detection. |
 | `GET /usage-service/config` | Read CPAMP Manager Server config. |
 | `PUT /usage-service/config` | Save CPAMP config and restart collector if needed. |

--- a/apps/docs/operations/backup.md
+++ b/apps/docs/operations/backup.md
@@ -69,3 +69,41 @@ Copy-Item -Recurse .\data .\data.backup
 6. 登录后检查配置、监控数据和采集器状态。
 
 如果恢复后出现解密失败，优先检查 `data.key` 是否和 SQLite 匹配。
+
+## 不保留请求历史，只迁移 Manager 配置
+
+如果旧 `usage.sqlite` 很大且请求历史不需要保留，可以让新实例使用空数据目录，然后通过现有 Manager 配置 API 导出和导入 CPA 连接、采集器、Codex 巡检与 External Usage Service 配置。该方式不会复制 `usage_events`、rollup、巡检运行历史、模型价格、API 密钥别名或账号处理策略。
+
+在旧实例仍可访问时导出：
+
+```bash
+export OLD_CPAMP_URL='http://old-host:18317'
+export OLD_CPAMP_ADMIN_KEY='cpamp_...'
+
+curl -fsS \
+  -H "Authorization: Bearer ${OLD_CPAMP_ADMIN_KEY}" \
+  "${OLD_CPAMP_URL}/usage-service/config" \
+  | jq '{config: .config}' \
+  > manager-config.json
+chmod 600 manager-config.json
+```
+
+`manager-config.json` 可能包含明文 CPA Management Key，应按 secret 管理，不要提交到版本库或发送到 Issue。
+
+然后停止旧实例，使用空目录启动新实例。记录新实例首次启动生成的管理员密钥，再导入：
+
+```bash
+export NEW_CPAMP_URL='http://new-host:18317'
+export NEW_CPAMP_ADMIN_KEY='cpamp_...'
+
+curl -fsS \
+  -X PUT \
+  -H "Authorization: Bearer ${NEW_CPAMP_ADMIN_KEY}" \
+  -H 'Content-Type: application/json' \
+  --data-binary @manager-config.json \
+  "${NEW_CPAMP_URL}/usage-service/config"
+```
+
+导入时会校验 CPA Management API；成功后检查采集器状态和相关开关。确认恢复完成后安全删除导出文件。
+
+如果连接配置由环境变量或 secret 文件管理，API 返回的 `source` 为 `env`，连接字段不能通过导入覆盖；应改为迁移部署环境中的 `CPA_UPSTREAM_URL`、`CPA_MANAGEMENT_KEY` 或对应 secret 文件。管理员登录凭证也不属于 Manager 配置导出：新实例使用新生成或显式设置的 `CPA_MANAGER_ADMIN_KEY`。

--- a/apps/docs/operations/manager-server.md
+++ b/apps/docs/operations/manager-server.md
@@ -224,6 +224,17 @@ USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 
 关闭后需重启 Manager Server，Dashboard 和 Usage Analytics 将始终读取 raw events，已有 rollup 表不会被删除。该运行期开关不接入 UI。
 
+升级旧数据库时，Manager Server 只在启动阶段执行快速 schema 变更；需要扫描历史 `usage_events` 的 cache accounting 修正会在 HTTP 服务开始监听后，以每批 1000 条的方式在后台执行。每批数据更新和 checkpoint 在同一个事务中提交，进程重启后会从最后成功的 event ID 继续，不会重新处理已经提交的批次。
+
+迁移期间：
+
+- 新采集的事件会按新格式直接写入，不进入旧数据迁移目标范围。
+- account history 和 dashboard hourly rollup 暂停追平，避免基于半迁移数据生成错误汇总。
+- 日志输出迁移进度、完成状态或可重试错误。
+- `GET /status` 的 `dataMigration` 字段可查看 `status`、`lastEventId`、`targetEventId` 和 `processedRows`；该接口不返回底层迁移错误文本。
+
+迁移完成后，response metadata backfill 和两个 rollup worker 会自动继续。不要为了缩短迁移时间同时启动第二个 Manager Server 连接同一 SQLite 或消费同一 CPA 队列。
+
 完整的优化原因、实现阶段和 100k benchmark 数据见 [2026-07-10 性能优化报告](./performance-optimization-2026-07-10.md)。
 
 如果 `USAGE_QUOTA_COOLDOWN_ENABLED`、`USAGE_ACCOUNT_ACTIONS_ENABLED` 或 `USAGE_ACCOUNT_ACTIONS_AUTO_DISABLE` 由环境变量设置，面板中的对应开关会显示为环境变量来源并被锁定。要改成面板可编辑，需要移除环境变量并重启 Manager Server。
@@ -233,7 +244,7 @@ USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 | Endpoint | 用途 |
 |---|---|
 | `GET /health` | 健康检查。 |
-| `GET /status` | 采集器、SQLite、事件计数和错误。 |
+| `GET /status` | 采集器、SQLite、事件计数和后台数据迁移进度。 |
 | `GET /usage-service/info` | Manager Server 模式探测。 |
 | `GET /usage-service/config` | 读取 CPAMP Manager Server 配置。 |
 | `PUT /usage-service/config` | 保存 CPAMP 配置，必要时重启采集器。 |

--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -80,7 +80,6 @@ func runServer() {
 	collectorWorker := worker.NewCollectorWorker(cfg, db, collectorService)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	go runUsageResponseMetadataBackfill(ctx, db)
 
 	serverApp := httpapi.New(cfg, db, manager)
 	automationSettingsService := serverApp.AppContext().AccountProcessingPolicyService
@@ -140,12 +139,25 @@ func runServer() {
 		}()
 	}
 
+	listener, err := net.Listen("tcp", cfg.HTTPAddr)
+	if err != nil {
+		log.Fatalf("http listen: %v", err)
+	}
 	go func() {
-		log.Printf("cpa-manager-plus listening on %s", cfg.HTTPAddr)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Printf("cpa-manager-plus listening on %s", listener.Addr())
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("http server: %v", err)
 		}
 	}()
+
+	usageCacheAccountingMigrationWorker := worker.NewUsageCacheAccountingMigrationWorker(db, func() {
+		go runUsageResponseMetadataBackfill(ctx, db)
+		accountHistoryRollupWorker.Wake()
+		if dashboardHourlyRollupWorker != nil {
+			dashboardHourlyRollupWorker.Wake()
+		}
+	})
+	usageCacheAccountingMigrationWorker.Start(ctx)
 
 	<-ctx.Done()
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/apps/manager-server/internal/http/controller/system/handler.go
+++ b/apps/manager-server/internal/http/controller/system/handler.go
@@ -12,6 +12,17 @@ type Handler struct {
 	App *app.Context
 }
 
+type dataMigrationStatus struct {
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	LastEventID   int64  `json:"lastEventId"`
+	TargetEventID int64  `json:"targetEventId"`
+	ProcessedRows int64  `json:"processedRows"`
+	StartedAtMS   int64  `json:"startedAtMs,omitempty"`
+	UpdatedAtMS   int64  `json:"updatedAtMs"`
+	FinishedAtMS  int64  `json:"finishedAtMs,omitempty"`
+}
+
 func (h *Handler) Info(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		response.MethodNotAllowed(w)
@@ -40,11 +51,26 @@ func (h *Handler) Status(w http.ResponseWriter, r *http.Request) {
 	}
 	status := h.App.CollectorService.Status()
 	status.DeadLetters = deadLetters
+	migration, err := h.App.Store.UsageCacheAccountingMigrationState(r.Context())
+	if err != nil {
+		response.Error(w, http.StatusInternalServerError, err)
+		return
+	}
 	response.JSON(w, http.StatusOK, map[string]any{
 		"service":     h.App.ServiceID,
 		"dbPath":      h.App.Config.DBPath,
 		"events":      events,
 		"deadLetters": deadLetters,
 		"collector":   status,
+		"dataMigration": dataMigrationStatus{
+			Name:          migration.Name,
+			Status:        migration.Status,
+			LastEventID:   migration.LastEventID,
+			TargetEventID: migration.TargetEventID,
+			ProcessedRows: migration.ProcessedRows,
+			StartedAtMS:   migration.StartedAtMS,
+			UpdatedAtMS:   migration.UpdatedAtMS,
+			FinishedAtMS:  migration.FinishedAtMS,
+		},
 	})
 }

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/testutil"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
@@ -352,13 +353,27 @@ func TestServerCompatStatusAuthAndCounts(t *testing.T) {
 
 	cpa := testutil.NewCPAMock(t)
 	setup := &store.Setup{CPAUpstreamURL: cpa.URL(), ManagementKey: "management-key", Queue: "usage", PopSide: "right"}
-	configuredHandler, db := newCompatHandler(t, testutil.NewConfig(t), setup)
+	configuredCfg := testutil.NewConfig(t)
+	configuredHandler, db := newCompatHandler(t, configuredCfg, setup)
 	if err := db.AddDeadLetter(context.Background(), `{"bad":true}`, errors.New("parse failed")); err != nil {
 		t.Fatalf("add dead letter: %v", err)
 	}
 	_, err := db.InsertEvents(context.Background(), []usage.Event{compatEvent("status-event", 1)})
 	if err != nil {
 		t.Fatalf("insert event: %v", err)
+	}
+	rawDB, err := sqliterepo.Open(configuredCfg.DBPath)
+	if err != nil {
+		t.Fatalf("open migration state database: %v", err)
+	}
+	if _, err := rawDB.Exec(`update usage_data_migrations set
+		status = 'failed', last_error = 'secret migration detail'
+		where name = 'usage_cache_accounting_v1'`); err != nil {
+		_ = rawDB.Close()
+		t.Fatalf("set failed migration state: %v", err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close migration state database: %v", err)
 	}
 
 	unauthorizedRR := testutil.Request(t, configuredHandler, http.MethodGet, "/status", "", "")
@@ -368,7 +383,12 @@ func TestServerCompatStatusAuthAndCounts(t *testing.T) {
 	testutil.RequireStatus(t, statusRR, http.StatusOK)
 	if !strings.Contains(statusRR.Body.String(), `"events":1`) ||
 		!strings.Contains(statusRR.Body.String(), `"deadLetters":1`) ||
-		!strings.Contains(statusRR.Body.String(), `"collector"`) {
+		!strings.Contains(statusRR.Body.String(), `"collector"`) ||
+		!strings.Contains(statusRR.Body.String(), `"dataMigration"`) ||
+		!strings.Contains(statusRR.Body.String(), `"name":"usage_cache_accounting_v1"`) ||
+		!strings.Contains(statusRR.Body.String(), `"status":"failed"`) ||
+		strings.Contains(statusRR.Body.String(), `"lastError"`) ||
+		strings.Contains(statusRR.Body.String(), "secret migration detail") {
 		t.Fatalf("status body = %s", statusRR.Body.String())
 	}
 }

--- a/apps/manager-server/internal/repository/datamigration/repository.go
+++ b/apps/manager-server/internal/repository/datamigration/repository.go
@@ -1,0 +1,393 @@
+package datamigration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const UsageCacheAccountingMigrationName = "usage_cache_accounting_v1"
+
+const (
+	StatusDiscovering = "discovering"
+	StatusPending     = "pending"
+	StatusRunning     = "running"
+	StatusCompleted   = "completed"
+	StatusFailed      = "failed"
+)
+
+const incompleteUsageCacheAccountingPredicate = `(cache_input_mode is null
+	or trim(cache_input_mode) = ''
+	or normalized_uncached_input_tokens is null
+	or normalized_total_input_tokens is null
+	or normalized_cache_read_tokens is null
+	or normalized_cache_creation_tokens is null)`
+
+type State struct {
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	LastEventID   int64  `json:"lastEventId"`
+	TargetEventID int64  `json:"targetEventId"`
+	ProcessedRows int64  `json:"processedRows"`
+	StartedAtMS   int64  `json:"startedAtMs,omitempty"`
+	UpdatedAtMS   int64  `json:"updatedAtMs"`
+	FinishedAtMS  int64  `json:"finishedAtMs,omitempty"`
+	LastError     string `json:"lastError,omitempty"`
+}
+
+type BatchResult struct {
+	State     State
+	Processed int64
+	Completed bool
+}
+
+type Repository interface {
+	UsageCacheAccountingState(ctx context.Context) (State, bool, error)
+	DiscoverUsageCacheAccounting(ctx context.Context) (State, error)
+	RunUsageCacheAccountingBatch(ctx context.Context, batchSize int) (BatchResult, error)
+	RecordUsageCacheAccountingFailure(ctx context.Context, err error) error
+}
+
+type repository struct {
+	db *sql.DB
+}
+
+func New(db *sql.DB) Repository {
+	return &repository{db: db}
+}
+
+func (r *repository) UsageCacheAccountingState(ctx context.Context) (State, bool, error) {
+	var state State
+	var startedAtMS, finishedAtMS sql.NullInt64
+	var lastError sql.NullString
+	err := r.db.QueryRowContext(ctx, `select
+		name, status, last_event_id, target_event_id, processed_rows,
+		started_at_ms, updated_at_ms, finished_at_ms, last_error
+	from usage_data_migrations
+	where name = ?`, UsageCacheAccountingMigrationName).Scan(
+		&state.Name,
+		&state.Status,
+		&state.LastEventID,
+		&state.TargetEventID,
+		&state.ProcessedRows,
+		&startedAtMS,
+		&state.UpdatedAtMS,
+		&finishedAtMS,
+		&lastError,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return State{}, false, nil
+	}
+	if err != nil {
+		return State{}, false, err
+	}
+	state.StartedAtMS = startedAtMS.Int64
+	state.FinishedAtMS = finishedAtMS.Int64
+	state.LastError = lastError.String
+	return state, true, nil
+}
+
+func (r *repository) DiscoverUsageCacheAccounting(ctx context.Context) (State, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return State{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	state, err := stateInTx(ctx, tx)
+	if err != nil {
+		return State{}, err
+	}
+	if state.Status == StatusFailed {
+		nowMS := time.Now().UnixMilli()
+		if state.TargetEventID == 0 && state.LastEventID == 0 && state.ProcessedRows == 0 {
+			if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+				status = ?, updated_at_ms = ?, last_error = null
+			where name = ?`, StatusDiscovering, nowMS, UsageCacheAccountingMigrationName); err != nil {
+				return State{}, err
+			}
+			state.Status = StatusDiscovering
+			state.UpdatedAtMS = nowMS
+			state.LastError = ""
+		} else {
+			if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+				status = ?, updated_at_ms = ?, last_error = null
+			where name = ?`, StatusPending, nowMS, UsageCacheAccountingMigrationName); err != nil {
+				return State{}, err
+			}
+			state.Status = StatusPending
+			state.UpdatedAtMS = nowMS
+			state.LastError = ""
+			if err := tx.Commit(); err != nil {
+				return State{}, err
+			}
+			return state, nil
+		}
+	}
+	if state.Status == StatusCompleted || state.Status == StatusPending || state.Status == StatusRunning {
+		return state, nil
+	}
+	if state.Status != StatusDiscovering {
+		return State{}, fmt.Errorf("invalid usage cache accounting migration status %q", state.Status)
+	}
+
+	var firstIncompleteID int64
+	err = tx.QueryRowContext(ctx, `select id
+	from usage_events
+	where `+incompleteUsageCacheAccountingPredicate+`
+	order by id
+	limit 1`).Scan(&firstIncompleteID)
+	if errors.Is(err, sql.ErrNoRows) {
+		nowMS := time.Now().UnixMilli()
+		if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+			status = ?, updated_at_ms = ?, finished_at_ms = ?, last_error = null
+		where name = ?`, StatusCompleted, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+			return State{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return State{}, err
+		}
+		return State{
+			Name:         UsageCacheAccountingMigrationName,
+			Status:       StatusCompleted,
+			UpdatedAtMS:  nowMS,
+			FinishedAtMS: nowMS,
+		}, nil
+	}
+	if err != nil {
+		return State{}, err
+	}
+
+	var targetEventID int64
+	if err := tx.QueryRowContext(ctx, `select coalesce(max(id), 0) from usage_events`).Scan(&targetEventID); err != nil {
+		return State{}, err
+	}
+	lastEventID := firstIncompleteID - 1
+	if lastEventID < 0 {
+		lastEventID = 0
+	}
+	nowMS := time.Now().UnixMilli()
+	for _, statement := range []string{
+		`delete from usage_account_model_rollups`,
+		`delete from usage_dashboard_hourly_rollups`,
+		`update usage_rollup_checkpoints set last_event_id = 0, updated_at_ms = 0, last_error = null`,
+	} {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return State{}, err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+		status = ?, last_event_id = ?, target_event_id = ?, processed_rows = 0,
+		started_at_ms = ?, updated_at_ms = ?, finished_at_ms = null, last_error = null
+	where name = ?`, StatusPending, lastEventID, targetEventID, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+		return State{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return State{}, err
+	}
+	return State{
+		Name:          UsageCacheAccountingMigrationName,
+		Status:        StatusPending,
+		LastEventID:   lastEventID,
+		TargetEventID: targetEventID,
+		ProcessedRows: 0,
+		StartedAtMS:   nowMS,
+		UpdatedAtMS:   nowMS,
+	}, nil
+}
+
+func (r *repository) RunUsageCacheAccountingBatch(ctx context.Context, batchSize int) (BatchResult, error) {
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return BatchResult{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	state, err := stateInTx(ctx, tx)
+	if err != nil {
+		return BatchResult{}, err
+	}
+	switch state.Status {
+	case StatusCompleted:
+		return BatchResult{State: state, Completed: true}, nil
+	case StatusDiscovering:
+		return BatchResult{}, errors.New("usage cache accounting migration has not been discovered")
+	case StatusFailed:
+		return BatchResult{}, errors.New("usage cache accounting migration failure must be resumed before running a batch")
+	case StatusPending, StatusRunning:
+		// Continue below.
+	default:
+		return BatchResult{}, fmt.Errorf("invalid usage cache accounting migration status %q", state.Status)
+	}
+	if state.TargetEventID <= state.LastEventID {
+		completed, err := completeInTx(ctx, tx, state)
+		if err != nil {
+			return BatchResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return BatchResult{}, err
+		}
+		return BatchResult{State: completed, Completed: true}, nil
+	}
+
+	var firstEventID, lastEventID, count int64
+	if err := tx.QueryRowContext(ctx, `select coalesce(min(id), 0), coalesce(max(id), 0), count(*)
+	from (
+		select id
+		from usage_events
+		where id > ? and id <= ?
+		order by id
+		limit ?
+	)`, state.LastEventID, state.TargetEventID, batchSize).Scan(&firstEventID, &lastEventID, &count); err != nil {
+		return BatchResult{}, err
+	}
+	if count == 0 {
+		completed, err := completeInTx(ctx, tx, state)
+		if err != nil {
+			return BatchResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return BatchResult{}, err
+		}
+		return BatchResult{State: completed, Completed: true}, nil
+	}
+
+	if err := updateCacheAccountingInRange(ctx, tx, firstEventID, lastEventID); err != nil {
+		return BatchResult{}, err
+	}
+	nowMS := time.Now().UnixMilli()
+	state.LastEventID = lastEventID
+	state.ProcessedRows += count
+	state.Status = StatusRunning
+	state.UpdatedAtMS = nowMS
+	state.LastError = ""
+	if state.LastEventID >= state.TargetEventID {
+		state.Status = StatusCompleted
+		state.FinishedAtMS = nowMS
+		if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+			status = ?, last_event_id = ?, processed_rows = ?, updated_at_ms = ?, finished_at_ms = ?, last_error = null
+		where name = ?`, state.Status, state.LastEventID, state.ProcessedRows, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+			return BatchResult{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return BatchResult{}, err
+		}
+		return BatchResult{State: state, Processed: count, Completed: true}, nil
+	}
+	if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+		status = ?, last_event_id = ?, processed_rows = ?, updated_at_ms = ?, last_error = null
+	where name = ?`, state.Status, state.LastEventID, state.ProcessedRows, nowMS, UsageCacheAccountingMigrationName); err != nil {
+		return BatchResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return BatchResult{}, err
+	}
+	return BatchResult{State: state, Processed: count}, nil
+}
+
+func (r *repository) RecordUsageCacheAccountingFailure(ctx context.Context, migrationErr error) error {
+	message := "unknown migration error"
+	if migrationErr != nil {
+		message = migrationErr.Error()
+	}
+	_, err := r.db.ExecContext(ctx, `update usage_data_migrations set
+		status = ?, updated_at_ms = ?, last_error = ?
+	where name = ? and status in (?, ?, ?, ?)`,
+		StatusFailed,
+		time.Now().UnixMilli(),
+		message,
+		UsageCacheAccountingMigrationName,
+		StatusDiscovering,
+		StatusPending,
+		StatusRunning,
+		StatusFailed,
+	)
+	return err
+}
+
+func stateInTx(ctx context.Context, tx *sql.Tx) (State, error) {
+	var state State
+	var startedAtMS, finishedAtMS sql.NullInt64
+	var lastError sql.NullString
+	if err := tx.QueryRowContext(ctx, `select
+		name, status, last_event_id, target_event_id, processed_rows,
+		started_at_ms, updated_at_ms, finished_at_ms, last_error
+	from usage_data_migrations
+	where name = ?`, UsageCacheAccountingMigrationName).Scan(
+		&state.Name,
+		&state.Status,
+		&state.LastEventID,
+		&state.TargetEventID,
+		&state.ProcessedRows,
+		&startedAtMS,
+		&state.UpdatedAtMS,
+		&finishedAtMS,
+		&lastError,
+	); err != nil {
+		return State{}, err
+	}
+	state.StartedAtMS = startedAtMS.Int64
+	state.FinishedAtMS = finishedAtMS.Int64
+	state.LastError = lastError.String
+	return state, nil
+}
+
+func completeInTx(ctx context.Context, tx *sql.Tx, state State) (State, error) {
+	nowMS := time.Now().UnixMilli()
+	if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+		status = ?, last_event_id = ?, updated_at_ms = ?, finished_at_ms = ?, last_error = null
+	where name = ?`, StatusCompleted, state.TargetEventID, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+		return State{}, err
+	}
+	state.Status = StatusCompleted
+	state.LastEventID = state.TargetEventID
+	state.UpdatedAtMS = nowMS
+	state.FinishedAtMS = nowMS
+	state.LastError = ""
+	return state, nil
+}
+
+func updateCacheAccountingInRange(ctx context.Context, tx *sql.Tx, firstEventID, lastEventID int64) error {
+	if _, err := tx.ExecContext(ctx, `update usage_events set
+		cache_input_mode = case
+			when lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%anthropic%'
+				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%claude%'
+				then 'separate_from_input'
+			when lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%openai%'
+				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%codex%'
+				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%gemini%'
+				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%antigravity%'
+				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%gpt-%'
+				then 'included_in_input'
+			when coalesce(cache_read_tokens, 0) > 0 or coalesce(cache_creation_tokens, 0) > 0 then 'separate_from_input'
+			else 'included_in_input'
+		end
+	where id >= ? and id <= ?
+		and (cache_input_mode is null or trim(cache_input_mode) = '')`, firstEventID, lastEventID); err != nil {
+		return err
+	}
+	compatCache := `max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)`
+	normalizedRead := compatCache + ` + max(cache_read_tokens, 0)`
+	_, err := tx.ExecContext(ctx, `update usage_events set
+		normalized_cache_read_tokens = `+normalizedRead+`,
+		normalized_cache_creation_tokens = max(cache_creation_tokens, 0),
+		normalized_uncached_input_tokens = case
+			when cache_input_mode = 'separate_from_input' then max(input_tokens, 0)
+			else max(input_tokens - (`+normalizedRead+`) - max(cache_creation_tokens, 0), 0)
+		end,
+		normalized_total_input_tokens = case
+			when cache_input_mode = 'separate_from_input' then max(input_tokens, 0) + (`+normalizedRead+`) + max(cache_creation_tokens, 0)
+			else max(input_tokens, 0)
+		end
+	where id >= ? and id <= ?
+		and (normalized_uncached_input_tokens is null
+			or normalized_total_input_tokens is null
+			or normalized_cache_read_tokens is null
+			or normalized_cache_creation_tokens is null)`, firstEventID, lastEventID)
+	return err
+}

--- a/apps/manager-server/internal/repository/datamigration/repository_test.go
+++ b/apps/manager-server/internal/repository/datamigration/repository_test.go
@@ -1,0 +1,313 @@
+package datamigration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+)
+
+func TestDiscoverUsageCacheAccountingCompletesEmptyDatabaseWithoutResettingRollups(t *testing.T) {
+	db := openMigrationTestDB(t)
+	insertRollupFixtures(t, db)
+
+	state, err := New(db).DiscoverUsageCacheAccounting(context.Background())
+	if err != nil {
+		t.Fatalf("discover migration: %v", err)
+	}
+	if state.Status != StatusCompleted || state.TargetEventID != 0 || state.ProcessedRows != 0 {
+		t.Fatalf("state = %#v, want completed empty migration", state)
+	}
+	assertCount(t, db, "usage_account_model_rollups", 1)
+	assertCount(t, db, "usage_dashboard_hourly_rollups", 1)
+}
+
+func TestUsageCacheAccountingMigratesInBatchesAndExcludesNewRows(t *testing.T) {
+	db := openMigrationTestDB(t)
+	insertLegacyUsageEvent(t, db, "legacy-anthropic", "anthropic", "claude-sonnet", 100, 30, 20, 10)
+	insertLegacyUsageEvent(t, db, "legacy-openai", "openai", "gpt-5", 100, 30, 0, 0)
+	insertLegacyUsageEvent(t, db, "legacy-generic", "", "other", 50, 0, 0, 0)
+	markMigrationDiscovering(t, db)
+	insertRollupFixtures(t, db)
+
+	repo := New(db)
+	state, err := repo.DiscoverUsageCacheAccounting(context.Background())
+	if err != nil {
+		t.Fatalf("discover migration: %v", err)
+	}
+	if state.Status != StatusPending || state.TargetEventID != 3 || state.LastEventID != 0 {
+		t.Fatalf("discovered state = %#v", state)
+	}
+	assertCount(t, db, "usage_account_model_rollups", 0)
+	assertCount(t, db, "usage_dashboard_hourly_rollups", 0)
+
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, provider, model, cache_input_mode,
+		input_tokens, cached_tokens, normalized_uncached_input_tokens,
+		normalized_total_input_tokens, normalized_cache_read_tokens,
+		normalized_cache_creation_tokens, created_at_ms
+	) values ('new-normalized', 4, '4', 'openai', 'gpt-5', 'included_in_input',
+		999, 999, 999, 999, 999, 999, 4)`); err != nil {
+		t.Fatalf("insert post-discovery event: %v", err)
+	}
+
+	first, err := repo.RunUsageCacheAccountingBatch(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("first batch: %v", err)
+	}
+	if first.Processed != 2 || first.Completed || first.State.LastEventID != 2 || first.State.ProcessedRows != 2 {
+		t.Fatalf("first batch = %#v", first)
+	}
+	second, err := repo.RunUsageCacheAccountingBatch(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("second batch: %v", err)
+	}
+	if second.Processed != 1 || !second.Completed || second.State.Status != StatusCompleted || second.State.LastEventID != 3 || second.State.ProcessedRows != 3 {
+		t.Fatalf("second batch = %#v", second)
+	}
+
+	assertAccounting(t, db, "legacy-anthropic", "separate_from_input", 100, 130, 20, 10)
+	assertAccounting(t, db, "legacy-openai", "included_in_input", 70, 100, 30, 0)
+	assertAccounting(t, db, "legacy-generic", "included_in_input", 50, 50, 0, 0)
+	assertAccounting(t, db, "new-normalized", "included_in_input", 999, 999, 999, 999)
+}
+
+func TestUsageCacheAccountingStartsAfterCompletedPrefix(t *testing.T) {
+	db := openMigrationTestDB(t)
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, provider, model, cache_input_mode,
+		input_tokens, normalized_uncached_input_tokens, normalized_total_input_tokens,
+		normalized_cache_read_tokens, normalized_cache_creation_tokens, created_at_ms
+	) values ('already-normalized', 1, '1', 'openai', 'gpt-5', 'included_in_input',
+		100, 100, 100, 0, 0, 1)`); err != nil {
+		t.Fatalf("insert normalized prefix: %v", err)
+	}
+	insertLegacyUsageEvent(t, db, "legacy-tail", "openai", "gpt-5", 100, 10, 0, 0)
+	markMigrationDiscovering(t, db)
+	repo := New(db)
+
+	state, err := repo.DiscoverUsageCacheAccounting(context.Background())
+	if err != nil {
+		t.Fatalf("discover migration: %v", err)
+	}
+	if state.Status != StatusPending || state.LastEventID != 1 || state.TargetEventID != 2 {
+		t.Fatalf("discovered state = %#v", state)
+	}
+	result, err := repo.RunUsageCacheAccountingBatch(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("run tail batch: %v", err)
+	}
+	if !result.Completed || result.Processed != 1 || result.State.ProcessedRows != 1 {
+		t.Fatalf("tail batch = %#v", result)
+	}
+	assertAccounting(t, db, "already-normalized", "included_in_input", 100, 100, 0, 0)
+	assertAccounting(t, db, "legacy-tail", "included_in_input", 90, 100, 10, 0)
+}
+
+func TestUsageCacheAccountingFailurePreservesCheckpointAndResumes(t *testing.T) {
+	db := openMigrationTestDB(t)
+	insertLegacyUsageEvent(t, db, "legacy-1", "openai", "gpt-5", 100, 10, 0, 0)
+	insertLegacyUsageEvent(t, db, "legacy-2", "openai", "gpt-5", 200, 20, 0, 0)
+	markMigrationDiscovering(t, db)
+	repo := New(db)
+
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err != nil {
+		t.Fatalf("discover migration: %v", err)
+	}
+	first, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("first batch: %v", err)
+	}
+	if first.State.LastEventID != 1 || first.State.ProcessedRows != 1 {
+		t.Fatalf("first batch = %#v", first)
+	}
+	if _, err := db.Exec(`create trigger reject_second_usage_update before update on usage_events
+		when old.id = 2 begin select raise(abort, 'blocked'); end`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+
+	batchErr := errors.New("batch failed")
+	if _, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1); err == nil {
+		t.Fatal("second batch error = nil, want trigger failure")
+	} else {
+		batchErr = err
+	}
+	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), batchErr); err != nil {
+		t.Fatalf("record failure: %v", err)
+	}
+	failed, found, err := repo.UsageCacheAccountingState(context.Background())
+	if err != nil || !found {
+		t.Fatalf("failed state: found=%v err=%v", found, err)
+	}
+	if failed.Status != StatusFailed || failed.LastEventID != 1 || failed.ProcessedRows != 1 || failed.LastError == "" {
+		t.Fatalf("failed state = %#v", failed)
+	}
+
+	resumed, err := repo.DiscoverUsageCacheAccounting(context.Background())
+	if err != nil {
+		t.Fatalf("resume migration: %v", err)
+	}
+	if resumed.Status != StatusPending || resumed.LastEventID != 1 || resumed.ProcessedRows != 1 || resumed.TargetEventID != 2 {
+		t.Fatalf("resumed state = %#v", resumed)
+	}
+	if _, err := db.Exec(`drop trigger reject_second_usage_update`); err != nil {
+		t.Fatalf("drop failure trigger: %v", err)
+	}
+	final, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("resumed batch: %v", err)
+	}
+	if !final.Completed || final.State.ProcessedRows != 2 || final.State.LastEventID != 2 {
+		t.Fatalf("final batch = %#v", final)
+	}
+
+	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), errors.New("late failure")); err != nil {
+		t.Fatalf("record late failure: %v", err)
+	}
+	completed, _, err := repo.UsageCacheAccountingState(context.Background())
+	if err != nil {
+		t.Fatalf("completed state: %v", err)
+	}
+	if completed.Status != StatusCompleted || completed.LastError != "" {
+		t.Fatalf("completed state overwritten by late failure: %#v", completed)
+	}
+}
+
+func TestUsageCacheAccountingDiscoveryFailureRetriesDiscovery(t *testing.T) {
+	db := openMigrationTestDB(t)
+	insertLegacyUsageEvent(t, db, "legacy", "openai", "gpt-5", 100, 10, 0, 0)
+	markMigrationDiscovering(t, db)
+	insertRollupFixtures(t, db)
+	if _, err := db.Exec(`create trigger reject_rollup_delete before delete on usage_account_model_rollups
+		begin select raise(abort, 'blocked'); end`); err != nil {
+		t.Fatalf("create discovery failure trigger: %v", err)
+	}
+	repo := New(db)
+
+	_, discoveryErr := repo.DiscoverUsageCacheAccounting(context.Background())
+	if discoveryErr == nil {
+		t.Fatal("discovery error = nil, want trigger failure")
+	}
+	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), discoveryErr); err != nil {
+		t.Fatalf("record discovery failure: %v", err)
+	}
+	if _, err := db.Exec(`drop trigger reject_rollup_delete`); err != nil {
+		t.Fatalf("drop discovery failure trigger: %v", err)
+	}
+
+	state, err := repo.DiscoverUsageCacheAccounting(context.Background())
+	if err != nil {
+		t.Fatalf("retry discovery: %v", err)
+	}
+	if state.Status != StatusPending || state.TargetEventID != 1 || state.LastEventID != 0 {
+		t.Fatalf("retried discovery state = %#v", state)
+	}
+	assertCount(t, db, "usage_account_model_rollups", 0)
+	assertCount(t, db, "usage_dashboard_hourly_rollups", 0)
+}
+
+func TestUsageCacheAccountingRejectsUnknownState(t *testing.T) {
+	db := openMigrationTestDB(t)
+	if _, err := db.Exec(`update usage_data_migrations set status = 'future-state'
+		where name = ?`, UsageCacheAccountingMigrationName); err != nil {
+		t.Fatalf("set unknown migration state: %v", err)
+	}
+	repo := New(db)
+
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err == nil {
+		t.Fatal("discover unknown migration state error = nil")
+	}
+	if _, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1); err == nil {
+		t.Fatal("run unknown migration state error = nil")
+	}
+	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), errors.New("do not overwrite")); err != nil {
+		t.Fatalf("record failure for unknown state: %v", err)
+	}
+	state, found, err := repo.UsageCacheAccountingState(context.Background())
+	if err != nil || !found {
+		t.Fatalf("read unknown migration state: found=%v err=%v", found, err)
+	}
+	if state.Status != "future-state" {
+		t.Fatalf("unknown migration status = %q, want unchanged", state.Status)
+	}
+}
+
+func openMigrationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func insertLegacyUsageEvent(t *testing.T, db *sql.DB, hash, provider, model string, input, cached, cacheRead, cacheCreation int64) {
+	t.Helper()
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, provider, model, input_tokens,
+		cached_tokens, cache_read_tokens, cache_creation_tokens, created_at_ms
+	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, hash, input, hash, provider, model, input, cached, cacheRead, cacheCreation, input); err != nil {
+		t.Fatalf("insert legacy usage event %s: %v", hash, err)
+	}
+}
+
+func insertRollupFixtures(t *testing.T, db *sql.DB) {
+	t.Helper()
+	statements := []string{
+		`insert into usage_account_model_rollups (
+			account_key, model, billing_model, service_tier, first_seen_ms, last_seen_ms, updated_at_ms
+		) values ('account', 'model', 'model', '', 1, 1, 1)`,
+		`insert into usage_dashboard_hourly_rollups (
+			bucket_ms, model, billing_model, service_tier, updated_at_ms
+		) values (0, 'model', 'model', '', 1)`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("insert rollup fixture: %v", err)
+		}
+	}
+}
+
+func markMigrationDiscovering(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`update usage_data_migrations set
+		status = 'discovering', last_event_id = 0, target_event_id = 0,
+		processed_rows = 0, started_at_ms = null, updated_at_ms = 0,
+		finished_at_ms = null, last_error = null
+	where name = ?`, UsageCacheAccountingMigrationName); err != nil {
+		t.Fatalf("mark migration discovering: %v", err)
+	}
+}
+
+func assertCount(t *testing.T, db *sql.DB, table string, want int64) {
+	t.Helper()
+	var got int64
+	if err := db.QueryRow(`select count(*) from ` + table).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if got != want {
+		t.Fatalf("count %s = %d, want %d", table, got, want)
+	}
+}
+
+func assertAccounting(t *testing.T, db *sql.DB, hash, mode string, uncached, total, cacheRead, cacheCreation int64) {
+	t.Helper()
+	var gotMode string
+	var gotUncached, gotTotal, gotCacheRead, gotCacheCreation int64
+	if err := db.QueryRow(`select cache_input_mode, normalized_uncached_input_tokens,
+		normalized_total_input_tokens, normalized_cache_read_tokens,
+		normalized_cache_creation_tokens from usage_events where event_hash = ?`, hash).Scan(
+		&gotMode, &gotUncached, &gotTotal, &gotCacheRead, &gotCacheCreation,
+	); err != nil {
+		t.Fatalf("read accounting %s: %v", hash, err)
+	}
+	if gotMode != mode || gotUncached != uncached || gotTotal != total || gotCacheRead != cacheRead || gotCacheCreation != cacheCreation {
+		t.Fatalf("accounting %s = (%s, %d, %d, %d, %d), want (%s, %d, %d, %d, %d)",
+			hash, gotMode, gotUncached, gotTotal, gotCacheRead, gotCacheCreation,
+			mode, uncached, total, cacheRead, cacheCreation)
+	}
+}

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -141,6 +141,22 @@ func Migrate(db *sql.DB) error {
 			updated_at_ms integer not null,
 			primary key (bucket_ms, model, billing_model, service_tier)
 		)`,
+		`create table if not exists usage_data_migrations (
+			name text primary key,
+			status text not null,
+			last_event_id integer not null default 0,
+			target_event_id integer not null default 0,
+			processed_rows integer not null default 0,
+			started_at_ms integer,
+			updated_at_ms integer not null default 0,
+			finished_at_ms integer,
+			last_error text
+		)`,
+		`insert or ignore into usage_data_migrations (
+			name, status, last_event_id, target_event_id, processed_rows, updated_at_ms
+		) select 'usage_cache_accounting_v1',
+			case when exists (select 1 from usage_events limit 1) then 'discovering' else 'completed' end,
+			0, 0, 0, 0`,
 		`create table if not exists dead_letter_events (
 			id integer primary key autoincrement,
 			payload text not null,
@@ -665,55 +681,10 @@ func ensureUsageEventSnapshotColumns(db *sql.DB) error {
 			return err
 		}
 	}
-	if _, err := tx.Exec(`update usage_events set
-		cache_input_mode = case
-			when lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%anthropic%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%claude%'
-				then 'separate_from_input'
-			when lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%openai%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%codex%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%gemini%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%antigravity%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%gpt-%'
-				then 'included_in_input'
-			when coalesce(cache_read_tokens, 0) > 0 or coalesce(cache_creation_tokens, 0) > 0 then 'separate_from_input'
-			else 'included_in_input'
-		end
-	where cache_input_mode is null or trim(cache_input_mode) = ''`); err != nil {
+	if err := tx.Commit(); err != nil {
 		return err
 	}
-	compatCache := `max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)`
-	normalizedRead := compatCache + ` + max(cache_read_tokens, 0)`
-	result, err := tx.Exec(`update usage_events set
-		normalized_cache_read_tokens = ` + normalizedRead + `,
-		normalized_cache_creation_tokens = max(cache_creation_tokens, 0),
-		normalized_uncached_input_tokens = case
-			when cache_input_mode = 'separate_from_input' then max(input_tokens, 0)
-			else max(input_tokens - (` + normalizedRead + `) - max(cache_creation_tokens, 0), 0)
-		end,
-		normalized_total_input_tokens = case
-			when cache_input_mode = 'separate_from_input' then max(input_tokens, 0) + (` + normalizedRead + `) + max(cache_creation_tokens, 0)
-			else max(input_tokens, 0)
-		end
-	where normalized_uncached_input_tokens is null
-		or normalized_total_input_tokens is null
-		or normalized_cache_read_tokens is null
-		or normalized_cache_creation_tokens is null`)
-	if err != nil {
-		return err
-	}
-	if affected, _ := result.RowsAffected(); affected > 0 {
-		for _, statement := range []string{
-			`delete from usage_account_model_rollups`,
-			`delete from usage_dashboard_hourly_rollups`,
-			`update usage_rollup_checkpoints set last_event_id = 0, updated_at_ms = 0, last_error = null`,
-		} {
-			if _, err := tx.Exec(statement); err != nil {
-				return err
-			}
-		}
-	}
-	return tx.Commit()
+	return nil
 }
 
 func ensureModelPriceColumns(db *sql.DB) error {

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -6,6 +6,44 @@ import (
 	"testing"
 )
 
+func TestUsageDataMigrationInitialStateMatchesExistingUsageData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage-data-migration.sqlite")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open empty sqlite: %v", err)
+	}
+	var status string
+	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v1'`).Scan(&status); err != nil {
+		t.Fatalf("read empty migration state: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("empty migration status = %q, want completed", status)
+	}
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, model, input_tokens, created_at_ms
+	) values ('legacy', 1, '1', 'gpt-test', 1, 1)`); err != nil {
+		t.Fatalf("insert legacy event: %v", err)
+	}
+	if _, err := db.Exec(`drop table usage_data_migrations`); err != nil {
+		t.Fatalf("drop migration table: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("reopen legacy sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v1'`).Scan(&status); err != nil {
+		t.Fatalf("read legacy migration state: %v", err)
+	}
+	if status != "discovering" {
+		t.Fatalf("legacy migration status = %q, want discovering", status)
+	}
+}
+
 func TestCodexInspectionAutoRecoverySchema(t *testing.T) {
 	db, err := Open(filepath.Join(t.TempDir(), "codex-inspection.sqlite"))
 	if err != nil {
@@ -159,7 +197,7 @@ func TestEnsureUsageRollupLongContextColumnsRollsBackAndRetries(t *testing.T) {
 	assertTableCount(t, db, "usage_rollup_checkpoints", 0)
 }
 
-func TestEnsureUsageEventSnapshotColumnsRollsBackAndRetries(t *testing.T) {
+func TestEnsureUsageEventSnapshotColumnsOnlyMigratesSchema(t *testing.T) {
 	db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "usage-event-migration.sqlite")))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -189,7 +227,7 @@ func TestEnsureUsageEventSnapshotColumnsRollsBackAndRetries(t *testing.T) {
 		`insert into usage_dashboard_hourly_rollups (id) values (1)`,
 		`insert into usage_rollup_checkpoints (name, last_event_id, updated_at_ms, last_error)
 		values ('account_history', 1, 1, 'old')`,
-		`create trigger reject_dashboard_rollup_delete before delete on usage_dashboard_hourly_rollups
+		`create trigger reject_usage_event_update before update on usage_events
 		begin select raise(abort, 'blocked'); end`,
 	} {
 		if _, err := db.Exec(statement); err != nil {
@@ -197,56 +235,21 @@ func TestEnsureUsageEventSnapshotColumnsRollsBackAndRetries(t *testing.T) {
 		}
 	}
 
-	if err := ensureUsageEventSnapshotColumns(db); err == nil {
-		t.Fatal("migration error = nil, want trigger failure")
+	if err := ensureUsageEventSnapshotColumns(db); err != nil {
+		t.Fatalf("migrate usage event schema: %v", err)
 	}
 	columns := migrationTableColumns(t, db, "usage_events")
-	if columns["cache_input_mode"] || columns["normalized_total_input_tokens"] {
-		t.Fatalf("usage event columns committed after failed migration: %#v", columns)
+	if !columns["cache_input_mode"] || !columns["normalized_total_input_tokens"] {
+		t.Fatalf("usage event schema columns = %#v", columns)
 	}
 	assertTableCount(t, db, "usage_account_model_rollups", 1)
 	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 1)
-
-	if _, err := db.Exec(`drop trigger reject_dashboard_rollup_delete`); err != nil {
-		t.Fatalf("drop failure trigger: %v", err)
+	var normalizedTotal sql.NullInt64
+	if err := db.QueryRow(`select normalized_total_input_tokens from usage_events where id = 1`).Scan(&normalizedTotal); err != nil {
+		t.Fatalf("read partially migrated usage event: %v", err)
 	}
-	if err := ensureUsageEventSnapshotColumns(db); err != nil {
-		t.Fatalf("retry migration: %v", err)
-	}
-	columns = migrationTableColumns(t, db, "usage_events")
-	for _, column := range []string{
-		"request_service_tier",
-		"response_service_tier",
-		"cache_input_mode",
-		"normalized_uncached_input_tokens",
-		"normalized_total_input_tokens",
-		"normalized_cache_read_tokens",
-		"normalized_cache_creation_tokens",
-	} {
-		if !columns[column] {
-			t.Fatalf("usage_events missing column %s after retry: %#v", column, columns)
-		}
-	}
-	var mode string
-	var uncachedInput, totalInput, cacheRead, cacheCreation int64
-	if err := db.QueryRow(`select cache_input_mode, normalized_uncached_input_tokens,
-		normalized_total_input_tokens, normalized_cache_read_tokens, normalized_cache_creation_tokens
-		from usage_events where id = 1`).Scan(&mode, &uncachedInput, &totalInput, &cacheRead, &cacheCreation); err != nil {
-		t.Fatalf("read migrated usage event: %v", err)
-	}
-	if mode != "separate_from_input" || uncachedInput != 100 || totalInput != 400 || cacheRead != 300 || cacheCreation != 0 {
-		t.Fatalf("normalized usage = %q/%d/%d/%d/%d", mode, uncachedInput, totalInput, cacheRead, cacheCreation)
-	}
-	assertTableCount(t, db, "usage_account_model_rollups", 0)
-	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 0)
-	var lastEventID, updatedAt int64
-	var lastError sql.NullString
-	if err := db.QueryRow(`select last_event_id, updated_at_ms, last_error
-		from usage_rollup_checkpoints where name = 'account_history'`).Scan(&lastEventID, &updatedAt, &lastError); err != nil {
-		t.Fatalf("read reset checkpoint: %v", err)
-	}
-	if lastEventID != 0 || updatedAt != 0 || lastError.Valid {
-		t.Fatalf("checkpoint = %d/%d/%v", lastEventID, updatedAt, lastError)
+	if normalizedTotal.Valid {
+		t.Fatalf("schema migration unexpectedly backfilled normalized total: %d", normalizedTotal.Int64)
 	}
 }
 

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/accountaction"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/apikeyalias"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/codexinspection"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/datamigration"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/deadletter"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/modelprice"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/quotacooldown"
@@ -46,6 +47,8 @@ type QuotaCooldownUpsert = model.QuotaCooldownUpsert
 type AccountActionCandidate = model.AccountActionCandidate
 type AccountActionCandidateUpsert = model.AccountActionCandidateUpsert
 type AutomationSettings = model.AutomationSettings
+type DataMigrationState = datamigration.State
+type DataMigrationBatchResult = datamigration.BatchResult
 
 var DefaultCodexInspectionConfig = model.DefaultCodexInspectionConfig
 var NormalizeCodexInspectionConfig = model.NormalizeCodexInspectionConfig
@@ -87,6 +90,7 @@ type Store struct {
 	APIKeyAliases    apikeyalias.Repository
 	AccountActions   accountaction.Repository
 	CodexInspections codexinspection.Repository
+	DataMigrations   datamigration.Repository
 	QuotaCooldowns   quotacooldown.Repository
 	UsageRollups     usagerollup.Repository
 }
@@ -109,6 +113,7 @@ func New(db *sql.DB, protector ...*security.Protector) *Store {
 		APIKeyAliases:    apikeyalias.New(db),
 		AccountActions:   accountaction.New(db),
 		CodexInspections: codexinspection.New(db),
+		DataMigrations:   datamigration.New(db),
 		QuotaCooldowns:   quotacooldown.New(db),
 		UsageRollups:     usagerollup.New(db),
 	}
@@ -289,11 +294,59 @@ func (s *Store) InsertEvents(ctx context.Context, events []usage.Event) (InsertR
 	return s.UsageEvents.InsertBatch(ctx, events)
 }
 
+func (s *Store) UsageCacheAccountingMigrationState(ctx context.Context) (DataMigrationState, error) {
+	state, found, err := s.DataMigrations.UsageCacheAccountingState(ctx)
+	if err != nil {
+		return DataMigrationState{}, err
+	}
+	if found {
+		return state, nil
+	}
+	return DataMigrationState{
+		Name:   datamigration.UsageCacheAccountingMigrationName,
+		Status: datamigration.StatusDiscovering,
+	}, nil
+}
+
+func (s *Store) DiscoverUsageCacheAccounting(ctx context.Context) (DataMigrationState, error) {
+	return s.DataMigrations.DiscoverUsageCacheAccounting(ctx)
+}
+
+func (s *Store) RunUsageCacheAccountingBatch(ctx context.Context, batchSize int) (DataMigrationBatchResult, error) {
+	return s.DataMigrations.RunUsageCacheAccountingBatch(ctx, batchSize)
+}
+
+func (s *Store) RecordUsageCacheAccountingFailure(ctx context.Context, migrationErr error) error {
+	return s.DataMigrations.RecordUsageCacheAccountingFailure(ctx, migrationErr)
+}
+
+func (s *Store) UsageCacheAccountingMigrationReady(ctx context.Context) (bool, error) {
+	state, err := s.UsageCacheAccountingMigrationState(ctx)
+	if err != nil {
+		return false, err
+	}
+	return state.Status == datamigration.StatusCompleted, nil
+}
+
 func (s *Store) CatchUpAccountHistoryRollups(ctx context.Context, limit int, nowMS int64) (UsageRollupCatchUpResult, error) {
+	ready, err := s.UsageCacheAccountingMigrationReady(ctx)
+	if err != nil {
+		return UsageRollupCatchUpResult{}, err
+	}
+	if !ready {
+		return UsageRollupCatchUpResult{Pending: true}, nil
+	}
 	return s.UsageRollups.CatchUpAccountHistory(ctx, limit, nowMS)
 }
 
 func (s *Store) CatchUpDashboardHourlyRollups(ctx context.Context, limit int, nowMS int64) (UsageRollupCatchUpResult, error) {
+	ready, err := s.UsageCacheAccountingMigrationReady(ctx)
+	if err != nil {
+		return UsageRollupCatchUpResult{}, err
+	}
+	if !ready {
+		return UsageRollupCatchUpResult{Pending: true}, nil
+	}
 	return s.UsageRollups.CatchUpDashboardHourly(ctx, limit, nowMS)
 }
 

--- a/apps/manager-server/internal/store/store_test.go
+++ b/apps/manager-server/internal/store/store_test.go
@@ -8,6 +8,54 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
 
+func TestStorePausesRollupsUntilUsageCacheAccountingMigrationCompletes(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.InsertEvents(context.Background(), []usage.Event{{
+		EventHash:   "rollup-event",
+		TimestampMS: 1_778_000_000_000,
+		Timestamp:   "2026-05-06T00:00:00Z",
+		Model:       "gpt-test",
+		CreatedAtMS: 1_778_000_000_100,
+	}}); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	if _, err := db.db.Exec(`update usage_data_migrations set status = 'running' where name = 'usage_cache_accounting_v1'`); err != nil {
+		t.Fatalf("mark migration running: %v", err)
+	}
+
+	accountResult, err := db.CatchUpAccountHistoryRollups(context.Background(), 100, 1_778_000_001_000)
+	if err != nil {
+		t.Fatalf("account rollup while migrating: %v", err)
+	}
+	dashboardResult, err := db.CatchUpDashboardHourlyRollups(context.Background(), 100, 1_778_000_001_000)
+	if err != nil {
+		t.Fatalf("dashboard rollup while migrating: %v", err)
+	}
+	if !accountResult.Pending || accountResult.Processed != 0 || !dashboardResult.Pending || dashboardResult.Processed != 0 {
+		t.Fatalf("rollups were not paused: account=%#v dashboard=%#v", accountResult, dashboardResult)
+	}
+
+	if _, err := db.db.Exec(`update usage_data_migrations set status = 'completed' where name = 'usage_cache_accounting_v1'`); err != nil {
+		t.Fatalf("mark migration completed: %v", err)
+	}
+	accountResult, err = db.CatchUpAccountHistoryRollups(context.Background(), 100, 1_778_000_001_000)
+	if err != nil {
+		t.Fatalf("account rollup after migration: %v", err)
+	}
+	dashboardResult, err = db.CatchUpDashboardHourlyRollups(context.Background(), 100, 1_778_000_001_000)
+	if err != nil {
+		t.Fatalf("dashboard rollup after migration: %v", err)
+	}
+	if accountResult.Processed != 1 || dashboardResult.Processed != 1 {
+		t.Fatalf("rollups did not resume: account=%#v dashboard=%#v", accountResult, dashboardResult)
+	}
+}
+
 func TestStorePersistsAccountSnapshot(t *testing.T) {
 	db, err := Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {

--- a/apps/manager-server/internal/worker/usage_cache_accounting_migration.go
+++ b/apps/manager-server/internal/worker/usage_cache_accounting_migration.go
@@ -1,0 +1,123 @@
+package worker
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+)
+
+const (
+	defaultUsageCacheAccountingMigrationBatchSize = 1000
+	defaultUsageCacheAccountingMigrationDelay     = 200 * time.Millisecond
+	defaultUsageCacheAccountingMigrationRetry     = 5 * time.Second
+)
+
+// UsageCacheAccountingMigrationWorker incrementally backfills legacy usage rows
+// after the HTTP server is available. Its checkpoint is committed with each
+// batch, so a restart resumes from the last successful batch.
+type UsageCacheAccountingMigrationWorker struct {
+	store        *store.Store
+	batchSize    int
+	delay        time.Duration
+	retryDelay   time.Duration
+	onCompletion func()
+	start        sync.Once
+	logStarted   sync.Once
+	completion   sync.Once
+}
+
+func NewUsageCacheAccountingMigrationWorker(st *store.Store, onCompletion func()) *UsageCacheAccountingMigrationWorker {
+	return &UsageCacheAccountingMigrationWorker{
+		store:        st,
+		batchSize:    defaultUsageCacheAccountingMigrationBatchSize,
+		delay:        defaultUsageCacheAccountingMigrationDelay,
+		retryDelay:   defaultUsageCacheAccountingMigrationRetry,
+		onCompletion: onCompletion,
+	}
+}
+
+func (w *UsageCacheAccountingMigrationWorker) Start(ctx context.Context) {
+	if w == nil || w.store == nil {
+		return
+	}
+	w.start.Do(func() {
+		go w.run(ctx)
+	})
+}
+
+func (w *UsageCacheAccountingMigrationWorker) run(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		state, err := w.store.DiscoverUsageCacheAccounting(ctx)
+		if err != nil {
+			w.recordFailure(ctx, err)
+			if !waitFor(ctx, w.retryDelay) {
+				return
+			}
+			continue
+		}
+		if state.Status == "completed" {
+			w.complete(state)
+			return
+		}
+		w.logStarted.Do(func() {
+			log.Printf("usage cache accounting migration started: last_event_id=%d target_event_id=%d batch_size=%d", state.LastEventID, state.TargetEventID, w.batchSize)
+		})
+
+		result, err := w.store.RunUsageCacheAccountingBatch(ctx, w.batchSize)
+		if err != nil {
+			w.recordFailure(ctx, err)
+			if !waitFor(ctx, w.retryDelay) {
+				return
+			}
+			continue
+		}
+		progressLogEvery := int64(w.batchSize * 10)
+		if result.Processed > 0 && (result.Completed || progressLogEvery <= 0 || result.State.ProcessedRows%progressLogEvery == 0) {
+			log.Printf("usage cache accounting migration progress: processed=%d last_event_id=%d target_event_id=%d", result.State.ProcessedRows, result.State.LastEventID, result.State.TargetEventID)
+		}
+		if result.Completed {
+			w.complete(result.State)
+			return
+		}
+		if !waitFor(ctx, w.delay) {
+			return
+		}
+	}
+}
+
+func (w *UsageCacheAccountingMigrationWorker) complete(state store.DataMigrationState) {
+	w.completion.Do(func() {
+		log.Printf("usage cache accounting migration completed: processed=%d", state.ProcessedRows)
+		if w.onCompletion != nil {
+			w.onCompletion()
+		}
+	})
+}
+
+func (w *UsageCacheAccountingMigrationWorker) recordFailure(ctx context.Context, err error) {
+	if ctx.Err() != nil {
+		return
+	}
+	log.Printf("usage cache accounting migration failed; will retry: %v", err)
+	if recordErr := w.store.RecordUsageCacheAccountingFailure(ctx, err); recordErr != nil {
+		log.Printf("usage cache accounting migration failure state: %v", recordErr)
+	}
+}
+
+func waitFor(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/apps/manager-server/internal/worker/usage_cache_accounting_migration_test.go
+++ b/apps/manager-server/internal/worker/usage_cache_accounting_migration_test.go
@@ -1,0 +1,95 @@
+package worker
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+)
+
+func TestUsageCacheAccountingMigrationWorkerRunsBatchesBeforeCompletion(t *testing.T) {
+	rawDB, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	st := store.New(rawDB)
+	t.Cleanup(func() { _ = st.Close() })
+	for _, hash := range []string{"legacy-1", "legacy-2"} {
+		if _, err := rawDB.Exec(`insert into usage_events (
+			event_hash, timestamp_ms, timestamp, provider, model, input_tokens,
+			cached_tokens, created_at_ms
+		) values (?, 1, '1', 'openai', 'gpt-5', 100, 10, 1)`, hash); err != nil {
+			t.Fatalf("insert %s: %v", hash, err)
+		}
+	}
+	if _, err := rawDB.Exec(`update usage_data_migrations set
+		status = 'discovering', last_event_id = 0, target_event_id = 0,
+		processed_rows = 0, started_at_ms = null, updated_at_ms = 0,
+		finished_at_ms = null, last_error = null
+		where name = 'usage_cache_accounting_v1'`); err != nil {
+		t.Fatalf("reset migration state: %v", err)
+	}
+
+	completed := make(chan struct{}, 1)
+	w := NewUsageCacheAccountingMigrationWorker(st, func() { completed <- struct{}{} })
+	w.batchSize = 1
+	w.delay = time.Millisecond
+	w.retryDelay = time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	w.Start(ctx)
+
+	select {
+	case <-completed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("migration completion callback timed out")
+	}
+	state, err := st.UsageCacheAccountingMigrationState(context.Background())
+	if err != nil {
+		t.Fatalf("read migration state: %v", err)
+	}
+	if state.Status != "completed" || state.ProcessedRows != 2 || state.LastEventID != 2 {
+		t.Fatalf("migration state = %#v", state)
+	}
+	var remaining int
+	if err := rawDB.QueryRow(`select count(*) from usage_events
+		where normalized_total_input_tokens is null`).Scan(&remaining); err != nil {
+		t.Fatalf("count remaining legacy rows: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("remaining legacy rows = %d, want 0", remaining)
+	}
+}
+
+func TestUsageCacheAccountingMigrationWorkerCompletesOnce(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	completed := make(chan struct{}, 1)
+	var calls int32
+	w := NewUsageCacheAccountingMigrationWorker(db, func() {
+		atomic.AddInt32(&calls, 1)
+		completed <- struct{}{}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	w.Start(ctx)
+	w.Start(ctx)
+
+	select {
+	case <-completed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("migration completion callback timed out")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("completion callback calls = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
Move the v1.11 cache-accounting backfill out of synchronous startup and run it as a bounded, restart-safe background migration after the HTTP listener is available.

This prevents multi-gigabyte SQLite databases from holding Manager Server startup in a single CPU- and WAL-intensive transaction.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add a persistent SQLite migration state machine with transactional batch checkpoints, failure recovery, and completed-prefix detection.
- Bind the HTTP listener before starting the background migration, pause rollup catch-up until completion, and expose sanitized progress through `/status` and structured logs.
- Document the migration lifecycle and configuration-only recovery procedure in the English and Chinese operations guides.

## User Impact
Manager Server becomes reachable before historical cache-accounting migration finishes. Users with large databases can monitor bounded progress, restart safely, or migrate only Manager configuration to an empty data directory when request history is disposable.

## Compatibility / Runtime Notes
- CPA panel mode: Unchanged; it does not use the Manager Server SQLite database.
- Manager Server mode: Existing databases migrate historical usage rows in batches of 1,000. Account-history and dashboard-hourly rollup catch-up remains paused until migration completion.
- Full Docker / native packages: Both use the same background migration and restart-safe checkpoint behavior. No new environment variables are required.

## Data / Security Notes
Adds the `usage_data_migrations` SQLite table. Each data batch and checkpoint commit in the same transaction, and rows inserted after discovery are excluded from the legacy target range.

The authenticated `/status` response exposes migration identifiers and progress only; stored low-level error text is not returned. Configuration-only exports may contain the CPA Management Key in plaintext, and the documentation explicitly requires treating the export as a secret.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Stop Manager Server before switching versions and preserve `usage.sqlite`, `usage.sqlite-wal`, `usage.sqlite-shm`, and `data.key` together.
- Roll back to the previous release if necessary. The migration is idempotent and preserves committed checkpoints; older releases ignore the new migration-state table.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
go test ./...
go test -race ./internal/repository/datamigration ./internal/store ./internal/worker ./internal/httpapi ./internal/repository/sqlite
go vet ./...
git diff --check origin/main..HEAD

Runtime validation: started Manager Server with 20,000 legacy rows, confirmed the HTTP listener was available before migration, observed bounded progress logs, and verified the migration completed with no remaining NULL normalized rows.
```

Frontend and VitePress commands were not run in the isolated worktree because it intentionally has no `node_modules`; CI installs dependencies and runs the required frontend/build jobs.

## Screenshots / Recordings
N/A — backend and documentation changes only.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
Fixes #361
