### PR TITLE
fix(manager-server): correct cache input accounting semantics

### DIFF
--- a/apps/manager-server/internal/http/controller/system/handler.go
+++ b/apps/manager-server/internal/http/controller/system/handler.go
@@ -18,6 +18,7 @@ type dataMigrationStatus struct {
 	LastEventID   int64  `json:"lastEventId"`
 	TargetEventID int64  `json:"targetEventId"`
 	ProcessedRows int64  `json:"processedRows"`
+	ChangedRows   int64  `json:"changedRows"`
 	StartedAtMS   int64  `json:"startedAtMs,omitempty"`
 	UpdatedAtMS   int64  `json:"updatedAtMs"`
 	FinishedAtMS  int64  `json:"finishedAtMs,omitempty"`
@@ -68,6 +69,7 @@ func (h *Handler) Status(w http.ResponseWriter, r *http.Request) {
 			LastEventID:   migration.LastEventID,
 			TargetEventID: migration.TargetEventID,
 			ProcessedRows: migration.ProcessedRows,
+			ChangedRows:   migration.ChangedRows,
 			StartedAtMS:   migration.StartedAtMS,
 			UpdatedAtMS:   migration.UpdatedAtMS,
 			FinishedAtMS:  migration.FinishedAtMS,

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -368,7 +368,7 @@ func TestServerCompatStatusAuthAndCounts(t *testing.T) {
 	}
 	if _, err := rawDB.Exec(`update usage_data_migrations set
 		status = 'failed', last_error = 'secret migration detail'
-		where name = 'usage_cache_accounting_v1'`); err != nil {
+		where name = 'usage_cache_accounting_v2'`); err != nil {
 		_ = rawDB.Close()
 		t.Fatalf("set failed migration state: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestServerCompatStatusAuthAndCounts(t *testing.T) {
 		!strings.Contains(statusRR.Body.String(), `"deadLetters":1`) ||
 		!strings.Contains(statusRR.Body.String(), `"collector"`) ||
 		!strings.Contains(statusRR.Body.String(), `"dataMigration"`) ||
-		!strings.Contains(statusRR.Body.String(), `"name":"usage_cache_accounting_v1"`) ||
+		!strings.Contains(statusRR.Body.String(), `"name":"usage_cache_accounting_v2"`) ||
 		!strings.Contains(statusRR.Body.String(), `"status":"failed"`) ||
 		strings.Contains(statusRR.Body.String(), `"lastError"`) ||
 		strings.Contains(statusRR.Body.String(), "secret migration detail") {

--- a/apps/manager-server/internal/repository/datamigration/repository.go
+++ b/apps/manager-server/internal/repository/datamigration/repository.go
@@ -6,9 +6,21 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
 
-const UsageCacheAccountingMigrationName = "usage_cache_accounting_v1"
+const UsageCacheAccountingMigrationName = "usage_cache_accounting_v2"
+
+const usageCacheAccountingCandidatePredicate = `(coalesce(cached_tokens, 0) != 0
+	or coalesce(cache_tokens, 0) != 0
+	or coalesce(cache_read_tokens, 0) != 0
+	or coalesce(cache_creation_tokens, 0) != 0
+	or lower(trim(coalesce(cache_input_mode, ''))) not in ('included_in_input', 'separate_from_input')
+	or normalized_uncached_input_tokens is null
+	or normalized_total_input_tokens is null
+	or normalized_cache_read_tokens is null
+	or normalized_cache_creation_tokens is null)`
 
 const (
 	StatusDiscovering = "discovering"
@@ -18,19 +30,13 @@ const (
 	StatusFailed      = "failed"
 )
 
-const incompleteUsageCacheAccountingPredicate = `(cache_input_mode is null
-	or trim(cache_input_mode) = ''
-	or normalized_uncached_input_tokens is null
-	or normalized_total_input_tokens is null
-	or normalized_cache_read_tokens is null
-	or normalized_cache_creation_tokens is null)`
-
 type State struct {
 	Name          string `json:"name"`
 	Status        string `json:"status"`
 	LastEventID   int64  `json:"lastEventId"`
 	TargetEventID int64  `json:"targetEventId"`
 	ProcessedRows int64  `json:"processedRows"`
+	ChangedRows   int64  `json:"changedRows"`
 	StartedAtMS   int64  `json:"startedAtMs,omitempty"`
 	UpdatedAtMS   int64  `json:"updatedAtMs"`
 	FinishedAtMS  int64  `json:"finishedAtMs,omitempty"`
@@ -54,38 +60,46 @@ type repository struct {
 	db *sql.DB
 }
 
+type cacheAccountingRow struct {
+	ID                      int64
+	Provider                string
+	ExecutorType            string
+	ProviderSnapshot        string
+	ResolvedModel           string
+	RequestedModel          string
+	DisplayModel            string
+	StoredMode              sql.NullString
+	InputTokens             int64
+	OutputTokens            int64
+	ReasoningTokens         int64
+	CachedTokens            int64
+	CacheTokens             int64
+	CacheReadTokens         int64
+	CacheCreationTokens     int64
+	NormalizedUncachedInput sql.NullInt64
+	NormalizedTotalInput    sql.NullInt64
+	NormalizedCacheRead     sql.NullInt64
+	NormalizedCacheCreation sql.NullInt64
+	TotalTokens             int64
+	RawJSON                 string
+}
+
 func New(db *sql.DB) Repository {
 	return &repository{db: db}
 }
 
 func (r *repository) UsageCacheAccountingState(ctx context.Context) (State, bool, error) {
-	var state State
-	var startedAtMS, finishedAtMS sql.NullInt64
-	var lastError sql.NullString
-	err := r.db.QueryRowContext(ctx, `select
-		name, status, last_event_id, target_event_id, processed_rows,
+	state, err := readState(r.db.QueryRowContext(ctx, `select
+		name, status, last_event_id, target_event_id, processed_rows, changed_rows,
 		started_at_ms, updated_at_ms, finished_at_ms, last_error
 	from usage_data_migrations
-	where name = ?`, UsageCacheAccountingMigrationName).Scan(
-		&state.Name,
-		&state.Status,
-		&state.LastEventID,
-		&state.TargetEventID,
-		&state.ProcessedRows,
-		&startedAtMS,
-		&state.UpdatedAtMS,
-		&finishedAtMS,
-		&lastError,
-	)
+	where name = ?`, UsageCacheAccountingMigrationName))
 	if errors.Is(err, sql.ErrNoRows) {
 		return State{}, false, nil
 	}
 	if err != nil {
 		return State{}, false, err
 	}
-	state.StartedAtMS = startedAtMS.Int64
-	state.FinishedAtMS = finishedAtMS.Int64
-	state.LastError = lastError.String
 	return state, true, nil
 }
 
@@ -102,24 +116,19 @@ func (r *repository) DiscoverUsageCacheAccounting(ctx context.Context) (State, e
 	}
 	if state.Status == StatusFailed {
 		nowMS := time.Now().UnixMilli()
-		if state.TargetEventID == 0 && state.LastEventID == 0 && state.ProcessedRows == 0 {
-			if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-				status = ?, updated_at_ms = ?, last_error = null
-			where name = ?`, StatusDiscovering, nowMS, UsageCacheAccountingMigrationName); err != nil {
-				return State{}, err
-			}
-			state.Status = StatusDiscovering
-			state.UpdatedAtMS = nowMS
-			state.LastError = ""
-		} else {
-			if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-				status = ?, updated_at_ms = ?, last_error = null
-			where name = ?`, StatusPending, nowMS, UsageCacheAccountingMigrationName); err != nil {
-				return State{}, err
-			}
-			state.Status = StatusPending
-			state.UpdatedAtMS = nowMS
-			state.LastError = ""
+		resumeStatus := StatusPending
+		if state.TargetEventID == 0 && state.LastEventID == 0 && state.ProcessedRows == 0 && state.ChangedRows == 0 {
+			resumeStatus = StatusDiscovering
+		}
+		if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
+			status = ?, updated_at_ms = ?, last_error = null
+		where name = ?`, resumeStatus, nowMS, UsageCacheAccountingMigrationName); err != nil {
+			return State{}, err
+		}
+		state.Status = resumeStatus
+		state.UpdatedAtMS = nowMS
+		state.LastError = ""
+		if resumeStatus == StatusPending {
 			if err := tx.Commit(); err != nil {
 				return State{}, err
 			}
@@ -132,56 +141,34 @@ func (r *repository) DiscoverUsageCacheAccounting(ctx context.Context) (State, e
 	if state.Status != StatusDiscovering {
 		return State{}, fmt.Errorf("invalid usage cache accounting migration status %q", state.Status)
 	}
+	if _, err := tx.ExecContext(ctx, `delete from usage_cache_accounting_v2_changes`); err != nil {
+		return State{}, err
+	}
 
-	var firstIncompleteID int64
-	err = tx.QueryRowContext(ctx, `select id
+	var targetEventID int64
+	if err := tx.QueryRowContext(ctx, `select coalesce(max(id), 0)
 	from usage_events
-	where `+incompleteUsageCacheAccountingPredicate+`
-	order by id
-	limit 1`).Scan(&firstIncompleteID)
-	if errors.Is(err, sql.ErrNoRows) {
-		nowMS := time.Now().UnixMilli()
+	where `+usageCacheAccountingCandidatePredicate).Scan(&targetEventID); err != nil {
+		return State{}, err
+	}
+	nowMS := time.Now().UnixMilli()
+	if targetEventID == 0 {
 		if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-			status = ?, updated_at_ms = ?, finished_at_ms = ?, last_error = null
+			status = ?, last_event_id = 0, target_event_id = 0, processed_rows = 0, changed_rows = 0,
+			started_at_ms = null, updated_at_ms = ?, finished_at_ms = ?, last_error = null
 		where name = ?`, StatusCompleted, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
 			return State{}, err
 		}
 		if err := tx.Commit(); err != nil {
 			return State{}, err
 		}
-		return State{
-			Name:         UsageCacheAccountingMigrationName,
-			Status:       StatusCompleted,
-			UpdatedAtMS:  nowMS,
-			FinishedAtMS: nowMS,
-		}, nil
-	}
-	if err != nil {
-		return State{}, err
+		return State{Name: UsageCacheAccountingMigrationName, Status: StatusCompleted, UpdatedAtMS: nowMS, FinishedAtMS: nowMS}, nil
 	}
 
-	var targetEventID int64
-	if err := tx.QueryRowContext(ctx, `select coalesce(max(id), 0) from usage_events`).Scan(&targetEventID); err != nil {
-		return State{}, err
-	}
-	lastEventID := firstIncompleteID - 1
-	if lastEventID < 0 {
-		lastEventID = 0
-	}
-	nowMS := time.Now().UnixMilli()
-	for _, statement := range []string{
-		`delete from usage_account_model_rollups`,
-		`delete from usage_dashboard_hourly_rollups`,
-		`update usage_rollup_checkpoints set last_event_id = 0, updated_at_ms = 0, last_error = null`,
-	} {
-		if _, err := tx.ExecContext(ctx, statement); err != nil {
-			return State{}, err
-		}
-	}
 	if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-		status = ?, last_event_id = ?, target_event_id = ?, processed_rows = 0,
+		status = ?, last_event_id = 0, target_event_id = ?, processed_rows = 0, changed_rows = 0,
 		started_at_ms = ?, updated_at_ms = ?, finished_at_ms = null, last_error = null
-	where name = ?`, StatusPending, lastEventID, targetEventID, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+	where name = ?`, StatusPending, targetEventID, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
 		return State{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -190,9 +177,7 @@ func (r *repository) DiscoverUsageCacheAccounting(ctx context.Context) (State, e
 	return State{
 		Name:          UsageCacheAccountingMigrationName,
 		Status:        StatusPending,
-		LastEventID:   lastEventID,
 		TargetEventID: targetEventID,
-		ProcessedRows: 0,
 		StartedAtMS:   nowMS,
 		UpdatedAtMS:   nowMS,
 	}, nil
@@ -235,18 +220,11 @@ func (r *repository) RunUsageCacheAccountingBatch(ctx context.Context, batchSize
 		return BatchResult{State: completed, Completed: true}, nil
 	}
 
-	var firstEventID, lastEventID, count int64
-	if err := tx.QueryRowContext(ctx, `select coalesce(min(id), 0), coalesce(max(id), 0), count(*)
-	from (
-		select id
-		from usage_events
-		where id > ? and id <= ?
-		order by id
-		limit ?
-	)`, state.LastEventID, state.TargetEventID, batchSize).Scan(&firstEventID, &lastEventID, &count); err != nil {
+	rows, err := readCacheAccountingBatch(ctx, tx, state.LastEventID, state.TargetEventID, batchSize)
+	if err != nil {
 		return BatchResult{}, err
 	}
-	if count == 0 {
+	if len(rows) == 0 {
 		completed, err := completeInTx(ctx, tx, state)
 		if err != nil {
 			return BatchResult{}, err
@@ -257,37 +235,44 @@ func (r *repository) RunUsageCacheAccountingBatch(ctx context.Context, batchSize
 		return BatchResult{State: completed, Completed: true}, nil
 	}
 
-	if err := updateCacheAccountingInRange(ctx, tx, firstEventID, lastEventID); err != nil {
-		return BatchResult{}, err
+	changedRows := int64(0)
+	for _, row := range rows {
+		changed, err := stageCacheAccountingRow(ctx, tx, row)
+		if err != nil {
+			return BatchResult{}, err
+		}
+		if changed {
+			changedRows++
+		}
 	}
+
 	nowMS := time.Now().UnixMilli()
-	state.LastEventID = lastEventID
-	state.ProcessedRows += count
+	processed := int64(len(rows))
+	state.LastEventID = rows[len(rows)-1].ID
+	state.ProcessedRows += processed
+	state.ChangedRows += changedRows
 	state.Status = StatusRunning
 	state.UpdatedAtMS = nowMS
 	state.LastError = ""
 	if state.LastEventID >= state.TargetEventID {
-		state.Status = StatusCompleted
-		state.FinishedAtMS = nowMS
-		if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-			status = ?, last_event_id = ?, processed_rows = ?, updated_at_ms = ?, finished_at_ms = ?, last_error = null
-		where name = ?`, state.Status, state.LastEventID, state.ProcessedRows, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+		completed, err := completeInTx(ctx, tx, state)
+		if err != nil {
 			return BatchResult{}, err
 		}
 		if err := tx.Commit(); err != nil {
 			return BatchResult{}, err
 		}
-		return BatchResult{State: state, Processed: count, Completed: true}, nil
+		return BatchResult{State: completed, Processed: processed, Completed: true}, nil
 	}
 	if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-		status = ?, last_event_id = ?, processed_rows = ?, updated_at_ms = ?, last_error = null
-	where name = ?`, state.Status, state.LastEventID, state.ProcessedRows, nowMS, UsageCacheAccountingMigrationName); err != nil {
+		status = ?, last_event_id = ?, processed_rows = ?, changed_rows = ?, updated_at_ms = ?, last_error = null
+	where name = ?`, state.Status, state.LastEventID, state.ProcessedRows, state.ChangedRows, nowMS, UsageCacheAccountingMigrationName); err != nil {
 		return BatchResult{}, err
 	}
 	if err := tx.Commit(); err != nil {
 		return BatchResult{}, err
 	}
-	return BatchResult{State: state, Processed: count}, nil
+	return BatchResult{State: state, Processed: processed}, nil
 }
 
 func (r *repository) RecordUsageCacheAccountingFailure(ctx context.Context, migrationErr error) error {
@@ -310,20 +295,169 @@ func (r *repository) RecordUsageCacheAccountingFailure(ctx context.Context, migr
 	return err
 }
 
+func readCacheAccountingBatch(ctx context.Context, tx *sql.Tx, lastEventID, targetEventID int64, batchSize int) ([]cacheAccountingRow, error) {
+	result, err := tx.QueryContext(ctx, `select
+		id, coalesce(provider, ''), coalesce(executor_type, ''), coalesce(auth_provider_snapshot, ''),
+		coalesce(resolved_model, ''), coalesce(requested_model, ''), model, cache_input_mode,
+		input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_tokens,
+		cache_read_tokens, cache_creation_tokens,
+		normalized_uncached_input_tokens, normalized_total_input_tokens,
+		normalized_cache_read_tokens, normalized_cache_creation_tokens,
+		total_tokens, coalesce(raw_json, '')
+	from usage_events
+	where id > ? and id <= ?
+		and `+usageCacheAccountingCandidatePredicate+`
+	order by id
+	limit ?`, lastEventID, targetEventID, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer result.Close()
+
+	rows := make([]cacheAccountingRow, 0, batchSize)
+	for result.Next() {
+		var row cacheAccountingRow
+		if err := result.Scan(
+			&row.ID,
+			&row.Provider,
+			&row.ExecutorType,
+			&row.ProviderSnapshot,
+			&row.ResolvedModel,
+			&row.RequestedModel,
+			&row.DisplayModel,
+			&row.StoredMode,
+			&row.InputTokens,
+			&row.OutputTokens,
+			&row.ReasoningTokens,
+			&row.CachedTokens,
+			&row.CacheTokens,
+			&row.CacheReadTokens,
+			&row.CacheCreationTokens,
+			&row.NormalizedUncachedInput,
+			&row.NormalizedTotalInput,
+			&row.NormalizedCacheRead,
+			&row.NormalizedCacheCreation,
+			&row.TotalTokens,
+			&row.RawJSON,
+		); err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	if err := result.Err(); err != nil {
+		return nil, err
+	}
+	if err := result.Close(); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func stageCacheAccountingRow(ctx context.Context, tx *sql.Tx, row cacheAccountingRow) (bool, error) {
+	hints := usage.RawCacheAccountingHintsFromJSON(row.RawJSON)
+	context := usage.CacheInputContext{
+		ExplicitMode:     hints.ExplicitMode,
+		ExecutorType:     row.ExecutorType,
+		Provider:         row.Provider,
+		ProviderSnapshot: row.ProviderSnapshot,
+		ResolvedModel:    row.ResolvedModel,
+		RequestedModel:   row.RequestedModel,
+		DisplayModel:     row.DisplayModel,
+	}
+	accounting := usage.NormalizeCacheAccounting(
+		context,
+		row.InputTokens,
+		row.CachedTokens,
+		row.CacheTokens,
+		row.CacheReadTokens,
+		row.CacheCreationTokens,
+	)
+	correctedTotal := correctedDerivedTotal(row, hints, accounting)
+	changed := row.StoredMode.String != accounting.Mode ||
+		!equalNullableInt(row.NormalizedUncachedInput, accounting.UncachedInputTokens) ||
+		!equalNullableInt(row.NormalizedTotalInput, accounting.TotalInputTokens) ||
+		!equalNullableInt(row.NormalizedCacheRead, accounting.CacheReadTokens) ||
+		!equalNullableInt(row.NormalizedCacheCreation, accounting.CacheCreationTokens) ||
+		row.TotalTokens != correctedTotal
+	if !changed {
+		return false, nil
+	}
+	if _, err := tx.ExecContext(ctx, `insert into usage_cache_accounting_v2_changes (
+		event_id, cache_input_mode, normalized_uncached_input_tokens,
+		normalized_total_input_tokens, normalized_cache_read_tokens,
+		normalized_cache_creation_tokens, total_tokens
+	) values (?, ?, ?, ?, ?, ?, ?)
+		on conflict(event_id) do update set
+			cache_input_mode = excluded.cache_input_mode,
+			normalized_uncached_input_tokens = excluded.normalized_uncached_input_tokens,
+			normalized_total_input_tokens = excluded.normalized_total_input_tokens,
+			normalized_cache_read_tokens = excluded.normalized_cache_read_tokens,
+			normalized_cache_creation_tokens = excluded.normalized_cache_creation_tokens,
+			total_tokens = excluded.total_tokens`,
+		row.ID,
+		accounting.Mode,
+		accounting.UncachedInputTokens,
+		accounting.TotalInputTokens,
+		accounting.CacheReadTokens,
+		accounting.CacheCreationTokens,
+		correctedTotal,
+	); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func correctedDerivedTotal(row cacheAccountingRow, hints usage.RawCacheAccountingHints, accounting usage.CacheAccounting) int64 {
+	if !hints.ValidPayload || hints.HasExplicitTotal {
+		return row.TotalTokens
+	}
+	oldTotalInput := int64(0)
+	if row.NormalizedTotalInput.Valid {
+		oldTotalInput = row.NormalizedTotalInput.Int64
+	} else {
+		oldTotalInput = usage.NormalizeCacheAccounting(
+			usage.CacheInputContext{ExplicitMode: row.StoredMode.String},
+			row.InputTokens,
+			row.CachedTokens,
+			row.CacheTokens,
+			row.CacheReadTokens,
+			row.CacheCreationTokens,
+		).TotalInputTokens
+	}
+	oldDerived := oldTotalInput + max(row.OutputTokens, int64(0)) + max(row.ReasoningTokens, int64(0))
+	if row.TotalTokens != oldDerived {
+		return row.TotalTokens
+	}
+	return accounting.TotalInputTokens + max(row.OutputTokens, int64(0)) + max(row.ReasoningTokens, int64(0))
+}
+
+func equalNullableInt(value sql.NullInt64, want int64) bool {
+	return value.Valid && value.Int64 == want
+}
+
 func stateInTx(ctx context.Context, tx *sql.Tx) (State, error) {
+	return readState(tx.QueryRowContext(ctx, `select
+		name, status, last_event_id, target_event_id, processed_rows, changed_rows,
+		started_at_ms, updated_at_ms, finished_at_ms, last_error
+	from usage_data_migrations
+	where name = ?`, UsageCacheAccountingMigrationName))
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func readState(row rowScanner) (State, error) {
 	var state State
 	var startedAtMS, finishedAtMS sql.NullInt64
 	var lastError sql.NullString
-	if err := tx.QueryRowContext(ctx, `select
-		name, status, last_event_id, target_event_id, processed_rows,
-		started_at_ms, updated_at_ms, finished_at_ms, last_error
-	from usage_data_migrations
-	where name = ?`, UsageCacheAccountingMigrationName).Scan(
+	if err := row.Scan(
 		&state.Name,
 		&state.Status,
 		&state.LastEventID,
 		&state.TargetEventID,
 		&state.ProcessedRows,
+		&state.ChangedRows,
 		&startedAtMS,
 		&state.UpdatedAtMS,
 		&finishedAtMS,
@@ -338,10 +472,42 @@ func stateInTx(ctx context.Context, tx *sql.Tx) (State, error) {
 }
 
 func completeInTx(ctx context.Context, tx *sql.Tx, state State) (State, error) {
+	if state.ChangedRows > 0 {
+		for _, statement := range []string{
+			`update usage_events set
+				cache_input_mode = (select cache_input_mode from usage_cache_accounting_v2_changes where event_id = usage_events.id),
+				normalized_uncached_input_tokens = (select normalized_uncached_input_tokens from usage_cache_accounting_v2_changes where event_id = usage_events.id),
+				normalized_total_input_tokens = (select normalized_total_input_tokens from usage_cache_accounting_v2_changes where event_id = usage_events.id),
+				normalized_cache_read_tokens = (select normalized_cache_read_tokens from usage_cache_accounting_v2_changes where event_id = usage_events.id),
+				normalized_cache_creation_tokens = (select normalized_cache_creation_tokens from usage_cache_accounting_v2_changes where event_id = usage_events.id),
+				total_tokens = (select total_tokens from usage_cache_accounting_v2_changes where event_id = usage_events.id)
+			where id in (select event_id from usage_cache_accounting_v2_changes)`,
+			`delete from usage_account_model_rollups`,
+			`delete from usage_dashboard_hourly_rollups`,
+			`update usage_rollup_checkpoints set last_event_id = 0, updated_at_ms = 0, last_error = null
+				where name in ('account_history', 'dashboard_hourly')`,
+		} {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return State{}, err
+			}
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `delete from usage_cache_accounting_v2_changes`); err != nil {
+		return State{}, err
+	}
 	nowMS := time.Now().UnixMilli()
 	if _, err := tx.ExecContext(ctx, `update usage_data_migrations set
-		status = ?, last_event_id = ?, updated_at_ms = ?, finished_at_ms = ?, last_error = null
-	where name = ?`, StatusCompleted, state.TargetEventID, nowMS, nowMS, UsageCacheAccountingMigrationName); err != nil {
+		status = ?, last_event_id = ?, processed_rows = ?, changed_rows = ?,
+		updated_at_ms = ?, finished_at_ms = ?, last_error = null
+	where name = ?`,
+		StatusCompleted,
+		state.TargetEventID,
+		state.ProcessedRows,
+		state.ChangedRows,
+		nowMS,
+		nowMS,
+		UsageCacheAccountingMigrationName,
+	); err != nil {
 		return State{}, err
 	}
 	state.Status = StatusCompleted
@@ -350,44 +516,4 @@ func completeInTx(ctx context.Context, tx *sql.Tx, state State) (State, error) {
 	state.FinishedAtMS = nowMS
 	state.LastError = ""
 	return state, nil
-}
-
-func updateCacheAccountingInRange(ctx context.Context, tx *sql.Tx, firstEventID, lastEventID int64) error {
-	if _, err := tx.ExecContext(ctx, `update usage_events set
-		cache_input_mode = case
-			when lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%anthropic%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%claude%'
-				then 'separate_from_input'
-			when lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%openai%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%codex%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%gemini%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%antigravity%'
-				or lower(coalesce(provider, '') || ' ' || coalesce(executor_type, '') || ' ' || coalesce(resolved_model, '') || ' ' || coalesce(model, '')) like '%gpt-%'
-				then 'included_in_input'
-			when coalesce(cache_read_tokens, 0) > 0 or coalesce(cache_creation_tokens, 0) > 0 then 'separate_from_input'
-			else 'included_in_input'
-		end
-	where id >= ? and id <= ?
-		and (cache_input_mode is null or trim(cache_input_mode) = '')`, firstEventID, lastEventID); err != nil {
-		return err
-	}
-	compatCache := `max(max(cached_tokens, cache_tokens) - max(cache_read_tokens, 0) - max(cache_creation_tokens, 0), 0)`
-	normalizedRead := compatCache + ` + max(cache_read_tokens, 0)`
-	_, err := tx.ExecContext(ctx, `update usage_events set
-		normalized_cache_read_tokens = `+normalizedRead+`,
-		normalized_cache_creation_tokens = max(cache_creation_tokens, 0),
-		normalized_uncached_input_tokens = case
-			when cache_input_mode = 'separate_from_input' then max(input_tokens, 0)
-			else max(input_tokens - (`+normalizedRead+`) - max(cache_creation_tokens, 0), 0)
-		end,
-		normalized_total_input_tokens = case
-			when cache_input_mode = 'separate_from_input' then max(input_tokens, 0) + (`+normalizedRead+`) + max(cache_creation_tokens, 0)
-			else max(input_tokens, 0)
-		end
-	where id >= ? and id <= ?
-		and (normalized_uncached_input_tokens is null
-			or normalized_total_input_tokens is null
-			or normalized_cache_read_tokens is null
-			or normalized_cache_creation_tokens is null)`, firstEventID, lastEventID)
-	return err
 }

--- a/apps/manager-server/internal/repository/datamigration/repository_test.go
+++ b/apps/manager-server/internal/repository/datamigration/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -18,18 +19,20 @@ func TestDiscoverUsageCacheAccountingCompletesEmptyDatabaseWithoutResettingRollu
 	if err != nil {
 		t.Fatalf("discover migration: %v", err)
 	}
-	if state.Status != StatusCompleted || state.TargetEventID != 0 || state.ProcessedRows != 0 {
+	if state.Status != StatusCompleted || state.TargetEventID != 0 || state.ProcessedRows != 0 || state.ChangedRows != 0 {
 		t.Fatalf("state = %#v, want completed empty migration", state)
 	}
 	assertCount(t, db, "usage_account_model_rollups", 1)
 	assertCount(t, db, "usage_dashboard_hourly_rollups", 1)
+	assertCheckpoint(t, db, "account_history", 9)
+	assertCheckpoint(t, db, "dashboard_hourly", 9)
 }
 
-func TestUsageCacheAccountingMigratesInBatchesAndExcludesNewRows(t *testing.T) {
+func TestUsageCacheAccountingMigratesInBatchesExcludesNewRowsAndInvalidatesAtCompletion(t *testing.T) {
 	db := openMigrationTestDB(t)
-	insertLegacyUsageEvent(t, db, "legacy-anthropic", "anthropic", "claude-sonnet", 100, 30, 20, 10)
-	insertLegacyUsageEvent(t, db, "legacy-openai", "openai", "gpt-5", 100, 30, 0, 0)
-	insertLegacyUsageEvent(t, db, "legacy-generic", "", "other", 50, 0, 0, 0)
+	insertLegacyUsageEvent(t, db, "legacy-anthropic", "anthropic", "", "claude-sonnet", 100, 30, 20, 10, 0, "")
+	insertLegacyUsageEvent(t, db, "legacy-xai", "xai", "", "grok-4", 100, 30, 0, 0, 0, "")
+	insertLegacyUsageEvent(t, db, "legacy-generic", "", "", "other", 50, 0, 0, 0, 0, "")
 	markMigrationDiscovering(t, db)
 	insertRollupFixtures(t, db)
 
@@ -41,8 +44,8 @@ func TestUsageCacheAccountingMigratesInBatchesAndExcludesNewRows(t *testing.T) {
 	if state.Status != StatusPending || state.TargetEventID != 3 || state.LastEventID != 0 {
 		t.Fatalf("discovered state = %#v", state)
 	}
-	assertCount(t, db, "usage_account_model_rollups", 0)
-	assertCount(t, db, "usage_dashboard_hourly_rollups", 0)
+	assertCount(t, db, "usage_account_model_rollups", 1)
+	assertCount(t, db, "usage_dashboard_hourly_rollups", 1)
 
 	if _, err := db.Exec(`insert into usage_events (
 		event_hash, timestamp_ms, timestamp, provider, model, cache_input_mode,
@@ -58,59 +61,110 @@ func TestUsageCacheAccountingMigratesInBatchesAndExcludesNewRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first batch: %v", err)
 	}
-	if first.Processed != 2 || first.Completed || first.State.LastEventID != 2 || first.State.ProcessedRows != 2 {
+	if first.Processed != 2 || first.Completed || first.State.LastEventID != 2 || first.State.ProcessedRows != 2 || first.State.ChangedRows != 2 {
 		t.Fatalf("first batch = %#v", first)
 	}
+	assertNormalizedTotalNull(t, db, "legacy-anthropic")
+	assertNormalizedTotalNull(t, db, "legacy-xai")
+	assertCount(t, db, "usage_cache_accounting_v2_changes", 2)
+	assertCount(t, db, "usage_account_model_rollups", 1)
+	assertCheckpoint(t, db, "account_history", 9)
+
 	second, err := repo.RunUsageCacheAccountingBatch(context.Background(), 2)
 	if err != nil {
 		t.Fatalf("second batch: %v", err)
 	}
-	if second.Processed != 1 || !second.Completed || second.State.Status != StatusCompleted || second.State.LastEventID != 3 || second.State.ProcessedRows != 3 {
+	if second.Processed != 1 || !second.Completed || second.State.Status != StatusCompleted || second.State.LastEventID != 3 || second.State.ProcessedRows != 3 || second.State.ChangedRows != 3 {
 		t.Fatalf("second batch = %#v", second)
 	}
 
-	assertAccounting(t, db, "legacy-anthropic", "separate_from_input", 100, 130, 20, 10)
-	assertAccounting(t, db, "legacy-openai", "included_in_input", 70, 100, 30, 0)
-	assertAccounting(t, db, "legacy-generic", "included_in_input", 50, 50, 0, 0)
-	assertAccounting(t, db, "new-normalized", "included_in_input", 999, 999, 999, 999)
+	assertAccounting(t, db, "legacy-anthropic", "separate_from_input", 100, 130, 20, 10, 0)
+	assertAccounting(t, db, "legacy-xai", "included_in_input", 70, 100, 30, 0, 0)
+	assertAccounting(t, db, "legacy-generic", "included_in_input", 50, 50, 0, 0, 0)
+	assertAccounting(t, db, "new-normalized", "included_in_input", 999, 999, 999, 999, 0)
+	assertCount(t, db, "usage_account_model_rollups", 0)
+	assertCount(t, db, "usage_dashboard_hourly_rollups", 0)
+	assertCheckpoint(t, db, "account_history", 0)
+	assertCheckpoint(t, db, "dashboard_hourly", 0)
+	assertCheckpoint(t, db, "unrelated", 9)
 }
 
-func TestUsageCacheAccountingStartsAfterCompletedPrefix(t *testing.T) {
+func TestUsageCacheAccountingUsesPriorityAndPreservesExplicitProvenance(t *testing.T) {
 	db := openMigrationTestDB(t)
-	if _, err := db.Exec(`insert into usage_events (
-		event_hash, timestamp_ms, timestamp, provider, model, cache_input_mode,
-		input_tokens, normalized_uncached_input_tokens, normalized_total_input_tokens,
-		normalized_cache_read_tokens, normalized_cache_creation_tokens, created_at_ms
-	) values ('already-normalized', 1, '1', 'openai', 'gpt-5', 'included_in_input',
-		100, 100, 100, 0, 0, 1)`); err != nil {
-		t.Fatalf("insert normalized prefix: %v", err)
-	}
-	insertLegacyUsageEvent(t, db, "legacy-tail", "openai", "gpt-5", 100, 10, 0, 0)
+	insertAccountingEvent(t, db, accountingFixture{
+		Hash: "openai-compat-claude-alias", Executor: "OpenAICompatExecutor", Model: "claude-sonnet", RawJSON: `{}`,
+		Input: 100, CacheRead: 50, Output: 20, StoredMode: "separate_from_input", StoredUncached: 100, StoredTotalInput: 150, StoredRead: 50, Total: 170,
+	})
+	insertAccountingEvent(t, db, accountingFixture{
+		Hash: "claude-grok-alias", Executor: "ClaudeExecutor", Model: "grok-4", RawJSON: `{}`,
+		Input: 100, CacheRead: 50, Output: 20, StoredMode: "included_in_input", StoredUncached: 50, StoredTotalInput: 100, StoredRead: 50, Total: 120,
+	})
+	insertAccountingEvent(t, db, accountingFixture{
+		Hash: "explicit-separate", Executor: "XAIExecutor", Model: "grok-4", RawJSON: `{"tokens":{"cache_input_mode":"separate_from_input"}}`,
+		Input: 100, CacheRead: 50, StoredMode: "included_in_input", StoredUncached: 50, StoredTotalInput: 100, StoredRead: 50, Total: 100,
+	})
+	insertAccountingEvent(t, db, accountingFixture{
+		Hash: "explicit-total", Provider: "anthropic", Model: "claude-sonnet", RawJSON: `{"tokens":{"total_tokens":999}}`,
+		Input: 100, CacheRead: 50, Output: 20, StoredMode: "included_in_input", StoredUncached: 50, StoredTotalInput: 100, StoredRead: 50, Total: 999,
+	})
+	insertAccountingEvent(t, db, accountingFixture{
+		Hash: "unknown-total-provenance", Provider: "anthropic", Model: "claude-sonnet",
+		Input: 100, CacheRead: 50, Output: 20, StoredMode: "included_in_input", StoredUncached: 50, StoredTotalInput: 100, StoredRead: 50, Total: 120,
+	})
 	markMigrationDiscovering(t, db)
-	repo := New(db)
 
-	state, err := repo.DiscoverUsageCacheAccounting(context.Background())
-	if err != nil {
+	repo := New(db)
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err != nil {
 		t.Fatalf("discover migration: %v", err)
 	}
-	if state.Status != StatusPending || state.LastEventID != 1 || state.TargetEventID != 2 {
-		t.Fatalf("discovered state = %#v", state)
-	}
-	result, err := repo.RunUsageCacheAccountingBatch(context.Background(), 10)
+	result, err := repo.RunUsageCacheAccountingBatch(context.Background(), 20)
 	if err != nil {
-		t.Fatalf("run tail batch: %v", err)
+		t.Fatalf("run migration: %v", err)
 	}
-	if !result.Completed || result.Processed != 1 || result.State.ProcessedRows != 1 {
-		t.Fatalf("tail batch = %#v", result)
+	if !result.Completed || result.State.ChangedRows != 5 {
+		t.Fatalf("result = %#v", result)
 	}
-	assertAccounting(t, db, "already-normalized", "included_in_input", 100, 100, 0, 0)
-	assertAccounting(t, db, "legacy-tail", "included_in_input", 90, 100, 10, 0)
+
+	assertAccounting(t, db, "openai-compat-claude-alias", "included_in_input", 50, 100, 50, 0, 120)
+	assertAccounting(t, db, "claude-grok-alias", "separate_from_input", 100, 150, 50, 0, 170)
+	assertAccounting(t, db, "explicit-separate", "separate_from_input", 100, 150, 50, 0, 150)
+	assertAccounting(t, db, "explicit-total", "separate_from_input", 100, 150, 50, 0, 999)
+	assertAccounting(t, db, "unknown-total-provenance", "separate_from_input", 100, 150, 50, 0, 120)
+}
+
+func TestUsageCacheAccountingSecondRunIsIdempotentAndKeepsRollups(t *testing.T) {
+	db := openMigrationTestDB(t)
+	insertLegacyUsageEvent(t, db, "legacy", "xai", "XAIExecutor", "grok-4", 100, 20, 0, 0, 0, "")
+	markMigrationDiscovering(t, db)
+	repo := New(db)
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err != nil {
+		t.Fatalf("discover first run: %v", err)
+	}
+	if _, err := repo.RunUsageCacheAccountingBatch(context.Background(), 10); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	insertRollupFixtures(t, db)
+	markMigrationDiscovering(t, db)
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err != nil {
+		t.Fatalf("discover second run: %v", err)
+	}
+	second, err := repo.RunUsageCacheAccountingBatch(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if !second.Completed || second.State.ProcessedRows != 1 || second.State.ChangedRows != 0 {
+		t.Fatalf("second result = %#v", second)
+	}
+	assertCount(t, db, "usage_account_model_rollups", 1)
+	assertCount(t, db, "usage_dashboard_hourly_rollups", 1)
+	assertCheckpoint(t, db, "account_history", 9)
 }
 
 func TestUsageCacheAccountingFailurePreservesCheckpointAndResumes(t *testing.T) {
 	db := openMigrationTestDB(t)
-	insertLegacyUsageEvent(t, db, "legacy-1", "openai", "gpt-5", 100, 10, 0, 0)
-	insertLegacyUsageEvent(t, db, "legacy-2", "openai", "gpt-5", 200, 20, 0, 0)
+	insertLegacyUsageEvent(t, db, "legacy-1", "openai", "", "gpt-5", 100, 10, 0, 0, 0, "")
+	insertLegacyUsageEvent(t, db, "legacy-2", "openai", "", "gpt-5", 200, 20, 0, 0, 0, "")
 	markMigrationDiscovering(t, db)
 	repo := New(db)
 
@@ -121,11 +175,13 @@ func TestUsageCacheAccountingFailurePreservesCheckpointAndResumes(t *testing.T) 
 	if err != nil {
 		t.Fatalf("first batch: %v", err)
 	}
-	if first.State.LastEventID != 1 || first.State.ProcessedRows != 1 {
+	if first.State.LastEventID != 1 || first.State.ProcessedRows != 1 || first.State.ChangedRows != 1 {
 		t.Fatalf("first batch = %#v", first)
 	}
-	if _, err := db.Exec(`create trigger reject_second_usage_update before update on usage_events
-		when old.id = 2 begin select raise(abort, 'blocked'); end`); err != nil {
+	assertNormalizedTotalNull(t, db, "legacy-1")
+	assertCount(t, db, "usage_cache_accounting_v2_changes", 1)
+	if _, err := db.Exec(`create trigger reject_second_usage_stage before insert on usage_cache_accounting_v2_changes
+		when new.event_id = 2 begin select raise(abort, 'blocked'); end`); err != nil {
 		t.Fatalf("create failure trigger: %v", err)
 	}
 
@@ -142,7 +198,7 @@ func TestUsageCacheAccountingFailurePreservesCheckpointAndResumes(t *testing.T) 
 	if err != nil || !found {
 		t.Fatalf("failed state: found=%v err=%v", found, err)
 	}
-	if failed.Status != StatusFailed || failed.LastEventID != 1 || failed.ProcessedRows != 1 || failed.LastError == "" {
+	if failed.Status != StatusFailed || failed.LastEventID != 1 || failed.ProcessedRows != 1 || failed.ChangedRows != 1 || failed.LastError == "" {
 		t.Fatalf("failed state = %#v", failed)
 	}
 
@@ -150,63 +206,113 @@ func TestUsageCacheAccountingFailurePreservesCheckpointAndResumes(t *testing.T) 
 	if err != nil {
 		t.Fatalf("resume migration: %v", err)
 	}
-	if resumed.Status != StatusPending || resumed.LastEventID != 1 || resumed.ProcessedRows != 1 || resumed.TargetEventID != 2 {
+	if resumed.Status != StatusPending || resumed.LastEventID != 1 || resumed.ProcessedRows != 1 || resumed.ChangedRows != 1 || resumed.TargetEventID != 2 {
 		t.Fatalf("resumed state = %#v", resumed)
 	}
-	if _, err := db.Exec(`drop trigger reject_second_usage_update`); err != nil {
+	assertNormalizedTotalNull(t, db, "legacy-1")
+	assertNormalizedTotalNull(t, db, "legacy-2")
+	if _, err := db.Exec(`drop trigger reject_second_usage_stage`); err != nil {
 		t.Fatalf("drop failure trigger: %v", err)
 	}
 	final, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("resumed batch: %v", err)
 	}
-	if !final.Completed || final.State.ProcessedRows != 2 || final.State.LastEventID != 2 {
+	if !final.Completed || final.State.ProcessedRows != 2 || final.State.ChangedRows != 2 || final.State.LastEventID != 2 {
 		t.Fatalf("final batch = %#v", final)
 	}
+	assertAccounting(t, db, "legacy-1", "included_in_input", 90, 100, 10, 0, 0)
+	assertAccounting(t, db, "legacy-2", "included_in_input", 180, 200, 20, 0, 0)
+	assertCount(t, db, "usage_cache_accounting_v2_changes", 0)
+}
 
-	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), errors.New("late failure")); err != nil {
-		t.Fatalf("record late failure: %v", err)
+func TestUsageCacheAccountingScansOnlyCandidates(t *testing.T) {
+	db := openMigrationTestDB(t)
+	for index := 0; index < 25; index++ {
+		if _, err := db.Exec(`insert into usage_events (
+			event_hash, timestamp_ms, timestamp, provider, model, cache_input_mode,
+			input_tokens, normalized_uncached_input_tokens, normalized_total_input_tokens,
+			normalized_cache_read_tokens, normalized_cache_creation_tokens, total_tokens, created_at_ms
+		) values (?, ?, ?, 'openai', 'gpt-5', 'included_in_input', 10, 10, 10, 0, 0, 10, ?)`,
+			fmt.Sprintf("non-candidate-%d", index), index+1, index+1, index+1); err != nil {
+			t.Fatalf("insert non-candidate %d: %v", index, err)
+		}
 	}
-	completed, _, err := repo.UsageCacheAccountingState(context.Background())
+	insertLegacyUsageEvent(t, db, "cache-candidate", "xai", "XAIExecutor", "grok-4", 100, 20, 0, 0, 0, "")
+	markMigrationDiscovering(t, db)
+
+	repo := New(db)
+	state, err := repo.DiscoverUsageCacheAccounting(context.Background())
 	if err != nil {
-		t.Fatalf("completed state: %v", err)
+		t.Fatalf("discover migration: %v", err)
 	}
-	if completed.Status != StatusCompleted || completed.LastError != "" {
-		t.Fatalf("completed state overwritten by late failure: %#v", completed)
+	if state.TargetEventID != 26 {
+		t.Fatalf("target event id = %d, want 26", state.TargetEventID)
+	}
+	result, err := repo.RunUsageCacheAccountingBatch(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("run migration: %v", err)
+	}
+	if !result.Completed || result.State.ProcessedRows != 1 || result.State.ChangedRows != 1 {
+		t.Fatalf("result = %#v", result)
 	}
 }
 
-func TestUsageCacheAccountingDiscoveryFailureRetriesDiscovery(t *testing.T) {
+func TestUsageCacheAccountingFinalizationFailureRollsBackLastBatch(t *testing.T) {
 	db := openMigrationTestDB(t)
-	insertLegacyUsageEvent(t, db, "legacy", "openai", "gpt-5", 100, 10, 0, 0)
+	insertLegacyUsageEvent(t, db, "legacy-1", "openai", "", "gpt-5", 100, 10, 0, 0, 0, "")
+	insertLegacyUsageEvent(t, db, "legacy-2", "openai", "", "gpt-5", 200, 20, 0, 0, 0, "")
 	markMigrationDiscovering(t, db)
 	insertRollupFixtures(t, db)
+	repo := New(db)
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err != nil {
+		t.Fatalf("discover migration: %v", err)
+	}
+	first, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("run first batch: %v", err)
+	}
+	if first.Completed || first.State.LastEventID != 1 || first.State.ChangedRows != 1 {
+		t.Fatalf("first batch = %#v", first)
+	}
 	if _, err := db.Exec(`create trigger reject_rollup_delete before delete on usage_account_model_rollups
 		begin select raise(abort, 'blocked'); end`); err != nil {
-		t.Fatalf("create discovery failure trigger: %v", err)
+		t.Fatalf("create finalization failure trigger: %v", err)
 	}
-	repo := New(db)
 
-	_, discoveryErr := repo.DiscoverUsageCacheAccounting(context.Background())
-	if discoveryErr == nil {
-		t.Fatal("discovery error = nil, want trigger failure")
+	finalizationErr := errors.New("finalization failed")
+	if _, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1); err == nil {
+		t.Fatal("finalization error = nil, want trigger failure")
+	} else {
+		finalizationErr = err
 	}
-	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), discoveryErr); err != nil {
-		t.Fatalf("record discovery failure: %v", err)
+	assertNormalizedTotalNull(t, db, "legacy-1")
+	assertNormalizedTotalNull(t, db, "legacy-2")
+	assertCount(t, db, "usage_cache_accounting_v2_changes", 1)
+	state, _, err := repo.UsageCacheAccountingState(context.Background())
+	if err != nil {
+		t.Fatalf("read rolled back state: %v", err)
+	}
+	if state.Status != StatusRunning || state.ProcessedRows != 1 || state.ChangedRows != 1 || state.LastEventID != 1 {
+		t.Fatalf("rolled back state = %#v", state)
+	}
+	if err := repo.RecordUsageCacheAccountingFailure(context.Background(), finalizationErr); err != nil {
+		t.Fatalf("record failure: %v", err)
 	}
 	if _, err := db.Exec(`drop trigger reject_rollup_delete`); err != nil {
-		t.Fatalf("drop discovery failure trigger: %v", err)
+		t.Fatalf("drop finalization failure trigger: %v", err)
 	}
-
-	state, err := repo.DiscoverUsageCacheAccounting(context.Background())
-	if err != nil {
-		t.Fatalf("retry discovery: %v", err)
+	if _, err := repo.DiscoverUsageCacheAccounting(context.Background()); err != nil {
+		t.Fatalf("resume migration: %v", err)
 	}
-	if state.Status != StatusPending || state.TargetEventID != 1 || state.LastEventID != 0 {
-		t.Fatalf("retried discovery state = %#v", state)
+	result, err := repo.RunUsageCacheAccountingBatch(context.Background(), 1)
+	if err != nil || !result.Completed {
+		t.Fatalf("resumed result = %#v err=%v", result, err)
 	}
+	assertAccounting(t, db, "legacy-1", "included_in_input", 90, 100, 10, 0, 0)
+	assertAccounting(t, db, "legacy-2", "included_in_input", 180, 200, 20, 0, 0)
 	assertCount(t, db, "usage_account_model_rollups", 0)
-	assertCount(t, db, "usage_dashboard_hourly_rollups", 0)
+	assertCount(t, db, "usage_cache_accounting_v2_changes", 0)
 }
 
 func TestUsageCacheAccountingRejectsUnknownState(t *testing.T) {
@@ -235,6 +341,26 @@ func TestUsageCacheAccountingRejectsUnknownState(t *testing.T) {
 	}
 }
 
+type accountingFixture struct {
+	Hash             string
+	Provider         string
+	Executor         string
+	Model            string
+	RawJSON          string
+	Input            int64
+	Output           int64
+	Reasoning        int64
+	Cached           int64
+	CacheRead        int64
+	CacheCreation    int64
+	StoredMode       string
+	StoredUncached   int64
+	StoredTotalInput int64
+	StoredRead       int64
+	StoredCreation   int64
+	Total            int64
+}
+
 func openMigrationTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
@@ -245,13 +371,45 @@ func openMigrationTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-func insertLegacyUsageEvent(t *testing.T, db *sql.DB, hash, provider, model string, input, cached, cacheRead, cacheCreation int64) {
+func insertLegacyUsageEvent(t *testing.T, db *sql.DB, hash, provider, executor, model string, input, cached, cacheRead, cacheCreation, total int64, rawJSON string) {
 	t.Helper()
 	if _, err := db.Exec(`insert into usage_events (
-		event_hash, timestamp_ms, timestamp, provider, model, input_tokens,
-		cached_tokens, cache_read_tokens, cache_creation_tokens, created_at_ms
-	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, hash, input, hash, provider, model, input, cached, cacheRead, cacheCreation, input); err != nil {
+		event_hash, timestamp_ms, timestamp, provider, executor_type, model, input_tokens,
+		cached_tokens, cache_read_tokens, cache_creation_tokens, total_tokens, raw_json, created_at_ms
+	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, hash, input, hash, provider, executor, model, input, cached, cacheRead, cacheCreation, total, rawJSON, input); err != nil {
 		t.Fatalf("insert legacy usage event %s: %v", hash, err)
+	}
+}
+
+func insertAccountingEvent(t *testing.T, db *sql.DB, fixture accountingFixture) {
+	t.Helper()
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, provider, executor_type, model,
+		input_tokens, output_tokens, reasoning_tokens, cached_tokens,
+		cache_read_tokens, cache_creation_tokens, cache_input_mode,
+		normalized_uncached_input_tokens, normalized_total_input_tokens,
+		normalized_cache_read_tokens, normalized_cache_creation_tokens,
+		total_tokens, raw_json, created_at_ms
+	) values (?, 1, '1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+		fixture.Hash,
+		fixture.Provider,
+		fixture.Executor,
+		fixture.Model,
+		fixture.Input,
+		fixture.Output,
+		fixture.Reasoning,
+		fixture.Cached,
+		fixture.CacheRead,
+		fixture.CacheCreation,
+		fixture.StoredMode,
+		fixture.StoredUncached,
+		fixture.StoredTotalInput,
+		fixture.StoredRead,
+		fixture.StoredCreation,
+		fixture.Total,
+		fixture.RawJSON,
+	); err != nil {
+		t.Fatalf("insert accounting event %s: %v", fixture.Hash, err)
 	}
 }
 
@@ -264,6 +422,12 @@ func insertRollupFixtures(t *testing.T, db *sql.DB) {
 		`insert into usage_dashboard_hourly_rollups (
 			bucket_ms, model, billing_model, service_tier, updated_at_ms
 		) values (0, 'model', 'model', '', 1)`,
+		`insert or replace into usage_rollup_checkpoints (name, last_event_id, updated_at_ms, last_error)
+			values ('account_history', 9, 9, 'old')`,
+		`insert or replace into usage_rollup_checkpoints (name, last_event_id, updated_at_ms, last_error)
+			values ('dashboard_hourly', 9, 9, 'old')`,
+		`insert or replace into usage_rollup_checkpoints (name, last_event_id, updated_at_ms, last_error)
+			values ('unrelated', 9, 9, 'old')`,
 	}
 	for _, statement := range statements {
 		if _, err := db.Exec(statement); err != nil {
@@ -276,7 +440,7 @@ func markMigrationDiscovering(t *testing.T, db *sql.DB) {
 	t.Helper()
 	if _, err := db.Exec(`update usage_data_migrations set
 		status = 'discovering', last_event_id = 0, target_event_id = 0,
-		processed_rows = 0, started_at_ms = null, updated_at_ms = 0,
+		processed_rows = 0, changed_rows = 0, started_at_ms = null, updated_at_ms = 0,
 		finished_at_ms = null, last_error = null
 	where name = ?`, UsageCacheAccountingMigrationName); err != nil {
 		t.Fatalf("mark migration discovering: %v", err)
@@ -294,20 +458,42 @@ func assertCount(t *testing.T, db *sql.DB, table string, want int64) {
 	}
 }
 
-func assertAccounting(t *testing.T, db *sql.DB, hash, mode string, uncached, total, cacheRead, cacheCreation int64) {
+func assertCheckpoint(t *testing.T, db *sql.DB, name string, want int64) {
+	t.Helper()
+	var got int64
+	if err := db.QueryRow(`select last_event_id from usage_rollup_checkpoints where name = ?`, name).Scan(&got); err != nil {
+		t.Fatalf("checkpoint %s: %v", name, err)
+	}
+	if got != want {
+		t.Fatalf("checkpoint %s = %d, want %d", name, got, want)
+	}
+}
+
+func assertNormalizedTotalNull(t *testing.T, db *sql.DB, hash string) {
+	t.Helper()
+	var value sql.NullInt64
+	if err := db.QueryRow(`select normalized_total_input_tokens from usage_events where event_hash = ?`, hash).Scan(&value); err != nil {
+		t.Fatalf("read normalized total %s: %v", hash, err)
+	}
+	if value.Valid {
+		t.Fatalf("normalized total %s = %d, want null", hash, value.Int64)
+	}
+}
+
+func assertAccounting(t *testing.T, db *sql.DB, hash, mode string, uncached, total, cacheRead, cacheCreation, totalTokens int64) {
 	t.Helper()
 	var gotMode string
-	var gotUncached, gotTotal, gotCacheRead, gotCacheCreation int64
+	var gotUncached, gotTotal, gotCacheRead, gotCacheCreation, gotTotalTokens int64
 	if err := db.QueryRow(`select cache_input_mode, normalized_uncached_input_tokens,
 		normalized_total_input_tokens, normalized_cache_read_tokens,
-		normalized_cache_creation_tokens from usage_events where event_hash = ?`, hash).Scan(
-		&gotMode, &gotUncached, &gotTotal, &gotCacheRead, &gotCacheCreation,
+		normalized_cache_creation_tokens, total_tokens from usage_events where event_hash = ?`, hash).Scan(
+		&gotMode, &gotUncached, &gotTotal, &gotCacheRead, &gotCacheCreation, &gotTotalTokens,
 	); err != nil {
 		t.Fatalf("read accounting %s: %v", hash, err)
 	}
-	if gotMode != mode || gotUncached != uncached || gotTotal != total || gotCacheRead != cacheRead || gotCacheCreation != cacheCreation {
-		t.Fatalf("accounting %s = (%s, %d, %d, %d, %d), want (%s, %d, %d, %d, %d)",
-			hash, gotMode, gotUncached, gotTotal, gotCacheRead, gotCacheCreation,
-			mode, uncached, total, cacheRead, cacheCreation)
+	if gotMode != mode || gotUncached != uncached || gotTotal != total || gotCacheRead != cacheRead || gotCacheCreation != cacheCreation || gotTotalTokens != totalTokens {
+		t.Fatalf("accounting %s = (%s, %d, %d, %d, %d, %d), want (%s, %d, %d, %d, %d, %d)",
+			hash, gotMode, gotUncached, gotTotal, gotCacheRead, gotCacheCreation, gotTotalTokens,
+			mode, uncached, total, cacheRead, cacheCreation, totalTokens)
 	}
 }

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -147,6 +147,7 @@ func Migrate(db *sql.DB) error {
 			last_event_id integer not null default 0,
 			target_event_id integer not null default 0,
 			processed_rows integer not null default 0,
+			changed_rows integer not null default 0,
 			started_at_ms integer,
 			updated_at_ms integer not null default 0,
 			finished_at_ms integer,
@@ -157,6 +158,20 @@ func Migrate(db *sql.DB) error {
 		) select 'usage_cache_accounting_v1',
 			case when exists (select 1 from usage_events limit 1) then 'discovering' else 'completed' end,
 			0, 0, 0, 0`,
+		`insert or ignore into usage_data_migrations (
+			name, status, last_event_id, target_event_id, processed_rows, updated_at_ms
+		) select 'usage_cache_accounting_v2',
+			case when exists (select 1 from usage_events limit 1) then 'discovering' else 'completed' end,
+			0, 0, 0, 0`,
+		`create table if not exists usage_cache_accounting_v2_changes (
+			event_id integer primary key,
+			cache_input_mode text not null,
+			normalized_uncached_input_tokens integer not null,
+			normalized_total_input_tokens integer not null,
+			normalized_cache_read_tokens integer not null,
+			normalized_cache_creation_tokens integer not null,
+			total_tokens integer not null
+		)`,
 		`create table if not exists dead_letter_events (
 			id integer primary key autoincrement,
 			payload text not null,
@@ -315,6 +330,9 @@ func Migrate(db *sql.DB) error {
 			return err
 		}
 	}
+	if err := ensureUsageDataMigrationColumns(db); err != nil {
+		return err
+	}
 	if err := ensureUsageEventSnapshotColumns(db); err != nil {
 		return err
 	}
@@ -334,6 +352,34 @@ func Migrate(db *sql.DB) error {
 		return err
 	}
 	return ensureModelPriceColumns(db)
+}
+
+func ensureUsageDataMigrationColumns(db *sql.DB) error {
+	rows, err := db.Query(`pragma table_info(usage_data_migrations)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	existing := map[string]struct{}{}
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		existing[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if _, ok := existing["changed_rows"]; ok {
+		return nil
+	}
+	_, err = db.Exec(`alter table usage_data_migrations add column changed_rows integer not null default 0`)
+	return err
 }
 
 func ensureQuotaCooldownColumns(db *sql.DB) error {

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -13,7 +13,7 @@ func TestUsageDataMigrationInitialStateMatchesExistingUsageData(t *testing.T) {
 		t.Fatalf("open empty sqlite: %v", err)
 	}
 	var status string
-	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v1'`).Scan(&status); err != nil {
+	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v2'`).Scan(&status); err != nil {
 		t.Fatalf("read empty migration state: %v", err)
 	}
 	if status != "completed" {
@@ -36,11 +36,66 @@ func TestUsageDataMigrationInitialStateMatchesExistingUsageData(t *testing.T) {
 		t.Fatalf("reopen legacy sqlite: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v1'`).Scan(&status); err != nil {
+	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v2'`).Scan(&status); err != nil {
 		t.Fatalf("read legacy migration state: %v", err)
 	}
 	if status != "discovering" {
 		t.Fatalf("legacy migration status = %q, want discovering", status)
+	}
+	columns := migrationTableColumns(t, db, "usage_cache_accounting_v2_changes")
+	for _, column := range []string{
+		"event_id",
+		"cache_input_mode",
+		"normalized_uncached_input_tokens",
+		"normalized_total_input_tokens",
+		"normalized_cache_read_tokens",
+		"normalized_cache_creation_tokens",
+		"total_tokens",
+	} {
+		if !columns[column] {
+			t.Fatalf("staging columns = %#v, missing %s", columns, column)
+		}
+	}
+}
+
+func TestUsageDataMigrationUpgradeAddsChangedRowsAndPreservesV1(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage-data-migration-upgrade.sqlite")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, statement := range []string{
+		`drop table usage_data_migrations`,
+		`create table usage_data_migrations (name text primary key, status text not null, last_event_id integer not null default 0, target_event_id integer not null default 0, processed_rows integer not null default 0, started_at_ms integer, updated_at_ms integer not null default 0, finished_at_ms integer, last_error text)`,
+		`insert into usage_data_migrations (name, status) values ('usage_cache_accounting_v1', 'completed')`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			_ = db.Close()
+			t.Fatalf("setup legacy sqlite: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy sqlite: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("upgrade sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	columns := migrationTableColumns(t, db, "usage_data_migrations")
+	if !columns["changed_rows"] {
+		t.Fatalf("migration columns = %#v, missing changed_rows", columns)
+	}
+	var v1Status, v2Status string
+	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v1'`).Scan(&v1Status); err != nil {
+		t.Fatalf("read v1 status: %v", err)
+	}
+	if err := db.QueryRow(`select status from usage_data_migrations where name = 'usage_cache_accounting_v2'`).Scan(&v2Status); err != nil {
+		t.Fatalf("read v2 status: %v", err)
+	}
+	if v1Status != "completed" || v2Status != "completed" {
+		t.Fatalf("migration statuses = v1:%q v2:%q", v1Status, v2Status)
 	}
 }
 

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -1951,7 +1951,7 @@ func (r *repository) EventsPageWithFilter(ctx context.Context, filter AnalyticsF
 	coalesce(reasoning_effort, ''),
 	coalesce(service_tier, ''),
 	coalesce(executor_type, ''),
-	input_tokens,
+	`+normalizedInputExpr+`,
 	output_tokens,
 	`+compatCachedExpr+`,
 	cache_read_tokens,

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -87,12 +87,23 @@ func (r *repository) InsertBatch(ctx context.Context, events []model.UsageEvent)
 
 	result := model.InsertResult{}
 	for _, event := range events {
-		accounting := usage.NormalizeCacheAccounting(event.CacheInputMode, event.Provider, event.ExecutorType, event.ResolvedModel, event.InputTokens, event.CachedTokens, event.CacheTokens, event.CacheReadTokens, event.CacheCreationTokens)
+		accounting := usage.NormalizeCacheAccounting(usage.CacheInputContext{
+			ExplicitMode:     event.CacheInputMode,
+			ExecutorType:     event.ExecutorType,
+			Provider:         event.Provider,
+			ProviderSnapshot: event.AuthProviderSnapshot,
+			ResolvedModel:    event.ResolvedModel,
+			RequestedModel:   event.RequestedModel,
+			DisplayModel:     event.Model,
+		}, event.InputTokens, event.CachedTokens, event.CacheTokens, event.CacheReadTokens, event.CacheCreationTokens)
 		event.CacheInputMode = accounting.Mode
 		event.NormalizedUncachedInputTokens = accounting.UncachedInputTokens
 		event.NormalizedTotalInputTokens = accounting.TotalInputTokens
 		event.NormalizedCacheReadTokens = accounting.CacheReadTokens
 		event.NormalizedCacheCreationTokens = accounting.CacheCreationTokens
+		if event.TotalTokens <= 0 {
+			event.TotalTokens = accounting.TotalInputTokens + max(event.OutputTokens, int64(0)) + max(event.ReasoningTokens, int64(0))
+		}
 		if event.RequestServiceTier == "" {
 			event.RequestServiceTier = event.ServiceTier
 		}
@@ -198,7 +209,7 @@ func (r *repository) ListRecent(ctx context.Context, limit int) ([]model.UsageEv
 		normalized_uncached_input_tokens, normalized_total_input_tokens, normalized_cache_read_tokens, normalized_cache_creation_tokens, total_tokens,
 		latency_ms, ttft_ms, failed, fail_status_code, fail_summary,
 		coalesce(response_metadata_json, ''), header_quota_recover_at_ms, header_quota_used_percent, coalesce(header_quota_plan_type, ''), coalesce(header_error_kind, ''), coalesce(header_error_code, ''), coalesce(header_trace_id, ''),
-		created_at_ms
+		coalesce(raw_json, ''), created_at_ms
 		from usage_events
 		order by timestamp_ms desc, id desc
 		limit ?`, limit)
@@ -211,7 +222,7 @@ func (r *repository) ListRecent(ctx context.Context, limit int) ([]model.UsageEv
 	for rows.Next() {
 		var event model.UsageEvent
 		var requestID, provider, executorType, endpoint, method, path, authType, authIndex, source, sourceHash, apiKeyHash, accountSnapshot, authLabelSnapshot, authFileSnapshot, authProviderSnapshot, authProjectIDSnapshot, requestedModel, resolvedModel, reasoningEffort, serviceTier, requestServiceTier, responseServiceTier, cacheInputMode, failSummary sql.NullString
-		var responseMetadataJSON, quotaPlanType, errorKind, errorCode, traceID string
+		var responseMetadataJSON, quotaPlanType, errorKind, errorCode, traceID, rawJSON string
 		var authSnapshotAt sql.NullInt64
 		var latency, ttft sql.NullInt64
 		var failStatusCode sql.NullInt64
@@ -272,6 +283,7 @@ func (r *repository) ListRecent(ctx context.Context, limit int) ([]model.UsageEv
 			&errorKind,
 			&errorCode,
 			&traceID,
+			&rawJSON,
 			&event.CreatedAtMS,
 		); err != nil {
 			return nil, err
@@ -298,8 +310,16 @@ func (r *repository) ListRecent(ctx context.Context, limit int) ([]model.UsageEv
 		event.ServiceTier = serviceTier.String
 		event.RequestServiceTier = requestServiceTier.String
 		event.ResponseServiceTier = responseServiceTier.String
-		event.CacheInputMode = cacheInputMode.String
-		accounting := usage.NormalizeCacheAccounting(event.CacheInputMode, event.Provider, event.ExecutorType, event.ResolvedModel, event.InputTokens, event.CachedTokens, event.CacheTokens, event.CacheReadTokens, event.CacheCreationTokens)
+		hints := usage.RawCacheAccountingHintsFromJSON(rawJSON)
+		accounting := usage.NormalizeCacheAccounting(usage.CacheInputContext{
+			ExplicitMode:     hints.ExplicitMode,
+			ExecutorType:     event.ExecutorType,
+			Provider:         event.Provider,
+			ProviderSnapshot: event.AuthProviderSnapshot,
+			ResolvedModel:    event.ResolvedModel,
+			RequestedModel:   event.RequestedModel,
+			DisplayModel:     event.Model,
+		}, event.InputTokens, event.CachedTokens, event.CacheTokens, event.CacheReadTokens, event.CacheCreationTokens)
 		event.CacheInputMode = accounting.Mode
 		event.NormalizedUncachedInputTokens = accounting.UncachedInputTokens
 		event.NormalizedTotalInputTokens = accounting.TotalInputTokens

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -1466,6 +1466,46 @@ func TestAnalyticsEventsPageReportsTotalCountWhilePaging(t *testing.T) {
 	}
 }
 
+func TestAnalyticsEventsPageUsesNormalizedTotalInput(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_400_000_000)
+	events := []usage.Event{
+		{
+			EventHash: "xai-included", TimestampMS: fromMS + 1, Timestamp: "2026-05-06T00:00:00Z",
+			ExecutorType: "XAIExecutor", Model: "grok-4", InputTokens: 100, CacheReadTokens: 40, OutputTokens: 20, CreatedAtMS: fromMS + 1,
+		},
+		{
+			EventHash: "claude-separate", TimestampMS: fromMS + 2, Timestamp: "2026-05-06T00:00:01Z",
+			ExecutorType: "ClaudeExecutor", Model: "claude-sonnet", InputTokens: 100, CacheReadTokens: 40, OutputTokens: 20, CreatedAtMS: fromMS + 2,
+		},
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   fromMS + 60_000,
+		Include: Include{
+			EventsPage: &EventsPage{Limit: 10},
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if resp.Events == nil || len(resp.Events.Items) != 2 {
+		t.Fatalf("events = %#v", resp.Events)
+	}
+	inputs := map[string]int64{}
+	for _, item := range resp.Events.Items {
+		inputs[item.EventHash] = item.InputTokens
+	}
+	if inputs["xai-included"] != 100 || inputs["claude-separate"] != 140 {
+		t.Fatalf("normalized event inputs = %#v", inputs)
+	}
+}
+
 func TestAnalyticsEventsPageTotalCountRespectsFilters(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/store/store_test.go
+++ b/apps/manager-server/internal/store/store_test.go
@@ -24,7 +24,7 @@ func TestStorePausesRollupsUntilUsageCacheAccountingMigrationCompletes(t *testin
 	}}); err != nil {
 		t.Fatalf("insert event: %v", err)
 	}
-	if _, err := db.db.Exec(`update usage_data_migrations set status = 'running' where name = 'usage_cache_accounting_v1'`); err != nil {
+	if _, err := db.db.Exec(`update usage_data_migrations set status = 'running' where name = 'usage_cache_accounting_v2'`); err != nil {
 		t.Fatalf("mark migration running: %v", err)
 	}
 
@@ -40,7 +40,7 @@ func TestStorePausesRollupsUntilUsageCacheAccountingMigrationCompletes(t *testin
 		t.Fatalf("rollups were not paused: account=%#v dashboard=%#v", accountResult, dashboardResult)
 	}
 
-	if _, err := db.db.Exec(`update usage_data_migrations set status = 'completed' where name = 'usage_cache_accounting_v1'`); err != nil {
+	if _, err := db.db.Exec(`update usage_data_migrations set status = 'completed' where name = 'usage_cache_accounting_v2'`); err != nil {
 		t.Fatalf("mark migration completed: %v", err)
 	}
 	accountResult, err = db.CatchUpAccountHistoryRollups(context.Background(), 100, 1_778_000_001_000)

--- a/apps/manager-server/internal/usage/cpa_crosscheck_test.go
+++ b/apps/manager-server/internal/usage/cpa_crosscheck_test.go
@@ -1,0 +1,61 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type cacheAccountingFixture struct {
+	Name    string            `json:"name"`
+	Context CacheInputContext `json:"context"`
+	Tokens  struct {
+		Input    int64 `json:"input"`
+		Cached   int64 `json:"cached"`
+		Cache    int64 `json:"cache"`
+		Read     int64 `json:"read"`
+		Creation int64 `json:"creation"`
+	} `json:"tokens"`
+	Expected struct {
+		Mode          string `json:"mode"`
+		Uncached      int64  `json:"uncached"`
+		TotalInput    int64  `json:"totalInput"`
+		CacheRead     int64  `json:"cacheRead"`
+		CacheCreation int64  `json:"cacheCreation"`
+	} `json:"expected"`
+}
+
+func TestSharedCacheAccountingFixtures(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "web", "src", "utils", "cacheInputAccounting.fixtures.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read shared cache accounting fixtures: %v", err)
+	}
+	var fixtures []cacheAccountingFixture
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("decode shared cache accounting fixtures: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("shared cache accounting fixtures are empty")
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.Name, func(t *testing.T) {
+			got := NormalizeCacheAccounting(
+				fixture.Context,
+				fixture.Tokens.Input,
+				fixture.Tokens.Cached,
+				fixture.Tokens.Cache,
+				fixture.Tokens.Read,
+				fixture.Tokens.Creation,
+			)
+			if got.Mode != fixture.Expected.Mode ||
+				got.UncachedInputTokens != fixture.Expected.Uncached ||
+				got.TotalInputTokens != fixture.Expected.TotalInput ||
+				got.CacheReadTokens != fixture.Expected.CacheRead ||
+				got.CacheCreationTokens != fixture.Expected.CacheCreation {
+				t.Fatalf("accounting = %+v, want %+v", got, fixture.Expected)
+			}
+		})
+	}
+}

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -168,8 +168,25 @@ type CacheAccounting struct {
 	CacheCreationTokens int64
 }
 
-func NormalizeCacheAccounting(mode, provider, executorType, modelName string, inputTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens int64) CacheAccounting {
-	mode = inferCacheInputMode(mode, provider, executorType, modelName, cacheReadTokens, cacheCreationTokens)
+type CacheInputContext struct {
+	ExplicitMode     string
+	ExecutorType     string
+	Provider         string
+	ProviderSnapshot string
+	ResolvedModel    string
+	RequestedModel   string
+	DisplayModel     string
+}
+
+type RawCacheAccountingHints struct {
+	ExplicitMode     string
+	ExplicitTotal    int64
+	HasExplicitTotal bool
+	ValidPayload     bool
+}
+
+func NormalizeCacheAccounting(context CacheInputContext, inputTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens int64) CacheAccounting {
+	mode := InferCacheInputMode(context, cacheReadTokens, cacheCreationTokens)
 	input := maxInt64(inputTokens, 0)
 	cacheRead := CompatibleCachedTokens(cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens) + maxInt64(cacheReadTokens, 0)
 	cacheCreation := maxInt64(cacheCreationTokens, 0)
@@ -188,24 +205,178 @@ func NormalizeCacheAccounting(mode, provider, executorType, modelName string, in
 	return accounting
 }
 
-func inferCacheInputMode(mode, provider, executorType, modelName string, cacheReadTokens, cacheCreationTokens int64) string {
-	mode = strings.ToLower(strings.TrimSpace(mode))
+func InferCacheInputMode(context CacheInputContext, cacheReadTokens, cacheCreationTokens int64) string {
+	mode := normalizeCacheInputMode(context.ExplicitMode)
 	if mode == CacheInputModeIncluded || mode == CacheInputModeSeparate {
 		return mode
 	}
-	identity := strings.ToLower(strings.Join([]string{provider, executorType, modelName}, " "))
-	if strings.Contains(identity, "anthropic") || strings.Contains(identity, "claude") {
-		return CacheInputModeSeparate
+	if classified, ok := classifyExecutorCacheInputMode(context.ExecutorType); ok {
+		return classified
 	}
-	if strings.Contains(identity, "openai") || strings.Contains(identity, "codex") ||
-		strings.Contains(identity, "gemini") || strings.Contains(identity, "antigravity") ||
-		strings.Contains(identity, "interaction") || strings.Contains(identity, "gpt-") {
-		return CacheInputModeIncluded
+	for _, provider := range []string{context.Provider, context.ProviderSnapshot} {
+		if classified, ok := classifyProviderCacheInputMode(provider); ok {
+			return classified
+		}
+	}
+	for _, model := range []string{context.ResolvedModel, context.RequestedModel, context.DisplayModel} {
+		if classified, ok := classifyModelCacheInputMode(model); ok {
+			return classified
+		}
 	}
 	if cacheReadTokens > 0 || cacheCreationTokens > 0 {
 		return CacheInputModeSeparate
 	}
 	return CacheInputModeIncluded
+}
+
+func normalizeCacheInputMode(mode string) string {
+	return strings.ToLower(strings.TrimSpace(mode))
+}
+
+func classifyExecutorCacheInputMode(executorType string) (string, bool) {
+	executor := strings.ToLower(strings.TrimSpace(executorType))
+	if executor == "" {
+		return "", false
+	}
+	if strings.Contains(executor, "claude") {
+		return CacheInputModeSeparate, true
+	}
+	for _, marker := range []string{
+		"openaicompat", "openai_compat", "openai-compat", "openai",
+		"codex", "gemini", "aistudio", "ai_studio", "ai-studio",
+		"antigravity", "xai", "kimi",
+	} {
+		if strings.Contains(executor, marker) {
+			return CacheInputModeIncluded, true
+		}
+	}
+	return "", false
+}
+
+func classifyProviderCacheInputMode(provider string) (string, bool) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return "", false
+	}
+	if strings.Contains(provider, "anthropic") || strings.Contains(provider, "claude") {
+		return CacheInputModeSeparate, true
+	}
+	for _, marker := range []string{
+		"openai", "codex", "gemini", "vertex", "aistudio", "ai_studio",
+		"ai-studio", "interaction", "antigravity", "xai", "kimi", "moonshot",
+	} {
+		if strings.Contains(provider, marker) {
+			return CacheInputModeIncluded, true
+		}
+	}
+	return "", false
+}
+
+func classifyModelCacheInputMode(model string) (string, bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if model == "" {
+		return "", false
+	}
+	if strings.Contains(model, "anthropic") || strings.Contains(model, "claude") {
+		return CacheInputModeSeparate, true
+	}
+	for _, marker := range []string{
+		"gpt-", "openai", "codex", "gemini", "vertex", "aistudio",
+		"antigravity", "grok", "xai", "kimi", "moonshot",
+	} {
+		if strings.Contains(model, marker) {
+			return CacheInputModeIncluded, true
+		}
+	}
+	return "", false
+}
+
+func RawCacheAccountingHintsFromJSON(raw string) RawCacheAccountingHints {
+	return rawCacheAccountingHintsFromJSON(raw, 0)
+}
+
+func rawCacheAccountingHintsFromJSON(raw string, depth int) RawCacheAccountingHints {
+	if depth > 1 || strings.TrimSpace(raw) == "" {
+		return RawCacheAccountingHints{}
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return RawCacheAccountingHints{}
+	}
+	record, ok := payload.(map[string]any)
+	if !ok {
+		return RawCacheAccountingHints{}
+	}
+	if detail, ok := record["detail"].(map[string]any); ok {
+		record = detail
+	}
+	hints := RawCacheAccountingHints{ExplicitMode: cacheInputModeFromRecord(record), ValidPayload: true}
+	if total, ok := explicitPositiveTotalFromRecord(record); ok {
+		hints.ExplicitTotal = total
+		hints.HasExplicitTotal = true
+	}
+	if nestedRaw := readString(record, "raw_json", "rawJson"); nestedRaw != "" {
+		nested := rawCacheAccountingHintsFromJSON(nestedRaw, depth+1)
+		if hints.ExplicitMode == "" {
+			hints.ExplicitMode = nested.ExplicitMode
+		}
+		if !hints.HasExplicitTotal && nested.HasExplicitTotal {
+			hints.ExplicitTotal = nested.ExplicitTotal
+			hints.HasExplicitTotal = true
+		}
+	}
+	return hints
+}
+
+func cacheInputModeFromRecord(record map[string]any) string {
+	for _, parent := range []string{"tokens", "usage"} {
+		mode := normalizeCacheInputMode(readStringFromNested(record, parent, "cache_input_mode", "cacheInputMode"))
+		if mode == CacheInputModeIncluded || mode == CacheInputModeSeparate {
+			return mode
+		}
+	}
+	mode := normalizeCacheInputMode(readString(record, "cache_input_mode", "cacheInputMode"))
+	if mode == CacheInputModeIncluded || mode == CacheInputModeSeparate {
+		return mode
+	}
+	return ""
+}
+
+func explicitPositiveTotalFromRecord(record map[string]any) (int64, bool) {
+	for _, parent := range []string{"tokens", "usage"} {
+		if nested, ok := record[parent].(map[string]any); ok {
+			if total, ok := positiveIntValue(first(nested, "total_tokens", "totalTokens", "total")); ok {
+				return total, true
+			}
+		}
+	}
+	return positiveIntValue(first(record, "total_tokens", "totalTokens", "total"))
+}
+
+func positiveIntValue(value any) (int64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		if typed > 0 {
+			return int64(typed), true
+		}
+	case json.Number:
+		if parsed, err := typed.Int64(); err == nil && parsed > 0 {
+			return parsed, true
+		}
+	case string:
+		if parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64); err == nil && parsed > 0 {
+			return parsed, true
+		}
+	case int64:
+		if typed > 0 {
+			return typed, true
+		}
+	case int:
+		if typed > 0 {
+			return int64(typed), true
+		}
+	}
+	return 0, false
 }
 
 func IsLongContextInput(inputTokens int64) bool {
@@ -323,7 +494,7 @@ func NormalizeRaw(raw []byte) (Event, error) {
 	apiKey := readString(record, "api_key", "apiKey", "key")
 	authIndex := readString(record, "auth_index", "authIndex", "AuthIndex")
 	requestedModel := readString(record, "alias", "requested_model", "requestedModel")
-	resolvedModel := readString(record, "model", "model_name", "modelName", "resolved_model", "resolvedModel")
+	resolvedModel := readString(record, "resolved_model", "resolvedModel", "model", "model_name", "modelName")
 	model := requestedModel
 	if model == "" {
 		model = resolvedModel
@@ -336,11 +507,16 @@ func NormalizeRaw(raw []byte) (Event, error) {
 	if serviceTier == "" {
 		serviceTier = requestServiceTier
 	}
-	cacheInputMode := readStringFromNested(record, "tokens", "cache_input_mode", "cacheInputMode")
-	if cacheInputMode == "" {
-		cacheInputMode = readString(record, "cache_input_mode", "cacheInputMode")
-	}
-	cacheAccounting := NormalizeCacheAccounting(cacheInputMode, provider, executorType, resolvedModel, inputTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens)
+	authProviderSnapshot := readString(record, "auth_provider_snapshot", "authProviderSnapshot")
+	cacheAccounting := NormalizeCacheAccounting(CacheInputContext{
+		ExplicitMode:     cacheInputModeFromRecord(record),
+		ExecutorType:     executorType,
+		Provider:         provider,
+		ProviderSnapshot: authProviderSnapshot,
+		ResolvedModel:    resolvedModel,
+		RequestedModel:   requestedModel,
+		DisplayModel:     model,
+	}, inputTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens)
 	if totalTokens <= 0 {
 		totalTokens = cacheAccounting.TotalInputTokens + maxInt64(outputTokens, 0) + maxInt64(reasoningTokens, 0)
 	}
@@ -365,7 +541,7 @@ func NormalizeRaw(raw []byte) (Event, error) {
 		AccountSnapshot:               readString(record, "account_snapshot", "accountSnapshot"),
 		AuthLabelSnapshot:             readString(record, "auth_label_snapshot", "authLabelSnapshot"),
 		AuthFileSnapshot:              readString(record, "auth_file_snapshot", "authFileSnapshot"),
-		AuthProviderSnapshot:          readString(record, "auth_provider_snapshot", "authProviderSnapshot"),
+		AuthProviderSnapshot:          authProviderSnapshot,
 		AuthProjectIDSnapshot:         readString(record, "auth_project_id_snapshot", "authProjectIdSnapshot", "project_id", "projectId"),
 		AuthSnapshotAtMS:              readInt(record, "auth_snapshot_at_ms", "authSnapshotAtMs"),
 		ReasoningEffort:               readString(record, "reasoning_effort", "reasoningEffort"),
@@ -507,45 +683,18 @@ func readTimestamp(record map[string]any) (int64, string) {
 }
 
 func readTokenFields(record map[string]any) (int64, int64, int64, int64, int64, int64, int64, int64) {
-	tokens := map[string]any{}
-	if nested, ok := first(record, "tokens", "usage").(map[string]any); ok {
-		tokens = nested
-	}
-	input := readIntFrom(tokens, "input_tokens", "inputTokens", "prompt_tokens", "promptTokens")
-	if input == 0 {
-		input = readInt(record, "input_tokens", "inputTokens", "prompt_tokens", "promptTokens")
-	}
-	output := readIntFrom(tokens, "output_tokens", "outputTokens", "completion_tokens", "completionTokens")
-	if output == 0 {
-		output = readInt(record, "output_tokens", "outputTokens", "completion_tokens", "completionTokens")
-	}
-	reasoning := readIntFrom(tokens, "reasoning_tokens", "reasoningTokens")
-	if reasoning == 0 {
-		reasoning = readInt(record, "reasoning_tokens", "reasoningTokens")
-	}
-	cached := readIntFrom(tokens, "cached_tokens", "cachedTokens")
-	if cached == 0 {
-		cached = readInt(record, "cached_tokens", "cachedTokens")
-	}
-	cache := readIntFrom(tokens, "cache_tokens", "cacheTokens")
-	if cache == 0 {
-		cache = readInt(record, "cache_tokens", "cacheTokens")
-	}
-	cacheRead := readFirstIntFrom(tokens,
+	input := readNestedThenTopInt(record, []string{"input_tokens", "inputTokens", "prompt_tokens", "promptTokens"})
+	output := readNestedThenTopInt(record, []string{"output_tokens", "outputTokens", "completion_tokens", "completionTokens"})
+	reasoning := readNestedThenTopInt(record, []string{"reasoning_tokens", "reasoningTokens"})
+	cached := readNestedThenTopInt(record, []string{"cached_tokens", "cachedTokens"})
+	cache := readNestedThenTopInt(record, []string{"cache_tokens", "cacheTokens"})
+	cacheRead := readNestedThenTopInt(record, []string{
 		"cache_read_tokens",
 		"cacheReadTokens",
 		"cache_read_input_tokens",
 		"cacheReadInputTokens",
-	)
-	if cacheRead == 0 {
-		cacheRead = readFirstIntFrom(record,
-			"cache_read_tokens",
-			"cacheReadTokens",
-			"cache_read_input_tokens",
-			"cacheReadInputTokens",
-		)
-	}
-	cacheCreation := readFirstIntFrom(tokens,
+	})
+	cacheCreation := readNestedThenTopInt(record, []string{
 		"cache_creation_tokens",
 		"cacheCreationTokens",
 		"cache_creation_input_tokens",
@@ -554,24 +703,20 @@ func readTokenFields(record map[string]any) (int64, int64, int64, int64, int64, 
 		"cacheWriteTokens",
 		"cache_write_input_tokens",
 		"cacheWriteInputTokens",
-	)
-	if cacheCreation == 0 {
-		cacheCreation = readFirstIntFrom(record,
-			"cache_creation_tokens",
-			"cacheCreationTokens",
-			"cache_creation_input_tokens",
-			"cacheCreationInputTokens",
-			"cache_write_tokens",
-			"cacheWriteTokens",
-			"cache_write_input_tokens",
-			"cacheWriteInputTokens",
-		)
-	}
-	total := readIntFrom(tokens, "total_tokens", "totalTokens", "total")
-	if total == 0 {
-		total = readInt(record, "total_tokens", "totalTokens", "total")
-	}
+	})
+	total := readNestedThenTopInt(record, []string{"total_tokens", "totalTokens", "total"})
 	return input, output, reasoning, cached, cache, cacheRead, cacheCreation, total
+}
+
+func readNestedThenTopInt(record map[string]any, keys []string) int64 {
+	for _, parent := range []string{"tokens", "usage"} {
+		if nested, ok := record[parent].(map[string]any); ok {
+			if value := readFirstIntFrom(nested, keys...); value != 0 {
+				return value
+			}
+		}
+	}
+	return readFirstIntFrom(record, keys...)
 }
 
 func readFailed(record map[string]any) bool {

--- a/apps/manager-server/internal/usage/event_test.go
+++ b/apps/manager-server/internal/usage/event_test.go
@@ -53,9 +53,7 @@ func TestCacheHitRateUsesNormalizedInputTotals(t *testing.T) {
 func TestNormalizeCacheAccounting(t *testing.T) {
 	tests := []struct {
 		name      string
-		mode      string
-		provider  string
-		model     string
+		context   CacheInputContext
 		input     int64
 		cached    int64
 		read      int64
@@ -65,17 +63,88 @@ func TestNormalizeCacheAccounting(t *testing.T) {
 		wantTotal int64
 		wantRead  int64
 	}{
-		{name: "openai mirror is included", provider: "openai", model: "gpt-5.4", input: 1_000, cached: 400, read: 400, wantMode: CacheInputModeIncluded, wantInput: 600, wantTotal: 1_000, wantRead: 400},
-		{name: "gpt 5.6 read and write are included", mode: CacheInputModeIncluded, model: "gpt-5.6-sol", input: 1_000, read: 300, creation: 100, wantMode: CacheInputModeIncluded, wantInput: 600, wantTotal: 1_000, wantRead: 300},
-		{name: "claude cache is separate", mode: CacheInputModeSeparate, model: "claude-sonnet-4", input: 100, read: 300, creation: 50, wantMode: CacheInputModeSeparate, wantInput: 100, wantTotal: 450, wantRead: 300},
+		{name: "openai mirror is included", context: CacheInputContext{Provider: "openai", DisplayModel: "gpt-5.4"}, input: 1_000, cached: 400, read: 400, wantMode: CacheInputModeIncluded, wantInput: 600, wantTotal: 1_000, wantRead: 400},
+		{name: "gpt 5.6 read and write are included", context: CacheInputContext{ExplicitMode: CacheInputModeIncluded, DisplayModel: "gpt-5.6-sol"}, input: 1_000, read: 300, creation: 100, wantMode: CacheInputModeIncluded, wantInput: 600, wantTotal: 1_000, wantRead: 300},
+		{name: "claude cache is separate", context: CacheInputContext{ExplicitMode: CacheInputModeSeparate, DisplayModel: "claude-sonnet-4"}, input: 100, read: 300, creation: 50, wantMode: CacheInputModeSeparate, wantInput: 100, wantTotal: 450, wantRead: 300},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NormalizeCacheAccounting(tt.mode, tt.provider, "", tt.model, tt.input, tt.cached, 0, tt.read, tt.creation)
+			got := NormalizeCacheAccounting(tt.context, tt.input, tt.cached, 0, tt.read, tt.creation)
 			if got.Mode != tt.wantMode || got.UncachedInputTokens != tt.wantInput || got.TotalInputTokens != tt.wantTotal || got.CacheReadTokens != tt.wantRead {
 				t.Fatalf("accounting = %+v, want mode=%s input=%d total=%d read=%d", got, tt.wantMode, tt.wantInput, tt.wantTotal, tt.wantRead)
 			}
 		})
+	}
+}
+
+func TestInferCacheInputModeUsesStrictFieldPriority(t *testing.T) {
+	tests := []struct {
+		name    string
+		context CacheInputContext
+		want    string
+	}{
+		{name: "explicit wins", context: CacheInputContext{ExplicitMode: CacheInputModeSeparate, ExecutorType: "OpenAICompatExecutor"}, want: CacheInputModeSeparate},
+		{name: "invalid explicit is ignored", context: CacheInputContext{ExplicitMode: "legacy", ExecutorType: "XAIExecutor"}, want: CacheInputModeIncluded},
+		{name: "openai compat executor beats claude alias", context: CacheInputContext{ExecutorType: "OpenAICompatExecutor", ResolvedModel: "claude-sonnet-4"}, want: CacheInputModeIncluded},
+		{name: "claude executor beats grok alias", context: CacheInputContext{ExecutorType: "ClaudeExecutor", ResolvedModel: "grok-4"}, want: CacheInputModeSeparate},
+		{name: "claude executor beats kimi alias", context: CacheInputContext{ExecutorType: "ClaudeExecutor", RequestedModel: "kimi-k2"}, want: CacheInputModeSeparate},
+		{name: "xai executor beats claude alias", context: CacheInputContext{ExecutorType: "XAIWebsocketsExecutor", DisplayModel: "claude-alias"}, want: CacheInputModeIncluded},
+		{name: "provider beats snapshot", context: CacheInputContext{Provider: "anthropic", ProviderSnapshot: "openai"}, want: CacheInputModeSeparate},
+		{name: "snapshot beats model", context: CacheInputContext{ProviderSnapshot: "moonshot", ResolvedModel: "claude-sonnet"}, want: CacheInputModeIncluded},
+		{name: "resolved beats requested", context: CacheInputContext{ResolvedModel: "claude-sonnet", RequestedModel: "gpt-5"}, want: CacheInputModeSeparate},
+		{name: "requested beats display", context: CacheInputContext{RequestedModel: "grok-4", DisplayModel: "claude-sonnet"}, want: CacheInputModeIncluded},
+		{name: "xai model fallback", context: CacheInputContext{DisplayModel: "grok-4"}, want: CacheInputModeIncluded},
+		{name: "kimi model fallback", context: CacheInputContext{DisplayModel: "moonshot/kimi-k2"}, want: CacheInputModeIncluded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InferCacheInputMode(tt.context, 10, 0); got != tt.want {
+				t.Fatalf("mode = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRawCacheAccountingHintsFromJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantMode  string
+		wantTotal int64
+		hasTotal  bool
+	}{
+		{name: "tokens snake case", raw: `{"tokens":{"cache_input_mode":"included_in_input","total_tokens":123}}`, wantMode: CacheInputModeIncluded, wantTotal: 123, hasTotal: true},
+		{name: "usage camel case", raw: `{"usage":{"cacheInputMode":"separate_from_input","totalTokens":"456"}}`, wantMode: CacheInputModeSeparate, wantTotal: 456, hasTotal: true},
+		{name: "legacy detail wrapper", raw: `{"detail":{"tokens":{"cache_input_mode":"included_in_input","total_tokens":789}}}`, wantMode: CacheInputModeIncluded, wantTotal: 789, hasTotal: true},
+		{name: "nested raw json", raw: `{"raw_json":"{\"tokens\":{\"cache_input_mode\":\"separate_from_input\",\"total_tokens\":321}}"}`, wantMode: CacheInputModeSeparate, wantTotal: 321, hasTotal: true},
+		{name: "invalid values", raw: `{"cache_input_mode":"legacy","total_tokens":0}`, wantMode: "", hasTotal: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RawCacheAccountingHintsFromJSON(tt.raw)
+			if got.ExplicitMode != tt.wantMode || got.ExplicitTotal != tt.wantTotal || got.HasExplicitTotal != tt.hasTotal || !got.ValidPayload {
+				t.Fatalf("hints = %+v, want mode=%q total=%d hasTotal=%v", got, tt.wantMode, tt.wantTotal, tt.hasTotal)
+			}
+		})
+	}
+}
+
+func TestNormalizeRawPrefersResolvedModelOverRequestedAndDisplayAliases(t *testing.T) {
+	event, err := NormalizeRaw([]byte(`{
+		"timestamp":"2026-07-15T00:00:00Z",
+		"alias":"gpt-5-alias",
+		"model":"grok-display",
+		"resolved_model":"claude-sonnet-4",
+		"tokens":{"input_tokens":100,"cache_read_tokens":20}
+	}`))
+	if err != nil {
+		t.Fatalf("normalize raw: %v", err)
+	}
+	if event.ResolvedModel != "claude-sonnet-4" || event.RequestedModel != "gpt-5-alias" || event.Model != "gpt-5-alias" {
+		t.Fatalf("models = resolved:%q requested:%q display:%q", event.ResolvedModel, event.RequestedModel, event.Model)
+	}
+	if event.CacheInputMode != CacheInputModeSeparate || event.NormalizedTotalInputTokens != 120 {
+		t.Fatalf("accounting = mode:%q total:%d", event.CacheInputMode, event.NormalizedTotalInputTokens)
 	}
 }
 

--- a/apps/manager-server/internal/usage/import.go
+++ b/apps/manager-server/internal/usage/import.go
@@ -277,6 +277,12 @@ func parseJSONObjectImport(data []byte) (ImportParseResult, error) {
 	if err := decodeJSON(data, &record); err != nil {
 		return ImportParseResult{}, err
 	}
+	if event, ok, err := eventFromExportedRecord(record); ok || err != nil {
+		if err != nil {
+			return ImportParseResult{Format: ImportFormatJSONL, Failed: 1}, err
+		}
+		return ImportParseResult{Format: ImportFormatJSONL, Events: []Event{event}}, nil
+	}
 
 	if usageRaw, ok := record["usage"]; ok {
 		usageRecord, ok := usageRaw.(map[string]any)
@@ -298,13 +304,6 @@ func parseJSONObjectImport(data []byte) (ImportParseResult, error) {
 
 	if hasUsageAPIs(record) {
 		return eventsFromLegacyUsage(record, ImportFormatLegacyPayload)
-	}
-
-	if event, ok, err := eventFromExportedRecord(record); ok || err != nil {
-		if err != nil {
-			return ImportParseResult{Format: ImportFormatJSONL, Failed: 1}, err
-		}
-		return ImportParseResult{Format: ImportFormatJSONL, Events: []Event{event}}, nil
 	}
 
 	if looksLikeLegacyUsageSummary(record) {
@@ -392,68 +391,98 @@ func eventFromExportedRecord(record map[string]any) (Event, bool, error) {
 	}
 
 	inputTokens, outputTokens, reasoningTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens, totalTokens := readTokenFields(record)
-	if totalTokens <= 0 {
-		totalTokens = inputTokens + outputTokens + reasoningTokens +
-			CompatibleCachedTokens(cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens) +
-			maxInt64(cacheReadTokens, 0) + maxInt64(cacheCreationTokens, 0)
-	}
 	failStatusCode, failBody := readFailFields(record)
 	failSummary := readString(record, "fail_summary", "failSummary")
 	if failSummary == "" {
 		failSummary = FailSummaryFromBody(failBody)
 	}
 
-	event := Event{
-		RequestID:             readString(record, "request_id", "requestId"),
-		EventHash:             eventHash,
-		TimestampMS:           timestampMS,
-		Timestamp:             timestamp,
-		Provider:              readString(record, "provider"),
-		ExecutorType:          readString(record, "executor_type", "executorType"),
-		Model:                 readString(record, "model"),
-		RequestedModel:        readString(record, "requested_model", "requestedModel"),
-		ResolvedModel:         readString(record, "resolved_model", "resolvedModel"),
-		Endpoint:              readString(record, "endpoint"),
-		Method:                readString(record, "method"),
-		Path:                  readString(record, "path"),
-		AuthType:              readString(record, "auth_type", "authType"),
-		AuthIndex:             readString(record, "auth_index", "authIndex", "AuthIndex"),
-		Source:                readString(record, "source"),
-		SourceHash:            readString(record, "source_hash", "sourceHash"),
-		APIKeyHash:            readString(record, "api_key_hash", "apiKeyHash"),
-		AccountSnapshot:       readString(record, "account_snapshot", "accountSnapshot"),
-		AuthLabelSnapshot:     readString(record, "auth_label_snapshot", "authLabelSnapshot"),
-		AuthFileSnapshot:      readString(record, "auth_file_snapshot", "authFileSnapshot"),
-		AuthProviderSnapshot:  readString(record, "auth_provider_snapshot", "authProviderSnapshot"),
-		AuthProjectIDSnapshot: readString(record, "auth_project_id_snapshot", "authProjectIdSnapshot"),
-		AuthSnapshotAtMS:      readInt(record, "auth_snapshot_at_ms", "authSnapshotAtMs"),
-		ReasoningEffort:       readString(record, "reasoning_effort", "reasoningEffort"),
-		ServiceTier:           readString(record, "service_tier", "serviceTier"),
-		InputTokens:           inputTokens,
-		OutputTokens:          outputTokens,
-		ReasoningTokens:       reasoningTokens,
-		CachedTokens:          cachedTokens,
-		CacheTokens:           cacheTokens,
-		CacheReadTokens:       cacheReadTokens,
-		CacheCreationTokens:   cacheCreationTokens,
-		TotalTokens:           totalTokens,
-		LatencyMS:             readOptionalInt(record, "latency_ms", "latencyMs"),
-		TTFTMS:                readOptionalInt(record, "ttft_ms", "ttftMs", "time_to_first_token_ms", "timeToFirstTokenMs"),
-		Failed:                readBool(record, "failed", "is_failed", "isFailed"),
-		FailStatusCode:        int(failStatusCode),
-		FailSummary:           failSummary,
-		FailBody:              failBody,
-		RawJSON:               SafeRawJSON(readString(record, "raw_json", "rawJson")),
-		CreatedAtMS:           readInt(record, "created_at_ms", "createdAtMs"),
+	requestedModel := readString(record, "requested_model", "requestedModel")
+	resolvedModel := readString(record, "resolved_model", "resolvedModel")
+	model := readString(record, "model")
+	if model == "" {
+		model = requestedModel
 	}
-	if event.Model == "" {
-		if event.RequestedModel != "" {
-			event.Model = event.RequestedModel
-		} else if event.ResolvedModel != "" {
-			event.Model = event.ResolvedModel
-		} else {
-			event.Model = "-"
-		}
+	if model == "" {
+		model = resolvedModel
+	}
+	if model == "" {
+		model = "-"
+	}
+	provider := readString(record, "provider")
+	executorType := readString(record, "executor_type", "executorType")
+	providerSnapshot := readString(record, "auth_provider_snapshot", "authProviderSnapshot")
+	rawJSON := importCacheAccountingRawJSON(record)
+	rawHints := RawCacheAccountingHintsFromJSON(rawJSON)
+	explicitMode := cacheInputModeFromRecord(record)
+	if explicitMode == "" {
+		explicitMode = rawHints.ExplicitMode
+	}
+	accounting := NormalizeCacheAccounting(CacheInputContext{
+		ExplicitMode:     explicitMode,
+		ExecutorType:     executorType,
+		Provider:         provider,
+		ProviderSnapshot: providerSnapshot,
+		ResolvedModel:    resolvedModel,
+		RequestedModel:   requestedModel,
+		DisplayModel:     model,
+	}, inputTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens)
+	if totalTokens <= 0 && rawHints.HasExplicitTotal {
+		totalTokens = rawHints.ExplicitTotal
+	}
+	if totalTokens <= 0 {
+		totalTokens = accounting.TotalInputTokens + maxInt64(outputTokens, 0) + maxInt64(reasoningTokens, 0)
+	}
+
+	event := Event{
+		RequestID:                     readString(record, "request_id", "requestId"),
+		EventHash:                     eventHash,
+		TimestampMS:                   timestampMS,
+		Timestamp:                     timestamp,
+		Provider:                      provider,
+		ExecutorType:                  executorType,
+		Model:                         model,
+		RequestedModel:                requestedModel,
+		ResolvedModel:                 resolvedModel,
+		Endpoint:                      readString(record, "endpoint"),
+		Method:                        readString(record, "method"),
+		Path:                          readString(record, "path"),
+		AuthType:                      readString(record, "auth_type", "authType"),
+		AuthIndex:                     readString(record, "auth_index", "authIndex", "AuthIndex"),
+		Source:                        readString(record, "source"),
+		SourceHash:                    readString(record, "source_hash", "sourceHash"),
+		APIKeyHash:                    readString(record, "api_key_hash", "apiKeyHash"),
+		AccountSnapshot:               readString(record, "account_snapshot", "accountSnapshot"),
+		AuthLabelSnapshot:             readString(record, "auth_label_snapshot", "authLabelSnapshot"),
+		AuthFileSnapshot:              readString(record, "auth_file_snapshot", "authFileSnapshot"),
+		AuthProviderSnapshot:          providerSnapshot,
+		AuthProjectIDSnapshot:         readString(record, "auth_project_id_snapshot", "authProjectIdSnapshot"),
+		AuthSnapshotAtMS:              readInt(record, "auth_snapshot_at_ms", "authSnapshotAtMs"),
+		ReasoningEffort:               readString(record, "reasoning_effort", "reasoningEffort"),
+		ServiceTier:                   readString(record, "service_tier", "serviceTier"),
+		RequestServiceTier:            readString(record, "request_service_tier", "requestServiceTier"),
+		ResponseServiceTier:           readString(record, "response_service_tier", "responseServiceTier"),
+		CacheInputMode:                accounting.Mode,
+		InputTokens:                   inputTokens,
+		OutputTokens:                  outputTokens,
+		ReasoningTokens:               reasoningTokens,
+		CachedTokens:                  cachedTokens,
+		CacheTokens:                   cacheTokens,
+		CacheReadTokens:               cacheReadTokens,
+		CacheCreationTokens:           cacheCreationTokens,
+		NormalizedUncachedInputTokens: accounting.UncachedInputTokens,
+		NormalizedTotalInputTokens:    accounting.TotalInputTokens,
+		NormalizedCacheReadTokens:     accounting.CacheReadTokens,
+		NormalizedCacheCreationTokens: accounting.CacheCreationTokens,
+		TotalTokens:                   totalTokens,
+		LatencyMS:                     readOptionalInt(record, "latency_ms", "latencyMs"),
+		TTFTMS:                        readOptionalInt(record, "ttft_ms", "ttftMs", "time_to_first_token_ms", "timeToFirstTokenMs"),
+		Failed:                        readBool(record, "failed", "is_failed", "isFailed"),
+		FailStatusCode:                int(failStatusCode),
+		FailSummary:                   failSummary,
+		FailBody:                      failBody,
+		RawJSON:                       rawJSON,
+		CreatedAtMS:                   readInt(record, "created_at_ms", "createdAtMs"),
 	}
 	if event.Endpoint == "" {
 		event.Endpoint = "-"
@@ -559,11 +588,6 @@ func eventFromLegacyDetail(
 	timestampMS, normalizedTimestamp := readTimestamp(detail)
 
 	inputTokens, outputTokens, reasoningTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens, totalTokens := readTokenFields(detail)
-	if totalTokens <= 0 {
-		totalTokens = inputTokens + outputTokens + reasoningTokens +
-			CompatibleCachedTokens(cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens) +
-			maxInt64(cacheReadTokens, 0) + maxInt64(cacheCreationTokens, 0)
-	}
 	failStatusCode, failBody := readFailFields(detail)
 	failSummary := readString(detail, "fail_summary", "failSummary")
 	if failSummary == "" {
@@ -574,50 +598,76 @@ func eventFromLegacyDetail(
 	apiKey := readString(detail, "api_key", "apiKey", "key")
 	authIndex := readString(detail, "auth_index", "authIndex", "AuthIndex")
 	rawJSON := legacyRawJSON(endpoint, model, detail)
+	provider := readString(detail, "provider", "type", "auth_type", "authType")
+	executorType := readString(detail, "executor_type", "executorType")
+	providerSnapshot := readString(detail, "auth_provider_snapshot", "authProviderSnapshot")
+	requestedModel := readString(detail, "requested_model", "requestedModel", "alias")
+	resolvedModel := readString(detail, "resolved_model", "resolvedModel")
+	accounting := NormalizeCacheAccounting(CacheInputContext{
+		ExplicitMode:     cacheInputModeFromRecord(detail),
+		ExecutorType:     executorType,
+		Provider:         provider,
+		ProviderSnapshot: providerSnapshot,
+		ResolvedModel:    resolvedModel,
+		RequestedModel:   requestedModel,
+		DisplayModel:     model,
+	}, inputTokens, cachedTokens, cacheTokens, cacheReadTokens, cacheCreationTokens)
+	if totalTokens <= 0 {
+		totalTokens = accounting.TotalInputTokens + maxInt64(outputTokens, 0) + maxInt64(reasoningTokens, 0)
+	}
 	requestID := readString(detail, "request_id", "requestId", "id")
 	if requestID == "" {
 		requestID = legacyRequestID(endpoint, model, normalizedTimestamp, rawJSON, endpointIndex, modelIndex, detailIndex)
 	}
 
 	event := Event{
-		RequestID:             requestID,
-		TimestampMS:           timestampMS,
-		Timestamp:             normalizedTimestamp,
-		Provider:              readString(detail, "provider", "type", "auth_type", "authType"),
-		ExecutorType:          readString(detail, "executor_type", "executorType"),
-		Model:                 model,
-		Endpoint:              endpoint,
-		Method:                method,
-		Path:                  path,
-		AuthType:              readString(detail, "auth_type", "authType"),
-		AuthIndex:             authIndex,
-		Source:                maskSource(sourceRaw),
-		SourceHash:            hashString(sourceRaw),
-		APIKeyHash:            hashString(apiKey),
-		AccountSnapshot:       readString(detail, "account_snapshot", "accountSnapshot"),
-		AuthLabelSnapshot:     readString(detail, "auth_label_snapshot", "authLabelSnapshot"),
-		AuthFileSnapshot:      readString(detail, "auth_file_snapshot", "authFileSnapshot"),
-		AuthProviderSnapshot:  readString(detail, "auth_provider_snapshot", "authProviderSnapshot"),
-		AuthProjectIDSnapshot: readString(detail, "auth_project_id_snapshot", "authProjectIdSnapshot"),
-		AuthSnapshotAtMS:      readInt(detail, "auth_snapshot_at_ms", "authSnapshotAtMs"),
-		ReasoningEffort:       readString(detail, "reasoning_effort", "reasoningEffort"),
-		ServiceTier:           readString(detail, "service_tier", "serviceTier"),
-		InputTokens:           inputTokens,
-		OutputTokens:          outputTokens,
-		ReasoningTokens:       reasoningTokens,
-		CachedTokens:          cachedTokens,
-		CacheTokens:           cacheTokens,
-		CacheReadTokens:       cacheReadTokens,
-		CacheCreationTokens:   cacheCreationTokens,
-		TotalTokens:           totalTokens,
-		LatencyMS:             readOptionalInt(detail, "latency_ms", "latencyMs", "duration_ms", "durationMs", "elapsed_ms", "elapsedMs"),
-		TTFTMS:                readOptionalInt(detail, "ttft_ms", "ttftMs", "time_to_first_token_ms", "timeToFirstTokenMs"),
-		Failed:                readFailed(detail),
-		FailStatusCode:        int(failStatusCode),
-		FailSummary:           failSummary,
-		FailBody:              failBody,
-		RawJSON:               rawJSON,
-		CreatedAtMS:           now,
+		RequestID:                     requestID,
+		TimestampMS:                   timestampMS,
+		Timestamp:                     normalizedTimestamp,
+		Provider:                      provider,
+		ExecutorType:                  executorType,
+		Model:                         model,
+		RequestedModel:                requestedModel,
+		ResolvedModel:                 resolvedModel,
+		Endpoint:                      endpoint,
+		Method:                        method,
+		Path:                          path,
+		AuthType:                      readString(detail, "auth_type", "authType"),
+		AuthIndex:                     authIndex,
+		Source:                        maskSource(sourceRaw),
+		SourceHash:                    hashString(sourceRaw),
+		APIKeyHash:                    hashString(apiKey),
+		AccountSnapshot:               readString(detail, "account_snapshot", "accountSnapshot"),
+		AuthLabelSnapshot:             readString(detail, "auth_label_snapshot", "authLabelSnapshot"),
+		AuthFileSnapshot:              readString(detail, "auth_file_snapshot", "authFileSnapshot"),
+		AuthProviderSnapshot:          providerSnapshot,
+		AuthProjectIDSnapshot:         readString(detail, "auth_project_id_snapshot", "authProjectIdSnapshot"),
+		AuthSnapshotAtMS:              readInt(detail, "auth_snapshot_at_ms", "authSnapshotAtMs"),
+		ReasoningEffort:               readString(detail, "reasoning_effort", "reasoningEffort"),
+		ServiceTier:                   readString(detail, "service_tier", "serviceTier"),
+		RequestServiceTier:            readString(detail, "request_service_tier", "requestServiceTier"),
+		ResponseServiceTier:           readString(detail, "response_service_tier", "responseServiceTier"),
+		CacheInputMode:                accounting.Mode,
+		InputTokens:                   inputTokens,
+		OutputTokens:                  outputTokens,
+		ReasoningTokens:               reasoningTokens,
+		CachedTokens:                  cachedTokens,
+		CacheTokens:                   cacheTokens,
+		CacheReadTokens:               cacheReadTokens,
+		CacheCreationTokens:           cacheCreationTokens,
+		NormalizedUncachedInputTokens: accounting.UncachedInputTokens,
+		NormalizedTotalInputTokens:    accounting.TotalInputTokens,
+		NormalizedCacheReadTokens:     accounting.CacheReadTokens,
+		NormalizedCacheCreationTokens: accounting.CacheCreationTokens,
+		TotalTokens:                   totalTokens,
+		LatencyMS:                     readOptionalInt(detail, "latency_ms", "latencyMs", "duration_ms", "durationMs", "elapsed_ms", "elapsedMs"),
+		TTFTMS:                        readOptionalInt(detail, "ttft_ms", "ttftMs", "time_to_first_token_ms", "timeToFirstTokenMs"),
+		Failed:                        readFailed(detail),
+		FailStatusCode:                int(failStatusCode),
+		FailSummary:                   failSummary,
+		FailBody:                      failBody,
+		RawJSON:                       rawJSON,
+		CreatedAtMS:                   now,
 	}
 	if event.Model == "" {
 		event.Model = "-"
@@ -628,6 +678,35 @@ func eventFromLegacyDetail(
 	AttachResponseHeaderMetadata(&event, ResponseHeaderMetadataFromRecord(detail, time.UnixMilli(timestampMS)))
 	event.EventHash = buildEventHash(event)
 	return event, nil
+}
+
+func importCacheAccountingRawJSON(record map[string]any) string {
+	existing := SafeRawJSON(readString(record, "raw_json", "rawJson"))
+	recordHints := RawCacheAccountingHints{
+		ExplicitMode: cacheInputModeFromRecord(record),
+	}
+	if total, ok := explicitPositiveTotalFromRecord(record); ok {
+		recordHints.ExplicitTotal = total
+		recordHints.HasExplicitTotal = true
+	}
+	existingHints := RawCacheAccountingHintsFromJSON(existing)
+	modeCovered := recordHints.ExplicitMode == "" || existingHints.ExplicitMode == recordHints.ExplicitMode
+	totalCovered := !recordHints.HasExplicitTotal || (existingHints.HasExplicitTotal && existingHints.ExplicitTotal == recordHints.ExplicitTotal)
+	if modeCovered && totalCovered {
+		return existing
+	}
+	provenance := map[string]any{}
+	if recordHints.ExplicitMode != "" {
+		provenance["cache_input_mode"] = recordHints.ExplicitMode
+	}
+	if recordHints.HasExplicitTotal {
+		provenance["total_tokens"] = recordHints.ExplicitTotal
+	}
+	if existing != "" {
+		provenance["raw_json"] = existing
+	}
+	raw, _ := json.Marshal(provenance)
+	return string(raw)
 }
 
 func legacyRawJSON(endpoint string, model string, detail map[string]any) string {

--- a/apps/manager-server/internal/usage/import_test.go
+++ b/apps/manager-server/internal/usage/import_test.go
@@ -87,7 +87,7 @@ func TestParseImportPayloadLegacyUsageExport(t *testing.T) {
 	}
 
 	second := result.Events[1]
-	if second.TotalTokens != 26 || !second.Failed || second.AuthIndex != "auth-2" {
+	if second.TotalTokens != 18 || !second.Failed || second.AuthIndex != "auth-2" {
 		t.Fatalf("second event = %#v", second)
 	}
 
@@ -97,6 +97,64 @@ func TestParseImportPayloadLegacyUsageExport(t *testing.T) {
 	}
 	if again.Events[0].EventHash != first.EventHash || again.Events[1].EventHash != second.EventHash {
 		t.Fatalf("legacy event hashes are not stable")
+	}
+}
+
+func TestImportCacheAccountingUsesStructuredSemantics(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		wantMode    string
+		wantInput   int64
+		wantTotal   int64
+		wantUncache int64
+	}{
+		{
+			name:     "openai compat executor beats claude alias",
+			payload:  `{"event_hash":"openai-compat","timestamp_ms":1,"timestamp":"2026-07-15T00:00:00Z","executor_type":"OpenAICompatExecutor","model":"claude-sonnet","tokens":{"input_tokens":100,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
+			wantMode: CacheInputModeIncluded, wantInput: 100, wantTotal: 100, wantUncache: 70,
+		},
+		{
+			name:     "claude executor beats grok alias",
+			payload:  `{"eventHash":"claude-grok","timestampMs":1,"timestamp":"2026-07-15T00:00:00Z","executorType":"ClaudeExecutor","model":"grok-4","tokens":{"inputTokens":100,"cacheReadTokens":20,"cacheCreationTokens":10}}`,
+			wantMode: CacheInputModeSeparate, wantInput: 130, wantTotal: 130, wantUncache: 100,
+		},
+		{
+			name:     "usage object and moonshot provider are included",
+			payload:  `{"event_hash":"moonshot","timestamp_ms":1,"timestamp":"2026-07-15T00:00:00Z","provider":"moonshot","model":"claude-alias","usage":{"input_tokens":100,"cache_read_tokens":20,"cache_creation_tokens":10}}`,
+			wantMode: CacheInputModeIncluded, wantInput: 100, wantTotal: 100, wantUncache: 70,
+		},
+		{
+			name:     "nested explicit mode and total are preserved",
+			payload:  `{"event_hash":"explicit","timestamp_ms":1,"timestamp":"2026-07-15T00:00:00Z","executor_type":"XAIExecutor","model":"grok-4","tokens":{"input_tokens":100,"cache_read_tokens":20,"cache_creation_tokens":10,"cache_input_mode":"separate_from_input","total_tokens":777}}`,
+			wantMode: CacheInputModeSeparate, wantInput: 130, wantTotal: 777, wantUncache: 100,
+		},
+		{
+			name:     "explicit total from preserved raw json is retained",
+			payload:  `{"event_hash":"raw-explicit","timestamp_ms":1,"timestamp":"2026-07-15T00:00:00Z","executor_type":"XAIExecutor","model":"grok-4","tokens":{"input_tokens":100,"cache_read_tokens":20},"raw_json":"{\"tokens\":{\"total_tokens\":888}}"}`,
+			wantMode: CacheInputModeIncluded, wantInput: 100, wantTotal: 888, wantUncache: 80,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseImportPayload([]byte(tt.payload))
+			if err != nil {
+				t.Fatalf("parse import: %v", err)
+			}
+			if len(result.Events) != 1 {
+				t.Fatalf("events = %#v", result.Events)
+			}
+			event := result.Events[0]
+			if event.CacheInputMode != tt.wantMode || event.NormalizedTotalInputTokens != tt.wantInput || event.NormalizedUncachedInputTokens != tt.wantUncache || event.TotalTokens != tt.wantTotal {
+				t.Fatalf("event = %#v", event)
+			}
+			if tt.wantTotal == 777 {
+				hints := RawCacheAccountingHintsFromJSON(event.RawJSON)
+				if hints.ExplicitMode != CacheInputModeSeparate || !hints.HasExplicitTotal || hints.ExplicitTotal != 777 {
+					t.Fatalf("preserved hints = %#v raw=%s", hints, event.RawJSON)
+				}
+			}
+		})
 	}
 }
 

--- a/apps/manager-server/internal/worker/usage_cache_accounting_migration.go
+++ b/apps/manager-server/internal/worker/usage_cache_accounting_migration.go
@@ -80,7 +80,7 @@ func (w *UsageCacheAccountingMigrationWorker) run(ctx context.Context) {
 		}
 		progressLogEvery := int64(w.batchSize * 10)
 		if result.Processed > 0 && (result.Completed || progressLogEvery <= 0 || result.State.ProcessedRows%progressLogEvery == 0) {
-			log.Printf("usage cache accounting migration progress: processed=%d last_event_id=%d target_event_id=%d", result.State.ProcessedRows, result.State.LastEventID, result.State.TargetEventID)
+			log.Printf("usage cache accounting migration progress: processed=%d changed=%d last_event_id=%d target_event_id=%d", result.State.ProcessedRows, result.State.ChangedRows, result.State.LastEventID, result.State.TargetEventID)
 		}
 		if result.Completed {
 			w.complete(result.State)
@@ -94,7 +94,7 @@ func (w *UsageCacheAccountingMigrationWorker) run(ctx context.Context) {
 
 func (w *UsageCacheAccountingMigrationWorker) complete(state store.DataMigrationState) {
 	w.completion.Do(func() {
-		log.Printf("usage cache accounting migration completed: processed=%d", state.ProcessedRows)
+		log.Printf("usage cache accounting migration completed: processed=%d changed=%d", state.ProcessedRows, state.ChangedRows)
 		if w.onCompletion != nil {
 			w.onCompletion()
 		}

--- a/apps/manager-server/internal/worker/usage_cache_accounting_migration_test.go
+++ b/apps/manager-server/internal/worker/usage_cache_accounting_migration_test.go
@@ -28,9 +28,9 @@ func TestUsageCacheAccountingMigrationWorkerRunsBatchesBeforeCompletion(t *testi
 	}
 	if _, err := rawDB.Exec(`update usage_data_migrations set
 		status = 'discovering', last_event_id = 0, target_event_id = 0,
-		processed_rows = 0, started_at_ms = null, updated_at_ms = 0,
+		processed_rows = 0, changed_rows = 0, started_at_ms = null, updated_at_ms = 0,
 		finished_at_ms = null, last_error = null
-		where name = 'usage_cache_accounting_v1'`); err != nil {
+		where name = 'usage_cache_accounting_v2'`); err != nil {
 		t.Fatalf("reset migration state: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestUsageCacheAccountingMigrationWorkerRunsBatchesBeforeCompletion(t *testi
 	if err != nil {
 		t.Fatalf("read migration state: %v", err)
 	}
-	if state.Status != "completed" || state.ProcessedRows != 2 || state.LastEventID != 2 {
+	if state.Status != "completed" || state.ProcessedRows != 2 || state.ChangedRows != 2 || state.LastEventID != 2 {
 		t.Fatalf("migration state = %#v", state)
 	}
 	var remaining int

--- a/apps/web/src/features/monitoring/model/eventRows.test.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { buildRealtimeSourceDisplay } from '@/features/monitoring/realtimeSourceDisplay';
-import type { UsageDetailWithEndpoint } from '@/utils/usage';
+import type { ModelPrice, UsageDetailWithEndpoint } from '@/utils/usage';
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { buildEventRows } from './eventRows';
 
-const buildRows = (overrides: Partial<UsageDetailWithEndpoint> = {}) =>
+const buildRows = (
+  overrides: Partial<UsageDetailWithEndpoint> = {},
+  modelPrices: Record<string, ModelPrice> = {}
+) =>
   buildEventRows(
     [
       {
@@ -31,7 +34,7 @@ const buildRows = (overrides: Partial<UsageDetailWithEndpoint> = {}) =>
     new Map(),
     { byAuthIndex: new Map(), bySource: new Map(), byIdentityKey: new Map() },
     new Map(),
-    {},
+    modelPrices,
     new Map()
   );
 
@@ -62,6 +65,24 @@ describe('buildEventRows', () => {
     expect(noOutput.tokensPerSecond).toBeNull();
     expect(noLatency.tokensPerSecond).toBeNull();
     expect(zeroLatency.tokensPerSecond).toBeNull();
+  });
+
+  it('derives missing total from normalized input without adding cache twice', () => {
+    const [row] = buildRows(
+      {
+        tokens: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_read_tokens: 40,
+        },
+      },
+      {
+        'gpt-5.4': { prompt: 1, completion: 2, cache: 0.1, cacheRead: 0.1 },
+      }
+    );
+
+    expect(row.totalTokens).toBe(120);
+    expect(row.totalCost).toBeCloseTo(0.000104);
   });
 
   it('keeps CPA executor and service tier metadata searchable', () => {

--- a/apps/web/src/features/monitoring/model/eventRows.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.ts
@@ -2,7 +2,6 @@ import type { CredentialInfo } from '@/types/sourceInfo';
 import { buildSourceInfoMap, resolveSourceDisplay } from '@/utils/sourceResolver';
 import {
   calculateCost,
-  extractTotalTokens,
   normalizeAuthIndex,
   type ModelPrice,
   type UsageDetailWithEndpoint,
@@ -98,10 +97,11 @@ export const buildEventRows = (
         Math.max(Number(detail.tokens?.cached_tokens) || 0, 0),
         Math.max(Number(detail.tokens?.cache_tokens) || 0, 0)
       );
-      const totalTokens = Math.max(
-        Number(detail.tokens?.total_tokens) || 0,
-        extractTotalTokens(detail)
-      );
+      const explicitTotalTokens = Math.max(Number(detail.tokens?.total_tokens) || 0, 0);
+      const totalTokens =
+        explicitTotalTokens > 0
+          ? explicitTotalTokens
+          : inputTokens + outputTokens + reasoningTokens;
       const latencyMs = toDurationMs(detail.latency_ms);
       const ttftMs = toDurationMs(detail.ttft_ms);
       const tokensPerSecond = calculateOutputTokensPerSecond(outputTokens, latencyMs);

--- a/apps/web/src/utils/cacheInputAccounting.fixtures.json
+++ b/apps/web/src/utils/cacheInputAccounting.fixtures.json
@@ -1,0 +1,98 @@
+[
+  {
+    "name": "xai executor with grok",
+    "context": { "executorType": "XAIExecutor", "displayModel": "grok-4" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "kimi executor with kimi",
+    "context": { "executorType": "KimiExecutor", "displayModel": "kimi-k2" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "openai compat executor beats claude alias",
+    "context": { "executorType": "OpenAICompatExecutor", "resolvedModel": "claude-sonnet-4" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "claude executor beats kimi alias",
+    "context": { "executorType": "ClaudeExecutor", "requestedModel": "kimi-k2" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "separate_from_input", "uncached": 100, "totalInput": 130, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "claude executor beats grok alias",
+    "context": { "executorType": "ClaudeExecutor", "displayModel": "grok-4" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "separate_from_input", "uncached": 100, "totalInput": 130, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "explicit separate mode beats xai executor",
+    "context": { "explicitMode": "separate_from_input", "executorType": "XAIExecutor" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "separate_from_input", "uncached": 100, "totalInput": 130, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "resolved model beats requested and display models",
+    "context": { "resolvedModel": "claude-sonnet-4", "requestedModel": "gpt-5", "displayModel": "grok-4" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "separate_from_input", "uncached": 100, "totalInput": 130, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "grok model fallback without identity fields",
+    "context": { "displayModel": "grok-4" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "unknown fine grained cache fallback",
+    "context": { "displayModel": "custom-model" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "separate_from_input", "uncached": 100, "totalInput": 130, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "moonshot provider snapshot beats claude model",
+    "context": { "providerSnapshot": "moonshot", "resolvedModel": "claude-sonnet-4" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "legacy cached tokens stay included for openai",
+    "context": { "provider": "openai", "displayModel": "gpt-5" },
+    "tokens": { "input": 100, "cached": 40, "cache": 0, "read": 0, "creation": 0 },
+    "expected": { "mode": "included_in_input", "uncached": 60, "totalInput": 100, "cacheRead": 40, "cacheCreation": 0 }
+  },
+  {
+    "name": "codex websocket executor",
+    "context": { "executorType": "CodexWebsocketsExecutor", "displayModel": "claude-alias" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "codex auto executor",
+    "context": { "executorType": "CodexAutoExecutor", "displayModel": "claude-alias" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "xai websocket executor",
+    "context": { "executorType": "XAIWebsocketsExecutor", "displayModel": "claude-alias" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "xai auto executor",
+    "context": { "executorType": "XAIAutoExecutor", "displayModel": "claude-alias" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  },
+  {
+    "name": "gemini vertex executor",
+    "context": { "executorType": "GeminiVertexExecutor", "displayModel": "claude-alias" },
+    "tokens": { "input": 100, "cached": 0, "cache": 0, "read": 20, "creation": 10 },
+    "expected": { "mode": "included_in_input", "uncached": 70, "totalInput": 100, "cacheRead": 20, "cacheCreation": 10 }
+  }
+]

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -11,9 +11,12 @@ import {
   extractTotalTokens,
   formatCompactNumber,
   getServiceTierMultiplier,
+  inferCacheInputMode,
+  normalizeCacheAccounting,
   normalizeUsageSourceId,
 } from './usage';
 import { maskSensitiveText } from './format';
+import cacheInputAccountingFixtures from './cacheInputAccounting.fixtures.json';
 
 describe('formatCompactNumber', () => {
   it('keeps large values compact as data grows beyond millions', () => {
@@ -354,6 +357,194 @@ describe('usage token helpers', () => {
         },
       })
     ).toBe(154);
+  });
+});
+
+describe('cache input accounting semantics', () => {
+  it.each(cacheInputAccountingFixtures)('matches shared fixture: $name', (fixture) => {
+    const accounting = normalizeCacheAccounting({
+      context: fixture.context,
+      inputTokens: fixture.tokens.input,
+      cachedTokens: fixture.tokens.cached,
+      cacheTokens: fixture.tokens.cache,
+      cacheReadTokens: fixture.tokens.read,
+      cacheCreationTokens: fixture.tokens.creation,
+    });
+
+    expect(accounting).toMatchObject({
+      mode: fixture.expected.mode,
+      uncachedInputTokens: fixture.expected.uncached,
+      totalInputTokens: fixture.expected.totalInput,
+      cacheCreationTokens: fixture.expected.cacheCreation,
+    });
+    expect(accounting.legacyRead + accounting.cacheReadTokens).toBe(
+      fixture.expected.cacheRead
+    );
+  });
+
+  it.each([
+    {
+      name: 'OpenAICompat executor beats Claude alias',
+      context: { executorType: 'OpenAICompatExecutor', resolvedModel: 'claude-sonnet-4' },
+      mode: 'included_in_input',
+    },
+    {
+      name: 'Claude executor beats Grok alias',
+      context: { executorType: 'ClaudeExecutor', resolvedModel: 'grok-4' },
+      mode: 'separate_from_input',
+    },
+    {
+      name: 'XAI executor beats Claude alias',
+      context: { executorType: 'XAIWebsocketsExecutor', displayModel: 'claude-alias' },
+      mode: 'included_in_input',
+    },
+    {
+      name: 'provider snapshot beats model',
+      context: { providerSnapshot: 'moonshot', resolvedModel: 'claude-sonnet' },
+      mode: 'included_in_input',
+    },
+    {
+      name: 'resolved model beats requested model',
+      context: { resolvedModel: 'claude-sonnet', requestedModel: 'gpt-5' },
+      mode: 'separate_from_input',
+    },
+  ])('$name', ({ context, mode }) => {
+    expect(inferCacheInputMode(context, 20, 10)).toBe(mode);
+  });
+
+  it('keeps a valid explicit mode above executor classification', () => {
+    expect(
+      inferCacheInputMode(
+        { explicitMode: 'separate_from_input', executorType: 'XAIExecutor' },
+        20,
+        0
+      )
+    ).toBe('separate_from_input');
+  });
+
+  it('normalizes included and separate totals with the mirrored Go formulas', () => {
+    expect(
+      normalizeCacheAccounting({
+        context: { executorType: 'XAIExecutor' },
+        inputTokens: 100,
+        cachedTokens: 0,
+        cacheTokens: 0,
+        cacheReadTokens: 20,
+        cacheCreationTokens: 10,
+      })
+    ).toMatchObject({
+      mode: 'included_in_input',
+      uncachedInputTokens: 70,
+      totalInputTokens: 100,
+    });
+    expect(
+      normalizeCacheAccounting({
+        context: { executorType: 'ClaudeExecutor' },
+        inputTokens: 100,
+        cachedTokens: 0,
+        cacheTokens: 0,
+        cacheReadTokens: 20,
+        cacheCreationTokens: 10,
+      })
+    ).toMatchObject({
+      mode: 'separate_from_input',
+      uncachedInputTokens: 100,
+      totalInputTokens: 130,
+    });
+  });
+
+  it.each([
+    {
+      name: 'xAI included input',
+      model: 'grok-4',
+      detail: { executor_type: 'XAIExecutor' },
+      totalInput: 100,
+    },
+    {
+      name: 'Kimi provider included input',
+      model: 'claude-alias',
+      detail: { provider: 'moonshot' },
+      totalInput: 100,
+    },
+    {
+      name: 'Claude executor separate input',
+      model: 'grok-alias',
+      detail: { executor_type: 'ClaudeExecutor' },
+      totalInput: 130,
+    },
+    {
+      name: 'nested explicit mode',
+      model: 'grok-4',
+      detail: {},
+      tokenMode: 'separate_from_input',
+      totalInput: 130,
+    },
+  ])('$name is applied by readTokens', ({ model, detail, tokenMode, totalInput }) => {
+    const usageData = {
+      apis: {
+        'POST /v1/chat/completions': {
+          models: {
+            [model]: {
+              details: [
+                {
+                  timestamp: '2026-07-15T00:00:00Z',
+                  source: 'account',
+                  auth_index: 'auth-1',
+                  ...detail,
+                  tokens: {
+                    input_tokens: 100,
+                    cache_read_tokens: 20,
+                    cache_creation_tokens: 10,
+                    cache_input_mode: tokenMode,
+                  },
+                  failed: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const [normalized] = collectUsageDetails(usageData);
+
+    expect(normalized.tokens.input_tokens).toBe(totalInput);
+    expect(normalized.tokens.total_tokens).toBe(totalInput);
+  });
+
+  it('prices xAI cache without double-counting included input', () => {
+    const usageData = {
+      apis: {
+        'POST /v1/chat/completions': {
+          models: {
+            'grok-4': {
+              details: [
+                {
+                  timestamp: '2026-07-15T00:00:00Z',
+                  source: 'account',
+                  auth_index: 'auth-1',
+                  executor_type: 'XAIExecutor',
+                  tokens: { input_tokens: 100, cache_read_tokens: 40 },
+                  failed: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const [detail] = collectUsageDetails(usageData);
+    const cost = calculateCost(detail, {
+      'grok-4': { prompt: 1, completion: 2, cache: 0.1, cacheRead: 0.1 },
+    });
+
+    expect(detail.tokens.input_tokens).toBe(100);
+    expect(calculateCacheHitRate({
+      inputTokens: detail.tokens.input_tokens,
+      cachedTokens: detail.tokens.cached_tokens,
+      cacheReadTokens: detail.tokens.cache_read_tokens,
+      cacheCreationTokens: detail.tokens.cache_creation_tokens,
+    })).toBeCloseTo(0.4);
+    expect(cost).toBeCloseTo(0.000064);
   });
 });
 

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -39,6 +39,8 @@ export interface UsageTokens {
   cache_write_input_tokens?: number;
   cacheWriteInputTokens?: number;
   total_tokens?: number;
+  cache_input_mode?: CacheInputMode | string;
+  cacheInputMode?: CacheInputMode | string;
 }
 
 export type CacheInputMode = 'included_in_input' | 'separate_from_input';
@@ -142,6 +144,11 @@ export interface UsageDetail {
   cacheInputMode?: CacheInputMode | string;
   executor_type?: string;
   executorType?: string;
+  provider?: string;
+  requested_model?: string;
+  requestedModel?: string;
+  resolved_model?: string;
+  resolvedModel?: string;
   latency_ms?: number;
   ttft_ms?: number;
   tokens: UsageTokens;
@@ -366,39 +373,124 @@ export const compatibleCachedTokens = (
   return Math.max(cached - fineGrained, 0);
 };
 
-const inferCacheInputMode = (
-  mode: unknown,
-  identity: string,
-  cacheReadTokens: number,
-  cacheCreationTokens: number
-): CacheInputMode => {
-  const normalizedMode = String(mode ?? '')
+export interface CacheInputContext {
+  explicitMode?: unknown;
+  executorType?: unknown;
+  provider?: unknown;
+  providerSnapshot?: unknown;
+  resolvedModel?: unknown;
+  requestedModel?: unknown;
+  displayModel?: unknown;
+}
+
+const normalizeCacheIdentity = (value: unknown): string =>
+  String(value ?? '')
     .trim()
     .toLowerCase();
-  if (normalizedMode === 'separate_from_input') return 'separate_from_input';
-  if (normalizedMode === 'included_in_input') return 'included_in_input';
-  const normalizedIdentity = identity.toLowerCase();
-  if (normalizedIdentity.includes('anthropic') || normalizedIdentity.includes('claude')) {
+
+const classifyExecutorCacheInputMode = (value: unknown): CacheInputMode | undefined => {
+  const executor = normalizeCacheIdentity(value);
+  if (!executor) return undefined;
+  if (executor.includes('claude')) return 'separate_from_input';
+  if (
+    [
+      'openaicompat',
+      'openai_compat',
+      'openai-compat',
+      'openai',
+      'codex',
+      'gemini',
+      'aistudio',
+      'ai_studio',
+      'ai-studio',
+      'antigravity',
+      'xai',
+      'kimi',
+    ].some((marker) => executor.includes(marker))
+  ) {
+    return 'included_in_input';
+  }
+  return undefined;
+};
+
+const classifyProviderCacheInputMode = (value: unknown): CacheInputMode | undefined => {
+  const provider = normalizeCacheIdentity(value);
+  if (!provider) return undefined;
+  if (provider.includes('anthropic') || provider.includes('claude')) {
     return 'separate_from_input';
   }
   if (
-    normalizedIdentity.includes('openai') ||
-    normalizedIdentity.includes('codex') ||
-    normalizedIdentity.includes('gemini') ||
-    normalizedIdentity.includes('antigravity') ||
-    normalizedIdentity.includes('interaction') ||
-    normalizedIdentity.includes('gpt-')
+    [
+      'openai',
+      'codex',
+      'gemini',
+      'vertex',
+      'aistudio',
+      'ai_studio',
+      'ai-studio',
+      'interaction',
+      'antigravity',
+      'xai',
+      'kimi',
+      'moonshot',
+    ].some((marker) => provider.includes(marker))
   ) {
     return 'included_in_input';
+  }
+  return undefined;
+};
+
+const classifyModelCacheInputMode = (value: unknown): CacheInputMode | undefined => {
+  const model = normalizeCacheIdentity(value);
+  if (!model) return undefined;
+  if (model.includes('anthropic') || model.includes('claude')) {
+    return 'separate_from_input';
+  }
+  if (
+    [
+      'gpt-',
+      'openai',
+      'codex',
+      'gemini',
+      'vertex',
+      'aistudio',
+      'antigravity',
+      'grok',
+      'xai',
+      'kimi',
+      'moonshot',
+    ].some((marker) => model.includes(marker))
+  ) {
+    return 'included_in_input';
+  }
+  return undefined;
+};
+
+export const inferCacheInputMode = (
+  context: CacheInputContext,
+  cacheReadTokens: number,
+  cacheCreationTokens: number
+): CacheInputMode => {
+  const normalizedMode = normalizeCacheIdentity(context.explicitMode);
+  if (normalizedMode === 'separate_from_input') return 'separate_from_input';
+  if (normalizedMode === 'included_in_input') return 'included_in_input';
+  const executorMode = classifyExecutorCacheInputMode(context.executorType);
+  if (executorMode) return executorMode;
+  for (const provider of [context.provider, context.providerSnapshot]) {
+    const providerMode = classifyProviderCacheInputMode(provider);
+    if (providerMode) return providerMode;
+  }
+  for (const model of [context.resolvedModel, context.requestedModel, context.displayModel]) {
+    const modelMode = classifyModelCacheInputMode(model);
+    if (modelMode) return modelMode;
   }
   return cacheReadTokens > 0 || cacheCreationTokens > 0
     ? 'separate_from_input'
     : 'included_in_input';
 };
 
-const normalizeCacheAccounting = (input: {
-  mode?: unknown;
-  identity?: string;
+export const normalizeCacheAccounting = (input: {
+  context: CacheInputContext;
   inputTokens: unknown;
   cachedTokens: unknown;
   cacheTokens: unknown;
@@ -415,7 +507,7 @@ const normalizeCacheAccounting = (input: {
     creation
   );
   const read = legacyRead + rawRead;
-  const mode = inferCacheInputMode(input.mode, input.identity ?? '', rawRead, creation);
+  const mode = inferCacheInputMode(input.context, rawRead, creation);
   return {
     mode,
     legacyRead,
@@ -621,16 +713,20 @@ const readTokens = (detail: Record<string, unknown>, modelName: string): UsageTo
   const cacheReadTokens = readFirstTokenNumber(tokensRaw, CACHE_READ_TOKEN_KEYS);
   const cacheCreationTokens = readFirstTokenNumber(tokensRaw, CACHE_CREATION_TOKEN_KEYS);
   const accounting = normalizeCacheAccounting({
-    mode: detail.cache_input_mode ?? detail.cacheInputMode,
-    identity: [
-      modelName,
-      detail.executor_type,
-      detail.executorType,
-      detail.auth_provider_snapshot,
-      detail.authProviderSnapshot,
-    ]
-      .filter(Boolean)
-      .join(' '),
+    context: {
+      explicitMode:
+        tokensRaw.cache_input_mode ??
+        tokensRaw.cacheInputMode ??
+        detail.cache_input_mode ??
+        detail.cacheInputMode,
+      executorType: detail.executor_type ?? detail.executorType,
+      provider: detail.provider,
+      providerSnapshot: detail.auth_provider_snapshot ?? detail.authProviderSnapshot,
+      resolvedModel: detail.resolved_model ?? detail.resolvedModel,
+      requestedModel:
+        detail.requested_model ?? detail.requestedModel ?? detail.alias,
+      displayModel: modelName,
+    },
     inputTokens: tokensRaw.input_tokens ?? tokensRaw.inputTokens,
     cachedTokens: tokensRaw.cached_tokens ?? tokensRaw.cachedTokens,
     cacheTokens: tokensRaw.cache_tokens ?? tokensRaw.cacheTokens,
@@ -729,6 +825,13 @@ export function collectUsageDetails(usageData: unknown): UsageDetail[] {
           ),
           service_tier: readDetailString(detailRaw.service_tier ?? detailRaw.serviceTier),
           executor_type: readDetailString(detailRaw.executor_type ?? detailRaw.executorType),
+          provider: readDetailString(detailRaw.provider),
+          requested_model: readDetailString(
+            detailRaw.requested_model ?? detailRaw.requestedModel ?? detailRaw.alias
+          ),
+          resolved_model: readDetailString(
+            detailRaw.resolved_model ?? detailRaw.resolvedModel
+          ),
           latency_ms: latencyMs ?? undefined,
           ttft_ms: ttftMs ?? undefined,
           request_service_tier: readDetailString(
@@ -848,6 +951,13 @@ export function collectUsageDetailsWithEndpoint(usageData: unknown): UsageDetail
           ),
           service_tier: readDetailString(detailRaw.service_tier ?? detailRaw.serviceTier),
           executor_type: readDetailString(detailRaw.executor_type ?? detailRaw.executorType),
+          provider: readDetailString(detailRaw.provider),
+          requested_model: readDetailString(
+            detailRaw.requested_model ?? detailRaw.requestedModel ?? detailRaw.alias
+          ),
+          resolved_model: readDetailString(
+            detailRaw.resolved_model ?? detailRaw.resolvedModel
+          ),
           request_service_tier: readDetailString(
             detailRaw.request_service_tier ?? detailRaw.requestServiceTier
           ),


### PR DESCRIPTION
## Summary
Correct cache input accounting semantics across Manager Server, Full Docker monitoring, and CPA Panel usage views.
Prevent cache token double counting and make historical corrections atomic, resumable, and auditable.

## Scope
- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Replace concatenated identity matching with structured executor, provider, snapshot, and model precedence.
- Normalize new events, imports, monitoring events, costs, cache hit rates, and total tokens consistently.
- Add `usage_cache_accounting_v2` candidate scanning with persistent staging and final atomic application.
- Preserve explicit or unverifiable provider totals, rebuild rollups only after actual changes, and share semantic fixtures between Go and TypeScript.

## User Impact
Grok, xAI, Kimi, Moonshot, Gemini, and aliased Claude/OpenAI-compatible requests no longer double count cache input tokens. Historical corrections no longer expose partially applied event updates during migration failures.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the TypeScript mirror of the structured cache accounting matrix.
- Manager Server mode: Runs the resumable `usage_cache_accounting_v2` migration after startup and preserves the v1 migration record.
- Full Docker / native packages: Full Docker monitoring returns normalized total input; native packages use the same Manager Server SQLite migration path. No packaging format changes.

## Data / Security Notes
Adds a local SQLite staging table containing event IDs and normalized token aggregates only. It does not copy `raw_json`, credentials, API keys, or failure bodies. Final event updates and rollup invalidation occur in one transaction.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Revert the commits to stop the new runtime logic; original token columns and raw provenance remain intact.
- The additive staging table can be left unused safely by an older binary.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run type-check
npm run lint
npm run test                 # 95 files, 852 tests
npm run build
npm --workspace apps/web run build:bundle
npm run check:demo-isolation
npm --workspace apps/web run build:demo:bundle
npm run docs:build
cd apps/manager-server && go test ./...
cd apps/manager-server && go test -race ./...
cd apps/manager-server && go vet ./...
```

## Screenshots / Recordings
N/A: no new visual UI surface; this change corrects token accounting and migration behavior.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #359
