### PR TITLE
perf(manager-server): accelerate monitoring analytics

### DIFF
--- a/apps/docs/en/operations/manager-server.md
+++ b/apps/docs/en/operations/manager-server.md
@@ -224,9 +224,11 @@ Hourly rollup is enabled by default. The worker catches up historical events in 
 USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 ```
 
-Restart Manager Server after changing it. Dashboard and Usage Analytics will always use raw events while disabled, and existing rollup tables are left intact. This runtime switch is not exposed in the UI.
+Restart Manager Server after changing it. Dashboard and Usage Analytics will always use raw events while disabled. Except for the one-time startup format upgrade described below, disabling this runtime switch does not delete current-format rollup data. The switch is not exposed in the UI.
 
-When upgrading an existing database, Manager Server performs only fast schema changes during startup. Cache-accounting corrections that must scan historical `usage_events` begin in the background after the HTTP listener is bound, processing 1,000 rows per batch. Each data update and its checkpoint commit in the same transaction, so a restart resumes at the last successfully committed event ID instead of repeating completed batches.
+When upgrading to the lossless model encoding, Manager Server clears the old `usage_dashboard_hourly_rollups` rows and resets only the `dashboard_hourly` checkpoint. When hourly rollup is enabled, the worker then rebuilds it in bounded background batches; while disabled, it remains empty until the worker is enabled again. This format migration itself does not modify or delete `usage_events` and does not reset the account-history rollup. Long-window queries temporarily fall back to raw events until catch-up completes. The new encoding distinguishes an empty model, the literal `-` model, and models with surrounding whitespace, so a legitimate `-` model no longer disables the entire rollup path.
+
+When upgrading an existing database, Manager Server performs schema and metadata changes plus any required derived-rollup reset during startup, but does not scan historical `usage_events`. Cache-accounting corrections that require a historical event scan begin in the background after the HTTP listener is bound, processing 1,000 rows per batch. Each data update and its checkpoint commit in the same transaction, so a restart resumes at the last successfully committed event ID instead of repeating completed batches.
 
 While the migration is running:
 

--- a/apps/docs/en/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/en/operations/performance-optimization-2026-07-10.md
@@ -259,7 +259,7 @@ Hourly rollup is enabled by default. To disable it temporarily:
 USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 ```
 
-Restart Manager Server after changing the variable. Dashboard and Usage Analytics will use raw events while disabled, and existing rollup tables remain intact. The switch is intentionally not exposed in the UI.
+Restart Manager Server after changing the variable. Dashboard and Usage Analytics will use raw events while disabled. Except for the one-time startup format upgrade documented in the Manager Server guide, disabling this runtime switch does not delete current-format rollup data. The switch is intentionally not exposed in the UI.
 
 See the [Manager Server Guide](./manager-server.md) for the full runtime reference.
 

--- a/apps/docs/en/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/en/operations/performance-optimization-2026-07-10.md
@@ -4,12 +4,13 @@ This report documents the Manager Server, Dashboard, Request Monitoring, Usage A
 
 ## Executive Summary
 
-The work was delivered in four stages:
+The work was delivered in five stages:
 
 1. PR #319 bounded memory, request, and SQLite connection resources.
 2. PR #320 moved Dashboard core metrics to incremental hourly rollups.
 3. PR #323 scoped Usage Analytics requests to the active tab.
 4. Usage Analytics Hourly Rollup Phase 2B reused hourly rollups for strictly unfiltered long-window core metrics.
+5. Complete Monitoring requests reused duplicate dimension statistics and executed independent SQLite reads with bounded concurrency.
 
 Using the effective work required to open Usage Analytics Overview on a 100,000-event dataset:
 
@@ -200,6 +201,49 @@ This scope includes only the aggregate, model-stat, and timeline work owned by P
 
 The rollup-owned path is about 20 times faster, while the complete Overview request is about 23% faster because P95, TTFT, task, active-day, API key, and channel queries remain on raw events and now dominate the remaining time.
 
+## Stage 5: Complete Monitoring Request Deduplication And Bounded Concurrency
+
+### Cause
+
+Request Monitoring loads Summary, Timeline, hourly distribution, model/channel/account/API-key statistics, failure sources, task buckets, filter options, and event pagination in one analytics request. These independent reads previously ran sequentially. For an unfiltered request, `filter_options` also recalculated account, API-key, channel, and model statistics already requested by the main response.
+
+In the 100k, 30-day UTC Monitoring include profile:
+
+- The complete request took about 5.44s.
+- Removing `filter_options` reduced it to about 3.38s.
+- `filter_options` alone took about 2.09s.
+
+### Changes
+
+- Reuse loaded model, channel, account, and API-key source statistics when the main filter and filter-options base filter are equivalent.
+- Reuse the built main-response rows inside filter options so both values and tie ordering are identical.
+- Prefetch timeline percentiles, hourly distribution, high-dimensional statistics, filter options, recent failures, and the events page through a cancellable query group.
+- Limit background prefetch to two concurrent reads. Together with the foreground summary/task path, one request uses at most three SQLite connections, leaving one connection in the four-connection pool available for other work.
+- Cancel sibling work after the first query error and assemble the response on one goroutine only after all reads complete.
+- Add no schema, rollup table, resident cache, or API field. Requests with dimension or status filters that the filter-options base scope clears continue to calculate those options independently, preserving the original option semantics. Search-only requests remain reusable because search is retained in that base scope.
+
+### 100k Monitoring Include-Profile Results
+
+| Path | Duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| Before | about 5.44s | 16.26MB | about 984 thousand |
+| After | about 1.69–1.81s | 15.14MB | about 958 thousand |
+| Change | about 67%–69% lower | about 7% lower | about 3% lower |
+
+Twenty consecutive runs remained near 1.69s/op and 15.14MB/op. The change adds no cross-request cache or retained event array.
+
+A separate post-change benchmark using the curl scope (`from_ms=1`, `Asia/Shanghai`, and the same include payload) completed at about 1.815s/op, 26.02MB/op, and 1.093 million allocs/op. The wider time range increases allocation, but not elapsed time materially on this dataset.
+
+### 58,686-Event Real-Data Validation
+
+On a disposable SQLite backup of `bin/tmp/db/data`, after completing the cache-accounting migration and dashboard-rollup catch-up:
+
+- The complete request baseline after Phase 1 was about 5.80s.
+- This stage completed the service call in 2.21–2.38s.
+- That is another reduction of approximately 59%–62% from the previous stage.
+- Serializing the 7.58MB JSON response took only about 16ms, so SQLite reads still dominate the remaining time.
+- The original `bin/tmp/db/data` was not modified.
+
 ## Memory And Stability Validation
 
 - Ten-run and 200-run 100k rollup benchmarks remained stable.
@@ -265,7 +309,7 @@ See the [Manager Server Guide](./manager-server.md) for the full runtime referen
 
 ## Recommended Next Step
 
-The remaining time is concentrated in raw-only Summary metrics:
+Compact Summary, hourly rollups, compact latency-percentile reads, high-dimensional request shaping, and complete Monitoring request concurrency are now implemented. The remaining time depends primarily on queries that must preserve raw-event semantics:
 
 - P95 latency and P95 TTFT.
 - Task buckets.
@@ -273,4 +317,4 @@ The remaining time is concentrated in raw-only Summary metrics:
 - Zero-token models.
 - Overview API key and channel dimensions.
 
-The next optimization should evaluate a Compact Summary Profile so tabs that do not need full diagnostic metrics stop executing these raw queries. A bounded recent-event cache should only proceed if new pprof evidence shows short-window SQLite reads are still the dominant bottleneck.
+Re-profile on a larger real dataset before adding another optimization layer. If filter-option distinct reads or one high-dimensional aggregate consistently dominates, prefer a focused query-shaping change or a dedicated dimension rollup. Current evidence still does not justify a bounded recent-event cache.

--- a/apps/docs/operations/manager-server.md
+++ b/apps/docs/operations/manager-server.md
@@ -222,9 +222,11 @@ go tool pprof http://127.0.0.1:6060/debug/pprof/heap
 USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 ```
 
-关闭后需重启 Manager Server，Dashboard 和 Usage Analytics 将始终读取 raw events，已有 rollup 表不会被删除。该运行期开关不接入 UI。
+关闭后需重启 Manager Server，Dashboard 和 Usage Analytics 将始终读取 raw events。除下述启动时的一次性格式升级外，关闭该运行时开关本身不会删除当前格式的 rollup 数据。该开关不接入 UI。
 
-升级旧数据库时，Manager Server 只在启动阶段执行快速 schema 变更；需要扫描历史 `usage_events` 的 cache accounting 修正会在 HTTP 服务开始监听后，以每批 1000 条的方式在后台执行。每批数据更新和 checkpoint 在同一个事务中提交，进程重启后会从最后成功的 event ID 继续，不会重新处理已经提交的批次。
+升级到使用无损 model 编码的版本时，Manager Server 会清空旧的 `usage_dashboard_hourly_rollups` 并重置 `dashboard_hourly` checkpoint。小时汇总启用时，后台 worker 会随后分批重建；禁用时则保持为空，直到重新启用。该格式迁移本身不会修改或删除 `usage_events`，也不会重置 account-history rollup；重建完成前相关长窗口查询会临时回退 raw events。新的编码会区分空 model、字面量 `-` 和包含前后空格的 model，避免合法的 `-` model 使整个查询回退。
+
+升级旧数据库时，Manager Server 在启动阶段执行 schema/metadata 变更和必要的派生 rollup 重置，但不扫描历史 `usage_events`。需要扫描历史事件的 cache accounting 修正会在 HTTP 服务开始监听后，以每批 1000 条的方式在后台执行。每批数据更新和 checkpoint 在同一个事务中提交，进程重启后会从最后成功的 event ID 继续，不会重新处理已经提交的批次。
 
 迁移期间：
 

--- a/apps/docs/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/operations/performance-optimization-2026-07-10.md
@@ -259,7 +259,7 @@ Raw analytics 与 rollup reader 共用同一个时区 bucket 规则。每个 UTC
 USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 ```
 
-修改后重启 Manager Server。Dashboard 和 Usage Analytics 会回退 raw events，已有 rollup 表不会删除。该开关不接入 UI。
+修改后重启 Manager Server。Dashboard 和 Usage Analytics 会回退 raw events。除 Manager Server 指南说明的启动时一次性格式升级外，关闭该运行时开关本身不会删除当前格式的 rollup 数据。该开关不接入 UI。
 
 更多配置见 [Manager Server 指南](./manager-server.md)。
 

--- a/apps/docs/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/operations/performance-optimization-2026-07-10.md
@@ -4,12 +4,13 @@
 
 ## 执行摘要
 
-本轮优化分为四个阶段：
+本轮优化分为五个阶段：
 
 1. PR #319：限制无界内存、请求和 SQLite 连接资源。
 2. PR #320：Dashboard 核心统计改用增量小时汇总。
 3. PR #323：Usage Analytics 按当前 Tab 请求最小数据集。
 4. Usage Analytics Hourly Rollup Phase 2B：严格无筛选的长窗口核心统计复用小时汇总。
+5. Monitoring 完整请求复用重复维度统计，并以有界并发执行独立 SQLite 读取。
 
 在 100,000 条测试事件下，以打开 Usage Analytics Overview 的有效工作量为口径：
 
@@ -200,6 +201,49 @@ Raw analytics 与 rollup reader 共用同一个时区 bucket 规则。每个 UTC
 
 核心路径约快 20 倍，但 Overview 整体只快约 23%，是因为 P95、TTFT、task、active days、API Key 和 Channel 等保留的 raw 查询已经成为主要耗时来源。
 
+## 阶段五：Monitoring 完整请求去重与有界并发
+
+### 问题原因
+
+Request Monitoring 会在一次 analytics 请求中同时加载 Summary、Timeline、小时分布、Model/Channel/Account/API Key 统计、失败来源、task buckets、filter options 和事件分页。这些独立读取原本串行执行，且无筛选请求的 `filter_options` 会再次计算主响应已经请求的 account、API key、channel 和 model 统计。
+
+在 100k、30 天 UTC 的 Monitoring include profile 中：
+
+- 完整请求约 5.44s。
+- 移除 `filter_options` 后约 3.38s。
+- 单独 `filter_options` 约 2.09s。
+
+### 优化内容
+
+- 主 filter 与 filter-options 基准 filter 等价时，复用已加载的 model、channel、account 和 API key 原始统计。
+- Filter options 直接复用主响应构建后的行，保证数值与 tie ordering 完全一致。
+- Timeline percentile、小时分布、高维统计、filter options、recent failures 和 events page 使用可取消的查询组预取。
+- 后台预取最多并发 2 个读取；加上前台 Summary/task 路径，单请求最多占用 3 个 SQLite 连接，为四连接池中的其他工作保留 1 个连接。
+- 第一个查询错误会取消同组任务；响应仅在全部查询完成后单线程组装。
+- 不新增 schema、rollup 表、常驻 cache 或 API 字段。对于 filter-options 基准范围会清除的维度或状态筛选，选项继续独立计算并保持原有语义；仅搜索请求仍可复用，因为基准范围会保留搜索条件。
+
+### 100k Monitoring include-profile 测试
+
+| 路径 | 耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| 优化前 | 约 5.44s | 16.26MB | 约 98.4 万 |
+| 优化后 | 约 1.69～1.81s | 15.14MB | 约 95.8 万 |
+| 变化 | 降低约 67%～69% | 降低约 7% | 降低约 3% |
+
+20 次连续测试保持在约 1.69s/op、15.14MB/op，未新增跨请求持有的缓存或事件数组。
+
+另一次优化后 benchmark 使用 curl 范围（`from_ms=1`、`Asia/Shanghai` 和相同 include payload），结果约为 1.815s/op、26.02MB/op、109.3 万 allocs/op。更宽的时间范围会增加分配量，但在该数据集上没有显著增加耗时。
+
+### 58,686 条真实数据验证
+
+在 `bin/tmp/db/data` 的 disposable SQLite backup 上，完成 cache-accounting migration 和 dashboard rollup 追平后：
+
+- Phase 1 后完整请求基线约 5.80s。
+- 本阶段 service 耗时稳定在 2.21～2.38s。
+- 相对上一阶段再降低约 59%～62%。
+- 7.58MB JSON 响应的序列化仅约 16ms，剩余耗时仍主要来自 SQLite 查询。
+- 原始 `bin/tmp/db/data` 未被修改。
+
 ## 内存与稳定性验证
 
 - 10 次和 200 次连续 100k rollup benchmark 保持稳定。
@@ -265,7 +309,7 @@ USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 
 ## 后续方向
 
-当前剩余耗时主要集中在 Summary 的 raw-only 指标：
+当前 Compact Summary、hourly rollup、latency percentile 紧凑读取、高维请求裁剪和 Monitoring 完整请求并发均已完成。剩余耗时主要依赖必须保留 raw 语义的查询：
 
 - P95 latency 和 P95 TTFT。
 - Task buckets。
@@ -273,4 +317,4 @@ USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 - Zero-token models。
 - Overview 的 API Key 和 Channel 高维聚合。
 
-下一阶段应优先评估 Compact Summary Profile，让不需要完整诊断指标的 Tab 不再重复执行这些 raw 查询。只有新的 pprof 证据显示短窗口 SQLite 查询仍是瓶颈时，才应继续考虑 bounded recent event cache。
+继续优化前应先在更大真实数据上重新 profile。若 filter option distinct 或某个高维聚合稳定占据主导，再选择单一查询整形或专用维度 rollup；现有证据仍不支持引入 bounded recent event cache。

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -2,7 +2,14 @@ package sqlite
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"time"
+)
+
+const (
+	dashboardHourlyRollupFormatVersionKey = "usage_dashboard_hourly_format_version"
+	dashboardHourlyRollupFormatVersion    = "2"
 )
 
 func Migrate(db *sql.DB) error {
@@ -351,7 +358,46 @@ func Migrate(db *sql.DB) error {
 	if err := ensureUsageRollupLongContextColumns(db); err != nil {
 		return err
 	}
+	if err := ensureDashboardHourlyRollupFormatVersion(db); err != nil {
+		return err
+	}
 	return ensureModelPriceColumns(db)
+}
+
+func ensureDashboardHourlyRollupFormatVersion(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var version string
+	err = tx.QueryRow(`select value from settings where key = ?`, dashboardHourlyRollupFormatVersionKey).Scan(&version)
+	switch {
+	case err == nil && version == dashboardHourlyRollupFormatVersion:
+		return tx.Commit()
+	case err == nil:
+		return fmt.Errorf("unsupported dashboard hourly rollup format version %q", version)
+	case !errors.Is(err, sql.ErrNoRows):
+		return err
+	}
+
+	for _, statement := range []string{
+		`delete from usage_dashboard_hourly_rollups`,
+		`delete from usage_rollup_checkpoints where name = 'dashboard_hourly'`,
+	} {
+		if _, err := tx.Exec(statement); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`insert into settings (key, value, updated_at_ms) values (?, ?, ?)`,
+		dashboardHourlyRollupFormatVersionKey,
+		dashboardHourlyRollupFormatVersion,
+		time.Now().UnixMilli(),
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func ensureUsageDataMigrationColumns(db *sql.DB) error {

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -252,6 +252,169 @@ func TestEnsureUsageRollupLongContextColumnsRollsBackAndRetries(t *testing.T) {
 	assertTableCount(t, db, "usage_rollup_checkpoints", 0)
 }
 
+func TestDashboardHourlyRollupFormatUpgradeRebuildsOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dashboard-rollup-format.sqlite")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, statement := range []string{
+		`insert into usage_events (event_hash, timestamp_ms, timestamp, model, created_at_ms)
+		values ('preserved-event', 1, '1', '-', 1)`,
+		`insert into usage_dashboard_hourly_rollups (
+			bucket_ms, model, billing_model, service_tier, updated_at_ms
+		) values (0, '-', '-', '', 1)`,
+		`insert into usage_rollup_checkpoints (name, last_event_id, updated_at_ms)
+		values ('dashboard_hourly', 1, 1), ('account_history', 1, 1)`,
+		`delete from settings where key = 'usage_dashboard_hourly_format_version'`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			_ = db.Close()
+			t.Fatalf("setup legacy rollup: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy sqlite: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("upgrade sqlite: %v", err)
+	}
+	assertTableCount(t, db, "usage_events", 1)
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 0)
+	var dashboardCheckpoints, accountCheckpoints int
+	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'dashboard_hourly'`).Scan(&dashboardCheckpoints); err != nil {
+		t.Fatalf("read dashboard checkpoint count: %v", err)
+	}
+	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'account_history'`).Scan(&accountCheckpoints); err != nil {
+		t.Fatalf("read account checkpoint count: %v", err)
+	}
+	if dashboardCheckpoints != 0 || accountCheckpoints != 1 {
+		t.Fatalf("checkpoint counts = dashboard:%d account:%d", dashboardCheckpoints, accountCheckpoints)
+	}
+	var version string
+	if err := db.QueryRow(`select value from settings where key = ?`, dashboardHourlyRollupFormatVersionKey).Scan(&version); err != nil {
+		t.Fatalf("read rollup format version: %v", err)
+	}
+	if version != dashboardHourlyRollupFormatVersion {
+		t.Fatalf("rollup format version = %q, want %q", version, dashboardHourlyRollupFormatVersion)
+	}
+	if _, err := db.Exec(`insert into usage_dashboard_hourly_rollups (
+		bucket_ms, model, billing_model, service_tier, updated_at_ms
+	) values (0, '-', '-', '', 2)`); err != nil {
+		_ = db.Close()
+		t.Fatalf("insert rebuilt rollup: %v", err)
+	}
+	if _, err := db.Exec(`insert into usage_rollup_checkpoints (name, last_event_id, updated_at_ms)
+		values ('dashboard_hourly', 1, 2)`); err != nil {
+		_ = db.Close()
+		t.Fatalf("insert rebuilt checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close upgraded sqlite: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("reopen upgraded sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 1)
+	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'dashboard_hourly'`).Scan(&dashboardCheckpoints); err != nil {
+		t.Fatalf("read preserved dashboard checkpoint: %v", err)
+	}
+	if dashboardCheckpoints != 1 {
+		t.Fatalf("dashboard checkpoint count after idempotent reopen = %d, want 1", dashboardCheckpoints)
+	}
+}
+
+func TestDashboardHourlyRollupFormatUpgradeRollsBackAndRetries(t *testing.T) {
+	db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "dashboard-rollup-format-retry.sqlite")))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, statement := range []string{
+		`create table settings (key text primary key, value text not null, updated_at_ms integer not null)`,
+		`create table usage_dashboard_hourly_rollups (id integer primary key)`,
+		`create table usage_rollup_checkpoints (name text primary key)`,
+		`insert into usage_dashboard_hourly_rollups (id) values (1)`,
+		`insert into usage_rollup_checkpoints (name) values ('dashboard_hourly'), ('account_history')`,
+		`create trigger reject_dashboard_rollup_delete before delete on usage_dashboard_hourly_rollups
+		begin select raise(abort, 'blocked'); end`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("setup migration fixture: %v", err)
+		}
+	}
+
+	if err := ensureDashboardHourlyRollupFormatVersion(db); err == nil {
+		t.Fatal("format migration error = nil, want trigger failure")
+	}
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 1)
+	assertTableCount(t, db, "usage_rollup_checkpoints", 2)
+	var settingCount int
+	if err := db.QueryRow(`select count(*) from settings where key = ?`, dashboardHourlyRollupFormatVersionKey).Scan(&settingCount); err != nil {
+		t.Fatalf("read format setting count: %v", err)
+	}
+	if settingCount != 0 {
+		t.Fatalf("format setting count after rollback = %d, want 0", settingCount)
+	}
+
+	if _, err := db.Exec(`drop trigger reject_dashboard_rollup_delete`); err != nil {
+		t.Fatalf("drop failure trigger: %v", err)
+	}
+	if err := ensureDashboardHourlyRollupFormatVersion(db); err != nil {
+		t.Fatalf("retry format migration: %v", err)
+	}
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 0)
+	var dashboardCheckpoints, accountCheckpoints int
+	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'dashboard_hourly'`).Scan(&dashboardCheckpoints); err != nil {
+		t.Fatalf("read dashboard checkpoint count: %v", err)
+	}
+	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'account_history'`).Scan(&accountCheckpoints); err != nil {
+		t.Fatalf("read account checkpoint count: %v", err)
+	}
+	if dashboardCheckpoints != 0 || accountCheckpoints != 1 {
+		t.Fatalf("checkpoint counts after retry = dashboard:%d account:%d", dashboardCheckpoints, accountCheckpoints)
+	}
+}
+
+func TestDashboardHourlyRollupFormatUpgradeRejectsUnknownVersionWithoutMutation(t *testing.T) {
+	db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "dashboard-rollup-format-unknown.sqlite")))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, statement := range []string{
+		`create table settings (key text primary key, value text not null, updated_at_ms integer not null)`,
+		`create table usage_dashboard_hourly_rollups (id integer primary key)`,
+		`create table usage_rollup_checkpoints (name text primary key)`,
+		`insert into settings (key, value, updated_at_ms)
+		values ('usage_dashboard_hourly_format_version', 'future', 1)`,
+		`insert into usage_dashboard_hourly_rollups (id) values (1)`,
+		`insert into usage_rollup_checkpoints (name) values ('dashboard_hourly'), ('account_history')`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("setup unknown format fixture: %v", err)
+		}
+	}
+
+	if err := ensureDashboardHourlyRollupFormatVersion(db); err == nil {
+		t.Fatal("format migration error = nil, want unsupported version failure")
+	}
+	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 1)
+	assertTableCount(t, db, "usage_rollup_checkpoints", 2)
+	var version string
+	if err := db.QueryRow(`select value from settings where key = ?`, dashboardHourlyRollupFormatVersionKey).Scan(&version); err != nil {
+		t.Fatalf("read preserved format version: %v", err)
+	}
+	if version != "future" {
+		t.Fatalf("format version after rejection = %q, want future", version)
+	}
+}
+
 func TestEnsureUsageEventSnapshotColumnsOnlyMigratesSchema(t *testing.T) {
 	db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "usage-event-migration.sqlite")))
 	if err != nil {

--- a/apps/manager-server/internal/repository/usagerollup/dashboard.go
+++ b/apps/manager-server/internal/repository/usagerollup/dashboard.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"strings"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -357,11 +356,8 @@ limit ?`, lastEventID, limit)
 func aggregateDashboardHourly(events []dashboardEventRow, nowMS int64) []DashboardHourlyRow {
 	grouped := make(map[dashboardHourlyKey]*DashboardHourlyRow)
 	for _, event := range events {
-		model := strings.TrimSpace(event.Model)
-		if model == "" {
-			model = "-"
-		}
-		billingModel := strings.TrimSpace(event.BillingModel)
+		model := event.Model
+		billingModel := event.BillingModel
 		if billingModel == "" {
 			billingModel = model
 		}
@@ -369,7 +365,7 @@ func aggregateDashboardHourly(events []dashboardEventRow, nowMS int64) []Dashboa
 			BucketMS:     event.TimestampMS - event.TimestampMS%dashboardHourMS,
 			Model:        model,
 			BillingModel: billingModel,
-			ServiceTier:  strings.TrimSpace(event.ServiceTier),
+			ServiceTier:  event.ServiceTier,
 		}
 		row := grouped[key]
 		if row == nil {

--- a/apps/manager-server/internal/repository/usagerollup/dashboard_test.go
+++ b/apps/manager-server/internal/repository/usagerollup/dashboard_test.go
@@ -99,6 +99,47 @@ func TestCatchUpDashboardHourlyAggregatesByCheckpoint(t *testing.T) {
 	}
 }
 
+func TestCatchUpDashboardHourlyPreservesDimensionStrings(t *testing.T) {
+	db := newRollupTestDB(t)
+	ctx := context.Background()
+	events := usageevent.New(db)
+	repo := New(db)
+	baseMS := int64(1_700_000_000_000)
+	hourMS := baseMS - baseMS%dashboardHourMS
+
+	empty := rollupTestEvent("dashboard-empty-model", hourMS+1_000, "", "", "", "", "auth-empty", false, 1, 2, 0, 0, 0, 0, 3)
+	dash := rollupTestEvent("dashboard-dash-model", hourMS+2_000, "-", "", "", "", "auth-dash", false, 2, 3, 0, 0, 0, 0, 5)
+	padded := rollupTestEvent("dashboard-padded-model", hourMS+3_000, " model ", " resolved ", "", "", "auth-padded", false, 3, 4, 0, 0, 0, 0, 7)
+	padded.ServiceTier = " priority "
+	if _, err := events.InsertBatch(ctx, []usage.Event{empty, dash, padded}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	if _, err := repo.CatchUpDashboardHourly(ctx, 10, baseMS+10_000); err != nil {
+		t.Fatalf("catch up dashboard hourly: %v", err)
+	}
+
+	rows, err := repo.DashboardHourlyRows(ctx, hourMS, hourMS+dashboardHourMS)
+	if err != nil {
+		t.Fatalf("query dashboard hourly rows: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows = %#v, want 3 dimension-preserving rows", rows)
+	}
+	byModel := make(map[string]DashboardHourlyRow, len(rows))
+	for _, row := range rows {
+		byModel[row.Model] = row
+	}
+	if row, ok := byModel[""]; !ok || row.BillingModel != "" || row.ServiceTier != "" || row.Calls != 1 {
+		t.Fatalf("empty model row = %#v, present=%v", row, ok)
+	}
+	if row, ok := byModel["-"]; !ok || row.BillingModel != "-" || row.ServiceTier != "" || row.Calls != 1 {
+		t.Fatalf("literal dash row = %#v, present=%v", row, ok)
+	}
+	if row, ok := byModel[" model "]; !ok || row.BillingModel != " resolved " || row.ServiceTier != " priority " || row.Calls != 1 {
+		t.Fatalf("padded model row = %#v, present=%v", row, ok)
+	}
+}
+
 func TestCatchUpDashboardHourlyFailureDoesNotAdvanceCheckpoint(t *testing.T) {
 	db := newRollupTestDB(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
@@ -26,11 +27,71 @@ const (
 	maxAccountHistoryTargets   = 200
 	accountHistoryCatchUpLimit = 5000
 	recentWindowMS             = 30 * 60 * 1000
+	// analyticsPrefetchConcurrency limits background analytics reads. The
+	// foreground summary/task path may hold one additional SQLite connection.
+	analyticsPrefetchConcurrency = 2
 )
 
 type Service struct {
 	store        *store.Store
 	hourlyReader *usagehourly.Reader
+}
+
+type analyticsQueryGroup struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	semaphore chan struct{}
+	waitGroup sync.WaitGroup
+	errorOnce sync.Once
+	waitOnce  sync.Once
+	err       error
+}
+
+func newAnalyticsQueryGroup(ctx context.Context, concurrency int) *analyticsQueryGroup {
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	queryCtx, cancel := context.WithCancel(ctx)
+	return &analyticsQueryGroup{
+		ctx:       queryCtx,
+		cancel:    cancel,
+		semaphore: make(chan struct{}, concurrency),
+	}
+}
+
+func (g *analyticsQueryGroup) Go(query func(context.Context) error) {
+	g.waitGroup.Add(1)
+	go func() {
+		defer g.waitGroup.Done()
+		select {
+		case g.semaphore <- struct{}{}:
+			defer func() { <-g.semaphore }()
+		case <-g.ctx.Done():
+			return
+		}
+		if err := query(g.ctx); err != nil {
+			g.errorOnce.Do(func() {
+				g.err = err
+				g.cancel()
+			})
+		}
+	}()
+}
+
+func (g *analyticsQueryGroup) Wait() error {
+	g.waitOnce.Do(func() {
+		g.waitGroup.Wait()
+		if g.err == nil && g.ctx.Err() != nil {
+			g.err = g.ctx.Err()
+		}
+		g.cancel()
+	})
+	return g.err
+}
+
+func (g *analyticsQueryGroup) Close() {
+	g.cancel()
+	_ = g.Wait()
 }
 
 func New(store *store.Store, hourlyRollupEnabled ...bool) *Service {
@@ -685,6 +746,9 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 	}
 
 	var modelStats []store.ModelStat
+	var channelStats []store.ChannelModelStat
+	var accountStats []store.AccountModelStat
+	var apiKeyStats []store.APIKeyModelStat
 	needsModelStats := req.Include.Summary || req.Include.ModelShare || req.Include.ModelStats
 	if needsModelStats {
 		if hourlySnapshotAvailable {
@@ -695,6 +759,147 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 				return Response{}, err
 			}
 		}
+	}
+
+	queries := newAnalyticsQueryGroup(ctx, analyticsPrefetchConcurrency)
+	defer queries.Close()
+
+	var latencyPercentiles []store.LatencyPercentiles
+	if req.Include.Timeline || req.Include.AnomalyPoints {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			latencyPercentiles, queryErr = s.store.LatencyPercentilesWithFilter(queryCtx, filter, granularity, location)
+			return queryErr
+		})
+	}
+
+	var hourlyDistributionPoints []store.HourlyPoint
+	if req.Include.HourlyDistribution {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			hourlyDistributionPoints, queryErr = s.store.HourlyDistributionWithFilter(queryCtx, filter, location)
+			return queryErr
+		})
+	}
+
+	var heatmapPoints []store.HeatmapPoint
+	if req.Include.Heatmap {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			heatmapPoints, queryErr = s.store.HeatmapWithFilter(queryCtx, filter, location)
+			return queryErr
+		})
+	}
+
+	if req.Include.ChannelShare {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			channelStats, queryErr = s.store.ChannelModelStatsWithFilter(queryCtx, filter)
+			return queryErr
+		})
+	}
+
+	var failureSourceStats []store.FailureSourceStat
+	if req.Include.FailureSources {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			failureSourceStats, queryErr = s.store.FailureSourcesWithFilter(queryCtx, filter)
+			return queryErr
+		})
+	}
+
+	if req.Include.AccountStats {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			accountStats, queryErr = s.store.AccountModelStatsWithFilter(queryCtx, filter)
+			return queryErr
+		})
+	}
+
+	var credentialStats []store.CredentialModelStat
+	if req.Include.CredentialStats {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			credentialStats, queryErr = s.store.CredentialModelStatsWithFilter(queryCtx, filter)
+			return queryErr
+		})
+	}
+
+	var credentialTimelinePoints []store.CredentialTimelinePoint
+	if req.Include.CredentialTimeline {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			credentialTimelinePoints, queryErr = s.store.CredentialTimelineWithFilter(queryCtx, filter, granularity, location)
+			return queryErr
+		})
+	}
+
+	if req.Include.APIKeyStats {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			apiKeyStats, queryErr = s.store.APIKeyModelStatsWithFilter(queryCtx, filter)
+			return queryErr
+		})
+	}
+
+	var selectorOptions *FilterOptions
+	var prebuiltFilterOptions *FilterOptions
+	var filterOptionValues store.FilterOptionValues
+	var filterOptionValuesAvailable bool
+	if req.Include.FilterSelectors {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			selectorOptions, queryErr = s.filterSelectors(queryCtx, filter)
+			return queryErr
+		})
+	} else if req.Include.FilterOptions {
+		if filterOptionsMatchMainScope(filter) {
+			queries.Go(func(queryCtx context.Context) error {
+				var queryErr error
+				filterOptionValues, queryErr = s.store.FilterOptionValuesWithFilter(queryCtx, filterOptionsBaseFilter(filter))
+				filterOptionValuesAvailable = queryErr == nil
+				return queryErr
+			})
+		} else {
+			queries.Go(func(queryCtx context.Context) error {
+				var queryErr error
+				prebuiltFilterOptions, queryErr = s.filterOptions(queryCtx, filter, prices, filterOptionStats{})
+				return queryErr
+			})
+		}
+	}
+
+	var recentFailureRows []store.RecentFailure
+	if req.Include.RecentFailures > 0 {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			recentFailureRows, queryErr = s.store.RecentFailuresWithFilter(queryCtx, filter, req.Include.RecentFailures)
+			return queryErr
+		})
+	}
+
+	var eventsPage store.EventsPage
+	if req.Include.EventsPage != nil {
+		limit := req.Include.EventsPage.Limit
+		if limit <= 0 {
+			limit = defaultEventsLimit
+		}
+		if limit > maxEventsLimit {
+			limit = maxEventsLimit
+		}
+		beforeMS := int64(0)
+		if req.Include.EventsPage.BeforeMS != nil {
+			beforeMS = *req.Include.EventsPage.BeforeMS
+		}
+		beforeID := int64(0)
+		if req.Include.EventsPage.BeforeID != nil {
+			beforeID = *req.Include.EventsPage.BeforeID
+		}
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			eventsPage, queryErr = s.store.EventsPageWithFilter(queryCtx, filter, beforeMS, beforeID, limit)
+			return queryErr
+		})
 	}
 
 	var taskBuckets []store.TaskBucket
@@ -802,6 +1007,9 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 			}
 		}
 	}
+	if err := queries.Wait(); err != nil {
+		return Response{}, err
+	}
 	var timeline []TimelinePoint
 	if req.Include.Timeline || req.Include.AnomalyPoints {
 		var points []store.TimelinePoint
@@ -815,11 +1023,7 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 				return Response{}, err
 			}
 		}
-		percentiles, err := s.store.LatencyPercentilesWithFilter(ctx, filter, granularity, location)
-		if err != nil {
-			return Response{}, err
-		}
-		timeline = buildTimeline(points, percentiles, granularity, location, prices)
+		timeline = buildTimeline(points, latencyPercentiles, granularity, location, prices)
 		if req.Include.Timeline {
 			response.Timeline = timeline
 		}
@@ -828,18 +1032,10 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		}
 	}
 	if req.Include.HourlyDistribution {
-		points, err := s.store.HourlyDistributionWithFilter(ctx, filter, location)
-		if err != nil {
-			return Response{}, err
-		}
-		response.HourlyDistribution = buildHourly(points)
+		response.HourlyDistribution = buildHourly(hourlyDistributionPoints)
 	}
 	if req.Include.Heatmap {
-		points, err := s.store.HeatmapWithFilter(ctx, filter, location)
-		if err != nil {
-			return Response{}, err
-		}
-		response.Heatmap = buildHeatmap(points, prices)
+		response.Heatmap = buildHeatmap(heatmapPoints, prices)
 	}
 	if req.Include.ModelShare {
 		response.ModelShare = buildModelShare(modelStats, prices)
@@ -848,90 +1044,69 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		response.ModelStats = buildModelStats(modelStats, prices)
 	}
 	if req.Include.ChannelShare {
-		stats, err := s.store.ChannelModelStatsWithFilter(ctx, filter)
-		if err != nil {
-			return Response{}, err
-		}
-		response.ChannelShare = buildChannelShare(stats, prices)
+		response.ChannelShare = buildChannelShare(channelStats, prices)
 	}
 	if req.Include.FailureSources {
-		stats, err := s.store.FailureSourcesWithFilter(ctx, filter)
-		if err != nil {
-			return Response{}, err
-		}
-		response.FailureSources = buildFailureSources(stats)
+		response.FailureSources = buildFailureSources(failureSourceStats)
 	}
 	if req.Include.AccountStats {
-		stats, err := s.store.AccountModelStatsWithFilter(ctx, filter)
-		if err != nil {
-			return Response{}, err
-		}
-		response.AccountStats = buildAccountStats(stats, prices)
+		response.AccountStats = buildAccountStats(accountStats, prices)
 	}
 	if req.Include.CredentialStats {
-		stats, err := s.store.CredentialModelStatsWithFilter(ctx, filter)
-		if err != nil {
-			return Response{}, err
-		}
-		response.CredentialStats = buildCredentialStats(stats, prices)
+		response.CredentialStats = buildCredentialStats(credentialStats, prices)
 	}
 	if req.Include.CredentialTimeline {
-		points, err := s.store.CredentialTimelineWithFilter(ctx, filter, granularity, location)
-		if err != nil {
-			return Response{}, err
-		}
-		response.CredentialTimeline = buildCredentialTimeline(points, granularity, location, prices)
+		response.CredentialTimeline = buildCredentialTimeline(credentialTimelinePoints, granularity, location, prices)
 	}
 	if req.Include.APIKeyStats {
-		stats, err := s.store.APIKeyModelStatsWithFilter(ctx, filter)
-		if err != nil {
-			return Response{}, err
-		}
-		response.APIKeyStats = buildAPIKeyStats(stats, prices)
+		response.APIKeyStats = buildAPIKeyStats(apiKeyStats, prices)
 	}
 	if req.Include.FilterSelectors {
-		selectors, err := s.filterSelectors(ctx, filter)
-		if err != nil {
-			return Response{}, err
-		}
-		response.FilterOptions = selectors
+		response.FilterOptions = selectorOptions
 	} else if req.Include.FilterOptions {
-		options, err := s.filterOptions(ctx, filter, prices)
-		if err != nil {
-			return Response{}, err
+		if prebuiltFilterOptions != nil {
+			response.FilterOptions = prebuiltFilterOptions
+		} else {
+			reuse := filterOptionStats{
+				accountStats:          accountStats,
+				accountStatsAvailable: req.Include.AccountStats,
+				apiKeyStats:           apiKeyStats,
+				apiKeyStatsAvailable:  req.Include.APIKeyStats,
+				channelStats:          channelStats,
+				channelStatsAvailable: req.Include.ChannelShare,
+				modelStats:            modelStats,
+				modelStatsAvailable:   needsModelStats,
+				optionValues:          filterOptionValues,
+				optionValuesAvailable: filterOptionValuesAvailable,
+			}
+			options, err := s.filterOptions(ctx, filter, prices, reuse)
+			if err != nil {
+				return Response{}, err
+			}
+			if filterOptionsMatchMainScope(filter) {
+				if req.Include.AccountStats {
+					options.AccountStats = response.AccountStats
+				}
+				if req.Include.APIKeyStats {
+					options.APIKeyStats = response.APIKeyStats
+				}
+				if req.Include.ChannelShare {
+					options.ChannelShare = response.ChannelShare
+				}
+				if req.Include.ModelStats {
+					options.ModelStats = response.ModelStats
+				}
+			}
+			response.FilterOptions = options
 		}
-		response.FilterOptions = options
 	}
 	if req.Include.TaskBuckets {
 		response.TaskBuckets = buildTaskBuckets(taskBuckets)
 	}
 	if req.Include.RecentFailures > 0 {
-		failures, err := s.store.RecentFailuresWithFilter(ctx, filter, req.Include.RecentFailures)
-		if err != nil {
-			return Response{}, err
-		}
-		response.RecentFailures = buildRecentFailures(failures)
+		response.RecentFailures = buildRecentFailures(recentFailureRows)
 	}
 	if req.Include.EventsPage != nil {
-		limit := req.Include.EventsPage.Limit
-		if limit <= 0 {
-			limit = defaultEventsLimit
-		}
-		if limit > maxEventsLimit {
-			limit = maxEventsLimit
-		}
-		beforeMS := int64(0)
-		if req.Include.EventsPage.BeforeMS != nil {
-			beforeMS = *req.Include.EventsPage.BeforeMS
-		}
-		beforeID := int64(0)
-		if req.Include.EventsPage.BeforeID != nil {
-			beforeID = *req.Include.EventsPage.BeforeID
-		}
-		page, err := s.store.EventsPageWithFilter(ctx, filter, beforeMS, beforeID, limit)
-		if err != nil {
-			return Response{}, err
-		}
 		// total_count is the real number of events matching the current filter
 		// (time range + scope filters + search), independent of the pagination
 		// cursor. Reuse the summary aggregate count when it was already computed
@@ -944,7 +1119,7 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 				return Response{}, err
 			}
 		}
-		response.Events = buildEvents(page, total)
+		response.Events = buildEvents(eventsPage, total)
 	}
 	if req.Include.DrilldownPreview != nil {
 		preview := req.Include.DrilldownPreview
@@ -1151,28 +1326,66 @@ func analyticsHourlyRollupEligible(filter store.AnalyticsFilter) bool {
 		strings.TrimSpace(filter.CacheStatus) == ""
 }
 
-func (s *Service) filterOptions(ctx context.Context, filter store.AnalyticsFilter, prices map[string]store.ModelPrice) (*FilterOptions, error) {
+type filterOptionStats struct {
+	accountStats          []store.AccountModelStat
+	accountStatsAvailable bool
+	apiKeyStats           []store.APIKeyModelStat
+	apiKeyStatsAvailable  bool
+	channelStats          []store.ChannelModelStat
+	channelStatsAvailable bool
+	modelStats            []store.ModelStat
+	modelStatsAvailable   bool
+	optionValues          store.FilterOptionValues
+	optionValuesAvailable bool
+}
+
+func (s *Service) filterOptions(
+	ctx context.Context,
+	filter store.AnalyticsFilter,
+	prices map[string]store.ModelPrice,
+	reuse filterOptionStats,
+) (*FilterOptions, error) {
 	optionFilter := filterOptionsBaseFilter(filter)
 
-	accountStats, err := s.store.AccountModelStatsWithFilter(ctx, optionFilter)
-	if err != nil {
-		return nil, err
+	accountStats := reuse.accountStats
+	if !reuse.accountStatsAvailable {
+		var err error
+		accountStats, err = s.store.AccountModelStatsWithFilter(ctx, optionFilter)
+		if err != nil {
+			return nil, err
+		}
 	}
-	apiKeyStats, err := s.store.APIKeyModelStatsWithFilter(ctx, optionFilter)
-	if err != nil {
-		return nil, err
+	apiKeyStats := reuse.apiKeyStats
+	if !reuse.apiKeyStatsAvailable {
+		var err error
+		apiKeyStats, err = s.store.APIKeyModelStatsWithFilter(ctx, optionFilter)
+		if err != nil {
+			return nil, err
+		}
 	}
-	channelStats, err := s.store.ChannelModelStatsWithFilter(ctx, optionFilter)
-	if err != nil {
-		return nil, err
+	channelStats := reuse.channelStats
+	if !reuse.channelStatsAvailable {
+		var err error
+		channelStats, err = s.store.ChannelModelStatsWithFilter(ctx, optionFilter)
+		if err != nil {
+			return nil, err
+		}
 	}
-	modelStats, err := s.store.ModelStatsWithFilter(ctx, optionFilter, 0)
-	if err != nil {
-		return nil, err
+	modelStats := reuse.modelStats
+	if !reuse.modelStatsAvailable {
+		var err error
+		modelStats, err = s.store.ModelStatsWithFilter(ctx, optionFilter, 0)
+		if err != nil {
+			return nil, err
+		}
 	}
-	optionValues, err := s.store.FilterOptionValuesWithFilter(ctx, optionFilter)
-	if err != nil {
-		return nil, err
+	optionValues := reuse.optionValues
+	if !reuse.optionValuesAvailable {
+		var err error
+		optionValues, err = s.store.FilterOptionValuesWithFilter(ctx, optionFilter)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &FilterOptions{
@@ -1189,6 +1402,27 @@ func (s *Service) filterOptions(ctx context.Context, filter store.AnalyticsFilte
 		HeaderQuotaPlans: optionValues.HeaderQuotaPlans,
 		HeaderTraceIDs:   optionValues.HeaderTraceIDs,
 	}, nil
+}
+
+func filterOptionsMatchMainScope(filter store.AnalyticsFilter) bool {
+	return len(filter.Models) == 0 &&
+		len(filter.Providers) == 0 &&
+		len(filter.Accounts) == 0 &&
+		len(filter.CredentialIDs) == 0 &&
+		len(filter.AuthFiles) == 0 &&
+		len(filter.AuthIndices) == 0 &&
+		len(filter.APIKeyHashes) == 0 &&
+		len(filter.SourceHashes) == 0 &&
+		len(filter.ProjectIDs) == 0 &&
+		len(filter.RequestTypes) == 0 &&
+		len(filter.HeaderErrorKinds) == 0 &&
+		len(filter.HeaderErrorCodes) == 0 &&
+		len(filter.HeaderQuotaPlans) == 0 &&
+		len(filter.HeaderTraceIDs) == 0 &&
+		filter.IncludeFailed &&
+		!filter.FailedOnly &&
+		filter.MinLatencyMS == 0 &&
+		strings.TrimSpace(filter.CacheStatus) == ""
 }
 
 func (s *Service) filterSelectors(ctx context.Context, filter store.AnalyticsFilter) (*FilterOptions, error) {

--- a/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_benchmark_test.go
@@ -50,6 +50,29 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 		Granularity:        "day",
 	})
 	selectedCredentialTimeline.Filters.CredentialIDs = []string{"account-000.json"}
+	monitoringFull := request(Include{
+		Summary:            true,
+		Timeline:           true,
+		HourlyDistribution: true,
+		ModelShare:         true,
+		ChannelShare:       true,
+		ModelStats:         true,
+		FailureSources:     true,
+		AccountStats:       true,
+		APIKeyStats:        true,
+		FilterOptions:      true,
+		TaskBuckets:        true,
+		RecentFailures:     8,
+		EventsPage:         &EventsPage{Limit: 500},
+		Granularity:        "day",
+	})
+	monitoringCurlScope := monitoringFull
+	monitoringCurlScope.FromMS = 1
+	monitoringCurlScope.TimeZone = "Asia/Shanghai"
+	monitoringFullWithoutFilterOptions := monitoringFull
+	monitoringFullWithoutFilterOptions.Include.FilterOptions = false
+	monitoringFullFiltered := monitoringFull
+	monitoringFullFiltered.Filters.Models = []string{"gpt-00"}
 	profiles := []struct {
 		name     string
 		service  *Service
@@ -73,6 +96,11 @@ func BenchmarkUsageAnalyticsIncludeProfiles(b *testing.B) {
 				Granularity:        "day",
 			})},
 		},
+		{name: "monitoring_full", service: rollupService, requests: []Request{monitoringFull}},
+		{name: "monitoring_curl_scope", service: rollupService, requests: []Request{monitoringCurlScope}},
+		{name: "monitoring_full_without_filter_options", service: rollupService, requests: []Request{monitoringFullWithoutFilterOptions}},
+		{name: "monitoring_full_filtered", service: rollupService, requests: []Request{monitoringFullFiltered}},
+		{name: "filter_options_only", service: rollupService, requests: []Request{request(Include{FilterOptions: true})}},
 		{
 			name:    "overview_initial",
 			service: rollupService,

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -2,17 +2,94 @@ package monitoring
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
+
+func TestAnalyticsQueryGroupBoundsConcurrency(t *testing.T) {
+	group := newAnalyticsQueryGroup(context.Background(), 2)
+	release := make(chan struct{})
+	started := make(chan struct{}, 4)
+	var current atomic.Int64
+	var maximum atomic.Int64
+	for range 4 {
+		group.Go(func(ctx context.Context) error {
+			running := current.Add(1)
+			defer current.Add(-1)
+			for {
+				observed := maximum.Load()
+				if running <= observed || maximum.CompareAndSwap(observed, running) {
+					break
+				}
+			}
+			started <- struct{}{}
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+	}
+	<-started
+	<-started
+	close(release)
+	if err := group.Wait(); err != nil {
+		t.Fatalf("wait query group: %v", err)
+	}
+	if got := maximum.Load(); got != 2 {
+		t.Fatalf("maximum concurrency = %d, want 2", got)
+	}
+}
+
+func TestAnalyticsQueryGroupCancelsSiblingsOnError(t *testing.T) {
+	group := newAnalyticsQueryGroup(context.Background(), 2)
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	group.Go(func(ctx context.Context) error {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return nil
+	})
+	<-started
+	wantErr := errors.New("query failed")
+	group.Go(func(context.Context) error { return wantErr })
+	if err := group.Wait(); !errors.Is(err, wantErr) {
+		t.Fatalf("wait error = %v, want %v", err, wantErr)
+	}
+	select {
+	case <-cancelled:
+	default:
+		t.Fatal("sibling query did not observe cancellation")
+	}
+}
+
+func TestAnalyticsQueryGroupReturnsRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	group := newAnalyticsQueryGroup(ctx, 1)
+	started := make(chan struct{})
+	group.Go(func(queryCtx context.Context) error {
+		close(started)
+		<-queryCtx.Done()
+		return nil
+	})
+	<-started
+	cancel()
+	if err := group.Wait(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("wait error = %v, want context canceled", err)
+	}
+}
 
 func TestAnalyticsBuildsIncludedSections(t *testing.T) {
 	db := newMonitoringTestStore(t)
@@ -1289,6 +1366,51 @@ func TestAnalyticsAppliesAccountFallbackFilter(t *testing.T) {
 	}
 	if resp.Events == nil || len(resp.Events.Items) != 1 || resp.Events.Items[0].EventHash != "account-alice" {
 		t.Fatalf("auth label events = %#v", resp.Events)
+	}
+}
+
+func TestAnalyticsUnfilteredFullResponseKeepsFilterOptionStatsInSync(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_250_000_000)
+	toMS := fromMS + 60*60*1000
+
+	alice := monitoringEvent("reuse-alice", fromMS+1_000, "gpt-a", "auth-a", "source-a", false, 10, 5, 0, 0, 15, nil)
+	alice.AccountSnapshot = "alice@example.com"
+	alice.AuthLabelSnapshot = "Alice Auth"
+	alice.AuthProviderSnapshot = "codex"
+	alice.APIKeyHash = "key-alice"
+	bob := monitoringEvent("reuse-bob", fromMS+2_000, "gpt-b", "auth-b", "source-b", true, 20, 10, 0, 0, 30, nil)
+	bob.AccountSnapshot = "bob@example.com"
+	bob.AuthLabelSnapshot = "Bob Auth"
+	bob.AuthProviderSnapshot = "gemini"
+	bob.APIKeyHash = "key-bob"
+	if _, err := db.InsertEvents(ctx, []usage.Event{alice, bob}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Include: Include{
+			ModelStats:    true,
+			ChannelShare:  true,
+			AccountStats:  true,
+			APIKeyStats:   true,
+			FilterOptions: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if resp.FilterOptions == nil {
+		t.Fatal("filter options are nil")
+	}
+	if !reflect.DeepEqual(resp.FilterOptions.ModelStats, resp.ModelStats) ||
+		!reflect.DeepEqual(resp.FilterOptions.ChannelShare, resp.ChannelShare) ||
+		!reflect.DeepEqual(resp.FilterOptions.AccountStats, resp.AccountStats) ||
+		!reflect.DeepEqual(resp.FilterOptions.APIKeyStats, resp.APIKeyStats) {
+		t.Fatalf("filter option stats diverged from unfiltered response: options=%#v response=%#v", resp.FilterOptions, resp)
 	}
 }
 

--- a/apps/manager-server/internal/service/usagehourly/reader.go
+++ b/apps/manager-server/internal/service/usagehourly/reader.go
@@ -132,13 +132,6 @@ func (r *Reader) loadRows(
 		r.logFallback(fmt.Sprintf("hourly rows query failed: %v", err))
 		return Snapshot{}, false
 	}
-	for _, row := range rows {
-		if row.Model == "-" {
-			r.logFallback("hourly rows contain a normalized empty model")
-			return Snapshot{}, false
-		}
-	}
-
 	agg, modelStats := coreFromRows(rows)
 	edges := rawEdges(fromMS, toMS, fullStartMS, fullEndMS)
 	for _, edge := range edges {

--- a/apps/manager-server/internal/service/usagehourly/reader_test.go
+++ b/apps/manager-server/internal/service/usagehourly/reader_test.go
@@ -3,6 +3,7 @@ package usagehourly
 import (
 	"context"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -123,20 +124,66 @@ func TestReaderAnalyticsTimelineFallsBackForHalfHourBuckets(t *testing.T) {
 	}
 }
 
-func TestReaderFallsBackForNormalizedEmptyModel(t *testing.T) {
+func TestReaderPreservesEmptyLiteralDashAndWhitespaceModels(t *testing.T) {
 	db := newReaderTestStore(t)
 	ctx := context.Background()
 	fromMS := int64(1_800_000_000_000)
 	toMS := fromMS + 2*hourMS
-	if _, err := db.InsertEvents(ctx, []usage.Event{
-		readerEvent("empty-model", fromMS+1_000, "", false, 1, 2, nil),
-	}); err != nil {
+	empty := readerEvent("empty-model", fromMS+1_000, "", false, 1, 2, nil)
+	dash := readerEvent("dash-model", fromMS+2_000, "-", false, 2, 3, nil)
+	padded := readerEvent("padded-model", fromMS+3_000, " model ", false, 3, 4, nil)
+	padded.ResolvedModel = " resolved "
+	padded.ServiceTier = " priority "
+	if _, err := db.InsertEvents(ctx, []usage.Event{empty, dash, padded}); err != nil {
 		t.Fatalf("insert events: %v", err)
 	}
 	catchUpReaderRollup(t, ctx, db)
-	if _, ok := New(db, true).Load(ctx, fromMS, toMS); ok {
-		t.Fatal("normalized empty model used rollup instead of preserving raw model semantics")
+
+	rawAggregate, err := db.AggregateBetween(ctx, fromMS, toMS)
+	if err != nil {
+		t.Fatalf("raw aggregate: %v", err)
 	}
+	rawModels, err := db.ModelStatsBetween(ctx, fromMS, toMS)
+	if err != nil {
+		t.Fatalf("raw models: %v", err)
+	}
+	filter := store.AnalyticsFilter{FromMS: fromMS, ToMS: toMS, IncludeFailed: true}
+	rawTimeline, err := db.TimelineWithFilter(ctx, filter, "day", time.UTC)
+	if err != nil {
+		t.Fatalf("raw timeline: %v", err)
+	}
+	snapshot, ok := New(db, true).LoadAnalytics(ctx, fromMS, toMS, "day", time.UTC, false)
+	if !ok {
+		t.Fatal("dimension-preserving rollup was unavailable")
+	}
+	if !reflect.DeepEqual(snapshot.Aggregate, rawAggregate) || !reflect.DeepEqual(snapshot.ModelStats, rawModels) {
+		t.Fatalf("dimension-preserving rollup mismatch\nrollup=%#v %#v\nraw=%#v %#v", snapshot.Aggregate, snapshot.ModelStats, rawAggregate, rawModels)
+	}
+	timelineSnapshot, ok := New(db, true).LoadAnalytics(ctx, fromMS, toMS, "day", time.UTC, true)
+	if !ok {
+		t.Fatal("dimension-preserving timeline rollup was unavailable")
+	}
+	rolledTimeline, ok := New(db, true).AnalyticsTimeline(ctx, timelineSnapshot, "day", time.UTC)
+	sortTimelinePoints(rawTimeline)
+	sortTimelinePoints(rolledTimeline)
+	if !ok || !reflect.DeepEqual(rolledTimeline, rawTimeline) {
+		t.Fatalf("dimension-preserving timeline mismatch\nrollup=%#v\nraw=%#v", rolledTimeline, rawTimeline)
+	}
+}
+
+func sortTimelinePoints(points []store.TimelinePoint) {
+	sort.Slice(points, func(i, j int) bool {
+		if points[i].BucketMS != points[j].BucketMS {
+			return points[i].BucketMS < points[j].BucketMS
+		}
+		if points[i].Model != points[j].Model {
+			return points[i].Model < points[j].Model
+		}
+		if points[i].BillingModel != points[j].BillingModel {
+			return points[i].BillingModel < points[j].BillingModel
+		}
+		return points[i].ServiceTier < points[j].ServiceTier
+	})
 }
 
 func TestReaderFallsBackWhenDisabledOrPending(t *testing.T) {


### PR DESCRIPTION
## Summary
Accelerate long-range monitoring analytics while preserving raw usage semantics.
Add a versioned hourly-rollup migration, reuse duplicate dimension statistics, and prefetch independent SQLite reads with bounded concurrency.

## Scope
- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Version the dashboard hourly-rollup format, reset legacy derived rows atomically, and preserve empty, literal-dash, and whitespace model dimensions.
- Reuse model, channel, account, and API-key statistics where filter scopes match, and execute independent monitoring reads through a cancellable bounded query group.
- Add migration, concurrency, filter-scope, response-consistency, race, and benchmark coverage, plus English and Chinese operational documentation.

## User Impact
Complete monitoring requests are approximately 59%–69% faster in the measured synthetic and real-data profiles. Existing databases perform a one-time derived-rollup rebuild after upgrade; long-window analytics temporarily fall back to raw events until catch-up completes.

## Compatibility / Runtime Notes
- CPA panel mode: No API or authentication contract changes; monitoring requests use the optimized Manager Server path.
- Manager Server mode: Startup atomically resets only legacy dashboard hourly rollups and their checkpoint, then rebuilds them in bounded background batches when hourly rollups are enabled.
- Full Docker / native packages: Restarting the upgraded binary applies the same automatic migration. No new configuration is required.

## Data / Security Notes
The migration does not modify or delete `usage_events`, account-history rollups, credentials, or encryption keys. It clears only derived dashboard hourly-rollup rows and resets their checkpoint. Back up the SQLite database and `data.key` before upgrading large installations. No secrets or raw failure bodies are added to responses.

## Risk / Rollback
Risk level: Medium

Rollback notes:
- Stop Manager Server before rolling back. Either disable hourly rollups on the older binary or clear `usage_dashboard_hourly_rollups` and the `dashboard_hourly` checkpoint before starting it, so old and new rollup encodings are not mixed.
- Raw `usage_events` remain the source of truth and allow the rollup to be rebuilt after rollback.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run manager-server:test
cd apps/manager-server && go test -race ./...
cd apps/manager-server && go vet ./...
cd apps/manager-server && go test -count=20 ./internal/service/monitoring
cd apps/manager-server && go test -run '^$' -bench '^BenchmarkUsageAnalyticsIncludeProfiles/(monitoring_full|monitoring_curl_scope)$' -benchtime=3x -count=1 ./internal/service/monitoring
npm run docs:build
git diff --check
```

## Screenshots / Recordings
N/A — backend, migration, tests, benchmarks, and documentation only.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related
Fixes #370
