### PR TITLE
docs(release): add v1.11.2 notes

### DIFF
--- a/docs/release-notes/v1.11.2-en.md
+++ b/docs/release-notes/v1.11.2-en.md
@@ -1,0 +1,43 @@
+# CPA Manager Plus v1.11.2
+
+> 24 commits · 115 files changed · +12881 / -1413
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.2/docs/release-notes/v1.11.2-zh.md)
+
+## Overview
+
+This release adds billing-first xAI/Grok account health inspection and Sub2API account imports, systematically hardens account automation, CPA response handling, and cache-token accounting, and moves large-database historical migrations to a resumable background process. Long-range Monitoring queries also receive significant performance improvements.
+
+## Highlights
+
+### Features
+
+- Add local and scheduled xAI account inspection using billing endpoints for weekly and monthly quota diagnostics without invoking inference models, together with xAI OAuth reauthorization and identity-validated credential deletion (`web/inspection`, `manager-server/inspection`).
+- Import official Sub2API account exports through file upload or JSON paste. Multiple OpenAI OAuth accounts are converted in the browser into independent CPA Codex auth files with accurate partial-failure reporting (`web/auth-files`).
+- Show reauthorization, manual-review, automatic-disable, and quota-cooldown states in Auth Files to make account-automation decisions visible (`web/auth-files`, `manager-server/account-actions`).
+
+### Performance
+
+- Execute independent Monitoring queries with bounded concurrency and reuse dimension statistics when filter scopes match, improving complete-query performance by approximately 59%–69% in measured profiles (`manager-server/monitoring`).
+- Move historical cache-accounting corrections for large SQLite databases to a checkpointed background migration after the HTTP listener starts, processing 1,000 rows per batch (`manager-server/migration`).
+- Upgrade Dashboard hourly rollups to a versioned, lossless dimension format and rebuild derived data in the background so special model values no longer disable rollup queries (`manager-server/rollup`).
+
+### Fixes
+
+- Correct cache-input double counting for Grok, xAI, Kimi, Moonshot, Gemini, and aliased Claude/OpenAI-compatible traffic across new events, imports, Monitoring, costs, and cache-hit rates (`manager-server/usage`, `web/usage`).
+- Enforce “only the automation that disabled an account may restore it,” preventing recovery of manually disabled accounts or accounts owned by another connection. HTTP `401/403` alone no longer authorizes automatic disable (`manager-server/account-actions`, `manager-server/inspection`).
+- Delete shared auth files only when every associated account is eligible, preventing bulk actions from removing healthy sibling accounts (`web/auth-files`, `manager-server/account-actions`).
+- Add explicit size limits for CPA auth-file, inspection, and account-action responses, and detect business failures inside HTTP 2xx responses to prevent truncation, memory exhaustion, and false-success reporting (`manager-server/cpa`).
+
+## Upgrade Notes
+
+- No manual configuration change is required. Manager Server automatically applies the new SQLite tables, columns, and derived-rollup format.
+- Before upgrading a large production database, back up `usage.sqlite`, `usage.sqlite-wal`, `usage.sqlite-shm`, and `data.key` together.
+- Historical cache-accounting migration starts after the HTTP listener is available. Account-history and dashboard-hourly rollup catch-up pauses during migration, and progress is available through `GET /status`.
+- Do not start a second Manager Server against the same SQLite database or CPA queue to accelerate migration.
+- Existing Dashboard hourly rollups are cleared and rebuilt automatically. Related long-window queries temporarily fall back to raw events until catch-up completes.
+- Corrected cache-token semantics may change historical total-token, cache-hit-rate, and cost statistics; the new values more closely match Provider billing semantics.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.1...v1.11.2

--- a/docs/release-notes/v1.11.2-zh.md
+++ b/docs/release-notes/v1.11.2-zh.md
@@ -1,0 +1,43 @@
+# CPA Manager Plus v1.11.2
+
+> 24 commits · 115 files changed · +12881 / -1413
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.2/docs/release-notes/v1.11.2-en.md)
+
+## Overview
+
+本次发布新增 xAI/Grok 账单优先的账号健康巡检与 Sub2API 账号导入，系统性加固账号自动化、CPA 响应处理和缓存 Token 统计口径，并将大库历史迁移改为后台可恢复执行。长窗口 Monitoring 查询也获得显著性能提升。
+
+## Highlights
+
+### Features
+
+- 新增本地与定时 xAI 账号巡检，通过账单接口检查周/月额度和账号状态，无需调用推理模型；同时支持 xAI OAuth 重新授权和带身份校验的失效凭证删除（`web/inspection`、`manager-server/inspection`）。
+- 支持直接上传或粘贴官方 Sub2API 账号导出，浏览器会将多个 OpenAI OAuth 账号转换为独立的 CPA Codex 认证文件，并准确报告部分上传失败（`web/auth-files`）。
+- Auth Files 新增需要重新授权、人工复核、自动禁用和额度冷却状态提示，帮助定位账号自动化决策（`web/auth-files`、`manager-server/account-actions`）。
+
+### Performance
+
+- Monitoring 独立查询改为受控并行执行，并复用过滤范围一致的维度统计；完整查询在测试数据中提速约 59%～69%（`manager-server/monitoring`）。
+- 大型 SQLite 数据库的历史 cache accounting 修正改为 HTTP 服务启动后的分批后台迁移，每批 1,000 条，支持检查点续跑和进度查询（`manager-server/migration`）。
+- Dashboard 小时汇总升级为版本化无损维度格式，并在后台重建派生数据，避免特殊 model 值导致汇总路径失效（`manager-server/rollup`）。
+
+### Fixes
+
+- 修复 Grok、xAI、Kimi、Moonshot、Gemini 及 Claude/OpenAI 兼容别名的 cache input 重复计算，统一新事件、导入数据、Monitoring、成本和缓存命中率口径（`manager-server/usage`、`web/usage`）。
+- 账号自动恢复现在严格遵循“谁禁用、谁恢复”，不会重新启用人工禁用或其他连接管理的账号；`401/403` 也不再被单独视为自动禁用依据（`manager-server/account-actions`、`manager-server/inspection`）。
+- 共享认证文件只有在全部关联账号均符合删除条件时才能删除，避免批量操作误删健康账号（`web/auth-files`、`manager-server/account-actions`）。
+- CPA 认证文件、巡检和账号操作响应增加明确的大小限制，并识别 HTTP 2xx 响应中的业务失败，避免截断、内存耗尽或错误成功提示（`manager-server/cpa`）。
+
+## Upgrade Notes
+
+- 无需手工修改配置。Manager Server 会自动应用新增的 SQLite 表、字段和派生汇总格式。
+- 大型生产数据库升级前，建议同时备份 `usage.sqlite`、`usage.sqlite-wal`、`usage.sqlite-shm` 和 `data.key`。
+- 历史 cache accounting 迁移会在 HTTP 服务开始监听后后台执行；迁移期间 account-history 和 dashboard-hourly 汇总暂停追平，可通过 `GET /status` 查看进度。
+- 不要启动第二个 Manager Server 连接同一 SQLite 数据库或消费同一 CPA 队列来加速迁移。
+- 旧 Dashboard 小时汇总会自动清空并重建。重建完成前，相关长窗口查询会回退到 raw events，查询性能可能暂时降低。
+- 缓存 Token 口径修正后，部分历史总 Token、缓存命中率和成本统计可能与旧版本不同，新结果更接近 Provider 实际计费语义。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.1...v1.11.2


### PR DESCRIPTION
## Summary

Add the curated Chinese and English release notes for CPA Manager Plus v1.11.2.
The notes cover xAI account inspection, Sub2API imports, safer account automation, cache-accounting corrections, background migrations, and monitoring performance improvements.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `docs/release-notes/v1.11.2-zh.md` as the authored release body.
- Add the matching English translation at `docs/release-notes/v1.11.2-en.md`.
- Use tag-pinned language links and the `v1.11.1...v1.11.2` changelog range.

## User Impact

No runtime behavior change from this PR. It provides the curated GitHub Release notes for v1.11.2.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; release-notes-only change.
- Manager Server mode: N/A; release-notes-only change.
- Full Docker / native packages: The tag workflow will publish v1.11.2 artifacts after this PR is merged.

## Data / Security Notes

N/A. No runtime data, credentials, keys, or security behavior are changed.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert the release-note commit before tagging if the content requires correction.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
main == GitHub main at 400c8bb4125935a32b586d423d0c9a51cd2465bf before execution
v1.11.1..main: 24 non-merge commits, 115 files changed, +12881 / -1413
Validated tag-pinned bilingual links and v1.11.1...v1.11.2 changelog URLs.
Confirmed release/v1.11.2, tag v1.11.2, and release v1.11.2 did not exist remotely before execution.
Verified both note files at release branch commit 70fa848c60711827d2770c3a65630021a03207ed.
```

## Screenshots / Recordings

N/A. Release-notes-only change.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [x] Release notes needed
- [ ] Not needed

## Related

N/A
