### PR TITLE
docs(operations): expand performance and upgrade guidance

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -62,6 +62,7 @@ const zhSidebar: DefaultTheme.Sidebar = [
     text: '运维',
     items: [
       { text: 'Manager Server 指南', link: '/operations/manager-server' },
+      { text: '更新 CPAMP', link: '/operations/update' },
       { text: '性能优化报告（2026-07-10）', link: '/operations/performance-optimization-2026-07-10' },
       { text: '配置与数据目录', link: '/operations/configuration' },
       { text: '备份与恢复', link: '/operations/backup' },
@@ -139,6 +140,7 @@ const enSidebar: DefaultTheme.Sidebar = [
     text: 'Operations',
     items: [
       { text: 'Manager Server Guide', link: '/en/operations/manager-server' },
+      { text: 'Upgrade CPAMP', link: '/en/operations/update' },
       { text: 'Performance Report (2026-07-10)', link: '/en/operations/performance-optimization-2026-07-10' },
       { text: 'Configuration And Data Directory', link: '/en/operations/configuration' },
       { text: 'Backup And Restore', link: '/en/operations/backup' },

--- a/apps/docs/en/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/en/operations/performance-optimization-2026-07-10.md
@@ -1,25 +1,30 @@
 # Performance Optimization Report — July 10, 2026
 
-This report documents the Manager Server, Dashboard, Request Monitoring, Usage Analytics, and Model Prices performance work completed on July 10, 2026. It covers the causes, implementation strategy, benchmark methodology, and measured results.
+This report documents the Manager Server, Dashboard, Request Monitoring, Usage Analytics, and Model Prices performance work started on July 10 and completed on July 15, 2026. It covers the causes, implementation strategy, benchmark methodology, and measured results. The report was updated on July 16 with the later stages and fresh measurements from current `main`.
 
 ## Executive Summary
 
-The work was delivered in five stages:
+The work was delivered in ten stages:
 
 1. PR #319 bounded memory, request, and SQLite connection resources.
 2. PR #320 moved Dashboard core metrics to incremental hourly rollups.
 3. PR #323 scoped Usage Analytics requests to the active tab.
 4. Usage Analytics Hourly Rollup Phase 2B reused hourly rollups for strictly unfiltered long-window core metrics.
-5. Complete Monitoring requests reused duplicate dimension statistics and executed independent SQLite reads with bounded concurrency.
+5. Usage Analytics Compact Summary skipped Summary subqueries not required by the active tab.
+6. Credential Timeline SQL preaggregation and on-demand loading read timelines only for the selected credential.
+7. Usage Analytics Hourly Rollup Projected Read selected only the rollup dimensions required by the caller.
+8. Latency Percentile Compact Read used integer projections for latency and TTFT samples.
+9. Dashboard Refresh Bounded Concurrency executed independent Dashboard reads concurrently.
+10. Complete Monitoring requests reused duplicate dimension statistics and executed independent SQLite reads with bounded concurrency.
 
 Using the effective work required to open Usage Analytics Overview on a 100,000-event dataset:
 
 | Metric | Legacy path | Current path | Combined change |
 |---|---:|---:|---:|
-| Request time | about 7.00s | about 2.48s | about 65% lower |
-| Allocation per operation | about 215MB | about 20.24MB | about 91% lower |
+| Request time | about 7.00s | about 1.12s | about 84% lower |
+| Allocation per operation | about 215MB | about 5.23MB | about 97.6% lower |
 
-The legacy path requested every tab and the complete filter dataset. The current path executes only the queries required by Overview. This comparison represents the user-visible Overview workload rather than two identical SQL workloads.
+The legacy path requested every tab and the complete filter dataset. The current path executes only the main Overview query and selector request. Three fresh current-main runs measured about 1.119–1.126s and 5.23MB/op. This comparison represents the user-visible Overview workload rather than two identical SQL workloads.
 
 ## Benchmark Interpretation
 
@@ -201,7 +206,114 @@ This scope includes only the aggregate, model-stat, and timeline work owned by P
 
 The rollup-owned path is about 20 times faster, while the complete Overview request is about 23% faster because P95, TTFT, task, active-day, API key, and channel queries remain on raw events and now dominate the remaining time.
 
-## Stage 5: Complete Monitoring Request Deduplication And Bounded Concurrency
+## Stage 5: Usage Analytics Compact Summary
+
+### Cause
+
+Usage Analytics already scoped the main dataset by tab, but the original Summary contract still ran rolling 30m, task buckets, active days, zero-token models, and percentile subqueries. Most tabs only display calls, tokens, cost, and average latency, so they still paid for hidden metrics.
+
+### Changes
+
+- Added a backward-compatible `compact` Summary profile; the full contract remains the default.
+- All Usage Analytics tabs use the compact profile.
+- Only Overview requests P95 latency and P95 TTFT; other tabs skip percentile queries.
+- Request Monitoring and existing consumers continue using the full Summary contract.
+
+### Fresh 100k Results On Current main, Three Runs
+
+| Path | Average duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| Full Summary | about 1.66s | about 3.77MB | about 310k |
+| Compact Summary with percentiles | about 775ms | about 31KB | about 506 |
+| Compact Summary without percentiles | about 21.5ms | about 22.8KB | 399 |
+
+With percentiles retained, duration fell about 53% and allocation about 99%. Tabs that do not need percentiles reduced Summary duration by about 98.7%.
+
+## Stage 6: Credential Timeline SQL Preaggregation And On-Demand Loading
+
+### Cause
+
+The Credentials tab previously read credential events and constructed timelines for every credential in Go even when the user viewed only one credential. Hidden timelines added scans, transfer, and allocation as event and credential counts increased.
+
+### Changes
+
+- Moved hourly Credential Timeline aggregation into SQLite while preserving partial raw edges.
+- Shared UTC-hour representability checks; fractional-offset zones and non-lossless ranges safely fall back to raw events.
+- Added exact `credential_ids` filtering for auth file, auth index, source hash, and source-only identities.
+- The frontend loads credential rankings first and requests a timeline only for the selected credential.
+- Cancellation, stale-response protection, loading state, and error feedback remain intact.
+
+### Fresh 100k Results On Current main, Three Runs
+
+| Request | Average duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| Credential ranking and Summary | about 524ms | about 847KB | about 11.9k |
+| One selected credential timeline | about 50.0ms | about 340KB | about 3,275 |
+| Two-stage total | about 565ms | about 1.19MB | about 15.2k |
+
+Opening the tab executes only the first row. The second request runs only when a selected credential needs a timeline, avoiding timeline construction for credentials the user does not inspect.
+
+## Stage 7: Hourly Rollup Projected Read
+
+### Cause
+
+Phase 2B replaced many raw scans with hourly rollups, but the reader still loaded complete `hour + model + billing model + service tier` rows and built a full snapshot. Model-only and UTC-day callers still allocated unrelated dimensions and intermediate objects.
+
+### Changes
+
+- Added model-only and UTC daily projections.
+- Selected compact snapshots based on the requested Summary, Model Stats, and Timeline combination.
+- Preserved partial raw edges, current-price calculation, checkpoint checks, and timezone fallback.
+- No schema or API changes were required.
+
+### Fresh 100k Core Results On Current main, Three Runs
+
+| Path | Average duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| Raw | about 830ms | 23.78MB | about 1.865m |
+| Projected rollup | about 24.0ms | 611KB | 7,900 |
+| Versus raw | about 34.6 times faster | about 97.4% lower | about 99.6% lower |
+
+Compared with the Phase 2B rollup result of about 39ms and 9.51MB/op, projected reads reduced duration by another 38% and allocation by about 94%.
+
+## Stage 8: Latency Percentile Compact Read
+
+### Cause
+
+Nullable latency and TTFT samples read through `database/sql` created per-row integer-to-string-to-float conversions and temporary objects. Percentile paths in Trends, Models, and Overview retained unnecessary allocations.
+
+### Changes And Results
+
+- SQLite projects only valid integer latency and TTFT samples.
+- Go reads compact integers directly while preserving nearest-rank semantics.
+- Coverage includes DST, fractional-offset zones, filters, NULL samples, and 10k/100k datasets.
+- Trends and Models allocation fell from about 7.20MB/op to about 4.80MB/op, a reduction of about 33%, with unchanged response and filtering semantics.
+
+Fresh current-main runs kept Trends near 532–544ms and 4.81MB/op, and Models near 543–560ms and 4.80MB/op.
+
+## Stage 9: Dashboard Refresh Bounded Concurrency
+
+### Cause
+
+Hourly rollups made Dashboard core metrics cheap, but rolling 30m, health timeline, recent failures, channel stats, and failure sources still ran serially. These recent/raw queries became the refresh critical path as data volume grew.
+
+### Changes And Results
+
+- Independent Dashboard queries run concurrently within the existing four-connection SQLite pool.
+- Context cancellation and first-error propagation are preserved.
+- No resident recent-event cache or response-contract change was added.
+- Merge-time 10k, 100k, and 1m benchmarks reduced full-refresh latency by about 37%, 44%, and 50%, respectively.
+
+Fresh single-operation runs on current `main`:
+
+| Event count | Full refresh duration | B/op | allocs/op |
+|---|---:|---:|---:|
+| 10k | about 39.7–43.2ms | about 1.63MB | about 20.5k |
+| 100k | about 403–405ms | about 1.64MB | about 21.8k |
+
+Allocation remains nearly flat as event count grows; time is still dominated by queries that must scan recent/raw ranges.
+
+## Stage 10: Complete Monitoring Request Deduplication And Bounded Concurrency
 
 ### Cause
 
@@ -238,7 +350,7 @@ A separate post-change benchmark using the curl scope (`from_ms=1`, `Asia/Shangh
 
 On a disposable SQLite backup of `bin/tmp/db/data`, after completing the cache-accounting migration and dashboard-rollup catch-up:
 
-- The complete request baseline after Phase 1 was about 5.80s.
+- The complete request baseline after the first Monitoring query-shaping pass was about 5.80s.
 - This stage completed the service call in 2.21–2.38s.
 - That is another reduction of approximately 59%–62% from the previous stage.
 - Serializing the 7.58MB JSON response took only about 16ms, so SQLite reads still dominate the remaining time.
@@ -309,7 +421,7 @@ See the [Manager Server Guide](./manager-server.md) for the full runtime referen
 
 ## Recommended Next Step
 
-Compact Summary, hourly rollups, compact latency-percentile reads, high-dimensional request shaping, and complete Monitoring request concurrency are now implemented. The remaining time depends primarily on queries that must preserve raw-event semantics:
+Compact Summary, Credential Timeline SQL preaggregation and on-demand loading, projected hourly rollup reads, compact latency-percentile reads, bounded Dashboard/Monitoring concurrency, and high-dimensional request shaping are now implemented. The remaining time depends primarily on queries that must preserve raw-event semantics:
 
 - P95 latency and P95 TTFT.
 - Task buckets.

--- a/apps/docs/en/operations/update.md
+++ b/apps/docs/en/operations/update.md
@@ -1,0 +1,246 @@
+# Upgrade CPA Manager Plus
+
+This guide explains how to upgrade CPAMP without losing SQLite data, `data.key`, or locally managed secrets. Follow the section for the way CPAMP is currently deployed; do not overwrite an existing deployment with first-install commands.
+
+## Before You Upgrade
+
+1. Read the target [release notes](../reference/releases.md) and the GitHub Release Upgrade Notes.
+2. Record the current image tag or native version, launch command, environment variables, and data directory.
+3. Stop extra instances that could write to the same SQLite database. Only one Manager Server may consume a CPA usage queue.
+4. Back up:
+   - `usage.sqlite`, `usage.sqlite-wal`, and `usage.sqlite-shm`.
+   - `data.key`.
+   - Installer-managed `secrets/`, `.env`, `compose.yaml`, or `config.json`.
+   - Custom reverse-proxy, systemd, launchd, or Windows service configuration.
+
+See [Backup And Restore](./backup.md) for safe procedures. A CPA Management Key encrypted in SQLite cannot be recovered if `data.key` is lost.
+
+## What Happens After Startup
+
+- Manager Server applies compatible SQLite schema and metadata migrations automatically; do not run SQL manually.
+- Large historical corrections may continue in the background after the HTTP server starts listening.
+- Account-history or dashboard-hourly rollups may pause during migration. Related pages temporarily fall back to raw events and can be slower until catch-up completes.
+- Do not start a second Manager Server against the same SQLite database or CPA queue to accelerate migration or rollup rebuilds.
+- Use authenticated `GET /status` to inspect migration, collector, and event state.
+
+## Docker Deployment Created By The Installer
+
+Do not rerun the installer. Enter the original installation directory and update the images:
+
+```bash
+cd "$HOME/cpa-manager-plus"
+docker compose pull
+docker compose up -d
+docker compose ps
+```
+
+Replace the path if `CPAMP_INSTALL_DIR` selected another directory.
+
+A full CPA + CPAMP installation pulls both images declared in Compose. To update only CPAMP:
+
+```bash
+docker compose pull cpa-manager-plus
+docker compose up -d cpa-manager-plus
+```
+
+Do not rerun the installer with `CPAMP_OVERWRITE=1` as an upgrade shortcut. That option regenerates configuration and may overwrite maintained `.env`, `compose.yaml`, CPA configuration, or `run.sh` files.
+
+## Manually Maintained Docker Compose
+
+### Tracking `latest`
+
+```bash
+docker compose pull cpa-manager-plus
+docker compose up -d cpa-manager-plus
+docker compose logs --tail=100 cpa-manager-plus
+```
+
+### Pinned Version
+
+Change the Compose image to the target version:
+
+```yaml
+services:
+  cpa-manager-plus:
+    image: seakee/cpa-manager-plus:vX.Y.Z
+```
+
+Then run:
+
+```bash
+docker compose pull cpa-manager-plus
+docker compose up -d cpa-manager-plus
+```
+
+The corresponding GHCR image is also available:
+
+```text
+ghcr.io/seakee/cpa-manager-plus:vX.Y.Z
+```
+
+Confirm that the new container mounts the existing `/data` volume or host directory. Do not create a new empty volume for an upgrade.
+
+## Manual `docker run`
+
+Inspect the current ports, volumes, environment, network, and `--add-host` settings first:
+
+```bash
+docker inspect cpa-manager-plus
+```
+
+Pull the target image and recreate the container. This is a minimal example; retain every option used by the current deployment:
+
+```bash
+docker pull seakee/cpa-manager-plus:vX.Y.Z
+docker stop cpa-manager-plus
+docker rm cpa-manager-plus
+docker run -d \
+  --name cpa-manager-plus \
+  --restart unless-stopped \
+  -p 18317:18317 \
+  -v cpa-manager-plus-data:/data \
+  seakee/cpa-manager-plus:vX.Y.Z
+```
+
+If CPA runs on a Linux host, retain:
+
+```text
+--add-host=host.docker.internal:host-gateway
+```
+
+Removing the old container does not remove a named volume, but removing the volume destroys the data.
+
+## Native Deployment Created By The Installer
+
+The installer normally creates:
+
+```text
+runtime/cpa-manager-plus_<version>_<os>_<arch>/
+data/
+secrets/
+run.sh
+cpa-manager-plus.service
+```
+
+Do not overwrite the running version directory:
+
+1. Stop the current process or systemd service.
+2. Back up `data/`, `secrets/`, the old runtime, `run.sh`, and the service file.
+3. Download and extract the target release under `runtime/` as a new version directory.
+4. Copy `config.json` from the old version directory into the new one. Installer-generated relative paths continue to reference the shared `data/` and `secrets/` directories.
+5. Change the working directory and binary path in `run.sh` to the new version directory.
+6. If the generated systemd unit is installed, update `WorkingDirectory` and `ExecStart`, then run `systemctl daemon-reload`.
+7. Start and verify the new version before deciding whether to remove the old runtime.
+
+Do not copy only `usage.sqlite` and omit WAL/SHM. Back up while the process is stopped or use a safe SQLite method from [Backup And Restore](./backup.md).
+
+## Manual Native Packages
+
+### macOS Or Linux, Foreground Or Control Script
+
+1. Run `./cpa-manager-plusctl stop`, or stop your process supervisor.
+2. Back up the data directory and `data.key`.
+3. Extract the new package into a new version directory.
+4. Continue using the external `USAGE_DATA_DIR` / `USAGE_DB_PATH`, or copy `config.json` and `data/` while the process is stopped.
+5. Start with the control script from the new directory:
+
+```bash
+./cpa-manager-plusctl start
+./cpa-manager-plusctl status
+./cpa-manager-plusctl logs
+```
+
+Do not extract over a running directory; that can mix binary, control script, and embedded panel versions.
+
+### Linux systemd With A Fixed Program Directory
+
+If the service always launches `/opt/cpa-manager-plus/cpa-manager-plus`:
+
+```bash
+sudo systemctl stop cpa-manager-plus
+sudo cp -a /var/lib/cpa-manager-plus "/var/lib/cpa-manager-plus.backup.$(date +%Y%m%d%H%M%S)"
+sudo cp -a cpa-manager-plus_vX.Y.Z_linux_amd64/. /opt/cpa-manager-plus/
+sudo systemctl start cpa-manager-plus
+sudo systemctl status cpa-manager-plus
+```
+
+Keeping `/var/lib/cpa-manager-plus` outside the program directory prevents release files from overwriting runtime data.
+
+### Windows
+
+1. Stop CPAMP through its control script or service manager:
+
+```powershell
+.\cpa-manager-plusctl.ps1 stop
+```
+
+2. Back up `data`, `config.json`, and service configuration.
+3. Extract the new ZIP into a new version directory.
+4. Continue using the existing data directory, or copy configuration and data while stopped.
+5. Start from the new directory and inspect logs:
+
+```powershell
+.\cpa-manager-plusctl.ps1 start
+.\cpa-manager-plusctl.ps1 status
+.\cpa-manager-plusctl.ps1 logs
+```
+
+Update the Windows service configuration if its executable path contains the version directory.
+
+## CPA-Hosted Panel Compatibility Mode
+
+Updating a CPA-hosted panel updates only the browser frontend. It does not update the Manager Server binary, SQLite schema, or collector.
+
+Confirm that CPA points to this repository:
+
+```text
+remote-management.panel-repo = https://github.com/seakee/CPA-Manager-Plus
+```
+
+CPA normally refreshes its cached panel automatically. If it still serves an old panel, remove the cached file from the CPA working directory and reload or restart CPA:
+
+```bash
+rm static/management.html
+```
+
+When `Disable Panel Auto Updates` is enabled, CPA downloads a panel only when the cached file is absent. Confirm that the file is CPA's panel cache, not Manager Server persistent data, before removing it.
+
+## Custom `management.html` Or `PANEL_PATH`
+
+For a manually deployed single-file panel:
+
+1. Download `management.html` from the target release.
+2. Verify it against the release checksum.
+3. Keep the old file and atomically replace the static file or the file referenced by `PANEL_PATH`.
+4. Clear reverse-proxy and browser caches.
+
+Replacing only `management.html` does not update Manager Server APIs. Mixing a frontend and Manager Server across several releases can cause field or feature incompatibilities; use the panel and Manager Server from the same CPAMP release.
+
+## Verify The Upgrade
+
+Run:
+
+```bash
+curl -f http://127.0.0.1:18317/health
+curl -f http://127.0.0.1:18317/usage-service/info
+curl -f -H "Authorization: Bearer <CPAMP_ADMIN_KEY>" \
+  http://127.0.0.1:18317/status
+```
+
+Confirm:
+
+- The panel and server report the target version.
+- `configured` has the expected value.
+- `collector.lastError` is empty or understood.
+- `lastConsumedAt`, `lastInsertedAt`, and `eventCount` update normally.
+- Dashboard, Request Monitoring, and Usage Analytics load data.
+- Background migration completes and rollup checkpoints continue advancing in `/status`.
+- Reverse-proxied `/management.html`, `/usage-service/*`, and management API paths still route to the correct service.
+
+## Rollback Principles
+
+- Docker: restore the previous image tag and recreate the container while mounting the pre-upgrade data backup.
+- Native: stop the new version and restore the old binary, configuration, and pre-upgrade data backup.
+- Single-file panel: restore the previous `management.html`.
+- Do not assume an older binary can read a database migrated by a newer version. For schema or data-semantics changes, restore the pre-upgrade SQLite, WAL/SHM, and `data.key` together.
+- If the cause is unclear, preserve both versions' logs and database copies. Do not repeatedly start different versions against the same live database.

--- a/apps/docs/operations/performance-optimization-2026-07-10.md
+++ b/apps/docs/operations/performance-optimization-2026-07-10.md
@@ -1,25 +1,30 @@
 # 2026-07-10 性能优化报告
 
-本文记录 2026-07-10 完成的 Manager Server、Dashboard、请求监控、Usage Analytics 和 Model Prices 性能优化，包括问题原因、实现方式、测试口径和实测结果。
+本文记录自 2026-07-10 开始、并在 2026-07-15 完成的 Manager Server、Dashboard、请求监控、Usage Analytics 和 Model Prices 性能优化，包括问题原因、实现方式、测试口径和实测结果。报告于 2026-07-16 补充后续阶段及当前 `main` 的复测数据。
 
 ## 执行摘要
 
-本轮优化分为五个阶段：
+本轮优化分为十个阶段：
 
 1. PR #319：限制无界内存、请求和 SQLite 连接资源。
 2. PR #320：Dashboard 核心统计改用增量小时汇总。
 3. PR #323：Usage Analytics 按当前 Tab 请求最小数据集。
 4. Usage Analytics Hourly Rollup Phase 2B：严格无筛选的长窗口核心统计复用小时汇总。
-5. Monitoring 完整请求复用重复维度统计，并以有界并发执行独立 SQLite 读取。
+5. Usage Analytics Compact Summary：跳过当前 Tab 不需要的 Summary 子查询。
+6. Credential Timeline SQL 预聚合与按需加载：只为选中凭据读取时间线。
+7. Usage Analytics Hourly Rollup Projected Read：按调用方需要裁剪小时汇总字段。
+8. Latency Percentile Compact Read：使用整数投影读取延迟和 TTFT 样本。
+9. Dashboard Refresh Bounded Concurrency：并行执行独立 Dashboard 读取。
+10. Monitoring 完整请求复用重复维度统计，并以有界并发执行独立 SQLite 读取。
 
 在 100,000 条测试事件下，以打开 Usage Analytics Overview 的有效工作量为口径：
 
 | 指标 | 优化前 legacy 路径 | 当前路径 | 综合变化 |
 |---|---:|---:|---:|
-| 请求耗时 | 约 7.00s | 约 2.48s | 降低约 65% |
-| 单次内存分配 | 约 215MB | 约 20.24MB | 降低约 91% |
+| 请求耗时 | 约 7.00s | 约 1.12s | 降低约 84% |
+| 单次内存分配 | 约 215MB | 约 5.23MB | 降低约 97.6% |
 
-legacy 路径会请求全部 Tab 和完整筛选数据；当前路径只执行 Overview 实际需要的查询。因此该结果代表用户打开 Overview 时的有效工作量变化，而不是两组完全相同 SQL 的对比。
+legacy 路径会请求全部 Tab 和完整筛选数据；当前路径只执行 Overview 实际需要的主查询和 selector 请求。当前 `main` 三次复测为约 1.119～1.126s、5.23MB/op。因此该结果代表用户打开 Overview 时的有效工作量变化，而不是两组完全相同 SQL 的对比。
 
 ## 测试口径说明
 
@@ -201,7 +206,114 @@ Raw analytics 与 rollup reader 共用同一个时区 bucket 规则。每个 UTC
 
 核心路径约快 20 倍，但 Overview 整体只快约 23%，是因为 P95、TTFT、task、active days、API Key 和 Channel 等保留的 raw 查询已经成为主要耗时来源。
 
-## 阶段五：Monitoring 完整请求去重与有界并发
+## 阶段五：Usage Analytics Compact Summary
+
+### 问题原因
+
+Usage Analytics 各 Tab 虽然已经按需裁剪主数据集，但原有 Summary 合同仍会执行 rolling 30m、task buckets、active days、zero-token models 和 percentile 等完整子查询。多数 Tab 只显示调用数、Token、成本和平均延迟，仍为不可见指标支付查询成本。
+
+### 优化内容
+
+- 新增向后兼容的 `compact` Summary profile；未显式请求时继续保持完整合同。
+- 所有 Usage Analytics Tab 使用 compact profile。
+- 只有 Overview 请求 P95 latency 和 P95 TTFT；其他 Tab 跳过 percentile 查询。
+- Request Monitoring 等既有消费者继续使用完整 Summary，不改变响应语义。
+
+### 100k 当前 main 三次复测
+
+| 路径 | 平均耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| Full Summary | 约 1.66s | 约 3.77MB | 约 31.0 万 |
+| Compact Summary + percentiles | 约 775ms | 约 31KB | 约 506 |
+| Compact Summary，无 percentiles | 约 21.5ms | 约 22.8KB | 399 |
+
+保留 percentile 时耗时降低约 53%，分配降低约 99%；不需要 percentile 的 Tab，Summary 耗时降低约 98.7%。
+
+## 阶段六：Credential Timeline SQL 预聚合与按需加载
+
+### 问题原因
+
+Credentials Tab 原本会读取范围内的凭据事件并在 Go 中逐条构建所有凭据的时间线，即使用户最终只查看其中一个凭据。事件数量和凭据数量增长后，隐藏时间线成为额外的扫描、传输和分配成本。
+
+### 优化内容
+
+- 把 Credential Timeline 的小时聚合下推到 SQLite，并保留首尾 partial raw edge。
+- 共用 UTC 小时可表达性检查；半小时、45 分钟时区和无法无损表达的范围安全回退 raw。
+- 新增精确 `credential_ids` 筛选，兼容 auth file、auth index、source hash 和 source-only identity。
+- 前端先加载凭据排行，只有用户选中凭据后才发起对应 Timeline 请求。
+- 保留取消、stale response 防护、加载状态和错误反馈。
+
+### 100k 当前 main 三次复测
+
+| 请求 | 平均耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| Credentials 排行与 Summary | 约 524ms | 约 847KB | 约 1.19 万 |
+| 单个选中凭据 Timeline | 约 50.0ms | 约 340KB | 约 3,275 |
+| 两阶段合计 | 约 565ms | 约 1.19MB | 约 1.52 万 |
+
+首次进入 Credentials 时只执行第一行；第二行仅在存在选中凭据且需要时间线时执行，避免为未查看的凭据构建 Timeline。
+
+## 阶段七：Hourly Rollup Projected Read
+
+### 问题原因
+
+Phase 2B 已经用小时汇总替代大量 raw scan，但 reader 仍会加载完整的 `hour + model + billing model + service tier` 行并构建完整 snapshot。只需要 model 聚合或 UTC day timeline 的调用方仍承担无关维度和中间对象的分配。
+
+### 优化内容
+
+- 增加 model-only 和 UTC daily projection。
+- 按 Summary、Model Stats 和 Timeline 的实际组合选择紧凑 snapshot。
+- 保留 partial raw edge、价格重算、checkpoint 检查和时区 fallback。
+- 不修改 schema 和 API。
+
+### 100k 核心路径当前 main 三次复测
+
+| 路径 | 平均耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| Raw | 约 830ms | 23.78MB | 约 186.5 万 |
+| Projected rollup | 约 24.0ms | 611KB | 7,900 |
+| 相对 Raw | 约快 34.6 倍 | 降低约 97.4% | 降低约 99.6% |
+
+与 Phase 2B 当时的 rollup 结果（约 39ms、9.51MB/op）相比，投影读取又把耗时降低约 38%，分配降低约 94%。
+
+## 阶段八：Latency Percentile Compact Read
+
+### 问题原因
+
+Latency 和 TTFT percentile 查询经 `database/sql` 读取可空数值时，会产生 integer → string → float 的逐行转换和临时对象。Trends、Models 和 Overview 的 percentile 路径因此保留了不必要的分配。
+
+### 优化内容与结果
+
+- SQLite 只投影有效的整数 latency/TTFT 样本。
+- Go 端直接读取紧凑整数并保持 nearest-rank 语义。
+- 覆盖 DST、非整小时时区、筛选、NULL 样本和 10k/100k 数据。
+- Trends 和 Models 的分配从约 7.20MB/op 降至约 4.80MB/op，降低约 33%，响应和筛选语义不变。
+
+当前 `main` 三次复测中，Trends 约 532～544ms、4.81MB/op，Models 约 543～560ms、4.80MB/op，与优化记录的紧凑分配水平一致。
+
+## 阶段九：Dashboard Refresh 有界并发
+
+### 问题原因
+
+小时汇总已大幅降低 Dashboard 核心统计成本，但 rolling 30m、health timeline、recent failures、channel stats 和 failure sources 等独立读取仍串行执行。数据量增大后，这些 recent/raw 查询成为刷新关键路径。
+
+### 优化内容与结果
+
+- 在现有四连接 SQLite 连接池内并行执行独立 Dashboard 查询。
+- 保留 context cancellation 和 first-error propagation。
+- 不增加常驻 recent-event cache，不改变响应合同。
+- 合入时的 10k、100k、1m benchmark 分别降低完整刷新延迟约 37%、44% 和 50%。
+
+当前 `main` 三次单次复测结果：
+
+| 数据量 | 完整刷新耗时 | B/op | allocs/op |
+|---|---:|---:|---:|
+| 10k | 约 39.7～43.2ms | 约 1.63MB | 约 2.05 万 |
+| 100k | 约 403～405ms | 约 1.64MB | 约 2.18 万 |
+
+分配量随事件规模基本稳定，耗时仍主要来自必须扫描 recent/raw 范围的查询。
+
+## 阶段十：Monitoring 完整请求去重与有界并发
 
 ### 问题原因
 
@@ -238,7 +350,7 @@ Request Monitoring 会在一次 analytics 请求中同时加载 Summary、Timeli
 
 在 `bin/tmp/db/data` 的 disposable SQLite backup 上，完成 cache-accounting migration 和 dashboard rollup 追平后：
 
-- Phase 1 后完整请求基线约 5.80s。
+- Monitoring 第一轮查询整形后的完整请求基线约 5.80s。
 - 本阶段 service 耗时稳定在 2.21～2.38s。
 - 相对上一阶段再降低约 59%～62%。
 - 7.58MB JSON 响应的序列化仅约 16ms，剩余耗时仍主要来自 SQLite 查询。
@@ -309,7 +421,7 @@ USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED=false
 
 ## 后续方向
 
-当前 Compact Summary、hourly rollup、latency percentile 紧凑读取、高维请求裁剪和 Monitoring 完整请求并发均已完成。剩余耗时主要依赖必须保留 raw 语义的查询：
+当前 Compact Summary、credential timeline SQL 预聚合与按需加载、hourly rollup 投影读取、latency percentile 紧凑读取、Dashboard/Monitoring 有界并发和高维请求裁剪均已完成。剩余耗时主要依赖必须保留 raw 语义的查询：
 
 - P95 latency 和 P95 TTFT。
 - Task buckets。

--- a/apps/docs/operations/update.md
+++ b/apps/docs/operations/update.md
@@ -1,0 +1,246 @@
+# 更新 CPA Manager Plus
+
+本页说明如何在不丢失 SQLite 数据、`data.key` 和本机 secret 的前提下更新 CPAMP。请选择与你当前部署方式对应的章节，不要用首次安装命令覆盖已有配置。
+
+## 更新前检查
+
+1. 阅读目标版本的 [版本说明](../reference/releases.md) 和 GitHub Release Upgrade Notes。
+2. 记录当前镜像标签、原生包版本、启动命令、环境变量和数据目录。
+3. 停止会修改相同 SQLite 的额外实例。同一个 CPA 用量队列只能由一个 Manager Server 消费。
+4. 备份完整数据和配置：
+   - `usage.sqlite`、`usage.sqlite-wal`、`usage.sqlite-shm`。
+   - `data.key`。
+   - 安装器目录中的 `secrets/`、`.env`、`compose.yaml` 或 `config.json`。
+   - 自定义反向代理、systemd、launchd 或 Windows 服务配置。
+
+详细备份方法见 [备份与恢复](./backup.md)。`data.key` 丢失后，SQLite 中加密保存的 CPA Management Key 无法恢复。
+
+## 更新后会发生什么
+
+- Manager Server 启动时自动执行兼容的 SQLite schema 和 metadata 迁移，不需要手工运行 SQL。
+- 大型历史数据修正可能在 HTTP 服务开始监听后继续后台执行。
+- migration 期间 account-history 或 dashboard-hourly rollup 可能暂停追平；相关页面会临时回退 raw events，性能可能暂时降低。
+- 不要为了加速 migration 或 rollup 重建而启动第二个 Manager Server 连接同一 SQLite 或消费同一 CPA 队列。
+- 可通过带管理员密钥的 `GET /status` 查看迁移、采集器和事件状态。
+
+## 一键安装器生成的 Docker 部署
+
+安装器生成的 Docker 部署不需要重新运行安装脚本。进入原安装目录更新镜像：
+
+```bash
+cd "$HOME/cpa-manager-plus"
+docker compose pull
+docker compose up -d
+docker compose ps
+```
+
+如果安装时通过 `CPAMP_INSTALL_DIR` 选择了其他目录，请替换上面的路径。
+
+完整 CPA + CPAMP 安装会同时拉取 Compose 中配置的 CPA 和 CPAMP 镜像。只想更新 CPAMP 时可以指定服务：
+
+```bash
+docker compose pull cpa-manager-plus
+docker compose up -d cpa-manager-plus
+```
+
+不要为升级设置 `CPAMP_OVERWRITE=1` 重跑安装器。该选项用于重新生成配置，可能覆盖你维护的 `.env`、`compose.yaml`、CPA 配置或 `run.sh`。
+
+## 手动 Docker Compose
+
+### 使用 `latest`
+
+```bash
+docker compose pull cpa-manager-plus
+docker compose up -d cpa-manager-plus
+docker compose logs --tail=100 cpa-manager-plus
+```
+
+### 使用固定版本
+
+先把 Compose 中的镜像从旧版本改为目标版本，例如：
+
+```yaml
+services:
+  cpa-manager-plus:
+    image: seakee/cpa-manager-plus:vX.Y.Z
+```
+
+然后执行：
+
+```bash
+docker compose pull cpa-manager-plus
+docker compose up -d cpa-manager-plus
+```
+
+也可以使用对应的 GHCR 镜像：
+
+```text
+ghcr.io/seakee/cpa-manager-plus:vX.Y.Z
+```
+
+确认新容器继续挂载原来的 `/data` volume 或宿主机目录。不要为了更新创建新的空 volume。
+
+## 手动 `docker run`
+
+先检查当前容器的端口、volume、环境变量、network 和 `--add-host` 参数：
+
+```bash
+docker inspect cpa-manager-plus
+```
+
+拉取目标镜像并重建容器。下面是最小示例，实际命令必须保留原部署的全部参数：
+
+```bash
+docker pull seakee/cpa-manager-plus:vX.Y.Z
+docker stop cpa-manager-plus
+docker rm cpa-manager-plus
+docker run -d \
+  --name cpa-manager-plus \
+  --restart unless-stopped \
+  -p 18317:18317 \
+  -v cpa-manager-plus-data:/data \
+  seakee/cpa-manager-plus:vX.Y.Z
+```
+
+如果 CPA 跑在 Linux 宿主机，继续保留：
+
+```text
+--add-host=host.docker.internal:host-gateway
+```
+
+删除旧容器不会删除命名 volume，但删除 volume 会丢失数据。
+
+## 一键安装器生成的原生部署
+
+安装器通常生成如下结构：
+
+```text
+runtime/cpa-manager-plus_<version>_<os>_<arch>/
+data/
+secrets/
+run.sh
+cpa-manager-plus.service
+```
+
+更新时不要直接覆盖正在运行的旧目录：
+
+1. 停止当前进程或 systemd 服务。
+2. 备份 `data/`、`secrets/`、旧 runtime 目录、`run.sh` 和 service 文件。
+3. 从 GitHub Releases 下载并解压目标包到 `runtime/` 下的新版本目录。
+4. 把旧版本目录的 `config.json` 复制到新版本目录。安装器生成的相对路径会继续指向共享的 `data/` 和 `secrets/`。
+5. 把 `run.sh` 的工作目录和二进制路径改为新版本目录。
+6. 如果使用安装器生成的 systemd 文件，同步更新 `WorkingDirectory` 和 `ExecStart`，然后执行 `systemctl daemon-reload`。
+7. 启动并完成验证后再决定是否清理旧 runtime；保留旧包可以缩短程序回滚时间。
+
+不要只复制 `usage.sqlite` 而遗漏 WAL/SHM；备份应在进程停止后进行，或使用 [备份与恢复](./backup.md) 中的 SQLite 安全方法。
+
+## 手动原生包
+
+### macOS / Linux 前台或控制脚本
+
+1. 执行 `./cpa-manager-plusctl stop`，或停止你自己的进程管理器。
+2. 备份数据目录和 `data.key`。
+3. 解压新包到新的版本目录。
+4. 继续使用原来的外部 `USAGE_DATA_DIR` / `USAGE_DB_PATH`，或在停机状态下把 `config.json` 和 `data/` 复制到新目录。
+5. 使用新目录里的控制脚本启动：
+
+```bash
+./cpa-manager-plusctl start
+./cpa-manager-plusctl status
+./cpa-manager-plusctl logs
+```
+
+不要把新包直接解压到仍在运行的目录，以免二进制、控制脚本和静态面板来自不同版本。
+
+### Linux systemd 固定目录
+
+如果服务始终从 `/opt/cpa-manager-plus/cpa-manager-plus` 启动：
+
+```bash
+sudo systemctl stop cpa-manager-plus
+sudo cp -a /var/lib/cpa-manager-plus "/var/lib/cpa-manager-plus.backup.$(date +%Y%m%d%H%M%S)"
+sudo cp -a cpa-manager-plus_vX.Y.Z_linux_amd64/. /opt/cpa-manager-plus/
+sudo systemctl start cpa-manager-plus
+sudo systemctl status cpa-manager-plus
+```
+
+保持 `/var/lib/cpa-manager-plus` 独立于程序目录，可以避免更新包覆盖运行数据。
+
+### Windows
+
+1. 使用控制脚本或服务管理器停止 CPAMP：
+
+```powershell
+.\cpa-manager-plusctl.ps1 stop
+```
+
+2. 备份 `data`、`config.json` 和服务配置。
+3. 将新 ZIP 解压到新的版本目录。
+4. 继续使用原数据目录，或在停止状态下复制配置和数据。
+5. 使用新目录的脚本或 Windows 服务启动并检查日志：
+
+```powershell
+.\cpa-manager-plusctl.ps1 start
+.\cpa-manager-plusctl.ps1 status
+.\cpa-manager-plusctl.ps1 logs
+```
+
+如果 Windows 服务的可执行文件路径包含版本目录，需要同步修改服务配置。
+
+## CPA 托管面板兼容模式
+
+CPA 托管面板只更新浏览器前端，不会更新 Manager Server 二进制、SQLite schema 或后台采集能力。
+
+确认 CPA 指向本项目：
+
+```text
+remote-management.panel-repo = https://github.com/seakee/CPA-Manager-Plus
+```
+
+CPA 通常会自动更新缓存面板。如果仍显示旧版本，删除 CPA 工作目录中的缓存文件并重新加载或重启 CPA：
+
+```bash
+rm static/management.html
+```
+
+如果开启了 `Disable Panel Auto Updates`，只有缓存文件不存在时 CPA 才会重新下载。删除前确认操作的是 CPA 的 panel cache，不是 Manager Server 的持久化数据。
+
+## 自定义 `management.html` 或 `PANEL_PATH`
+
+如果从 Release 手工部署单文件面板：
+
+1. 下载目标版本的 `management.html`。
+2. 校验 Release 中提供的 checksum。
+3. 先保存旧文件，再用新文件原子替换静态站点或 `PANEL_PATH` 指向的文件。
+4. 刷新反向代理缓存和浏览器缓存。
+
+只替换 `management.html` 不会更新 Manager Server API。前端和 Manager Server 跨多个版本混用可能出现字段或功能不兼容，建议使用同一 CPAMP Release 的面板和 Manager Server。
+
+## 更新后验证
+
+基础检查：
+
+```bash
+curl -f http://127.0.0.1:18317/health
+curl -f http://127.0.0.1:18317/usage-service/info
+curl -f -H "Authorization: Bearer <CPAMP_ADMIN_KEY>" \
+  http://127.0.0.1:18317/status
+```
+
+确认：
+
+- 面板和服务显示目标版本。
+- `configured` 为预期值。
+- `collector.lastError` 为空或可解释。
+- `lastConsumedAt`、`lastInsertedAt` 和 `eventCount` 正常更新。
+- Dashboard、请求监控和 Usage Analytics 能读取数据。
+- `/status` 中的后台 migration 最终完成，rollup checkpoint 继续推进。
+- 反向代理部署的 `/management.html`、`/usage-service/*` 和管理 API 路径仍指向正确服务。
+
+## 回滚原则
+
+- Docker：将镜像标签改回旧版本并重建容器，继续挂载更新前的数据备份。
+- 原生包：停止新版本，恢复旧二进制、配置和更新前的数据备份后再启动。
+- 单文件面板：恢复旧 `management.html`。
+- 不要假设旧程序一定能读取新版本迁移后的数据库。涉及 schema 或数据语义变更时，应同时恢复更新前的 SQLite、WAL/SHM 和 `data.key`。
+- 如果失败原因不明确，保留新旧日志和数据库副本，不要反复启动多个版本写入同一数据库。


### PR DESCRIPTION
## Summary
Expand the July 2026 performance report with the optimization phases completed after the initial report and fresh benchmarks from current main.

Add a bilingual, deployment-wide CPAMP upgrade guide covering Docker, native packages, CPA-hosted panels, verification, and rollback.

## Scope
- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Document Compact Summary, credential timeline, projected rollup, percentile-read, Dashboard, and Monitoring optimizations.
- Update the Overview benchmark summary to approximately 1.12s and 5.23MB per operation on current main.
- Add Chinese and English upgrade guides for every supported installation and deployment mode.
- Add the upgrade guides to the VitePress operations navigation.

## User Impact
Operators get one upgrade reference with mode-specific backup, migration, verification, and rollback guidance. Readers also get complete and reproducible performance results for the July optimization work.

## Compatibility / Runtime Notes
- CPA panel mode: Documentation explains panel-cache refresh behavior; no runtime change.
- Manager Server mode: Documentation covers automatic migrations, rollup catch-up, and status verification; no runtime change.
- Full Docker / native packages: Documentation consolidates existing upgrade procedures; no packaging or image change.

## Data / Security Notes
The new guide emphasizes backing up SQLite, WAL/SHM files, data.key, and installer-managed secrets. No data handling or security behavior changes.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert commit 9f8d41cc to remove the documentation and navigation changes.

## Verification
- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:
```text
go test ./internal/service/monitoring -run '^$' -bench 'BenchmarkUsageAnalyticsIncludeProfiles/...' -benchmem -count=3
go test ./internal/service/monitoring -run '^$' -bench 'BenchmarkUsageAnalyticsHourlyCorePaths/(raw|rollup)$' -benchmem -count=3
go test ./internal/service/dashboard -run '^$' -bench 'BenchmarkDashboardMonitoringRefreshPaths/events_(10k|100k)/dashboard_full_refresh$' -benchmem -benchtime=1x -count=3
npm --workspace apps/docs run build
git diff --check
```

## Screenshots / Recordings
N/A — documentation-only change.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A