### PR TITLE
fix(quota): preserve Claude scoped quota identities

### DIFF
--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -945,6 +945,63 @@ describe('fetchClaudeQuota', () => {
     ]);
   });
 
+  it('prefers an active percent-only scoped candidate over an inactive reset-only candidate in both orders', async () => {
+    const resetAt = '2026-07-10T10:00:00Z';
+    const activePercentOnly = {
+      kind: 'weekly_scoped',
+      group: 'weekly',
+      percent: 35,
+      scope: { model: { id: 'model-partial', display_name: 'Active partial' } },
+      is_active: true,
+    };
+    const inactiveResetOnly = {
+      kind: 'weekly_scoped',
+      group: 'weekly',
+      percent: null,
+      resets_at: resetAt,
+      scope: { model: { id: 'model-partial', display_name: 'Inactive partial' } },
+      is_active: false,
+    };
+
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: { limits: [activePercentOnly, inactiveResetOnly] },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'))
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: { limits: [inactiveResetOnly, activePercentOnly] },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const first = await fetchClaudeQuota(
+      { name: 'claude-a.json', type: 'claude', authIndex: 'claude-a' },
+      t
+    );
+    const reversed = await fetchClaudeQuota(
+      { name: 'claude-b.json', type: 'claude', authIndex: 'claude-b' },
+      t
+    );
+
+    const expected = [
+      {
+        id: 'weekly-scoped-id-model-partial',
+        label: 'Active partial',
+        usedPercent: 35,
+        resetLabel: '-',
+      },
+    ];
+    expect(first.windows).toEqual(expected);
+    expect(reversed.windows).toEqual(expected);
+  });
+
   it('ignores unscoped duplicates, unrelated kinds, and malformed scoped limits', async () => {
     mocks.request
       .mockResolvedValueOnce({
@@ -1130,8 +1187,8 @@ describe('fetchClaudeQuota', () => {
     expect(result.windows.map((window) => [window.id, window.label, window.usedPercent])).toEqual([
       ['five-hour', 'claude_quota.five_hour', 10],
       ['seven-day', 'claude_quota.seven_day', 20],
-      ['weekly-scoped-id-model-a1', 'Alpha', 40],
-      ['weekly-scoped-id-model-a2', 'Alpha', 50],
+      ['weekly-scoped-id-model-a1', 'Alpha (model-a1)', 40],
+      ['weekly-scoped-id-model-a2', 'Alpha (model-a2)', 50],
       ['weekly-scoped-id-model-z', 'Zulu renamed', 90],
       ['seven-day-oauth-apps', 'claude_quota.seven_day_oauth_apps', 30],
     ]);
@@ -1150,8 +1207,8 @@ describe('fetchClaudeQuota', () => {
     const withoutId = {
       kind: 'weekly_scoped',
       group: 'weekly',
-      percent: 20,
-      resets_at: '2026-07-09T10:00:00Z',
+      percent: 40,
+      resets_at: resetAt,
       scope: { model: { id: null, display_name: 'Shared Model' } },
       is_active: true,
     };
@@ -1193,6 +1250,80 @@ describe('fetchClaudeQuota', () => {
     ];
     expect(withoutIdFirst.windows).toEqual(expectedWindows);
     expect(withIdFirst.windows).toEqual(expectedWindows);
+  });
+
+  it('preserves non-equivalent label-only scoped data instead of dropping it', async () => {
+    const resetAt = '2026-07-10T10:00:00Z';
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 40,
+              resets_at: resetAt,
+              scope: { model: { id: 'model-shared', display_name: 'Shared Model' } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 20,
+              resets_at: resetAt,
+              scope: { model: { display_name: 'Shared Model' } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      { name: 'claude-1.json', type: 'claude', authIndex: 'claude-1' },
+      t
+    );
+
+    expect(result.windows.map((window) => [window.id, window.label, window.usedPercent])).toEqual([
+      ['weekly-scoped-id-model-shared', 'Shared Model (model-shared)', 40],
+      ['weekly-scoped-shared%20model', 'Shared Model', 20],
+    ]);
+  });
+
+  it('ignores unrelated nested display names but accepts model details display names', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          limits: [
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 10,
+              scope: { model: { metadata: { display_name: 'Ignored' } } },
+            },
+            {
+              kind: 'weekly_scoped',
+              group: 'weekly',
+              percent: 20,
+              scope: { model: { details: { display_name: 'Details model' } } },
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error('profile unavailable'));
+
+    const result = await fetchClaudeQuota(
+      { name: 'claude-1.json', type: 'claude', authIndex: 'claude-1' },
+      t
+    );
+
+    expect(result.windows.map((window) => window.label)).toEqual(['Details model']);
   });
 
   it('keeps a label-only scoped entry separate when the label maps to multiple ids', async () => {

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -516,19 +516,22 @@ const parseClaudeLimitWindowValues = (
   return { usedPercent, resetLabel };
 };
 
-const findClaudeModelDisplayName = (value: unknown, depth = 0): string | null => {
+const findClaudeModelDisplayName = (value: unknown): string | null => {
   if (!isRecord(value)) return null;
 
-  const rawDisplayName = value.display_name ?? value.displayName;
-  if (typeof rawDisplayName === 'string') {
-    const direct = rawDisplayName.trim().replace(/\s+/g, ' ');
-    if (direct) return direct;
-  }
-  if (depth >= 1) return null;
+  const readDisplayName = (candidate: Record<string, unknown>): string | null => {
+    const rawDisplayName = candidate.display_name ?? candidate.displayName;
+    if (typeof rawDisplayName !== 'string') return null;
+    const normalized = rawDisplayName.trim().replace(/\s+/g, ' ');
+    return normalized || null;
+  };
 
-  for (const nested of Object.values(value)) {
-    const label = findClaudeModelDisplayName(nested, depth + 1);
-    if (label) return label;
+  const direct = readDisplayName(value);
+  if (direct) return direct;
+
+  const details = isRecord(value.details) ? value.details : null;
+  if (details) {
+    return readDisplayName(details);
   }
   return null;
 };
@@ -555,24 +558,54 @@ const encodeClaudeWindowIdPart = (value: string): string => {
 type ClaudeScopedWeeklyWindowEntry = {
   activityRank: number;
   identityKey: string;
+  modelId: string | null;
   resetAtRank: number;
   sortLabel: string;
   usedPercentRank: number;
   window: ClaudeQuotaWindow;
 };
 
+const hasValidClaudeReset = (entry: ClaudeScopedWeeklyWindowEntry): boolean =>
+  entry.resetAtRank >= 0;
+
+const getClaudeScopedCompletenessRank = (entry: ClaudeScopedWeeklyWindowEntry): number =>
+  (entry.usedPercentRank >= 0 ? 1 : 0) + (hasValidClaudeReset(entry) ? 1 : 0);
+
 const shouldReplaceClaudeScopedWindow = (
   existing: ClaudeScopedWeeklyWindowEntry,
   candidate: ClaudeScopedWeeklyWindowEntry
 ): boolean => {
-  if (candidate.resetAtRank !== existing.resetAtRank) {
+  if (
+    hasValidClaudeReset(existing) &&
+    hasValidClaudeReset(candidate) &&
+    candidate.resetAtRank !== existing.resetAtRank
+  ) {
     return candidate.resetAtRank > existing.resetAtRank;
   }
   if (candidate.activityRank !== existing.activityRank) {
     return candidate.activityRank > existing.activityRank;
   }
+  const candidateCompleteness = getClaudeScopedCompletenessRank(candidate);
+  const existingCompleteness = getClaudeScopedCompletenessRank(existing);
+  if (candidateCompleteness !== existingCompleteness) {
+    return candidateCompleteness > existingCompleteness;
+  }
+  if (hasValidClaudeReset(existing) !== hasValidClaudeReset(candidate)) {
+    return hasValidClaudeReset(candidate);
+  }
+  if (candidate.resetAtRank !== existing.resetAtRank) {
+    return candidate.resetAtRank > existing.resetAtRank;
+  }
   return candidate.usedPercentRank > existing.usedPercentRank;
 };
+
+const areEquivalentClaudeScopedWindows = (
+  left: ClaudeScopedWeeklyWindowEntry,
+  right: ClaudeScopedWeeklyWindowEntry
+): boolean =>
+  left.activityRank === right.activityRank &&
+  left.resetAtRank === right.resetAtRank &&
+  left.usedPercentRank === right.usedPercentRank;
 
 type ClaudeBaseLimitCandidate = {
   completenessRank: number;
@@ -671,6 +704,7 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
       const candidate: ClaudeScopedWeeklyWindowEntry = {
         activityRank,
         identityKey,
+        modelId,
         resetAtRank: resolveClaudeLimitResetRank(rawLimit),
         sortLabel: labelKey,
         usedPercentRank: values.usedPercent ?? -1,
@@ -701,20 +735,18 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
     if (!identityKey) continue;
     const idEntry = idWindowsByModel.get(identityKey);
     if (!idEntry) continue;
-    if (shouldReplaceClaudeScopedWindow(idEntry, labelEntry)) {
-      idWindowsByModel.set(identityKey, {
-        ...labelEntry,
-        identityKey,
-        window: {
-          ...labelEntry.window,
-          id: idEntry.window.id,
-        },
-      });
+    if (areEquivalentClaudeScopedWindows(idEntry, labelEntry)) {
+      labelOnlyWindowsByModel.delete(labelEntry.identityKey);
     }
-    labelOnlyWindowsByModel.delete(labelEntry.identityKey);
   }
 
-  return [...idWindowsByModel.values(), ...labelOnlyWindowsByModel.values()]
+  const entries = [...idWindowsByModel.values(), ...labelOnlyWindowsByModel.values()];
+  const labelCounts = new Map<string, number>();
+  for (const entry of entries) {
+    labelCounts.set(entry.sortLabel, (labelCounts.get(entry.sortLabel) ?? 0) + 1);
+  }
+
+  return entries
     .sort((left, right) => {
       if (left.sortLabel !== right.sortLabel) {
         return left.sortLabel < right.sortLabel ? -1 : 1;
@@ -725,7 +757,10 @@ const buildClaudeScopedWeeklyWindows = (payload: ClaudeUsagePayload): ClaudeQuot
           ? 1
           : 0;
     })
-    .map(({ window }) => window);
+    .map(({ sortLabel, modelId, window }) => {
+      if (!modelId || (labelCounts.get(sortLabel) ?? 0) < 2) return window;
+      return { ...window, label: `${window.label} (${modelId})` };
+    });
 };
 
 const buildClaudeQuotaWindows = (


### PR DESCRIPTION
## Summary

Fix Claude model-scoped weekly quota selection when upstream responses contain partial, duplicated, or inconsistently identified model entries.

## Scope

- [x] Frontend panel
- [x] CPA panel mode
- [x] Full Docker mode

## Changes

- Prefer active percent-only entries over inactive reset-only duplicates when reset data is incomplete.
- Merge ID-backed and label-only entries only when their quota values are equivalent.
- Preserve non-equivalent label-only entries to avoid silent data loss.
- Disambiguate duplicate model labels with the model ID.
- Restrict display-name lookup to supported direct and details fields.
- Add regression coverage for ordering, identity collisions, partial values, and nested metadata.

## User Impact

Claude scoped quota entries are represented more reliably when the upstream response contains duplicate or partial model records.

## Compatibility / Runtime Notes

- CPA panel mode: no configuration changes.
- Manager Server mode: no configuration changes.
- Full Docker / native packages: no configuration changes.

## Data / Security Notes

N/A.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert commit 76c7dfac.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test
npm run build
git diff --check
```

## Screenshots / Recordings

N/A.

## Docs

- [x] Not needed

## Related

Refs #344
