### PR TITLE
fix(ai-providers): prevent key test tooltip clipping

### DIFF
--- a/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx
+++ b/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx
@@ -1,6 +1,9 @@
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { OpenAIKeyTestStatusIndicator } from './OpenAIKeyTestStatusIndicator';
+import {
+  OpenAIKeyTestStatusIndicator,
+  resolveOpenAIKeyTestTooltipPosition,
+} from './OpenAIKeyTestStatusIndicator';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -18,9 +21,7 @@ describe('OpenAIKeyTestStatusIndicator', () => {
 
   it('shows a tooltip on focus when an error message exists', () => {
     act(() => {
-      renderer = create(
-        <OpenAIKeyTestStatusIndicator status="error" message="invalid api key" />
-      );
+      renderer = create(<OpenAIKeyTestStatusIndicator status="error" message="invalid api key" />);
     });
 
     const trigger = renderer!.root.find(
@@ -76,5 +77,31 @@ describe('OpenAIKeyTestStatusIndicator', () => {
     );
     expect(trigger.props.tabIndex).toBe(-1);
     expect(() => renderer!.root.findByProps({ role: 'tooltip' })).toThrow();
+  });
+
+  it('keeps a long tooltip inside the viewport near the left edge', () => {
+    const position = resolveOpenAIKeyTestTooltipPosition(
+      { bottom: 120, height: 16, left: 20, top: 104, width: 16 },
+      320,
+      640
+    );
+
+    expect(position.placement).toBe('below');
+    expect(position.style.left).toBe(160);
+    expect(position.style.maxWidth).toBe(296);
+    expect(position.style.top).toBe(130);
+  });
+
+  it('places the tooltip above when there is more room above the trigger', () => {
+    const position = resolveOpenAIKeyTestTooltipPosition(
+      { bottom: 620, height: 16, left: 292, top: 604, width: 16 },
+      320,
+      640
+    );
+
+    expect(position.placement).toBe('above');
+    expect(position.style.left).toBe(160);
+    expect(position.style.bottom).toBe(46);
+    expect(position.style.maxHeight).toBe(240);
   });
 });

--- a/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.tsx
+++ b/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.tsx
@@ -1,8 +1,82 @@
-import { useId, useState } from 'react';
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
 
 type OpenAIKeyTestStatus = 'idle' | 'loading' | 'success' | 'error';
+
+const TOOLTIP_VIEWPORT_MARGIN = 12;
+const TOOLTIP_OFFSET = 10;
+const TOOLTIP_MAX_WIDTH = 360;
+const TOOLTIP_MAX_HEIGHT = 240;
+
+type TooltipPlacement = 'above' | 'below';
+
+export type OpenAIKeyTestTooltipPosition = {
+  placement: TooltipPlacement;
+  style: CSSProperties;
+};
+
+type TooltipAnchorRect = Pick<DOMRect, 'bottom' | 'height' | 'left' | 'top' | 'width'>;
+
+const clampNumber = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const resolveOpenAIKeyTestTooltipPosition = (
+  rect: TooltipAnchorRect,
+  viewportWidth: number,
+  viewportHeight: number
+): OpenAIKeyTestTooltipPosition => {
+  const maxWidth = Math.max(
+    0,
+    Math.min(TOOLTIP_MAX_WIDTH, viewportWidth - TOOLTIP_VIEWPORT_MARGIN * 2)
+  );
+  const halfMaxWidth = maxWidth / 2;
+  const anchorCenter = rect.left + rect.width / 2;
+  const left = clampNumber(
+    anchorCenter,
+    TOOLTIP_VIEWPORT_MARGIN + halfMaxWidth,
+    Math.max(
+      TOOLTIP_VIEWPORT_MARGIN + halfMaxWidth,
+      viewportWidth - TOOLTIP_VIEWPORT_MARGIN - halfMaxWidth
+    )
+  );
+  const spaceAbove = rect.top - TOOLTIP_VIEWPORT_MARGIN - TOOLTIP_OFFSET;
+  const spaceBelow = viewportHeight - rect.bottom - TOOLTIP_VIEWPORT_MARGIN - TOOLTIP_OFFSET;
+  const placement: TooltipPlacement =
+    spaceAbove >= TOOLTIP_MAX_HEIGHT || spaceAbove >= spaceBelow ? 'above' : 'below';
+  const availableHeight = Math.max(0, placement === 'above' ? spaceAbove : spaceBelow);
+  const baseStyle: CSSProperties = {
+    left,
+    maxHeight: Math.min(TOOLTIP_MAX_HEIGHT, availableHeight),
+    maxWidth,
+  };
+
+  return placement === 'above'
+    ? {
+        placement,
+        style: {
+          ...baseStyle,
+          bottom: viewportHeight - rect.top + TOOLTIP_OFFSET,
+        },
+      }
+    : {
+        placement,
+        style: {
+          ...baseStyle,
+          top: rect.bottom + TOOLTIP_OFFSET,
+        },
+      };
+};
 
 interface OpenAIKeyTestStatusIndicatorProps {
   status: OpenAIKeyTestStatus;
@@ -13,12 +87,7 @@ function StatusLoadingIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className={styles.statusIconSpin}>
       <circle cx="8" cy="8" r="7" stroke="currentColor" strokeOpacity="0.25" strokeWidth="2" />
-      <path
-        d="M8 1A7 7 0 0 1 8 15"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
+      <path d="M8 1A7 7 0 0 1 8 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
     </svg>
   );
 }
@@ -80,11 +149,69 @@ export function OpenAIKeyTestStatusIndicator({
 }: OpenAIKeyTestStatusIndicatorProps) {
   const { t } = useTranslation();
   const tooltipId = useId();
+  const triggerRef = useRef<HTMLSpanElement | null>(null);
+  const rafRef = useRef<number | null>(null);
   const [open, setOpen] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState<OpenAIKeyTestTooltipPosition | null>(null);
+  const isBrowser = typeof document !== 'undefined';
 
   const trimmedMessage = String(message ?? '').trim();
   const resolvedMessage = trimmedMessage || t('ai_providers.openai_test_failed');
   const hasTooltip = status === 'error' && Boolean(resolvedMessage);
+
+  const updateTooltipPosition = useCallback(() => {
+    if (!triggerRef.current || typeof window === 'undefined') return;
+    setTooltipPosition(
+      resolveOpenAIKeyTestTooltipPosition(
+        triggerRef.current.getBoundingClientRect(),
+        window.innerWidth,
+        window.innerHeight
+      )
+    );
+  }, []);
+
+  const scheduleTooltipPositionUpdate = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (rafRef.current !== null) window.cancelAnimationFrame(rafRef.current);
+    rafRef.current = window.requestAnimationFrame(() => {
+      rafRef.current = null;
+      updateTooltipPosition();
+    });
+  }, [updateTooltipPosition]);
+
+  const showTooltip = useCallback(() => {
+    updateTooltipPosition();
+    setOpen(true);
+  }, [updateTooltipPosition]);
+
+  const hideTooltip = useCallback(() => setOpen(false), []);
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!open || typeof window === 'undefined') return undefined;
+    scheduleTooltipPositionUpdate();
+    window.addEventListener('resize', scheduleTooltipPositionUpdate);
+    window.addEventListener('scroll', scheduleTooltipPositionUpdate, true);
+
+    return () => {
+      window.removeEventListener('resize', scheduleTooltipPositionUpdate);
+      window.removeEventListener('scroll', scheduleTooltipPositionUpdate, true);
+    };
+  }, [open, scheduleTooltipPositionUpdate]);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null && typeof window !== 'undefined') {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+    },
+    []
+  );
 
   const ariaLabel =
     status === 'error'
@@ -95,27 +222,35 @@ export function OpenAIKeyTestStatusIndicator({
           ? t('ai_providers.openai_test_running')
           : 'Idle';
 
+  const tooltip = (
+    <span
+      id={tooltipId}
+      role="tooltip"
+      className={styles.keyStatusTooltip}
+      style={isBrowser ? tooltipPosition?.style : undefined}
+    >
+      <span className={styles.keyStatusTooltipText}>{resolvedMessage}</span>
+    </span>
+  );
+
   return (
     <span
+      ref={triggerRef}
       className={`${styles.keyStatusTrigger} ${hasTooltip ? styles.keyStatusTriggerInteractive : ''}`}
       tabIndex={hasTooltip ? 0 : -1}
       aria-label={ariaLabel}
       aria-describedby={hasTooltip && open ? tooltipId : undefined}
-      onMouseEnter={hasTooltip ? () => setOpen(true) : undefined}
-      onMouseLeave={hasTooltip ? () => setOpen(false) : undefined}
-      onFocus={hasTooltip ? () => setOpen(true) : undefined}
-      onBlur={hasTooltip ? () => setOpen(false) : undefined}
+      onMouseEnter={hasTooltip ? showTooltip : undefined}
+      onMouseLeave={hasTooltip ? hideTooltip : undefined}
+      onFocus={hasTooltip ? showTooltip : undefined}
+      onBlur={hasTooltip ? hideTooltip : undefined}
+      onKeyDown={hasTooltip ? handleKeyDown : undefined}
     >
       <StatusIcon status={status} />
-      {hasTooltip && open ? (
-        <span
-          id={tooltipId}
-          role="tooltip"
-          className={`${styles.statusTooltip} ${styles.keyStatusTooltip}`}
-        >
-          <span className={styles.keyStatusTooltipText}>{resolvedMessage}</span>
-        </span>
-      ) : null}
+      {hasTooltip && open && !isBrowser ? tooltip : null}
+      {hasTooltip && open && isBrowser && tooltipPosition
+        ? createPortal(tooltip, document.body)
+        : null}
     </span>
   );
 }

--- a/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
+++ b/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
@@ -817,11 +817,22 @@
 }
 
 .keyStatusTooltip {
-  bottom: calc(100% + 10px);
+  position: fixed;
+  transform: translateX(-50%);
   width: max-content;
-  max-width: min(280px, 42vw);
+  padding: 8px 10px;
+  overflow-y: auto;
+  background: var(--bg-primary, #fff);
+  border: 1px solid var(--border-subtle, #d8e5f2);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  color: var(--text-primary);
+  font-size: 11px;
+  line-height: 1.5;
+  pointer-events: none;
   white-space: normal;
   text-align: left;
+  z-index: $z-dropdown;
 }
 
 .keyStatusTooltipText {
@@ -928,5 +939,4 @@
     background: rgba($error-color, 0.24);
     color: #f1b0a6;
   }
-
 }


### PR DESCRIPTION
## Summary
Fix OpenAI-compatible provider key-test error tooltips being clipped by the horizontally scrollable key table.
Render the tooltip outside the table overflow boundary and keep long error details within the visible viewport.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Render per-key test error tooltips through a body-level portal.
- Clamp tooltip width and position to the viewport and choose above/below placement based on available space.
- Reposition open tooltips on scrolling or viewport resizing and add positioning regression tests.

## User Impact
Users can read the complete model-test error message instead of seeing it clipped by the API-key table.

## Compatibility / Runtime Notes
- CPA panel mode: Uses the shared frontend component; no API or configuration changes.
- Manager Server mode: Server APIs and persistence are unchanged.
- Full Docker / native packages: The embedded frontend receives the same tooltip behavior after the normal panel build.

## Data / Security Notes
N/A. The change only affects presentation of error messages already available in the authenticated frontend.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert commit `bd4e23ed` to restore the previous inline tooltip behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm --workspace apps/web run test -- src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx
# 1 file passed, 5 tests passed

npm run type-check
npm run lint
npm run test
# 98 files passed, 926 tests passed

npm run build
# Vite single-file production build completed successfully

npm exec prettier -- --check apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.tsx apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx apps/web/src/features/aiProviders/AiProvidersPage.module.scss
git diff --check
```

Manual UI verification was not performed because an interactive browser surface was unavailable in the implementation session.

## Screenshots / Recordings
Before: see the reproduction screenshot in issue #384.
After: not captured; viewport placement and overflow behavior are covered by focused regression tests.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
Fixes #384