### PR TITLE
fix(web): copy original client API keys in monitoring views

### DIFF
--- a/apps/web/src/features/monitoring/components/ApiKeySummaryPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/ApiKeySummaryPanel.test.tsx
@@ -1,0 +1,102 @@
+import { act } from 'react';
+import { create, type ReactTestRenderer } from 'react-test-renderer';
+import type { TFunction } from 'i18next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MonitoringApiKeyRow } from '@/features/monitoring/hooks/useMonitoringData';
+import { ApiKeySummaryPanel } from './ApiKeySummaryPanel';
+
+const { copyToClipboard } = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(async () => true),
+}));
+
+vi.mock('@/utils/clipboard', () => ({ copyToClipboard }));
+
+const t = ((key: string) => (key === 'common.copy' ? 'Copy' : key)) as unknown as TFunction;
+
+const createRow = (overrides: Partial<MonitoringApiKeyRow> = {}): MonitoringApiKeyRow => ({
+  id: 'hash-a',
+  apiKeyHash: 'hash-a',
+  apiKeyLabel: 'Team A',
+  apiKeyMasked: 'sk********aa',
+  apiKeyCopyValue: 'sk-original-aa',
+  isUnknown: false,
+  authLabels: [],
+  sourceLabels: [],
+  channels: [],
+  totalCalls: 2,
+  successCalls: 2,
+  failureCalls: 0,
+  successRate: 1,
+  inputTokens: 10,
+  outputTokens: 5,
+  cachedTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 15,
+  totalCost: 0,
+  averageLatencyMs: null,
+  lastSeenAt: 1_780_000_000_000,
+  models: [],
+  ...overrides,
+});
+
+const renderPanel = (row: MonitoringApiKeyRow) => {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <ApiKeySummaryPanel
+        rows={[row]}
+        columns={[{ key: 'api-key', label: 'API Key' }]}
+        pagination={{
+          currentPage: 1,
+          totalPages: 1,
+          pageItems: [row],
+          startItem: 1,
+          endItem: 1,
+        }}
+        expandedApiKeys={{}}
+        hasPrices={false}
+        locale="en-US"
+        pageSize={10}
+        pageSizeOptions={[10]}
+        emptyState="Empty"
+        t={t}
+        onToggleApiKey={vi.fn()}
+        onPageChange={vi.fn()}
+        onPageSizeChange={vi.fn()}
+      />
+    );
+  });
+  return renderer;
+};
+
+beforeEach(() => {
+  copyToClipboard.mockReset();
+  copyToClipboard.mockResolvedValue(true);
+});
+
+describe('ApiKeySummaryPanel', () => {
+  it('copies the original configured API key instead of its masked label', async () => {
+    const renderer = renderPanel(createRow());
+    const copyButton = renderer.root
+      .findAllByType('button')
+      .find((node) => node.props['aria-label'] === 'Copy');
+    if (!copyButton) throw new Error('API key copy button not found');
+
+    act(() => {
+      copyButton.props.onClick();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(copyToClipboard).toHaveBeenCalledWith('sk-original-aa');
+    expect(copyToClipboard).not.toHaveBeenCalledWith('sk********aa');
+  });
+
+  it('does not offer a misleading copy button when the original key is unavailable', () => {
+    const renderer = renderPanel(createRow({ apiKeyCopyValue: undefined }));
+
+    expect(
+      renderer.root.findAllByType('button').some((node) => node.props['aria-label'] === 'Copy')
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/monitoring/components/ApiKeySummaryPanel.tsx
+++ b/apps/web/src/features/monitoring/components/ApiKeySummaryPanel.tsx
@@ -178,7 +178,7 @@ function ApiKeySummaryPrimary({
   const keyLabel = row.isUnknown
     ? t('monitoring.api_key_unknown_label')
     : row.apiKeyLabel || row.apiKeyMasked || t('monitoring.api_key_unknown_label');
-  const copyText = row.apiKeyMasked || row.apiKeyHash || secondaryText || keyLabel;
+  const copyValue = row.apiKeyCopyValue;
 
   return (
     <div className={styles.apiKeyPrimaryCell}>
@@ -203,11 +203,11 @@ function ApiKeySummaryPrimary({
         {secondaryText ? <small>{secondaryText}</small> : null}
       </button>
       <span className={styles.apiKeyInlineMeta}>
-        {copyText ? (
+        {copyValue ? (
           <button
             type="button"
             className={styles.apiKeyCopyButton}
-            onClick={() => onCopyText(copyText)}
+            onClick={() => onCopyText(copyValue)}
             title={t('common.copy')}
             aria-label={t('common.copy')}
           >

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -224,7 +224,12 @@ describe('analytics aggregate row adapters', () => {
       authFileMap,
       sourceInfoMap,
       channelByAuthIndex,
-      new Map([['client-key-hash', { label: 'Team Key', masked: 'sk********ey' }]])
+      new Map([
+        [
+          'client-key-hash',
+          { label: 'Team Key', masked: 'sk********ey', copyValue: 'sk-client-key-original' },
+        ],
+      ])
     );
 
     expect(rows).toHaveLength(1);
@@ -232,6 +237,7 @@ describe('analytics aggregate row adapters', () => {
       apiKeyHash: 'client-key-hash',
       apiKeyLabel: 'Team Key',
       apiKeyMasked: 'sk********ey',
+      apiKeyCopyValue: 'sk-client-key-original',
       totalCalls: 3,
       failureCalls: 1,
       totalTokens: 43,
@@ -285,6 +291,7 @@ describe('buildApiKeyDisplayMap', () => {
 
     expect(map.get(apiKeyHash)?.label).toBe('Team A');
     expect(map.get(apiKeyHash)?.masked).toMatch(/^sk/);
+    expect(map.get(apiKeyHash)?.copyValue).toBe(apiKey);
   });
 
   it('masks key-like aliases before display', () => {
@@ -303,32 +310,38 @@ describe('buildApiKeyDisplayMap', () => {
 
 describe('buildApiKeyRows', () => {
   it('groups usage by client api key and aggregates model spend', () => {
-    const rows = buildApiKeyRows([
-      createMonitoringEventRow({
-        id: 'row-1',
-        apiKeyHash: 'hash-a',
-        apiKeyLabel: 'Team A',
-        apiKeyMasked: 'sk********aa',
-        model: 'gpt-4.1',
-        totalTokens: 18,
-        totalCost: 0.12,
-      }),
-      createMonitoringEventRow({
-        id: 'row-2',
-        apiKeyHash: 'hash-a',
-        apiKeyLabel: 'Team A',
-        apiKeyMasked: 'sk********aa',
-        model: 'gpt-4.1',
-        failed: true,
-        totalTokens: 7,
-        totalCost: 0.03,
-      }),
-    ]);
+    const rows = buildApiKeyRows(
+      [
+        createMonitoringEventRow({
+          id: 'row-1',
+          apiKeyHash: 'hash-a',
+          apiKeyLabel: 'Team A',
+          apiKeyMasked: 'sk********aa',
+          model: 'gpt-4.1',
+          totalTokens: 18,
+          totalCost: 0.12,
+        }),
+        createMonitoringEventRow({
+          id: 'row-2',
+          apiKeyHash: 'hash-a',
+          apiKeyLabel: 'Team A',
+          apiKeyMasked: 'sk********aa',
+          model: 'gpt-4.1',
+          failed: true,
+          totalTokens: 7,
+          totalCost: 0.03,
+        }),
+      ],
+      new Map([
+        ['hash-a', { label: 'Team A', masked: 'sk********aa', copyValue: 'sk-original-aa' }],
+      ])
+    );
 
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       apiKeyHash: 'hash-a',
       apiKeyLabel: 'Team A',
+      apiKeyCopyValue: 'sk-original-aa',
       totalCalls: 2,
       successCalls: 1,
       failureCalls: 1,

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.ts
@@ -757,7 +757,7 @@ export function useMonitoringData({
             channelByAuthIndex,
             apiKeyDisplayMap
           )
-        : buildApiKeyRows(filteredRows),
+        : buildApiKeyRows(filteredRows, apiKeyDisplayMap),
     [
       apiKeyDisplayMap,
       currentAnalyticsData,
@@ -771,13 +771,13 @@ export function useMonitoringData({
   const fallbackFilterOptions = useMemo<MonitoringFilterOptions>(
     () => ({
       accountRows: buildAccountRows(rangeFilteredRows),
-      apiKeyRows: buildApiKeyRows(rangeFilteredRows),
+      apiKeyRows: buildApiKeyRows(rangeFilteredRows, apiKeyDisplayMap),
       providers: uniqueOptionValues(rangeFilteredRows.map((row) => row.provider)),
       models: uniqueOptionValues(rangeFilteredRows.map((row) => row.model)),
       channels: uniqueOptionValues(rangeFilteredRows.map((row) => row.channel)),
       headerTraceIds: uniqueOptionValues(rangeFilteredRows.map((row) => row.headerTraceId)),
     }),
-    [rangeFilteredRows]
+    [apiKeyDisplayMap, rangeFilteredRows]
   );
   const analyticsFilterOptions = currentAnalyticsData?.filter_options;
   const filterOptions = useMemo(

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -703,6 +703,7 @@ export const buildApiKeyRowsFromAnalytics = (
         apiKeyHash,
         apiKeyLabel: isUnknown ? '' : apiKeyLabel,
         apiKeyMasked: isUnknown ? '' : apiKeyMasked,
+        apiKeyCopyValue: isUnknown ? undefined : apiKeyDisplay?.copyValue,
         isUnknown,
         authLabels: uniqueReadableValues([
           ...authMetas.map((meta) => meta.label),

--- a/apps/web/src/features/monitoring/model/apiKeys.ts
+++ b/apps/web/src/features/monitoring/model/apiKeys.ts
@@ -6,6 +6,7 @@ import { formatApiKeyHashLabel, readString } from './base';
 export type ApiKeyDisplayInfo = {
   label: string;
   masked: string;
+  copyValue?: string;
 };
 
 export const sanitizeApiKeyDisplayText = (value: string, fallback = '') => {
@@ -23,7 +24,7 @@ export const buildApiKeyDisplayMap = (
     const hash = sha256Hex(apiKey).toLowerCase();
     if (!hash || map.has(hash)) return;
     const masked = maskApiKey(apiKey) || formatApiKeyHashLabel(hash);
-    map.set(hash, { label: masked, masked });
+    map.set(hash, { label: masked, masked, copyValue: apiKey });
   });
   apiKeyAliases.forEach((entry) => {
     const hash = readString(entry.apiKeyHash).toLowerCase();
@@ -33,6 +34,7 @@ export const buildApiKeyDisplayMap = (
     map.set(hash, {
       label: alias,
       masked: existing?.masked || existing?.label || formatApiKeyHashLabel(hash),
+      copyValue: existing?.copyValue,
     });
   });
   return map;

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -1,6 +1,10 @@
 import { formatApiKeyHashLabel } from './base';
 import { calculateCacheHitRateFromTotals, getCacheHitTotals } from '@/utils/usage';
-import { sanitizeApiKeyDisplayText, shouldPreferApiKeyAlias } from './apiKeys';
+import {
+  sanitizeApiKeyDisplayText,
+  shouldPreferApiKeyAlias,
+  type ApiKeyDisplayInfo,
+} from './apiKeys';
 import {
   buildMonitoringAccountFilterValue,
   parseMonitoringAccountFilterValue,
@@ -490,7 +494,10 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     );
 };
 
-export const buildApiKeyRows = (rows: MonitoringEventRow[]): MonitoringApiKeyRow[] => {
+export const buildApiKeyRows = (
+  rows: MonitoringEventRow[],
+  apiKeyDisplayMap?: ReadonlyMap<string, ApiKeyDisplayInfo>
+): MonitoringApiKeyRow[] => {
   const grouped = new Map<
     string,
     {
@@ -498,6 +505,7 @@ export const buildApiKeyRows = (rows: MonitoringEventRow[]): MonitoringApiKeyRow
       apiKeyHash: string;
       apiKeyLabel: string;
       apiKeyMasked: string;
+      apiKeyCopyValue?: string;
       isUnknown: boolean;
       authLabels: Set<string>;
       sourceLabels: Set<string>;
@@ -549,6 +557,9 @@ export const buildApiKeyRows = (rows: MonitoringEventRow[]): MonitoringApiKeyRow
       apiKeyHash: row.apiKeyHash,
       apiKeyLabel: sanitizeApiKeyDisplayText(row.apiKeyLabel),
       apiKeyMasked: sanitizeApiKeyDisplayText(row.apiKeyMasked),
+      apiKeyCopyValue: row.apiKeyHash
+        ? apiKeyDisplayMap?.get(row.apiKeyHash.toLowerCase())?.copyValue
+        : undefined,
       isUnknown: !hasKnownApiKey,
       authLabels: new Set<string>(),
       sourceLabels: new Set<string>(),
@@ -571,6 +582,11 @@ export const buildApiKeyRows = (rows: MonitoringEventRow[]): MonitoringApiKeyRow
 
     if (!existing.apiKeyHash && row.apiKeyHash) {
       existing.apiKeyHash = row.apiKeyHash;
+    }
+    if (!existing.apiKeyCopyValue && existing.apiKeyHash) {
+      existing.apiKeyCopyValue = apiKeyDisplayMap?.get(
+        existing.apiKeyHash.toLowerCase()
+      )?.copyValue;
     }
     if (!existing.apiKeyMasked && row.apiKeyMasked) {
       existing.apiKeyMasked = sanitizeApiKeyDisplayText(row.apiKeyMasked);
@@ -639,6 +655,7 @@ export const buildApiKeyRows = (rows: MonitoringEventRow[]): MonitoringApiKeyRow
       apiKeyHash: item.apiKeyHash,
       apiKeyLabel: item.apiKeyLabel || item.apiKeyMasked || formatApiKeyHashLabel(item.apiKeyHash),
       apiKeyMasked: item.apiKeyMasked || item.apiKeyLabel || formatApiKeyHashLabel(item.apiKeyHash),
+      apiKeyCopyValue: item.apiKeyCopyValue,
       isUnknown: item.isUnknown,
       authLabels: Array.from(item.authLabels).filter(Boolean).sort(),
       sourceLabels: Array.from(item.sourceLabels).filter(Boolean).sort(),

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -273,6 +273,7 @@ export type MonitoringApiKeyRow = {
   apiKeyHash: string;
   apiKeyLabel: string;
   apiKeyMasked: string;
+  apiKeyCopyValue?: string;
   isUnknown: boolean;
   authLabels: string[];
   sourceLabels: string[];

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.module.scss
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.module.scss
@@ -1240,6 +1240,31 @@
   font-weight: 700;
 }
 
+.entityCopyButton {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--usage-muted);
+  cursor: pointer;
+}
+
+.entityCopyButton:hover {
+  border-color: color-mix(in srgb, var(--usage-primary) 30%, var(--usage-border));
+  background: color-mix(in srgb, var(--usage-primary) 8%, var(--usage-surface));
+  color: var(--usage-primary);
+}
+
+.entityCopyButton:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--usage-primary) 45%, transparent);
+  outline-offset: 2px;
+}
+
 .trendUnavailable {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
@@ -14,6 +14,7 @@ import { UsageAnalyticsPage } from './UsageAnalyticsPage';
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     navigate: vi.fn(),
+    copyToClipboard: vi.fn(async () => true),
     usageState: null as unknown,
   },
 }));
@@ -38,6 +39,10 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('./useUsageAnalytics', () => ({
   useUsageAnalytics: () => mocks.usageState,
+}));
+
+vi.mock('@/utils/clipboard', () => ({
+  copyToClipboard: mocks.copyToClipboard,
 }));
 
 const getText = (node: ReactTestInstance): string =>
@@ -122,6 +127,7 @@ const createUsageState = (overrides: Record<string, unknown> = {}) => {
     id: 'abcdef1234567890',
     label: 'sk-****7890',
     apiKeyHash: 'abcdef1234567890',
+    apiKeyCopyValue: 'sk-client-key-original',
     model: undefined,
     provider: 'codex',
     account: 'team-alpha',
@@ -485,6 +491,8 @@ const createUsageState = (overrides: Record<string, unknown> = {}) => {
 
 beforeEach(() => {
   mocks.navigate.mockReset();
+  mocks.copyToClipboard.mockReset();
+  mocks.copyToClipboard.mockResolvedValue(true);
   mocks.usageState = createUsageState();
 });
 
@@ -701,6 +709,26 @@ describe('UsageAnalyticsPage', () => {
     expect(text).toContain('sk-****7890');
     expect(text).not.toContain('abcdef1234567890');
     expect(text).not.toContain('usage_analytics.trend_pending_data');
+  });
+
+  it('copies the original API key without selecting the row', async () => {
+    const usageState = createUsageState({ activeTab: 'apiKeys' });
+    mocks.usageState = usageState;
+    const renderer = renderPage();
+    const copyButton = renderer.root
+      .findAllByType('button')
+      .find((node) => node.props['aria-label'] === 'common.copy');
+    if (!copyButton) throw new Error('API key copy button not found');
+    const event = { stopPropagation: vi.fn() };
+
+    act(() => {
+      copyButton.props.onClick(event);
+    });
+    await act(async () => Promise.resolve());
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith('sk-client-key-original');
+    expect(usageState.setSelectedApiKeyHash).not.toHaveBeenCalled();
   });
 
   it('renders the API Key tab with key-dimension cards, unit-economics columns, and anomaly drilldown', () => {

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -30,7 +30,8 @@ import {
   IconTrendingUp,
   IconX,
 } from '@/components/ui/icons';
-import { useThemeStore } from '@/stores';
+import { useNotificationStore, useThemeStore } from '@/stores';
+import { copyToClipboard } from '@/utils/clipboard';
 import {
   buildUsageHeatmapChartData,
   buildModelKeyDistribution,
@@ -2300,6 +2301,7 @@ function UsageAnalyticsPageInner() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const usage = useUsageAnalytics();
+  const showNotification = useNotificationStore((state) => state.showNotification);
   const chartTheme = useUsageChartTheme();
   const themedUsageMetrics = useMemo(() => getThemedUsageMetrics(chartTheme), [chartTheme]);
   const [selectedMetrics, setSelectedMetrics] =
@@ -2395,6 +2397,16 @@ function UsageAnalyticsPageInner() {
     rememberVisibleOptions();
     usage.setFilters(patch);
   };
+  const handleCopyApiKey = useCallback(
+    async (copyValue: string) => {
+      const copied = await copyToClipboard(copyValue);
+      showNotification(
+        t(copied ? 'notification.link_copied' : 'notification.copy_failed'),
+        copied ? 'success' : 'error'
+      );
+    },
+    [showNotification, t]
+  );
   const buildApiKeyMonitoringUrl = (apiKeyHash: string, status?: UsageAnalyticsStatus) =>
     usage.bounds
       ? buildMonitoringDetailUrl(
@@ -3190,6 +3202,9 @@ function UsageAnalyticsPageInner() {
                 type="apiKey"
                 selectedId={usage.selectedApiKey?.apiKeyHash}
                 onSelect={(row) => usage.setSelectedApiKeyHash(row.apiKeyHash || row.id)}
+                onCopyApiKey={(row) => {
+                  if (row.apiKeyCopyValue) void handleCopyApiKey(row.apiKeyCopyValue);
+                }}
               />
             </div>
             <div className={styles.panel}>
@@ -3638,11 +3653,13 @@ function RankTable({
   type,
   selectedId,
   onSelect,
+  onCopyApiKey,
 }: {
   rows: UsageRankRow[];
   type: 'model' | 'apiKey' | 'credential';
   selectedId?: string;
   onSelect: (row: UsageRankRow) => void;
+  onCopyApiKey?: (row: UsageRankRow) => void;
 }) {
   const { t } = useTranslation();
   const entityHeader =
@@ -3701,7 +3718,20 @@ function RankTable({
                       <IconModelCluster size={16} />
                     )}
                     {type === 'apiKey' ? getApiKeyRowDisplayLabel(row) : row.label}
-                    {type === 'apiKey' ? <IconCopy size={13} /> : null}
+                    {type === 'apiKey' && row.apiKeyCopyValue && onCopyApiKey ? (
+                      <button
+                        type="button"
+                        className={styles.entityCopyButton}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onCopyApiKey(row);
+                        }}
+                        title={t('common.copy')}
+                        aria-label={t('common.copy')}
+                      >
+                        <IconCopy size={13} />
+                      </button>
+                    ) : null}
                   </span>
                 </td>
                 <td>{compactNumber(row.requestCount)}</td>

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -709,7 +709,14 @@ describe('usage analytics adapters', () => {
 
   it('resolves API key aliases by hash across analytics views', () => {
     const displayMap = new Map([
-      ['abcdef1234567890', { label: 'Team Alpha Key', masked: 'sk-****7890' }],
+      [
+        'abcdef1234567890',
+        {
+          label: 'Team Alpha Key',
+          masked: 'sk-****7890',
+          copyValue: 'sk-team-alpha-original',
+        },
+      ],
     ]);
     const apiKeyRows = buildApiKeyRows(
       [
@@ -757,6 +764,7 @@ describe('usage analytics adapters', () => {
     expect(apiKeyRows[0]).toMatchObject({
       apiKeyHash: 'abcdef1234567890',
       label: 'Team Alpha Key',
+      apiKeyCopyValue: 'sk-team-alpha-original',
     });
     expect(
       buildUsageMatrix({

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -159,6 +159,7 @@ export type UsageRankRow = {
   label: string;
   model?: string;
   apiKeyHash?: string;
+  apiKeyCopyValue?: string;
   provider?: string;
   authFile?: string;
   authIndex?: string;
@@ -1411,6 +1412,7 @@ export const buildApiKeyRows = (
         id: hash || row.id || '-',
         label: resolveUsageApiKeyLabel(hash, apiKeyDisplayMap),
         apiKeyHash: hash,
+        apiKeyCopyValue: apiKeyDisplayMap?.get(hash)?.copyValue,
         provider: row.auth_provider_snapshot,
         authIndex: row.auth_indices?.[0],
         source: row.sources?.[0],


### PR DESCRIPTION
## Summary

Fix client API key copy actions in request monitoring and usage analytics.
The UI continues to display masked values, while explicit copy actions use the configured original key only when it can be resolved safely.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Preserve a copy-only client key value in the existing hash-based frontend display mapping without changing rendered labels.
- Copy the configured original key from request monitoring and hide the action for historical, deleted, or unmatched keys.
- Replace the decorative usage analytics copy icon with an accessible action that does not also select the table row.
- Add regression coverage for analytics aggregation, fallback aggregation, unavailable originals, and copy interactions.

## User Impact

Users can copy the original configured client API key from request monitoring and usage analytics while the visible value remains masked.
Keys that are no longer present in the current configuration do not expose a misleading copy action.

## Compatibility / Runtime Notes

- CPA panel mode: Uses the client keys already available in the authenticated panel configuration.
- Manager Server mode: Uses the existing proxied configuration path; no API or server changes are required.
- Full Docker / native packages: Uses the same embedded frontend behavior with no configuration or packaging changes.

## Data / Security Notes

Configured client API keys remain in the existing authenticated frontend configuration state.
The change derives copy-only values in UI memory; keys are not rendered, persisted, added to monitoring events, placed in search text or URLs, exported, or logged.
Historical or deleted keys cannot be recovered from their SHA-256 hashes, so their copy actions remain unavailable.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert commits `6fe83c48` and `e325b665` to restore the previous copy behavior.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
TypeScript 6 tsc --noEmit: passed
ESLint apps/web: passed
Vitest: 99 test files passed, 927 tests passed
Vite 8 single-file production build: passed; output contained only index.html
Focused regression suite: 4 test files passed, 80 tests passed
git diff --check: passed
```

## Screenshots / Recordings

N/A — the existing copy icon is retained; this PR changes its behavior, availability, accessibility, and hover/focus treatment.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

Fixes #369