### PR TITLE
fix(installer): prevent stale-volume admin key mismatches

### DIFF
--- a/apps/docs/deployment/installer.md
+++ b/apps/docs/deployment/installer.md
@@ -30,10 +30,10 @@ bash install-cpamp.sh
 
 ## 支持的组合
 
-| 安装范围 | Docker | 原生包 |
-|---|---:|---:|
-| CPA + CPAMP | 支持 | 暂不支持 |
-| 仅 CPAMP | 支持 | 支持 |
+| 安装范围    | Docker |   原生包 |
+| ----------- | -----: | -------: |
+| CPA + CPAMP |   支持 | 暂不支持 |
+| 仅 CPAMP    |   支持 |     支持 |
 
 完整安装推荐 Docker。CPAMP 原生包只包含 Manager Server，不包含 CPA 运行时；如果要用原生包，需要先单独部署 CPA。
 
@@ -66,10 +66,10 @@ CPA 最小配置会启用远程管理和用量发布：
 
 ```yaml
 api-keys:
-  - "sk-..."
+  - 'sk-...'
 
 remote-management:
-  secret-key: "cpa_..."
+  secret-key: 'cpa_...'
   allow-remote: true
 
 usage-statistics-enabled: true
@@ -100,7 +100,7 @@ http://cli-proxy-api:8317
 http://<host>:18317/management.html
 ```
 
-脚本会在最后打印 CPAMP 管理员密钥。演示客户端 API Key 只用于安装后快速连通性验证，生产客户端建议在面板里重新创建并按用途命名。
+脚本会保存 CPAMP 管理员密钥并打印文件路径和查看命令。交互安装可以选择是否立即在终端显示完整密钥；不要分享包含密钥的终端截图。演示客户端 API Key 只用于安装后快速连通性验证，生产客户端建议在面板里重新创建并按用途命名。
 
 ## 仅安装 CPAMP
 
@@ -177,27 +177,66 @@ bash install-cpamp.sh
 
 常用变量：
 
-| 变量 | 说明 |
-|---|---|
-| `CPAMP_LANG` | `zh-CN` 或 `en-US`。 |
-| `CPAMP_INSTALL_MODE` | `stack` 或 `cpamp`。 |
-| `CPAMP_DEPLOY_METHOD` | `docker` 或 `native`。 |
-| `CPAMP_INSTALL_DIR` | 安装目录，默认 `~/cpa-manager-plus`。 |
-| `CPAMP_PORT` | CPAMP 对外端口，默认 `18317`。 |
-| `CPAMP_CPA_PORT` | 完整 Docker 安装时 CPA 对外端口，默认 `8317`。 |
-| `CPAMP_IMAGE` | CPAMP Docker 镜像。 |
-| `CPAMP_CPA_IMAGE` | CPA Docker 镜像。 |
-| `CPAMP_VERSION` | 原生包版本，默认 `latest`。 |
-| `CPAMP_CPA_CONNECTION_MODE` | `setup` 或 `env`。 |
-| `CPAMP_CPA_URL` | `env` 模式下的 CPA URL。 |
-| `CPAMP_CPA_MANAGEMENT_KEY` | `env` 模式下的 CPA Management Key。 |
+| 变量                        | 说明                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| `CPAMP_LANG`                | `zh-CN` 或 `en-US`。                                                               |
+| `CPAMP_INSTALL_MODE`        | `stack` 或 `cpamp`。                                                               |
+| `CPAMP_DEPLOY_METHOD`       | `docker` 或 `native`。                                                             |
+| `CPAMP_INSTALL_DIR`         | 安装目录，默认 `~/cpa-manager-plus`。                                              |
+| `CPAMP_PORT`                | CPAMP 对外端口，默认 `18317`。                                                     |
+| `CPAMP_CPA_PORT`            | 完整 Docker 安装时 CPA 对外端口，默认 `8317`。                                     |
+| `CPAMP_IMAGE`               | CPAMP Docker 镜像。                                                                |
+| `CPAMP_CPA_IMAGE`           | CPA Docker 镜像。                                                                  |
+| `CPAMP_VERSION`             | 原生包版本，默认 `latest`。                                                        |
+| `CPAMP_CPA_CONNECTION_MODE` | `setup` 或 `env`。                                                                 |
+| `CPAMP_CPA_URL`             | `env` 模式下的 CPA URL。                                                           |
+| `CPAMP_CPA_MANAGEMENT_KEY`  | `env` 模式下的 CPA Management Key。                                                |
+| `CPAMP_OPERATION`           | `install`、`upgrade`、`repair` 或 `regenerate`。已有部署的非交互操作必须明确设置。 |
+| `CPAMP_PROJECT_NAME`        | Docker Compose 项目名，默认 `cpamp`；需要在同一主机创建隔离的新部署时使用。        |
 
 ## 重跑和覆盖
 
-脚本会复用已经存在的 secret 文件，但不会默认覆盖 `compose.yaml`、`.env`、`config.yaml` 或 `run.sh`。如果确定要重新生成配置，可以设置：
+以下 `CPAMP_OPERATION` 操作模式用于 Docker 部署；原生包继续使用原有的版本和覆盖参数。
+
+脚本会在写文件前检查安装目录和 Docker 数据卷。检测到已有部署时，交互模式会提供：
+
+1. **升级现有部署**：只执行镜像拉取和容器更新，不修改配置或密钥。
+2. **修复管理员登录**：停止 CPAMP，把 SQLite 中的管理员凭证同步为 `secrets/cpamp-admin-key`，然后重启并验证登录；CPA 服务和业务数据不会被删除。
+3. **重新生成配置**：备份现有生成配置后重新写入，继续复用 secret 和数据卷。
+4. **退出**。
+
+如果安装目录已经被删除、但 `cpamp_cpa-manager-plus-data` 仍然存在，脚本不会再静默创建新密钥并报告成功，而是要求恢复旧数据或使用新的 Compose 项目名进行全新安装。
+
+非交互升级：
 
 ```bash
-CPAMP_OVERWRITE=1 bash install-cpamp.sh
+CPAMP_OPERATION=upgrade \
+CPAMP_NON_INTERACTIVE=1 \
+CPAMP_CONFIRM=1 \
+bash install-cpamp.sh
 ```
 
-覆盖配置前先备份安装目录，尤其是 `secrets/`、`data/` 和 `cliproxyapi/`。丢失 `data.key` 后，已保存的 CPA Management Key 无法恢复。
+非交互修复管理员登录：
+
+```bash
+CPAMP_OPERATION=repair \
+CPAMP_NON_INTERACTIVE=1 \
+CPAMP_CONFIRM=1 \
+bash install-cpamp.sh
+```
+
+如果安装目录已经丢失、只剩旧 Docker 数据卷，非交互修复还必须设置原来的 `CPAMP_INSTALL_MODE=stack` 或 `CPAMP_INSTALL_MODE=cpamp`，避免生成错误的服务组合。
+
+如果确定要重新生成配置：
+
+```bash
+CPAMP_OPERATION=regenerate bash install-cpamp.sh
+```
+
+`CPAMP_OVERWRITE=1` 继续兼容旧用法，并会映射到配置重新生成流程。脚本会把旧的 `.env`、`compose.yaml`、CPA 配置、`run.sh` 和 service 文件备份到安装目录的 `backups/installer-*`，但仍建议单独备份 `secrets/`、`data/` 和 `cliproxyapi/`。丢失 `data.key` 后，已保存的 CPA Management Key 无法恢复。
+
+## 启动和登录验证
+
+Docker 安装、升级或修复后，脚本会等待 CPAMP 健康检查通过，再使用当前管理员密钥请求受保护的 Manager Server 接口。只有健康检查和管理员密钥验证都成功后，才会输出“安装步骤已完成”。
+
+如果容器已启动但密钥验证失败，交互模式会询问是否自动停止 CPAMP 并修复管理员凭证；非交互模式会返回失败状态，并提示使用 `CPAMP_OPERATION=repair`。这可以避免用户拿到一个与旧数据库不匹配的“新密钥”。

--- a/apps/docs/en/deployment/installer.md
+++ b/apps/docs/en/deployment/installer.md
@@ -30,10 +30,10 @@ The wizard walks through:
 
 ## Supported Combinations
 
-| Install scope | Docker | Native package |
-|---|---:|---:|
-| CPA + CPAMP | Supported | Not supported yet |
-| CPAMP only | Supported | Supported |
+| Install scope |    Docker |    Native package |
+| ------------- | --------: | ----------------: |
+| CPA + CPAMP   | Supported | Not supported yet |
+| CPAMP only    | Supported |         Supported |
 
 Use Docker for a full CPA + CPAMP install. The CPAMP native package contains Manager Server only; CPA must already be deployed separately.
 
@@ -66,10 +66,10 @@ The CPA minimal config enables remote management and usage publishing:
 
 ```yaml
 api-keys:
-  - "sk-..."
+  - 'sk-...'
 
 remote-management:
-  secret-key: "cpa_..."
+  secret-key: 'cpa_...'
   allow-remote: true
 
 usage-statistics-enabled: true
@@ -100,7 +100,7 @@ After deployment, open:
 http://<host>:18317/management.html
 ```
 
-The script prints the CPAMP Admin Key at the end. The demo client API key is only for a quick post-install connectivity check; create named production clients in the panel.
+The script saves the CPAMP Admin Key and prints its file path and view command. Interactive installs can choose whether to reveal the full key in the terminal; do not share terminal screenshots containing it. The demo client API key is only for a quick post-install connectivity check; create named production clients in the panel.
 
 ## CPAMP-Only Install
 
@@ -177,27 +177,66 @@ bash install-cpamp.sh
 
 Common variables:
 
-| Variable | Description |
-|---|---|
-| `CPAMP_LANG` | `zh-CN` or `en-US`. |
-| `CPAMP_INSTALL_MODE` | `stack` or `cpamp`. |
-| `CPAMP_DEPLOY_METHOD` | `docker` or `native`. |
-| `CPAMP_INSTALL_DIR` | Install directory. Defaults to `~/cpa-manager-plus`. |
-| `CPAMP_PORT` | Public CPAMP port. Defaults to `18317`. |
-| `CPAMP_CPA_PORT` | Public CPA port for full Docker install. Defaults to `8317`. |
-| `CPAMP_IMAGE` | CPAMP Docker image. |
-| `CPAMP_CPA_IMAGE` | CPA Docker image. |
-| `CPAMP_VERSION` | Native package version. Defaults to `latest`. |
-| `CPAMP_CPA_CONNECTION_MODE` | `setup` or `env`. |
-| `CPAMP_CPA_URL` | CPA URL for `env` mode. |
-| `CPAMP_CPA_MANAGEMENT_KEY` | CPA Management Key for `env` mode. |
+| Variable                    | Description                                                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `CPAMP_LANG`                | `zh-CN` or `en-US`.                                                                                                  |
+| `CPAMP_INSTALL_MODE`        | `stack` or `cpamp`.                                                                                                  |
+| `CPAMP_DEPLOY_METHOD`       | `docker` or `native`.                                                                                                |
+| `CPAMP_INSTALL_DIR`         | Install directory. Defaults to `~/cpa-manager-plus`.                                                                 |
+| `CPAMP_PORT`                | Public CPAMP port. Defaults to `18317`.                                                                              |
+| `CPAMP_CPA_PORT`            | Public CPA port for full Docker install. Defaults to `8317`.                                                         |
+| `CPAMP_IMAGE`               | CPAMP Docker image.                                                                                                  |
+| `CPAMP_CPA_IMAGE`           | CPA Docker image.                                                                                                    |
+| `CPAMP_VERSION`             | Native package version. Defaults to `latest`.                                                                        |
+| `CPAMP_CPA_CONNECTION_MODE` | `setup` or `env`.                                                                                                    |
+| `CPAMP_CPA_URL`             | CPA URL for `env` mode.                                                                                              |
+| `CPAMP_CPA_MANAGEMENT_KEY`  | CPA Management Key for `env` mode.                                                                                   |
+| `CPAMP_OPERATION`           | `install`, `upgrade`, `repair`, or `regenerate`. Existing non-interactive deployments require an explicit operation. |
+| `CPAMP_PROJECT_NAME`        | Docker Compose project name. Defaults to `cpamp`; use another name for an isolated deployment on the same host.      |
 
 ## Rerun And Overwrite
 
-The script reuses existing secret files, but it does not overwrite `compose.yaml`, `.env`, `config.yaml`, or `run.sh` by default. To regenerate those files:
+The following `CPAMP_OPERATION` modes apply to Docker deployments. Native packages continue to use their existing version and overwrite options.
+
+Before writing files, the installer checks both the install directory and Docker data volume. When it detects an existing deployment, interactive mode offers:
+
+1. **Upgrade existing deployment**: pull and recreate containers without changing config or secrets.
+2. **Repair admin login**: stop CPAMP, synchronize the SQLite admin credential with `secrets/cpamp-admin-key`, restart, and verify login. CPA and application data are not deleted.
+3. **Regenerate deployment config**: back up generated config before replacing it while preserving secrets and the data volume.
+4. **Exit**.
+
+If the install directory was deleted but `cpamp_cpa-manager-plus-data` still exists, the installer no longer silently generates a new key and reports success. It requires either recovery of the old data or a fresh install with a different Compose project name.
+
+Non-interactive upgrade:
 
 ```bash
-CPAMP_OVERWRITE=1 bash install-cpamp.sh
+CPAMP_OPERATION=upgrade \
+CPAMP_NON_INTERACTIVE=1 \
+CPAMP_CONFIRM=1 \
+bash install-cpamp.sh
 ```
 
-Back up the install directory before overwriting config, especially `secrets/`, `data/`, and `cliproxyapi/`. If `data.key` is lost, stored CPA Management Keys cannot be recovered.
+Non-interactive admin-login repair:
+
+```bash
+CPAMP_OPERATION=repair \
+CPAMP_NON_INTERACTIVE=1 \
+CPAMP_CONFIRM=1 \
+bash install-cpamp.sh
+```
+
+If the install directory is gone and only the old Docker volume remains, non-interactive repair must also set the original `CPAMP_INSTALL_MODE=stack` or `CPAMP_INSTALL_MODE=cpamp` so the installer does not generate the wrong service combination.
+
+To regenerate deployment config:
+
+```bash
+CPAMP_OPERATION=regenerate bash install-cpamp.sh
+```
+
+`CPAMP_OVERWRITE=1` remains compatible with the old workflow and maps to config regeneration. The installer backs up the previous `.env`, `compose.yaml`, CPA config, `run.sh`, and service file under `backups/installer-*`. You should still separately back up `secrets/`, `data/`, and `cliproxyapi/`. If `data.key` is lost, stored CPA Management Keys cannot be recovered.
+
+## Startup And Login Verification
+
+After Docker installation, upgrade, or repair, the script waits for CPAMP health and then uses the current admin key against a protected Manager Server endpoint. It reports the install as completed only after both checks pass.
+
+If the container is healthy but the key is rejected, interactive mode offers to stop CPAMP and repair the database credential automatically. Non-interactive mode exits with a failure and instructs the operator to use `CPAMP_OPERATION=repair`. This prevents the installer from presenting a newly generated key that does not match an existing database.

--- a/apps/docs/en/operations/reset-admin-key.md
+++ b/apps/docs/en/operations/reset-admin-key.md
@@ -40,6 +40,30 @@ New admin key: cpamp_...
 Save this value now. It will not be shown again.
 ```
 
+### One-Click Installer Docker Deployments
+
+If `install-cpamp.sh` created the Docker deployment, prefer letting the installer stop the service, reset the credential, restart, and verify login:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/seakee/CPA-Manager-Plus/main/bin/install-cpamp.sh
+CPAMP_OPERATION=repair \
+CPAMP_INSTALL_DIR="$HOME/cpa-manager-plus" \
+bash install-cpamp.sh
+```
+
+The repair flow synchronizes the SQLite admin credential with `secrets/cpamp-admin-key` in the install directory, so the file and actual login key remain aligned. It does not delete the Docker data volume, CPA Management Key, or request history.
+
+Non-interactive environments require explicit confirmation:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/seakee/CPA-Manager-Plus/main/bin/install-cpamp.sh
+CPAMP_OPERATION=repair \
+CPAMP_INSTALL_DIR="$HOME/cpa-manager-plus" \
+CPAMP_NON_INTERACTIVE=1 \
+CPAMP_CONFIRM=1 \
+bash install-cpamp.sh
+```
+
 ## Docker Named Volume
 
 ```bash

--- a/apps/docs/operations/reset-admin-key.md
+++ b/apps/docs/operations/reset-admin-key.md
@@ -40,6 +40,30 @@ New admin key: cpamp_...
 Save this value now. It will not be shown again.
 ```
 
+### 一键安装脚本创建的 Docker 部署
+
+如果 Docker 部署由 `install-cpamp.sh` 创建，优先让安装器完成停止、重置、重启和登录验证：
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/seakee/CPA-Manager-Plus/main/bin/install-cpamp.sh
+CPAMP_OPERATION=repair \
+CPAMP_INSTALL_DIR="$HOME/cpa-manager-plus" \
+bash install-cpamp.sh
+```
+
+修复流程会把 SQLite 中的管理员凭证同步为安装目录中的 `secrets/cpamp-admin-key`，因此文件中的密钥和实际登录密钥会保持一致。它不会删除 Docker 数据卷、CPA Management Key 或请求历史。
+
+非交互环境需要明确确认：
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/seakee/CPA-Manager-Plus/main/bin/install-cpamp.sh
+CPAMP_OPERATION=repair \
+CPAMP_INSTALL_DIR="$HOME/cpa-manager-plus" \
+CPAMP_NON_INTERACTIVE=1 \
+CPAMP_CONFIRM=1 \
+bash install-cpamp.sh
+```
+
 ## Docker Named Volume
 
 ```bash

--- a/bin/install-cpamp.sh
+++ b/bin/install-cpamp.sh
@@ -10,6 +10,7 @@ dry_run="${CPAMP_DRY_RUN:-0}"
 non_interactive="${CPAMP_NON_INTERACTIVE:-0}"
 skip_execute="${CPAMP_SKIP_EXECUTE:-0}"
 lang_code="${CPAMP_LANG:-}"
+operation="${CPAMP_OPERATION:-}"
 
 os_name="unknown"
 arch_name="unknown"
@@ -33,6 +34,11 @@ demo_client_key=""
 generated_admin_key=""
 generated_cpa_management_key=""
 generated_demo_client_key=""
+compose_project_name="${CPAMP_PROJECT_NAME:-cpamp}"
+existing_install_state="fresh"
+existing_volume_name=""
+auth_validation_status="pending"
+admin_secret_missing="0"
 
 die() {
   printf '%s\n' "$*" >&2
@@ -109,6 +115,12 @@ text() {
     en-US:run_command) printf 'Will run command' ;;
     zh-CN:done) printf '安装步骤已完成' ;;
     en-US:done) printf 'Install steps completed' ;;
+    zh-CN:dry_run_done) printf 'Dry-run 计划预览完成，未写入文件或启动服务' ;;
+    en-US:dry_run_done) printf 'Dry-run plan completed; no files were written and no services were started' ;;
+    zh-CN:config_done) printf '部署配置已生成，服务尚未启动' ;;
+    en-US:config_done) printf 'Deployment config generated; services have not been started' ;;
+    zh-CN:operation_skipped) printf '已保留现有部署，按要求跳过升级或修复命令' ;;
+    en-US:operation_skipped) printf 'Existing deployment preserved; upgrade or repair commands were skipped' ;;
     zh-CN:open_panel) printf '打开面板' ;;
     en-US:open_panel) printf 'Open panel' ;;
     zh-CN:admin_key) printf 'CPAMP 管理员密钥' ;;
@@ -133,6 +145,66 @@ text() {
     en-US:port_busy) printf 'Port may already be in use' ;;
     zh-CN:missing_command) printf '缺少命令' ;;
     en-US:missing_command) printf 'Missing command' ;;
+    zh-CN:existing_install) printf '检测到已有 CPA Manager Plus 部署' ;;
+    en-US:existing_install) printf 'Existing CPA Manager Plus deployment detected' ;;
+    zh-CN:existing_volume) printf '检测到已有 Docker 数据卷' ;;
+    en-US:existing_volume) printf 'Existing Docker data volume detected' ;;
+    zh-CN:select_existing_action) printf '选择操作: 1) 升级现有部署  2) 修复管理员登录  3) 重新生成配置  4) 退出' ;;
+    en-US:select_existing_action) printf 'Select action: 1) upgrade existing deployment  2) repair admin login  3) regenerate config  4) exit' ;;
+    zh-CN:select_partial_action) printf '检测到不完整的部署配置。选择操作: 1) 备份并重新生成配置  2) 退出' ;;
+    en-US:select_partial_action) printf 'Incomplete deployment config detected. Select action: 1) back up and regenerate config  2) exit' ;;
+    zh-CN:select_orphan_action) printf '安装目录缺少配置，但发现旧数据卷。选择操作: 1) 修复并继续使用旧数据  2) 使用新项目名全新安装（旧服务仍运行时请改端口）  3) 退出' ;;
+    en-US:select_orphan_action) printf 'The install directory has no config, but an old data volume exists. Select action: 1) repair and keep old data  2) fresh install with a new project name (choose different ports if the old service is still running)  3) exit' ;;
+    zh-CN:operation_upgrade) printf '升级现有部署' ;;
+    en-US:operation_upgrade) printf 'Upgrade existing deployment' ;;
+    zh-CN:operation_repair) printf '修复管理员登录' ;;
+    en-US:operation_repair) printf 'Repair admin login' ;;
+    zh-CN:operation_regenerate) printf '重新生成部署配置' ;;
+    en-US:operation_regenerate) printf 'Regenerate deployment config' ;;
+    zh-CN:operation_install) printf '首次安装' ;;
+    en-US:operation_install) printf 'Fresh install' ;;
+    zh-CN:operation_label) printf '执行操作' ;;
+    en-US:operation_label) printf 'Operation' ;;
+    zh-CN:noninteractive_existing) printf '检测到已有部署。非交互模式必须设置 CPAMP_OPERATION=upgrade、repair 或 regenerate。' ;;
+    en-US:noninteractive_existing) printf 'An existing deployment was detected. Non-interactive mode requires CPAMP_OPERATION=upgrade, repair, or regenerate.' ;;
+    zh-CN:orphan_noninteractive) printf '检测到旧 Docker 数据卷但安装目录缺少配置。请设置 CPAMP_OPERATION=repair，或设置新的 CPAMP_PROJECT_NAME 后使用 CPAMP_OPERATION=install。' ;;
+    en-US:orphan_noninteractive) printf 'An old Docker data volume exists but the install directory has no config. Set CPAMP_OPERATION=repair, or choose a new CPAMP_PROJECT_NAME with CPAMP_OPERATION=install.' ;;
+    zh-CN:orphan_mode_required) printf '非交互修复旧数据卷时必须设置 CPAMP_INSTALL_MODE=stack 或 cpamp，避免创建错误的服务组合。' ;;
+    en-US:orphan_mode_required) printf 'Non-interactive orphan-volume repair requires CPAMP_INSTALL_MODE=stack or cpamp to avoid creating the wrong service combination.' ;;
+    zh-CN:repair_skip_execute) printf '旧数据卷修复必须执行数据库同步，不能使用 CPAMP_SKIP_EXECUTE=1；如只想预览，请使用 CPAMP_DRY_RUN=1。' ;;
+    en-US:repair_skip_execute) printf 'Orphan-volume repair must execute the database sync and cannot use CPAMP_SKIP_EXECUTE=1; use CPAMP_DRY_RUN=1 for a preview.' ;;
+    zh-CN:repairing_admin) printf '正在把数据库管理员凭证同步为安装目录中的管理员密钥' ;;
+    en-US:repairing_admin) printf 'Synchronizing the database admin credential with the install-directory admin key' ;;
+    zh-CN:auth_verified) printf '管理员密钥验证通过' ;;
+    en-US:auth_verified) printf 'Admin key verification passed' ;;
+    zh-CN:auth_failed) printf 'CPAMP 已启动，但管理员密钥验证失败。数据库凭证可能与安装目录中的密钥不一致。' ;;
+    en-US:auth_failed) printf 'CPAMP started, but admin key verification failed. The database credential may not match the install-directory key.' ;;
+    zh-CN:auth_repair_prompt) printf '是否停止 CPAMP 并自动修复管理员登录? 输入 yes/no' ;;
+    en-US:auth_repair_prompt) printf 'Stop CPAMP and repair the admin login automatically? Enter yes/no' ;;
+    zh-CN:health_failed) printf 'CPAMP 容器未能在规定时间内通过健康检查。' ;;
+    en-US:health_failed) printf 'The CPAMP container did not become healthy in time.' ;;
+    zh-CN:key_saved) printf '管理员密钥已保存' ;;
+    en-US:key_saved) printf 'Admin key saved' ;;
+    zh-CN:key_view_command) printf '查看管理员密钥' ;;
+    en-US:key_view_command) printf 'View admin key' ;;
+    zh-CN:key_reveal_prompt) printf '现在在终端显示完整管理员密钥吗? 请勿分享包含密钥的截图。输入 yes/no' ;;
+    en-US:key_reveal_prompt) printf 'Show the full admin key in the terminal now? Do not share screenshots containing it. Enter yes/no' ;;
+    zh-CN:config_backup) printf '旧配置已备份到' ;;
+    en-US:config_backup) printf 'Previous config backed up to' ;;
+    zh-CN:project_name) printf 'Docker Compose 项目名' ;;
+    en-US:project_name) printf 'Docker Compose project name' ;;
+    zh-CN:project_name_empty) printf 'Docker Compose 项目名不能为空。' ;;
+    en-US:project_name_empty) printf 'Docker Compose project name must not be empty.' ;;
+    zh-CN:docker_unavailable) printf 'Docker daemon 不可用。请启动 Docker 后重新运行安装器。' ;;
+    en-US:docker_unavailable) printf 'Docker daemon is not available. Start Docker and run the installer again.' ;;
+    zh-CN:missing_config) printf '已有安装配置不完整，请选择重新生成配置。' ;;
+    en-US:missing_config) printf 'The existing install directory is incomplete. Choose config regeneration.' ;;
+    zh-CN:repair_failed) printf '管理员密钥修复失败，CPAMP 已使用原数据库凭证重新启动。' ;;
+    en-US:repair_failed) printf 'Admin key repair failed. CPAMP was restarted with the previous database credential.' ;;
+    zh-CN:repair_restart_failed) printf '管理员密钥已重置，但 CPAMP 重启失败。请在安装目录执行 docker compose up -d。' ;;
+    en-US:repair_restart_failed) printf 'Admin key reset succeeded, but CPAMP failed to restart. Run docker compose up -d from the install directory.' ;;
+    zh-CN:repair_verify_failed) printf '管理员密钥修复后验证仍失败，请确认面板和修复命令使用同一个 Docker 数据卷。' ;;
+    en-US:repair_verify_failed) printf 'Admin key repair completed, but verification still failed. Confirm that the panel and repair command use the same Docker volume.' ;;
     *) printf '%s' "$1" ;;
   esac
 }
@@ -284,6 +356,259 @@ expand_path() {
   esac
 }
 
+validate_project_name() {
+  local value="$1"
+  validate_single_line "$(text project_name)" "$value"
+  case "$value" in
+    [-_]*|*[!a-z0-9_-]*) die "$(text project_name) contains unsupported characters." ;;
+    *) ;;
+  esac
+}
+
+read_env_value() {
+  local file="$1"
+  local key="$2"
+  local line=""
+  local value=""
+  local found="0"
+
+  [ -f "$file" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "$key="*) value="${line#*=}"; found="1" ;;
+    esac
+  done < "$file"
+  if [ "$found" = "1" ]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
+collect_install_directory() {
+  install_dir="$(expand_path "$(prompt_line "$(text install_dir)" "${CPAMP_INSTALL_DIR:-$default_install_dir}")")"
+  validate_single_line "$(text install_dir)" "$install_dir"
+}
+
+docker_volume_exists() {
+  local volume="$1"
+  command_exists docker && docker volume inspect "$volume" >/dev/null 2>&1
+}
+
+detect_existing_installation() {
+  local configured_project=""
+  local has_docker_files="0"
+  local has_native_files="0"
+
+  if configured_project="$(read_env_value "$install_dir/.env" COMPOSE_PROJECT_NAME 2>/dev/null)"; then
+    [ -n "$configured_project" ] || die "$(text project_name_empty)"
+    compose_project_name="$configured_project"
+  fi
+  validate_project_name "$compose_project_name"
+  existing_volume_name="${compose_project_name}_cpa-manager-plus-data"
+
+  if [ -e "$install_dir/.env" ] ||
+     [ -e "$install_dir/compose.yaml" ] ||
+     [ -e "$install_dir/cliproxyapi/config.yaml" ]; then
+    has_docker_files="1"
+  fi
+  if [ -e "$install_dir/run.sh" ] ||
+     [ -d "$install_dir/runtime" ] ||
+     [ -e "$install_dir/data/usage.sqlite" ]; then
+    has_native_files="1"
+  fi
+
+  if [ -f "$install_dir/.env" ] && [ -f "$install_dir/compose.yaml" ]; then
+    existing_install_state="managed"
+  elif [ "$has_docker_files" = "1" ]; then
+    existing_install_state="partial"
+  elif [ "$has_native_files" = "1" ]; then
+    existing_install_state="fresh"
+  elif docker_volume_exists "$existing_volume_name"; then
+    existing_install_state="orphan-volume"
+  elif [ -e "$install_dir/secrets/cpamp-admin-key" ]; then
+    existing_install_state="partial"
+  else
+    existing_install_state="fresh"
+  fi
+
+  if [ -e "$install_dir/secrets/cpamp-admin-key" ]; then
+    read_existing_secret "$install_dir/secrets/cpamp-admin-key" >/dev/null
+  fi
+}
+
+normalize_operation() {
+  case "$operation" in
+    '') ;;
+    install|new|fresh) operation="install" ;;
+    upgrade|update) operation="upgrade" ;;
+    repair|recover|reset-admin-key) operation="repair" ;;
+    regenerate|overwrite|reconfigure) operation="regenerate" ;;
+    *) die "Unsupported CPAMP_OPERATION: $operation" ;;
+  esac
+}
+
+choose_new_project_name() {
+  compose_project_name="$(prompt_line "$(text project_name)" "${CPAMP_PROJECT_NAME:-cpamp-new}")"
+  validate_project_name "$compose_project_name"
+  existing_volume_name="${compose_project_name}_cpa-manager-plus-data"
+  if docker_volume_exists "$existing_volume_name"; then
+    die "Docker volume already exists: $existing_volume_name"
+  fi
+  operation="install"
+  existing_install_state="fresh"
+}
+
+resolve_operation() {
+  local choice=""
+
+  normalize_operation
+  if [ "$existing_install_state" = "fresh" ]; then
+    [ -n "$operation" ] || operation="install"
+    [ "$operation" = "install" ] || die "CPAMP_OPERATION=$operation requires an existing Docker deployment."
+    return
+  fi
+
+  if [ -z "$operation" ] && [ "${CPAMP_OVERWRITE:-0}" = "1" ]; then
+    operation="regenerate"
+  fi
+
+  if [ "$existing_install_state" = "orphan-volume" ]; then
+    say ""
+    say "== $(text existing_volume) =="
+    say "$(text project_name): $compose_project_name"
+    say "Docker volume: $existing_volume_name"
+    if [ -z "$operation" ]; then
+      if [ "$non_interactive" = "1" ]; then
+        die "$(text orphan_noninteractive)"
+      fi
+      choice="$(prompt_choice "$(text select_orphan_action)" "1" "1 2 3")"
+      case "$choice" in
+        1) operation="repair" ;;
+        2) choose_new_project_name; return ;;
+        3) exit 0 ;;
+      esac
+    fi
+    case "$operation" in
+      repair)
+        if [ "$non_interactive" = "1" ] && [ -z "${CPAMP_INSTALL_MODE:-}" ]; then
+          die "$(text orphan_mode_required)"
+        fi
+        if [ "$skip_execute" = "1" ] && [ "$dry_run" != "1" ]; then
+          die "$(text repair_skip_execute)"
+        fi
+        return
+        ;;
+      install) die "$(text orphan_noninteractive)" ;;
+      *) die "CPAMP_OPERATION=$operation is not available without an existing compose.yaml." ;;
+    esac
+    return
+  fi
+
+  if [ "$existing_install_state" = "partial" ]; then
+    say ""
+    say "== $(text existing_install) =="
+    say "$(text directory_label): $install_dir"
+    if [ -z "$operation" ]; then
+      if [ "$non_interactive" = "1" ]; then
+        die "$(text noninteractive_existing)"
+      fi
+      choice="$(prompt_choice "$(text select_partial_action)" "1" "1 2")"
+      case "$choice" in
+        1) operation="regenerate" ;;
+        2) exit 0 ;;
+      esac
+    fi
+    [ "$operation" = "regenerate" ] || die "$(text missing_config) Set CPAMP_OPERATION=regenerate to rebuild its config."
+    return
+  fi
+
+  say ""
+  say "== $(text existing_install) =="
+  say "$(text directory_label): $install_dir"
+  say "$(text project_name): $compose_project_name"
+  if [ -z "$operation" ]; then
+    if [ "$non_interactive" = "1" ]; then
+      die "$(text noninteractive_existing)"
+    fi
+    choice="$(prompt_choice "$(text select_existing_action)" "1" "1 2 3 4")"
+    case "$choice" in
+      1) operation="upgrade" ;;
+      2) operation="repair" ;;
+      3) operation="regenerate" ;;
+      4) exit 0 ;;
+    esac
+  fi
+
+  case "$operation" in
+    upgrade|repair)
+      if [ "$existing_install_state" != "managed" ]; then
+        die "$(text missing_config) Set CPAMP_OPERATION=regenerate to rebuild its config."
+      fi
+      ;;
+    regenerate) ;;
+    *) die "CPAMP_OPERATION=$operation is not valid for an existing deployment." ;;
+  esac
+}
+
+read_existing_secret() {
+  local file="$1"
+  local value=""
+  [ -f "$file" ] || return 1
+  if [ "$dry_run" != "1" ]; then
+    chmod 600 "$file" 2>/dev/null || die "Unable to restrict secret file permissions: $file"
+  fi
+  value="$(< "$file")"
+  value="${value%$'\r'}"
+  validate_secret_value "$file" "$value"
+  printf '%s\n' "$value"
+}
+
+load_existing_docker_config() {
+  local value=""
+
+  [ -f "$install_dir/.env" ] || die "Missing existing config: $install_dir/.env"
+  [ -f "$install_dir/compose.yaml" ] || die "Missing existing config: $install_dir/compose.yaml"
+  deploy_method="docker"
+  cpamp_image="$(read_env_value "$install_dir/.env" CPAMP_IMAGE 2>/dev/null || printf '%s' "$default_cpamp_image")"
+  validate_image_ref "$(text cpamp_image)" "$cpamp_image"
+  cpamp_port="$(read_env_value "$install_dir/.env" CPAMP_PORT 2>/dev/null || printf '18317')"
+  normalize_port "$cpamp_port" || die "Invalid CPAMP port in existing .env: $cpamp_port"
+  if grep -q '^[[:space:]]*cli-proxy-api:' "$install_dir/compose.yaml"; then
+    install_mode="stack"
+    cpa_image="$(read_env_value "$install_dir/.env" CPA_IMAGE 2>/dev/null || printf '%s' "$default_cpa_image")"
+    validate_image_ref "$(text cpa_image)" "$cpa_image"
+    cpa_port="$(read_env_value "$install_dir/.env" CPA_PORT 2>/dev/null || printf '8317')"
+    normalize_port "$cpa_port" || die "Invalid CPA port in existing .env: $cpa_port"
+    cpa_url="http://cli-proxy-api:8317"
+    cpa_connection_mode="env"
+  else
+    install_mode="cpamp"
+    if grep -q 'CPA_MANAGEMENT_KEY_FILE:' "$install_dir/compose.yaml"; then
+      cpa_connection_mode="env"
+      cpa_url="$(read_env_value "$install_dir/.env" CPA_UPSTREAM_URL 2>/dev/null || true)"
+    else
+      cpa_connection_mode="setup"
+    fi
+  fi
+  if value="$(read_existing_secret "$install_dir/secrets/cpamp-admin-key")"; then
+    admin_key="$value"
+  elif [ "$operation" = "repair" ]; then
+    admin_secret_missing="1"
+  else
+    die "Admin key file is missing: $install_dir/secrets/cpamp-admin-key. Run with CPAMP_OPERATION=repair."
+  fi
+}
+
+ensure_repair_admin_key() {
+  if [ "$admin_secret_missing" != "1" ]; then
+    return 0
+  fi
+  generated_admin_key="cpamp_$(random_alnum 32)"
+  admin_key="$(ensure_secret_file "$install_dir/secrets/cpamp-admin-key" "$generated_admin_key")"
+  admin_secret_missing="0"
+}
+
 normalize_port() {
   local value="$1"
   case "$value" in
@@ -359,7 +684,7 @@ collect_choices() {
   local method_choice=""
   local conn_choice=""
 
-  mode_choice="${CPAMP_INSTALL_MODE:-}"
+  mode_choice="${CPAMP_INSTALL_MODE:-${install_mode:-}}"
   if [ -z "$mode_choice" ]; then
     mode_choice="$(prompt_choice "$(text select_mode)" "1" "1 2")"
     case "$mode_choice" in
@@ -370,7 +695,10 @@ collect_choices() {
     install_mode="$mode_choice"
   fi
 
-  method_choice="${CPAMP_DEPLOY_METHOD:-}"
+  method_choice="${CPAMP_DEPLOY_METHOD:-${deploy_method:-}}"
+  if [ "$existing_install_state" = "orphan-volume" ] && [ "$operation" = "repair" ]; then
+    method_choice="docker"
+  fi
   if [ -z "$method_choice" ]; then
     method_choice="$(prompt_choice "$(text select_method)" "1" "1 2")"
     case "$method_choice" in
@@ -401,17 +729,16 @@ collect_choices() {
     return 1
   fi
 
-  install_dir="$(expand_path "$(prompt_line "$(text install_dir)" "${CPAMP_INSTALL_DIR:-$default_install_dir}")")"
-  cpamp_port="$(prompt_line "$(text cpamp_port)" "${CPAMP_PORT:-18317}")"
+  cpamp_port="$(prompt_line "$(text cpamp_port)" "${CPAMP_PORT:-${cpamp_port:-18317}}")"
   normalize_port "$cpamp_port" || die "Invalid CPAMP port: $cpamp_port"
 
   if [ "$deploy_method" = "docker" ]; then
-    cpamp_image="$(prompt_line "$(text cpamp_image)" "${CPAMP_IMAGE:-$default_cpamp_image}")"
+    cpamp_image="$(prompt_line "$(text cpamp_image)" "${CPAMP_IMAGE:-${cpamp_image:-$default_cpamp_image}}")"
     validate_image_ref "$(text cpamp_image)" "$cpamp_image"
     if [ "$install_mode" = "stack" ]; then
-      cpa_port="$(prompt_line "$(text cpa_port)" "${CPAMP_CPA_PORT:-8317}")"
+      cpa_port="$(prompt_line "$(text cpa_port)" "${CPAMP_CPA_PORT:-${cpa_port:-8317}}")"
       normalize_port "$cpa_port" || die "Invalid CPA port: $cpa_port"
-      cpa_image="$(prompt_line "$(text cpa_image)" "${CPAMP_CPA_IMAGE:-$default_cpa_image}")"
+      cpa_image="$(prompt_line "$(text cpa_image)" "${CPAMP_CPA_IMAGE:-${cpa_image:-$default_cpa_image}}")"
       validate_image_ref "$(text cpa_image)" "$cpa_image"
       cpa_url="http://cli-proxy-api:8317"
       cpa_connection_mode="env"
@@ -422,7 +749,7 @@ collect_choices() {
   fi
 
   if [ "$install_mode" = "cpamp" ]; then
-    conn_choice="${CPAMP_CPA_CONNECTION_MODE:-}"
+    conn_choice="${CPAMP_CPA_CONNECTION_MODE:-${cpa_connection_mode:-}}"
     if [ -z "$conn_choice" ]; then
       if [ "$non_interactive" = "1" ]; then
         cpa_connection_mode="setup"
@@ -448,7 +775,7 @@ collect_choices() {
       if [ "$deploy_method" = "docker" ]; then
         default_cpa_url="http://host.docker.internal:8317"
       fi
-      cpa_url="$(prompt_line "$(text cpa_url)" "${CPAMP_CPA_URL:-$default_cpa_url}")"
+      cpa_url="$(prompt_line "$(text cpa_url)" "${CPAMP_CPA_URL:-${cpa_url:-$default_cpa_url}}")"
       validate_url_value "$(text cpa_url)" "$cpa_url"
       cpa_management_key="$(prompt_secret "$(text cpa_key)" "${CPAMP_CPA_MANAGEMENT_KEY:-}")"
       if [ -n "$cpa_management_key" ]; then
@@ -461,6 +788,7 @@ collect_choices() {
 print_summary() {
   say ""
   say "== $(text summary) =="
+  say "$(text operation_label): $(text "operation_${operation}")"
   if [ "$install_mode" = "stack" ]; then
     say "$(text install_mode_label): $(text stack_mode)"
   else
@@ -472,6 +800,9 @@ print_summary() {
     say "$(text deploy_method_label): $(text native_method)"
   fi
   say "$(text directory_label): $install_dir"
+  if [ "$deploy_method" = "docker" ]; then
+    say "$(text project_name): $compose_project_name"
+  fi
   say "$(text cpamp_port): $cpamp_port"
   if [ "$deploy_method" = "docker" ]; then
     say "$(text cpamp_image): $cpamp_image"
@@ -551,8 +882,13 @@ check_requirements() {
 
   if [ "$deploy_method" = "docker" ]; then
     require_command docker
-    if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ] && ! docker compose version >/dev/null 2>&1; then
-      die "docker compose is required."
+    if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+      if ! docker compose version >/dev/null 2>&1; then
+        die "docker compose is required."
+      fi
+      if ! docker info >/dev/null 2>&1; then
+        die "$(text docker_unavailable)"
+      fi
     fi
   else
     case "$normalized_os" in
@@ -606,9 +942,33 @@ ensure_dir() {
   mkdir -p "$dir"
 }
 
+overwrite_enabled() {
+  [ "${CPAMP_OVERWRITE:-0}" = "1" ] || [ "$operation" = "regenerate" ]
+}
+
+backup_generated_config() {
+  local backup_dir=""
+  local source=""
+  local relative=""
+
+  if [ "$operation" != "regenerate" ] || [ "$dry_run" = "1" ]; then
+    return 0
+  fi
+  backup_dir="$install_dir/backups/installer-$(date '+%Y%m%d-%H%M%S')"
+  for relative in .env compose.yaml cliproxyapi/config.yaml run.sh cpa-manager-plus.service; do
+    source="$install_dir/$relative"
+    [ -e "$source" ] || continue
+    mkdir -p "$backup_dir/$(dirname "$relative")"
+    cp -p "$source" "$backup_dir/$relative"
+  done
+  if [ -d "$backup_dir" ]; then
+    say "$(text config_backup): $backup_dir"
+  fi
+}
+
 prepare_file() {
   local file="$1"
-  if [ -e "$file" ] && [ "${CPAMP_OVERWRITE:-0}" != "1" ]; then
+  if [ -e "$file" ] && ! overwrite_enabled; then
     die "File already exists: $file. Set CPAMP_OVERWRITE=1 if you want to overwrite generated config files."
   fi
   mkdir -p "$(dirname "$file")"
@@ -619,7 +979,7 @@ preflight_file_write() {
   if [ "$dry_run" = "1" ]; then
     return
   fi
-  if [ -e "$file" ] && [ "${CPAMP_OVERWRITE:-0}" != "1" ]; then
+  if [ -e "$file" ] && ! overwrite_enabled; then
     die "File already exists: $file. Set CPAMP_OVERWRITE=1 if you want to overwrite generated config files."
   fi
 }
@@ -629,7 +989,7 @@ preflight_native_binary_dir() {
   if [ "$dry_run" = "1" ]; then
     return
   fi
-  if [ -d "$dir" ] && [ "${CPAMP_OVERWRITE:-0}" != "1" ]; then
+  if [ -d "$dir" ] && ! overwrite_enabled; then
     die "Directory already exists: $dir. Set CPAMP_OVERWRITE=1 if you want to reuse it."
   fi
 }
@@ -671,24 +1031,29 @@ ensure_secret_file() {
 
 write_env_file() {
   local file="$install_dir/.env"
+  local tmp="${file}.tmp.$$"
   if [ "$dry_run" = "1" ]; then
     say "$(text write_file): $file"
     return
   fi
   prepare_file "$file"
   {
-    printf 'COMPOSE_PROJECT_NAME=cpamp\n'
+    printf 'COMPOSE_PROJECT_NAME=%s\n' "$compose_project_name"
     printf 'CPAMP_IMAGE=%s\n' "$cpamp_image"
     printf 'CPAMP_PORT=%s\n' "$cpamp_port"
     if [ "$install_mode" = "stack" ]; then
       printf 'CPA_IMAGE=%s\n' "$cpa_image"
       printf 'CPA_PORT=%s\n' "$cpa_port"
+    elif [ "$cpa_connection_mode" = "env" ]; then
+      printf 'CPA_UPSTREAM_URL=%s\n' "$cpa_url"
     fi
-  } > "$file"
+  } > "$tmp"
+  mv -f "$tmp" "$file"
 }
 
 write_cpa_config() {
   local file="$install_dir/cliproxyapi/config.yaml"
+  local tmp="${file}.tmp.$$"
   local escaped_cpa_management_key=""
   local escaped_demo_client_key=""
   if [ "$dry_run" = "1" ]; then
@@ -698,7 +1063,7 @@ write_cpa_config() {
   prepare_file "$file"
   escaped_cpa_management_key="$(yaml_double_quote_escape "$cpa_management_key")"
   escaped_demo_client_key="$(yaml_double_quote_escape "$demo_client_key")"
-  cat > "$file" <<EOF
+  cat > "$tmp" <<EOF
 host: "0.0.0.0"
 port: 8317
 
@@ -717,6 +1082,7 @@ auth-dir: "/root/.cli-proxy-api"
 api-keys:
   - "$escaped_demo_client_key"
 EOF
+  mv -f "$tmp" "$file"
 }
 
 docker_needs_host_gateway() {
@@ -732,6 +1098,7 @@ docker_needs_host_gateway() {
 
 write_docker_compose() {
   local file="$install_dir/compose.yaml"
+  local tmp="${file}.tmp.$$"
   if [ "$dry_run" = "1" ]; then
     say "$(text write_file): $file"
     return
@@ -739,7 +1106,7 @@ write_docker_compose() {
   prepare_file "$file"
 
   if [ "$install_mode" = "stack" ]; then
-    cat > "$file" <<'EOF'
+    cat > "$tmp" <<'EOF'
 services:
   cli-proxy-api:
     image: ${CPA_IMAGE}
@@ -793,7 +1160,7 @@ secrets:
     file: ./secrets/cpa-management-key
 EOF
   elif [ "$cpa_connection_mode" = "env" ]; then
-    cat > "$file" <<'EOF'
+    cat > "$tmp" <<'EOF'
 services:
   cpa-manager-plus:
     image: ${CPAMP_IMAGE}
@@ -802,12 +1169,12 @@ services:
       - "${CPAMP_PORT}:18317"
 EOF
     if docker_needs_host_gateway; then
-      cat >> "$file" <<'EOF'
+      cat >> "$tmp" <<'EOF'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 EOF
     fi
-    cat >> "$file" <<'EOF'
+    cat >> "$tmp" <<'EOF'
     environment:
       HTTP_ADDR: "0.0.0.0:18317"
       USAGE_DB_PATH: "/data/usage.sqlite"
@@ -842,9 +1209,8 @@ secrets:
   cpa_management_key:
     file: ./secrets/cpa-management-key
 EOF
-    printf '\nCPA_UPSTREAM_URL=%s\n' "$cpa_url" >> "$install_dir/.env"
   else
-    cat > "$file" <<'EOF'
+    cat > "$tmp" <<'EOF'
 services:
   cpa-manager-plus:
     image: ${CPAMP_IMAGE}
@@ -881,6 +1247,7 @@ secrets:
     file: ./secrets/cpamp-admin-key
 EOF
   fi
+  mv -f "$tmp" "$file"
 }
 
 preflight_docker_files() {
@@ -934,6 +1301,95 @@ run_docker_install() {
   )
 }
 
+run_docker_repair() {
+  if [ "$dry_run" = "1" ]; then
+    say "$(text run_command): cd \"$install_dir\" && docker compose stop cpa-manager-plus"
+    say "$(text run_command): docker compose run --rm cpa-manager-plus reset-admin-key --admin-key-file /run/secrets/cpamp_admin_key"
+    say "$(text run_command): docker compose up -d"
+    return
+  fi
+  if [ "$skip_execute" = "1" ]; then
+    say "$(text skip_execute)"
+    return
+  fi
+  say "$(text repairing_admin)"
+  (
+    cd "$install_dir"
+    if [ "$existing_install_state" = "orphan-volume" ]; then
+      docker compose pull
+    fi
+    docker compose stop cpa-manager-plus
+    if ! docker compose run --rm cpa-manager-plus reset-admin-key --admin-key-file /run/secrets/cpamp_admin_key; then
+      docker compose up -d || true
+      die "$(text repair_failed)"
+    fi
+    if ! docker compose up -d; then
+      die "$(text repair_restart_failed)"
+    fi
+  )
+}
+
+wait_docker_health() {
+  local attempts=30
+  local i=1
+
+  while [ "$i" -le "$attempts" ]; do
+    if (
+      cd "$install_dir"
+      docker compose exec -T cpa-manager-plus wget -qO- http://127.0.0.1:18317/health >/dev/null 2>&1
+    ); then
+      return
+    fi
+    sleep 2
+    i=$((i + 1))
+  done
+  return 1
+}
+
+verify_docker_admin_key() {
+  [ -n "$admin_key" ] || return 1
+  (
+    cd "$install_dir"
+    docker compose exec -T cpa-manager-plus wget -qO- \
+      --header="Authorization: Bearer $admin_key" \
+      http://127.0.0.1:18317/status >/dev/null 2>&1
+  )
+}
+
+validate_docker_install() {
+  local answer=""
+
+  if [ "$dry_run" = "1" ] || [ "$skip_execute" = "1" ]; then
+    auth_validation_status="skipped"
+    return
+  fi
+  if ! wait_docker_health; then
+    die "$(text health_failed) Run 'cd \"$install_dir\" && docker compose logs cpa-manager-plus' for details."
+  fi
+  if verify_docker_admin_key; then
+    auth_validation_status="verified"
+    return
+  fi
+
+  say "$(text auth_failed)" >&2
+  if [ "$operation" = "repair" ]; then
+    die "$(text repair_verify_failed)"
+  fi
+  if [ "$non_interactive" = "1" ]; then
+    die "Run again with CPAMP_OPERATION=repair to synchronize the admin credential without deleting data."
+  fi
+  answer="$(prompt_choice "$(text auth_repair_prompt)" "yes" "yes no")"
+  if [ "$answer" != "yes" ]; then
+    die "Run the installer again and choose repair admin login."
+  fi
+  operation="repair"
+  run_docker_repair
+  if ! wait_docker_health || ! verify_docker_admin_key; then
+    die "$(text repair_verify_failed)"
+  fi
+  auth_validation_status="verified"
+}
+
 resolve_latest_version() {
   local version="$cpamp_version"
   local effective_url=""
@@ -952,13 +1408,14 @@ resolve_latest_version() {
 write_native_config() {
   local binary_dir="$1"
   local file="$binary_dir/config.json"
+  local tmp="${file}.tmp.$$"
   if [ "$dry_run" = "1" ]; then
     say "$(text write_file): $file"
     return
   fi
   prepare_file "$file"
   if [ "$cpa_connection_mode" = "env" ]; then
-    cat > "$file" <<EOF
+    cat > "$tmp" <<EOF
 {
   "httpAddr": "0.0.0.0:$cpamp_port",
   "dataDir": "../../data",
@@ -975,7 +1432,7 @@ write_native_config() {
 }
 EOF
   else
-    cat > "$file" <<EOF
+    cat > "$tmp" <<EOF
 {
   "httpAddr": "0.0.0.0:$cpamp_port",
   "dataDir": "../../data",
@@ -990,22 +1447,25 @@ EOF
 }
 EOF
   fi
+  mv -f "$tmp" "$file"
 }
 
 write_native_run_script() {
   local binary_dir="$1"
   local file="$install_dir/run.sh"
+  local tmp="${file}.tmp.$$"
   if [ "$dry_run" = "1" ]; then
     say "$(text write_file): $file"
     return
   fi
   prepare_file "$file"
-  cat > "$file" <<EOF
+  cat > "$tmp" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$binary_dir"
 exec ./cpa-manager-plus
 EOF
+  mv -f "$tmp" "$file"
   chmod 755 "$file"
 }
 
@@ -1022,6 +1482,7 @@ preflight_native_files() {
 write_native_systemd_service() {
   local binary_dir="$1"
   local file="$install_dir/cpa-manager-plus.service"
+  local tmp="${file}.tmp.$$"
   if [ "$normalized_os" != "linux" ]; then
     return
   fi
@@ -1030,7 +1491,7 @@ write_native_systemd_service() {
     return
   fi
   prepare_file "$file"
-  cat > "$file" <<EOF
+  cat > "$tmp" <<EOF
 [Unit]
 Description=CPA Manager Plus
 Wants=network-online.target
@@ -1046,6 +1507,7 @@ RestartSec=5s
 [Install]
 WantedBy=multi-user.target
 EOF
+  mv -f "$tmp" "$file"
 }
 
 generate_native_files() {
@@ -1162,22 +1624,51 @@ run_native_install() {
 }
 
 post_install_message() {
+  local reveal=""
   say ""
-  say "== $(text done) =="
-  say "$(text open_panel): http://127.0.0.1:${cpamp_port}/management.html"
-  say "$(text admin_key_file): $install_dir/secrets/cpamp-admin-key"
-  if [ -n "$admin_key" ]; then
-    say "$(text admin_key): $admin_key"
+  if [ "$dry_run" = "1" ]; then
+    say "== $(text dry_run_done) =="
+  elif [ "$skip_execute" = "1" ] && { [ "$operation" = "install" ] || [ "$operation" = "regenerate" ]; }; then
+    say "== $(text config_done) =="
+  elif [ "$skip_execute" = "1" ]; then
+    say "== $(text operation_skipped) =="
+  else
+    say "== $(text done) =="
+  fi
+  say "$(text operation_label): $(text "operation_${operation}")"
+  if [ "$dry_run" = "1" ] || [ "$admin_secret_missing" = "1" ]; then
+    say "$(text admin_key_file): $install_dir/secrets/cpamp-admin-key"
+  else
+    say "$(text key_saved): $install_dir/secrets/cpamp-admin-key"
+    say "$(text key_view_command): cat \"$install_dir/secrets/cpamp-admin-key\""
+  fi
+  if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+    say "$(text open_panel): http://127.0.0.1:${cpamp_port}/management.html"
+  fi
+  if [ "$auth_validation_status" = "verified" ]; then
+    say "$(text auth_verified)"
+  fi
+  if [ -n "$admin_key" ] && [ "$non_interactive" != "1" ] && [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+    reveal="$(prompt_choice "$(text key_reveal_prompt)" "no" "yes no")"
+    if [ "$reveal" = "yes" ]; then
+      say "$(text admin_key): $admin_key"
+    fi
   fi
   if [ "$install_mode" = "stack" ]; then
     say "$(text cpa_key_file): $install_dir/secrets/cpa-management-key"
     say "$(text demo_client_key_file): $install_dir/secrets/cpa-demo-client-key"
-    say "$(text next_full_stack)"
+    if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+      say "$(text next_full_stack)"
+    fi
   elif [ "$cpa_connection_mode" = "setup" ]; then
-    say "$(text next_setup)"
+    if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+      say "$(text next_setup)"
+    fi
   else
     say "$(text cpa_key_file): $install_dir/secrets/cpa-management-key"
-    say "$(text next_env_managed)"
+    if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+      say "$(text next_env_managed)"
+    fi
   fi
   if [ "$deploy_method" = "native" ] && [ "$normalized_os" = "linux" ]; then
     say "$(text systemd_file): $install_dir/cpa-manager-plus.service"
@@ -1194,6 +1685,32 @@ main() {
   show_environment
   confirm_environment
 
+  collect_install_directory
+  detect_existing_installation
+  resolve_operation
+  export COMPOSE_PROJECT_NAME="$compose_project_name"
+
+  if [ "$operation" = "upgrade" ] || { [ "$operation" = "repair" ] && [ "$existing_install_state" = "managed" ]; }; then
+    load_existing_docker_config
+    print_summary
+    check_requirements
+    if [ "$operation" = "upgrade" ]; then
+      run_docker_install
+    else
+      if [ "$dry_run" != "1" ] && [ "$skip_execute" != "1" ]; then
+        ensure_repair_admin_key
+      fi
+      run_docker_repair
+    fi
+    validate_docker_install
+    post_install_message
+    return
+  fi
+
+  if [ "$operation" = "regenerate" ] && [ "$existing_install_state" = "managed" ]; then
+    load_existing_docker_config
+  fi
+
   while true; do
     collect_choices || continue
     print_summary
@@ -1205,9 +1722,16 @@ main() {
   check_requirements
 
   if [ "$deploy_method" = "docker" ]; then
+    backup_generated_config
     generate_docker_files
-    run_docker_install
+    if [ "$operation" = "repair" ]; then
+      run_docker_repair
+    else
+      run_docker_install
+    fi
+    validate_docker_install
   else
+    backup_generated_config
     generate_native_files
     run_native_install
   fi

--- a/tests/installerScript.test.mjs
+++ b/tests/installerScript.test.mjs
@@ -1,5 +1,15 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,6 +45,42 @@ const runInstallerFromStdin = (env) =>
     },
     encoding: 'utf8',
   });
+
+const writeFakeDocker = (dir) => {
+  const fakeDocker = path.join(dir, 'docker');
+  writeFileSync(
+    fakeDocker,
+    `#!/usr/bin/env bash
+set -eu
+if [ -n "\${FAKE_DOCKER_LOG:-}" ]; then
+  printf '%s|%s\n' "\${COMPOSE_PROJECT_NAME:-}" "$*" >> "$FAKE_DOCKER_LOG"
+fi
+if [ "$1" = "volume" ] && [ "\${2:-}" = "inspect" ]; then
+  if [ "\${FAKE_DOCKER_VOLUME_EXISTS:-0}" = "1" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+if [ "$1" = "info" ] && [ "\${FAKE_DOCKER_DAEMON_OK:-1}" != "1" ]; then
+  exit 1
+fi
+if [ "$1" = "compose" ] && [ "\${2:-}" = "exec" ]; then
+  case "$*" in
+    *'/status'*)
+      if [ "\${FAKE_DOCKER_AUTH_OK:-1}" = "1" ]; then
+        exit 0
+      fi
+      exit 1
+      ;;
+    *) exit 0 ;;
+  esac
+fi
+exit 0
+`
+  );
+  chmodSync(fakeDocker, 0o755);
+  return fakeDocker;
+};
 
 describe('installer script', () => {
   it('passes shell syntax validation', () => {
@@ -77,7 +123,7 @@ describe('installer script', () => {
     expect(result.stdout).toContain('Install scope: CPA + CPAMP stack');
     expect(result.stdout).toContain('CPA URL for CPAMP: http://cli-proxy-api:8317');
     expect(result.stdout).toContain('docker compose pull');
-    expect(result.stdout).toContain('first setup is not required');
+    expect(result.stdout).toContain('Dry-run plan completed');
   });
 
   it('keeps CPAMP-only non-interactive installs in first-setup mode by default', () => {
@@ -88,7 +134,7 @@ describe('installer script', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('CPA connection: enter during first setup');
-    expect(result.stdout).toContain('After opening the panel, enter the CPA URL and CPA Management Key in setup.');
+    expect(result.stdout).toContain('Dry-run plan completed');
   });
 
   it('rejects native full stack installs', () => {
@@ -152,6 +198,51 @@ describe('installer script', () => {
     expect(combinedOutput(result)).toContain('CPAMP Docker image contains unsupported characters');
   });
 
+  it('rejects Docker Compose project names that Docker would normalize differently', () => {
+    const result = runInstaller({
+      CPAMP_PROJECT_NAME: 'CPAMP.Bad',
+      CPAMP_INSTALL_MODE: 'stack',
+      CPAMP_DEPLOY_METHOD: 'docker',
+    });
+
+    expect(result.status).toBe(1);
+    expect(combinedOutput(result)).toContain(
+      'Docker Compose project name contains unsupported characters'
+    );
+  });
+
+  it('rejects an empty persisted Docker Compose project name', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+
+    try {
+      mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
+      writeFileSync(path.join(installDir, '.env'), 'COMPOSE_PROJECT_NAME=\nCPAMP_PORT=18317\n');
+      writeFileSync(
+        path.join(installDir, 'compose.yaml'),
+        'services:\n  cpa-manager-plus:\n    image: example/cpamp:v1\n'
+      );
+      writeFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'cpamp_existing_admin_key\n');
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_DRY_RUN: '1',
+          CPAMP_OPERATION: 'upgrade',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('Docker Compose project name must not be empty');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+    }
+  });
+
   it('fails instead of looping when the random source yields no alphanumeric characters', () => {
     const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
 
@@ -167,7 +258,9 @@ describe('installer script', () => {
       });
 
       expect(result.status).toBe(1);
-      expect(combinedOutput(result)).toContain('Random source produced no usable alphanumeric characters');
+      expect(combinedOutput(result)).toContain(
+        'Random source produced no usable alphanumeric characters'
+      );
     } finally {
       rmSync(fakeBin, { recursive: true, force: true });
     }
@@ -196,9 +289,18 @@ describe('installer script', () => {
 
       const compose = readFileSync(path.join(installDir, 'compose.yaml'), 'utf8');
       const cpaConfig = readFileSync(path.join(installDir, 'cliproxyapi/config.yaml'), 'utf8');
-      const adminKey = readFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'utf8').trim();
-      const cpaManagementKey = readFileSync(path.join(installDir, 'secrets/cpa-management-key'), 'utf8').trim();
-      const demoClientKey = readFileSync(path.join(installDir, 'secrets/cpa-demo-client-key'), 'utf8').trim();
+      const adminKey = readFileSync(
+        path.join(installDir, 'secrets/cpamp-admin-key'),
+        'utf8'
+      ).trim();
+      const cpaManagementKey = readFileSync(
+        path.join(installDir, 'secrets/cpa-management-key'),
+        'utf8'
+      ).trim();
+      const demoClientKey = readFileSync(
+        path.join(installDir, 'secrets/cpa-demo-client-key'),
+        'utf8'
+      ).trim();
 
       expect(compose).toContain('./cliproxyapi/config.yaml:/CLIProxyAPI/config.yaml');
       expect(compose).toContain('./cliproxyapi/auths:/root/.cli-proxy-api');
@@ -243,7 +345,7 @@ describe('installer script', () => {
 
       expect(envFile).toContain('CPA_UPSTREAM_URL=http://host.docker.internal:8317');
       expect(result.stdout).toContain('first setup');
-      expect(result.stdout).toContain('Open the panel and log in with the CPAMP Admin Key');
+      expect(result.stdout).toContain('Deployment config generated');
       if (process.platform === 'linux') {
         expect(compose).toContain('host.docker.internal:host-gateway');
       }
@@ -257,7 +359,10 @@ describe('installer script', () => {
 
     try {
       mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
-      writeFileSync(path.join(installDir, 'secrets/cpa-management-key'), 'cpa_reused_management_key\n');
+      writeFileSync(
+        path.join(installDir, 'secrets/cpa-management-key'),
+        'cpa_reused_management_key\n'
+      );
 
       const result = spawnSync('bash', [installerPath], {
         cwd: repoRoot,
@@ -293,7 +398,10 @@ describe('installer script', () => {
 
     try {
       mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
-      writeFileSync(path.join(installDir, 'secrets/cpa-management-key'), 'cpa_reused_management_key\n');
+      writeFileSync(
+        path.join(installDir, 'secrets/cpa-management-key'),
+        'cpa_reused_management_key\n'
+      );
 
       const result = spawnSync('bash', [installerPath], {
         cwd: repoRoot,
@@ -319,7 +427,443 @@ describe('installer script', () => {
     }
   });
 
-  it('does not leave partial Docker files when generated config already exists', () => {
+  it('blocks non-interactive installs when an orphaned Docker data volume exists', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+
+    try {
+      writeFakeDocker(fakeBin);
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_SKIP_EXECUTE: '1',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_VOLUME_EXISTS: '1',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('old Docker data volume exists');
+      expect(existsSync(path.join(installDir, 'compose.yaml'))).toBe(false);
+      expect(existsSync(path.join(installDir, 'secrets/cpamp-admin-key'))).toBe(false);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('requires the original install scope for non-interactive orphan-volume repair', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+
+    try {
+      writeFakeDocker(fakeBin);
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'repair',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_VOLUME_EXISTS: '1',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('requires CPAMP_INSTALL_MODE=stack or cpamp');
+      expect(existsSync(path.join(installDir, 'compose.yaml'))).toBe(false);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects skipped execution for orphan-volume repair before writing a new secret', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+
+    try {
+      writeFakeDocker(fakeBin);
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'repair',
+          CPAMP_SKIP_EXECUTE: '1',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_MODE: 'stack',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_VOLUME_EXISTS: '1',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('cannot use CPAMP_SKIP_EXECUTE=1');
+      expect(existsSync(path.join(installDir, 'secrets/cpamp-admin-key'))).toBe(false);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('fails before writing Docker config when the Docker daemon is unavailable', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+
+    try {
+      writeFakeDocker(fakeBin);
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_MODE: 'stack',
+          CPAMP_DEPLOY_METHOD: 'docker',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_DAEMON_OK: '0',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('Docker daemon is not available');
+      expect(existsSync(path.join(installDir, '.env'))).toBe(false);
+      expect(existsSync(path.join(installDir, 'compose.yaml'))).toBe(false);
+      expect(existsSync(path.join(installDir, 'secrets/cpamp-admin-key'))).toBe(false);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a replacement admin secret before repair preflight succeeds', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+
+    try {
+      writeFileSync(
+        path.join(installDir, '.env'),
+        'COMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/cpamp:v1\nCPAMP_PORT=18317\n'
+      );
+      writeFileSync(
+        path.join(installDir, 'compose.yaml'),
+        'services:\n  cpa-manager-plus:\n    image: ${CPAMP_IMAGE}\n'
+      );
+      writeFakeDocker(fakeBin);
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'repair',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_DAEMON_OK: '0',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('Docker daemon is not available');
+      expect(existsSync(path.join(installDir, 'secrets/cpamp-admin-key'))).toBe(false);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a half-repaired admin secret when repair execution is skipped', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+
+    try {
+      writeFileSync(
+        path.join(installDir, '.env'),
+        'COMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/cpamp:v1\nCPAMP_PORT=18317\n'
+      );
+      writeFileSync(
+        path.join(installDir, 'compose.yaml'),
+        'services:\n  cpa-manager-plus:\n    image: ${CPAMP_IMAGE}\n'
+      );
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'repair',
+          CPAMP_SKIP_EXECUTE: '1',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(existsSync(path.join(installDir, 'secrets/cpamp-admin-key'))).toBe(false);
+      expect(result.stdout).toContain('upgrade or repair commands were skipped');
+      expect(result.stdout).not.toContain('Admin key saved');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs an orphaned Docker deployment and verifies the generated admin key', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+    const dockerLog = path.join(
+      os.tmpdir(),
+      `cpamp-installer-docker-${process.pid}-${Date.now()}.log`
+    );
+
+    try {
+      writeFakeDocker(fakeBin);
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'repair',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_MODE: 'stack',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_LOG: dockerLog,
+          FAKE_DOCKER_VOLUME_EXISTS: '1',
+          FAKE_DOCKER_AUTH_OK: '1',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(dockerLog, 'utf8')).toContain(
+        'compose run --rm cpa-manager-plus reset-admin-key --admin-key-file /run/secrets/cpamp_admin_key'
+      );
+      expect(readFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'utf8').trim()).toMatch(
+        /^cpamp_[A-Za-z0-9]{32}$/
+      );
+      expect(result.stdout).toContain('Admin key verification passed');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+      rmSync(dockerLog, { force: true });
+    }
+  });
+
+  it('upgrades a managed Docker install without rewriting config or secrets', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+    const dockerLog = path.join(
+      os.tmpdir(),
+      `cpamp-installer-docker-${process.pid}-${Date.now()}.log`
+    );
+    const envContent =
+      'COMPOSE_PROJECT_NAME=oldproject\nCOMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/cpamp:v1\nCPAMP_PORT=19999\nCPAMP_PORT=18317\n';
+    const composeContent = 'services:\n  cpa-manager-plus:\n    image: ${CPAMP_IMAGE}\n';
+    const secretContent = 'cpamp_existing_admin_key\n';
+
+    try {
+      mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
+      writeFileSync(path.join(installDir, '.env'), envContent);
+      writeFileSync(path.join(installDir, 'compose.yaml'), composeContent);
+      writeFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), secretContent);
+      writeFakeDocker(fakeBin);
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'upgrade',
+          COMPOSE_PROJECT_NAME: 'wrong-project',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_LOG: dockerLog,
+          FAKE_DOCKER_AUTH_OK: '1',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(path.join(installDir, '.env'), 'utf8')).toBe(envContent);
+      expect(readFileSync(path.join(installDir, 'compose.yaml'), 'utf8')).toBe(composeContent);
+      expect(readFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'utf8')).toBe(
+        secretContent
+      );
+      expect(readFileSync(dockerLog, 'utf8')).toContain('compose pull');
+      expect(readFileSync(dockerLog, 'utf8')).toContain('compose up -d');
+      expect(readFileSync(dockerLog, 'utf8')).not.toContain('reset-admin-key');
+      expect(readFileSync(dockerLog, 'utf8')).toContain('cpamp|compose pull');
+      expect(result.stdout).toContain('Public CPAMP port: 18317');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+      rmSync(dockerLog, { force: true });
+    }
+  });
+
+  it('repairs a managed Docker login without pulling unrelated service images', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+    const dockerLog = path.join(
+      os.tmpdir(),
+      `cpamp-installer-docker-${process.pid}-${Date.now()}.log`
+    );
+
+    try {
+      mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
+      writeFileSync(
+        path.join(installDir, '.env'),
+        'COMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/cpamp:v1\nCPAMP_PORT=18317\n'
+      );
+      writeFileSync(
+        path.join(installDir, 'compose.yaml'),
+        'services:\n  cpa-manager-plus:\n    image: ${CPAMP_IMAGE}\n'
+      );
+      writeFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'cpamp_existing_admin_key\n');
+      writeFakeDocker(fakeBin);
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'repair',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_LOG: dockerLog,
+          FAKE_DOCKER_AUTH_OK: '1',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      const calls = readFileSync(dockerLog, 'utf8');
+      expect(calls).toContain(
+        'compose run --rm cpa-manager-plus reset-admin-key --admin-key-file /run/secrets/cpamp_admin_key'
+      );
+      expect(calls).not.toContain('compose pull');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+      rmSync(dockerLog, { force: true });
+    }
+  });
+
+  it('does not report success when post-start admin key verification fails', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const fakeBin = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-bin-'));
+
+    try {
+      mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
+      writeFileSync(
+        path.join(installDir, '.env'),
+        'COMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/cpamp:v1\nCPAMP_PORT=18317\n'
+      );
+      writeFileSync(
+        path.join(installDir, 'compose.yaml'),
+        'services:\n  cpa-manager-plus:\n    image: ${CPAMP_IMAGE}\n'
+      );
+      writeFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'cpamp_wrong_admin_key\n');
+      writeFakeDocker(fakeBin);
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'upgrade',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+          FAKE_DOCKER_AUTH_OK: '0',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(combinedOutput(result)).toContain('admin key verification failed');
+      expect(result.stdout).not.toContain('Install steps completed');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('backs up generated config before regenerating a managed Docker install', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const oldEnv = 'COMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/old:v1\nCPAMP_PORT=18317\n';
+    const oldCompose = 'services:\n  cpa-manager-plus:\n    image: old\n';
+
+    try {
+      mkdirSync(path.join(installDir, 'secrets'), { recursive: true });
+      writeFileSync(path.join(installDir, '.env'), oldEnv);
+      writeFileSync(path.join(installDir, 'compose.yaml'), oldCompose);
+      writeFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'cpamp_existing_admin_key\n');
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_OPERATION: 'regenerate',
+          CPAMP_SKIP_EXECUTE: '1',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_CONFIRM: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_MODE: 'cpamp',
+          CPAMP_DEPLOY_METHOD: 'docker',
+          CPAMP_CPA_CONNECTION_MODE: 'setup',
+          CPAMP_INSTALL_DIR: installDir,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      const backupNames = readdirSync(path.join(installDir, 'backups'));
+      expect(backupNames).toHaveLength(1);
+      const backupDir = path.join(installDir, 'backups', backupNames[0]);
+      expect(readFileSync(path.join(backupDir, '.env'), 'utf8')).toBe(oldEnv);
+      expect(readFileSync(path.join(backupDir, 'compose.yaml'), 'utf8')).toBe(oldCompose);
+      expect(readFileSync(path.join(installDir, 'secrets/cpamp-admin-key'), 'utf8')).toBe(
+        'cpamp_existing_admin_key\n'
+      );
+      expect(readFileSync(path.join(installDir, '.env'), 'utf8')).toContain(
+        'CPAMP_IMAGE=example/old:v1'
+      );
+      expect(readFileSync(path.join(installDir, '.env'), 'utf8')).toContain('CPAMP_PORT=18317');
+      expect(result.stdout).toContain('Previous config backed up to');
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks a partial Docker install before writing additional generated files', () => {
     const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
 
     try {
@@ -342,9 +886,46 @@ describe('installer script', () => {
       });
 
       expect(result.status).toBe(1);
-      expect(combinedOutput(result)).toContain('File already exists');
+      expect(combinedOutput(result)).toContain('Non-interactive mode requires CPAMP_OPERATION');
       expect(existsSync(path.join(installDir, '.env'))).toBe(false);
       expect(existsSync(path.join(installDir, 'secrets/cpamp-admin-key'))).toBe(false);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not change existing admin-secret permissions during dry runs', () => {
+    const installDir = mkdtempSync(path.join(os.tmpdir(), 'cpamp-installer-'));
+    const secretFile = path.join(installDir, 'secrets/cpamp-admin-key');
+
+    try {
+      mkdirSync(path.dirname(secretFile), { recursive: true });
+      writeFileSync(
+        path.join(installDir, '.env'),
+        'COMPOSE_PROJECT_NAME=cpamp\nCPAMP_IMAGE=example/cpamp:v1\nCPAMP_PORT=18317\n'
+      );
+      writeFileSync(
+        path.join(installDir, 'compose.yaml'),
+        'services:\n  cpa-manager-plus:\n    image: ${CPAMP_IMAGE}\n'
+      );
+      writeFileSync(secretFile, 'cpamp_existing_admin_key\n');
+      chmodSync(secretFile, 0o644);
+
+      const result = spawnSync('bash', [installerPath], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CPAMP_DRY_RUN: '1',
+          CPAMP_OPERATION: 'upgrade',
+          CPAMP_NON_INTERACTIVE: '1',
+          CPAMP_LANG: 'en-US',
+          CPAMP_INSTALL_DIR: installDir,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+      expect(statSync(secretFile).mode & 0o777).toBe(0o644);
     } finally {
       rmSync(installDir, { recursive: true, force: true });
     }
@@ -462,7 +1043,10 @@ describe('installer script', () => {
     try {
       mkdirSync(packageDir, { recursive: true });
       const fakeBinary = path.join(packageDir, 'cpa-manager-plus');
-      writeFileSync(fakeBinary, '#!/usr/bin/env bash\necho "fake native process exited" >&2\nexit 42\n');
+      writeFileSync(
+        fakeBinary,
+        '#!/usr/bin/env bash\necho "fake native process exited" >&2\nexit 42\n'
+      );
       chmodSync(fakeBinary, 0o755);
       const tarResult = spawnSync('tar', ['-czf', archivePath, '-C', fixtureDir, packageName], {
         cwd: repoRoot,
@@ -518,7 +1102,9 @@ exit 22
       });
 
       expect(result.status).toBe(1);
-      expect(combinedOutput(result)).toContain('Native CPAMP process exited before becoming healthy');
+      expect(combinedOutput(result)).toContain(
+        'Native CPAMP process exited before becoming healthy'
+      );
       expect(combinedOutput(result)).toContain('fake native process exited');
     } finally {
       rmSync(installDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Improve the CPAMP installer recovery experience for reruns, stale Docker volumes, and administrator-key/database mismatches. The change preserves existing secrets during upgrades, repairs mismatches explicitly, and validates authentication before reporting success.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Add explicit install, upgrade, repair, and regenerate paths with detection for partial configuration and orphaned Docker volumes.
- Reuse existing Docker configuration and secrets during upgrades; provide safe admin-key repair and authentication validation.
- Add regression coverage and bilingual deployment/reset documentation for rerun, backup, and recovery workflows.

## User Impact

Users can rerun the installer without unintentionally replacing existing administrator or CPA management credentials. When a preserved volume and configuration disagree, the installer now guides the user through repair and refuses to claim success until login validation passes.

## Compatibility / Runtime Notes

- CPA panel mode: Native-install detection behavior is preserved.
- Manager Server mode: Existing configuration and secret files are reused for upgrades; repair uses the supported reset-admin-key command.
- Full Docker / native packages: Docker health and /status authentication are validated before success output; generated configuration replacement is atomic and backed up for regeneration.

## Data / Security Notes

Existing secrets are preserved rather than printed or regenerated by default. Admin-key repair updates the stored administrator credential through the Manager Server command path; SQLite data and encryption material remain in their existing locations. No secrets, runtime databases, or generated artifacts are committed.

## Risk / Rollback

Risk level: Medium

Rollback notes:
- Revert the two commits and rerun the previous installer version.
- Before regeneration, restore the timestamped configuration backup if needed.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
35 focused installer tests passed
npm run test: 941 tests passed
npm run docs:build passed
bash -n bin/install-cpamp.sh passed
Prettier checks and git diff --check passed
Real Docker install, upgrade, mismatch repair, and orphan-volume repair passed in an isolated temporary deployment
```

## Screenshots / Recordings

N/A — installer, backend recovery, and documentation changes only.

## Docs

- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related

N/A