### PR TITLE
fix(web): guard OAuth writes and isolate provider request caches

### DIFF
--- a/apps/web/src/components/providers/hooks/useProviderRecentRequests.test.ts
+++ b/apps/web/src/components/providers/hooks/useProviderRecentRequests.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createProviderRecentRequestsCacheController } from './useProviderRecentRequests';
+
+describe('provider recent request cache isolation', () => {
+  it('creates a fresh cache when the connection scope changes', () => {
+    const controller = createProviderRecentRequestsCacheController();
+    const serverA = controller.forScope('scope-a');
+    serverA.cachedUsageByProvider = new Map([['provider-a', new Map()]]);
+    serverA.cachedAt = Date.now();
+    serverA.inFlightRequest = Promise.resolve(serverA.cachedUsageByProvider);
+
+    const serverB = controller.forScope('scope-b');
+
+    expect(serverB).not.toBe(serverA);
+    expect(serverB.cachedUsageByProvider.size).toBe(0);
+    expect(serverB.cachedAt).toBe(0);
+    expect(serverB.inFlightRequest).toBeNull();
+
+    serverA.cachedUsageByProvider = new Map([['late-provider-a', new Map()]]);
+    expect(controller.forScope('scope-b')).toBe(serverB);
+    expect(serverB.cachedUsageByProvider.size).toBe(0);
+  });
+
+  it('reuses the cache only within the same hashed connection scope', () => {
+    const controller = createProviderRecentRequestsCacheController();
+    const first = controller.forScope('scope-a');
+
+    expect(controller.forScope('scope-a')).toBe(first);
+    expect(controller.forScope('scope-b')).not.toBe(first);
+  });
+});

--- a/apps/web/src/components/providers/hooks/useProviderRecentRequests.ts
+++ b/apps/web/src/components/providers/hooks/useProviderRecentRequests.ts
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useInterval } from '@/hooks/useInterval';
 import { apiKeyUsageApi } from '@/services/api';
+import { useAuthStore } from '@/stores';
+import { sha256Hex } from '@/utils/apiKeyHash';
 import {
   normalizeRecentRequestUsageEntry,
   type ApiKeyUsageResponse,
@@ -17,11 +19,39 @@ export type UseProviderRecentRequestsOptions = {
 
 const EMPTY_USAGE_BY_PROVIDER: ProviderRecentRequests = new Map();
 
-let cachedUsageByProvider: ProviderRecentRequests = EMPTY_USAGE_BY_PROVIDER;
-let cachedAt = 0;
-let inFlightRequest: Promise<ProviderRecentRequests> | null = null;
+export type ProviderRecentRequestsCache = {
+  cachedUsageByProvider: ProviderRecentRequests;
+  cachedAt: number;
+  inFlightRequest: Promise<ProviderRecentRequests> | null;
+};
 
-const normalizeProviderKey = (value: unknown): string => String(value ?? '').trim().toLowerCase();
+const createProviderRecentRequestsCache = (): ProviderRecentRequestsCache => ({
+  cachedUsageByProvider: EMPTY_USAGE_BY_PROVIDER,
+  cachedAt: 0,
+  inFlightRequest: null,
+});
+
+export const createProviderRecentRequestsCacheController = () => {
+  let currentScope = '';
+  let currentCache = createProviderRecentRequestsCache();
+
+  return {
+    forScope(scope: string): ProviderRecentRequestsCache {
+      if (scope !== currentScope) {
+        currentScope = scope;
+        currentCache = createProviderRecentRequestsCache();
+      }
+      return currentCache;
+    },
+  };
+};
+
+const providerRecentRequestsCacheController = createProviderRecentRequestsCacheController();
+
+const normalizeProviderKey = (value: unknown): string =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase();
 
 const normalizeApiKeyUsageResponse = (payload: ApiKeyUsageResponse): ProviderRecentRequests => {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
@@ -47,30 +77,53 @@ const normalizeApiKeyUsageResponse = (payload: ApiKeyUsageResponse): ProviderRec
   return usageByProvider;
 };
 
-const fetchProviderRecentRequests = async (): Promise<ProviderRecentRequests> => {
-  if (!inFlightRequest) {
-    inFlightRequest = apiKeyUsageApi
+const fetchProviderRecentRequests = async (
+  cache: ProviderRecentRequestsCache
+): Promise<ProviderRecentRequests> => {
+  if (!cache.inFlightRequest) {
+    const request = apiKeyUsageApi
       .getUsage()
       .then((payload) => {
         const normalized = normalizeApiKeyUsageResponse(payload);
-        cachedUsageByProvider = normalized;
-        cachedAt = Date.now();
+        cache.cachedUsageByProvider = normalized;
+        cache.cachedAt = Date.now();
         return normalized;
       })
       .finally(() => {
-        inFlightRequest = null;
+        if (cache.inFlightRequest === request) {
+          cache.inFlightRequest = null;
+        }
       });
+    cache.inFlightRequest = request;
   }
 
-  return inFlightRequest;
+  return cache.inFlightRequest;
 };
 
 export function useProviderRecentRequests(options: UseProviderRecentRequestsOptions = {}) {
   const enabled = options.enabled ?? true;
-  const [usageByProvider, setUsageByProvider] = useState<ProviderRecentRequests>(
-    cachedUsageByProvider
+  const apiBase = useAuthStore((state) => state.apiBase);
+  const managementKey = useAuthStore((state) => state.managementKey);
+  const scope = useMemo(
+    () => (apiBase || managementKey ? sha256Hex(`${apiBase}\u0000${managementKey}`) : ''),
+    [apiBase, managementKey]
   );
-  const [isLoading, setIsLoading] = useState(false);
+  const cache = useMemo(() => providerRecentRequestsCacheController.forScope(scope), [scope]);
+  const [usageState, setUsageState] = useState(() => ({
+    cache,
+    value: cache.cachedUsageByProvider,
+  }));
+  const [loadingState, setLoadingState] = useState(() => ({ cache, value: false }));
+
+  const setUsageForCurrentScope = useCallback(
+    (value: ProviderRecentRequests) => setUsageState({ cache, value }),
+    [cache]
+  );
+
+  const setLoadingForCurrentScope = useCallback(
+    (value: boolean) => setLoadingState({ cache, value }),
+    [cache]
+  );
 
   const loadRecentRequests = useCallback(
     async (loadOptions: { force?: boolean } = {}) => {
@@ -79,29 +132,28 @@ export function useProviderRecentRequests(options: UseProviderRecentRequestsOpti
       }
 
       const hasFreshCache =
-        cachedAt > 0 &&
-        Date.now() - cachedAt < PROVIDER_RECENT_REQUESTS_STALE_TIME_MS;
+        cache.cachedAt > 0 && Date.now() - cache.cachedAt < PROVIDER_RECENT_REQUESTS_STALE_TIME_MS;
 
       if (!loadOptions.force && hasFreshCache) {
-        setUsageByProvider(cachedUsageByProvider);
-        return cachedUsageByProvider;
+        setUsageForCurrentScope(cache.cachedUsageByProvider);
+        return cache.cachedUsageByProvider;
       }
 
-      setIsLoading(true);
+      setLoadingForCurrentScope(true);
       try {
-        const nextUsage = await fetchProviderRecentRequests();
-        setUsageByProvider(nextUsage);
+        const nextUsage = await fetchProviderRecentRequests(cache);
+        setUsageForCurrentScope(nextUsage);
         return nextUsage;
       } catch {
-        if (cachedAt > 0) {
-          setUsageByProvider(cachedUsageByProvider);
+        if (cache.cachedAt > 0) {
+          setUsageForCurrentScope(cache.cachedUsageByProvider);
         }
-        return cachedUsageByProvider;
+        return cache.cachedUsageByProvider;
       } finally {
-        setIsLoading(false);
+        setLoadingForCurrentScope(false);
       }
     },
-    [enabled]
+    [cache, enabled, setLoadingForCurrentScope, setUsageForCurrentScope]
   );
 
   const refreshRecentRequests = useCallback(
@@ -110,12 +162,24 @@ export function useProviderRecentRequests(options: UseProviderRecentRequestsOpti
   );
 
   useEffect(() => {
-    setUsageByProvider(enabled ? cachedUsageByProvider : EMPTY_USAGE_BY_PROVIDER);
-  }, [enabled]);
+    if (!enabled) {
+      setUsageForCurrentScope(EMPTY_USAGE_BY_PROVIDER);
+      return;
+    }
+    void loadRecentRequests().catch(() => {});
+  }, [enabled, loadRecentRequests, setUsageForCurrentScope]);
 
-  useInterval(() => {
-    void refreshRecentRequests().catch(() => {});
-  }, enabled ? PROVIDER_RECENT_REQUESTS_STALE_TIME_MS : null);
+  useInterval(
+    () => {
+      void refreshRecentRequests().catch(() => {});
+    },
+    enabled ? PROVIDER_RECENT_REQUESTS_STALE_TIME_MS : null
+  );
+
+  const usageByProvider =
+    usageState.cache === cache ? usageState.value : cache.cachedUsageByProvider;
+  const isLoading =
+    loadingState.cache === cache ? loadingState.value : cache.inFlightRequest !== null;
 
   return {
     usageByProvider: enabled ? usageByProvider : EMPTY_USAGE_BY_PROVIDER,

--- a/apps/web/src/features/authFiles/AuthFilesOAuthExcludedEditPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesOAuthExcludedEditPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
@@ -15,11 +15,9 @@ import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard';
 import { useAuthStore, useNotificationStore } from '@/stores';
 import { authFilesApi } from '@/services/api';
 import type { AuthFileItem, OAuthModelAliasEntry } from '@/types';
+import { getErrorMessage } from '@/utils/helpers';
 import styles from './AuthFilesOAuthExcludedEditPage.module.scss';
-import {
-  addOAuthExcludedRule,
-  serializeOAuthExcludedRules,
-} from './oauthExcludedRules';
+import { addOAuthExcludedRule, serializeOAuthExcludedRules } from './oauthExcludedRules';
 
 type AuthFileModelItem = { id: string; display_name?: string; type?: string; owned_by?: string };
 
@@ -56,7 +54,10 @@ export function AuthFilesOAuthExcludedEditPage() {
   const [excluded, setExcluded] = useState<Record<string, string[]>>({});
   const [modelAlias, setModelAlias] = useState<Record<string, OAuthModelAliasEntry[]>>({});
   const [initialLoading, setInitialLoading] = useState(true);
+  const [initialLoadError, setInitialLoadError] = useState<string | null>(null);
+  const [baselineReady, setBaselineReady] = useState(false);
   const [excludedUnsupported, setExcludedUnsupported] = useState(false);
+  const loadRequestRef = useRef(0);
 
   const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set());
   const [modelsList, setModelsList] = useState<AuthFileModelItem[]>([]);
@@ -114,10 +115,7 @@ export function AuthFilesOAuthExcludedEditPage() {
     () => serializeOAuthExcludedRules(excluded[resolvedProviderKey] ?? []),
     [excluded, resolvedProviderKey]
   );
-  const currentRules = useMemo(
-    () => serializeOAuthExcludedRules(selectedModels),
-    [selectedModels]
-  );
+  const currentRules = useMemo(() => serializeOAuthExcludedRules(selectedModels), [selectedModels]);
   const isDirty =
     customRule.trim().length > 0 || JSON.stringify(currentRules) !== JSON.stringify(initialRules);
   const { allowNextNavigation } = useUnsavedChangesGuard({
@@ -160,61 +158,60 @@ export function AuthFilesOAuthExcludedEditPage() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleBack]);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadInitialData = useCallback(async () => {
+    const requestId = ++loadRequestRef.current;
+    setInitialLoading(true);
+    setInitialLoadError(null);
+    setBaselineReady(false);
+    setExcludedUnsupported(false);
+    try {
+      const [filesResult, excludedResult, aliasResult] = await Promise.allSettled([
+        authFilesApi.list(),
+        authFilesApi.getOauthExcludedModels(),
+        authFilesApi.getOauthModelAlias(),
+      ]);
 
-    const load = async () => {
-      setInitialLoading(true);
-      setExcludedUnsupported(false);
-      try {
-        const [filesResult, excludedResult, aliasResult] = await Promise.allSettled([
-          authFilesApi.list(),
-          authFilesApi.getOauthExcludedModels(),
-          authFilesApi.getOauthModelAlias(),
-        ]);
+      if (requestId !== loadRequestRef.current) return;
 
-        if (cancelled) return;
-
-        if (filesResult.status === 'fulfilled') {
-          setFiles(filesResult.value?.files ?? []);
-        }
-
-        if (aliasResult.status === 'fulfilled') {
-          setModelAlias(aliasResult.value ?? {});
-        }
-
-        if (excludedResult.status === 'fulfilled') {
-          setExcluded(excludedResult.value ?? {});
-          return;
-        }
-
-        const err = excludedResult.status === 'rejected' ? excludedResult.reason : null;
-        const status =
-          typeof err === 'object' && err !== null && 'status' in err
-            ? (err as { status?: unknown }).status
-            : undefined;
-
-        if (status === 404) {
-          setExcludedUnsupported(true);
-          return;
-        }
-      } finally {
-        if (!cancelled) {
-          setInitialLoading(false);
-        }
+      if (filesResult.status === 'fulfilled') {
+        setFiles(filesResult.value?.files ?? []);
       }
-    };
+      if (aliasResult.status === 'fulfilled') {
+        setModelAlias(aliasResult.value ?? {});
+      }
+      if (excludedResult.status === 'fulfilled') {
+        setExcluded(excludedResult.value ?? {});
+        setBaselineReady(true);
+        return;
+      }
 
-    load().catch(() => {
-      if (!cancelled) {
+      const err = excludedResult.reason;
+      const status =
+        typeof err === 'object' && err !== null && 'status' in err
+          ? (err as { status?: unknown }).status
+          : undefined;
+      if (status === 404) {
+        setExcludedUnsupported(true);
+        return;
+      }
+      setInitialLoadError(getErrorMessage(err));
+    } catch (err: unknown) {
+      if (requestId === loadRequestRef.current) {
+        setInitialLoadError(getErrorMessage(err));
+      }
+    } finally {
+      if (requestId === loadRequestRef.current) {
         setInitialLoading(false);
       }
-    });
-
-    return () => {
-      cancelled = true;
-    };
+    }
   }, []);
+
+  useEffect(() => {
+    void loadInitialData();
+    return () => {
+      loadRequestRef.current += 1;
+    };
+  }, [loadInitialData]);
 
   useEffect(() => {
     if (!resolvedProviderKey) {
@@ -297,6 +294,10 @@ export function AuthFilesOAuthExcludedEditPage() {
   }, []);
 
   const handleSave = useCallback(async () => {
+    if (!baselineReady || initialLoadError !== null) {
+      showNotification(t('notification.refresh_failed'), 'error');
+      return;
+    }
     const normalizedProvider = normalizeProviderKey(provider);
     if (!normalizedProvider) {
       showNotification(t('oauth_excluded.provider_required'), 'error');
@@ -320,9 +321,24 @@ export function AuthFilesOAuthExcludedEditPage() {
     } finally {
       setSaving(false);
     }
-  }, [allowNextNavigation, customRule, handleBack, provider, selectedModels, showNotification, t]);
+  }, [
+    allowNextNavigation,
+    baselineReady,
+    customRule,
+    handleBack,
+    initialLoadError,
+    provider,
+    selectedModels,
+    showNotification,
+    t,
+  ]);
 
-  const canSave = !disableControls && !saving && !excludedUnsupported;
+  const canSave =
+    !disableControls &&
+    !saving &&
+    baselineReady &&
+    !excludedUnsupported &&
+    initialLoadError === null;
 
   return (
     <SecondaryScreenShell
@@ -345,6 +361,18 @@ export function AuthFilesOAuthExcludedEditPage() {
           <EmptyState
             title={t('oauth_excluded.upgrade_required_title')}
             description={t('oauth_excluded.upgrade_required_desc')}
+          />
+        </Card>
+      ) : initialLoadError !== null ? (
+        <Card>
+          <EmptyState
+            title={t('notification.refresh_failed')}
+            description={initialLoadError || t('notification.refresh_failed')}
+            action={
+              <Button variant="secondary" size="sm" onClick={() => void loadInitialData()}>
+                {t('common.refresh')}
+              </Button>
+            }
           />
         </Card>
       ) : (
@@ -460,7 +488,9 @@ export function AuthFilesOAuthExcludedEditPage() {
             <div className={styles.settingsSection}>
               <div className={styles.settingsRow}>
                 <div className={styles.settingsInfo}>
-                  <div className={styles.settingsLabel}>{t('oauth_excluded.custom_rule_label')}</div>
+                  <div className={styles.settingsLabel}>
+                    {t('oauth_excluded.custom_rule_label')}
+                  </div>
                   <div className={styles.settingsDesc}>{t('oauth_excluded.custom_rule_hint')}</div>
                 </div>
                 <div className={styles.settingsControl}>

--- a/apps/web/src/features/authFiles/AuthFilesOAuthModelAliasEditPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesOAuthModelAliasEditPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
@@ -13,7 +13,7 @@ import { useUnsavedChangesGuard } from '@/hooks/useUnsavedChangesGuard';
 import { useAuthStore, useNotificationStore } from '@/stores';
 import { authFilesApi } from '@/services/api';
 import type { AuthFileItem, OAuthModelAliasEntry } from '@/types';
-import { generateId } from '@/utils/helpers';
+import { generateId, getErrorMessage } from '@/utils/helpers';
 import styles from './AuthFilesOAuthModelAliasEditPage.module.scss';
 import { isOAuthAliasDraftDirty } from './oauthEditorState';
 
@@ -77,9 +77,14 @@ export function AuthFilesOAuthModelAliasEditPage() {
   const [excluded, setExcluded] = useState<Record<string, string[]>>({});
   const [modelAlias, setModelAlias] = useState<Record<string, OAuthModelAliasEntry[]>>({});
   const [initialLoading, setInitialLoading] = useState(true);
+  const [initialLoadError, setInitialLoadError] = useState<string | null>(null);
+  const [baselineReady, setBaselineReady] = useState(false);
   const [modelAliasUnsupported, setModelAliasUnsupported] = useState(false);
+  const loadRequestRef = useRef(0);
 
-  const [mappings, setMappings] = useState<OAuthModelMappingFormEntry[]>([buildEmptyMappingEntry()]);
+  const [mappings, setMappings] = useState<OAuthModelMappingFormEntry[]>([
+    buildEmptyMappingEntry(),
+  ]);
   const [modelsList, setModelsList] = useState<AuthFileModelItem[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState<'unsupported' | null>(null);
@@ -177,61 +182,60 @@ export function AuthFilesOAuthModelAliasEditPage() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleBack]);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadInitialData = useCallback(async () => {
+    const requestId = ++loadRequestRef.current;
+    setInitialLoading(true);
+    setInitialLoadError(null);
+    setBaselineReady(false);
+    setModelAliasUnsupported(false);
+    try {
+      const [filesResult, excludedResult, aliasResult] = await Promise.allSettled([
+        authFilesApi.list(),
+        authFilesApi.getOauthExcludedModels(),
+        authFilesApi.getOauthModelAlias(),
+      ]);
 
-    const load = async () => {
-      setInitialLoading(true);
-      setModelAliasUnsupported(false);
-      try {
-        const [filesResult, excludedResult, aliasResult] = await Promise.allSettled([
-          authFilesApi.list(),
-          authFilesApi.getOauthExcludedModels(),
-          authFilesApi.getOauthModelAlias(),
-        ]);
+      if (requestId !== loadRequestRef.current) return;
 
-        if (cancelled) return;
-
-        if (filesResult.status === 'fulfilled') {
-          setFiles(filesResult.value?.files ?? []);
-        }
-
-        if (excludedResult.status === 'fulfilled') {
-          setExcluded(excludedResult.value ?? {});
-        }
-
-        if (aliasResult.status === 'fulfilled') {
-          setModelAlias(aliasResult.value ?? {});
-          return;
-        }
-
-        const err = aliasResult.status === 'rejected' ? aliasResult.reason : null;
-        const status =
-          typeof err === 'object' && err !== null && 'status' in err
-            ? (err as { status?: unknown }).status
-            : undefined;
-
-        if (status === 404) {
-          setModelAliasUnsupported(true);
-          return;
-        }
-      } finally {
-        if (!cancelled) {
-          setInitialLoading(false);
-        }
+      if (filesResult.status === 'fulfilled') {
+        setFiles(filesResult.value?.files ?? []);
       }
-    };
+      if (excludedResult.status === 'fulfilled') {
+        setExcluded(excludedResult.value ?? {});
+      }
+      if (aliasResult.status === 'fulfilled') {
+        setModelAlias(aliasResult.value ?? {});
+        setBaselineReady(true);
+        return;
+      }
 
-    load().catch(() => {
-      if (!cancelled) {
+      const err = aliasResult.reason;
+      const status =
+        typeof err === 'object' && err !== null && 'status' in err
+          ? (err as { status?: unknown }).status
+          : undefined;
+      if (status === 404) {
+        setModelAliasUnsupported(true);
+        return;
+      }
+      setInitialLoadError(getErrorMessage(err));
+    } catch (err: unknown) {
+      if (requestId === loadRequestRef.current) {
+        setInitialLoadError(getErrorMessage(err));
+      }
+    } finally {
+      if (requestId === loadRequestRef.current) {
         setInitialLoading(false);
       }
-    });
-
-    return () => {
-      cancelled = true;
-    };
+    }
   }, []);
+
+  useEffect(() => {
+    void loadInitialData();
+    return () => {
+      loadRequestRef.current += 1;
+    };
+  }, [loadInitialData]);
 
   useEffect(() => {
     if (!resolvedProviderKey) {
@@ -322,6 +326,10 @@ export function AuthFilesOAuthModelAliasEditPage() {
   }, []);
 
   const handleSave = useCallback(async () => {
+    if (!baselineReady || initialLoadError !== null) {
+      showNotification(t('notification.refresh_failed'), 'error');
+      return;
+    }
     const channel = provider.trim();
     if (!channel) {
       showNotification(t('oauth_model_alias.provider_required'), 'error');
@@ -362,9 +370,23 @@ export function AuthFilesOAuthModelAliasEditPage() {
     } finally {
       setSaving(false);
     }
-  }, [allowNextNavigation, handleBack, mappings, provider, showNotification, t]);
+  }, [
+    allowNextNavigation,
+    baselineReady,
+    handleBack,
+    initialLoadError,
+    mappings,
+    provider,
+    showNotification,
+    t,
+  ]);
 
-  const canSave = !disableControls && !saving && !modelAliasUnsupported;
+  const canSave =
+    !disableControls &&
+    !saving &&
+    baselineReady &&
+    !modelAliasUnsupported &&
+    initialLoadError === null;
 
   return (
     <SecondaryScreenShell
@@ -389,6 +411,18 @@ export function AuthFilesOAuthModelAliasEditPage() {
             description={t('oauth_model_alias.upgrade_required_desc')}
           />
         </Card>
+      ) : initialLoadError !== null ? (
+        <Card>
+          <EmptyState
+            title={t('notification.refresh_failed')}
+            description={initialLoadError || t('notification.refresh_failed')}
+            action={
+              <Button variant="secondary" size="sm" onClick={() => void loadInitialData()}>
+                {t('common.refresh')}
+              </Button>
+            }
+          />
+        </Card>
       ) : (
         <>
           <Card className={styles.settingsCard}>
@@ -403,7 +437,9 @@ export function AuthFilesOAuthModelAliasEditPage() {
             <div className={styles.settingsSection}>
               <div className={styles.settingsRow}>
                 <div className={styles.settingsInfo}>
-                  <div className={styles.settingsLabel}>{t('oauth_model_alias.provider_label')}</div>
+                  <div className={styles.settingsLabel}>
+                    {t('oauth_model_alias.provider_label')}
+                  </div>
                   <div className={styles.settingsDesc}>{t('oauth_model_alias.provider_hint')}</div>
                 </div>
                 <div className={styles.settingsControl}>

--- a/apps/web/src/features/authFiles/AuthFilesPage.authJsonPaste.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.authJsonPaste.test.tsx
@@ -89,9 +89,9 @@ vi.mock('@/features/authFiles/hooks/useAuthFilesData', () => ({
 vi.mock('@/features/authFiles/hooks/useAuthFilesOauth', () => ({
   useAuthFilesOauth: () => ({
     excluded: [],
-    excludedError: '',
+    excludedError: 'ready',
     modelAlias: [],
-    modelAliasError: '',
+    modelAliasError: 'ready',
     allProviderModels: {},
     loadExcluded: vi.fn(async () => undefined),
     loadModelAlias: vi.fn(async () => undefined),

--- a/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.pasteIntegration.test.tsx
@@ -162,9 +162,9 @@ vi.mock('@/stores', () => ({
 vi.mock('@/features/authFiles/hooks/useAuthFilesOauth', () => ({
   useAuthFilesOauth: () => ({
     excluded: [],
-    excludedError: '',
+    excludedError: 'ready',
     modelAlias: [],
-    modelAliasError: '',
+    modelAliasError: 'ready',
     allProviderModels: {},
     loadExcluded: mocks.loadExcluded,
     loadModelAlias: mocks.loadModelAlias,

--- a/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.quotaCooldown.test.tsx
@@ -195,9 +195,9 @@ vi.mock('@/features/authFiles/hooks/useAuthFilesData', () => ({
 vi.mock('@/features/authFiles/hooks/useAuthFilesOauth', () => ({
   useAuthFilesOauth: () => ({
     excluded: [],
-    excludedError: '',
+    excludedError: 'ready',
     modelAlias: [],
-    modelAliasError: '',
+    modelAliasError: 'ready',
     allProviderModels: {},
     loadExcluded: mocks.loadExcluded,
     loadModelAlias: mocks.loadModelAlias,

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -1954,8 +1954,9 @@ export function AuthFilesPage() {
 
       <OAuthExcludedCard
         disableControls={disableControls}
-        excludedError={excludedError}
+        loadState={excludedError}
         excluded={excluded}
+        onRetry={loadExcluded}
         onAdd={() => openExcludedEditor()}
         onEdit={openExcludedEditor}
         onDelete={deleteExcluded}
@@ -1965,10 +1966,11 @@ export function AuthFilesPage() {
         disableControls={disableControls}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
+        onRetry={loadModelAlias}
         onAdd={() => openModelAliasEditor()}
         onEditProvider={openModelAliasEditor}
         onDeleteProvider={deleteModelAlias}
-        modelAliasError={modelAliasError}
+        loadState={modelAliasError}
         modelAlias={modelAlias}
         allProviderModels={allProviderModels}
         onUpdate={handleMappingUpdate}

--- a/apps/web/src/features/authFiles/components/OAuthConfigLoadGuard.test.tsx
+++ b/apps/web/src/features/authFiles/components/OAuthConfigLoadGuard.test.tsx
@@ -1,0 +1,53 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import '@/i18n';
+import { OAuthExcludedCard } from './OAuthExcludedCard';
+import { OAuthModelAliasCard } from './OAuthModelAliasCard';
+
+const noop = () => {};
+const noopAsync = async () => {};
+
+describe('OAuth configuration load guards', () => {
+  it('disables excluded-model writes and exposes retry after a load failure', () => {
+    const markup = renderToStaticMarkup(
+      createElement(OAuthExcludedCard, {
+        disableControls: false,
+        loadState: 'error',
+        excluded: {},
+        onRetry: noop,
+        onAdd: noop,
+        onEdit: noop,
+        onDelete: noop,
+      })
+    );
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('empty-action');
+  });
+
+  it('disables model-alias writes and exposes retry after a load failure', () => {
+    const markup = renderToStaticMarkup(
+      createElement(OAuthModelAliasCard, {
+        disableControls: false,
+        viewMode: 'list',
+        onViewModeChange: noop,
+        onRetry: noop,
+        onAdd: noop,
+        onEditProvider: noop,
+        onDeleteProvider: noop,
+        loadState: 'error',
+        modelAlias: {},
+        allProviderModels: {},
+        onUpdate: noopAsync,
+        onDeleteLink: noop,
+        onToggleFork: noopAsync,
+        onRenameAlias: noopAsync,
+        onDeleteAlias: noop,
+      })
+    );
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('empty-action');
+  });
+});

--- a/apps/web/src/features/authFiles/components/OAuthExcludedCard.tsx
+++ b/apps/web/src/features/authFiles/components/OAuthExcludedCard.tsx
@@ -2,14 +2,14 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
+import type { OAuthConfigLoadState } from '@/features/authFiles/constants';
 import styles from '@/features/authFiles/AuthFilesPage.module.scss';
-
-type UnsupportedError = 'unsupported' | null;
 
 export type OAuthExcludedCardProps = {
   disableControls: boolean;
-  excludedError: UnsupportedError;
+  loadState: OAuthConfigLoadState;
   excluded: Record<string, string[]>;
+  onRetry: () => void | Promise<void>;
   onAdd: () => void;
   onEdit: (provider: string) => void;
   onDelete: (provider: string) => void;
@@ -17,22 +17,34 @@ export type OAuthExcludedCardProps = {
 
 export function OAuthExcludedCard(props: OAuthExcludedCardProps) {
   const { t } = useTranslation();
-  const { disableControls, excludedError, excluded, onAdd, onEdit, onDelete } = props;
+  const { disableControls, loadState, excluded, onRetry, onAdd, onEdit, onDelete } = props;
+  const writesDisabled = disableControls || loadState !== 'ready';
 
   return (
     <Card
       title={t('oauth_excluded.title')}
       extra={
-        <Button size="sm" onClick={onAdd} disabled={disableControls || excludedError === 'unsupported'}>
+        <Button size="sm" onClick={onAdd} disabled={writesDisabled}>
           {t('oauth_excluded.add')}
         </Button>
       }
     >
-      {excludedError === 'unsupported' ? (
+      {loadState === 'unsupported' ? (
         <EmptyState
           title={t('oauth_excluded.upgrade_required_title')}
           description={t('oauth_excluded.upgrade_required_desc')}
         />
+      ) : loadState === 'error' ? (
+        <EmptyState
+          title={t('notification.refresh_failed')}
+          action={
+            <Button variant="secondary" size="sm" onClick={() => void onRetry()}>
+              {t('common.refresh')}
+            </Button>
+          }
+        />
+      ) : loadState === 'loading' ? (
+        <EmptyState title={t('common.loading')} />
       ) : Object.keys(excluded).length === 0 ? (
         <EmptyState title={t('oauth_excluded.list_empty_all')} />
       ) : (
@@ -48,10 +60,20 @@ export function OAuthExcludedCard(props: OAuthExcludedCardProps) {
                 </div>
               </div>
               <div className={styles.excludedActions}>
-                <Button variant="secondary" size="xs" onClick={() => onEdit(provider)}>
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  onClick={() => onEdit(provider)}
+                  disabled={writesDisabled}
+                >
                   {t('common.edit')}
                 </Button>
-                <Button variant="danger" size="xs" onClick={() => onDelete(provider)}>
+                <Button
+                  variant="danger"
+                  size="xs"
+                  onClick={() => onDelete(provider)}
+                  disabled={writesDisabled}
+                >
                   {t('oauth_excluded.delete')}
                 </Button>
               </div>

--- a/apps/web/src/features/authFiles/components/OAuthModelAliasCard.tsx
+++ b/apps/web/src/features/authFiles/components/OAuthModelAliasCard.tsx
@@ -6,25 +6,29 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { ModelMappingDiagram, type ModelMappingDiagramRef } from '@/components/modelAlias';
 import { IconChevronUp } from '@/components/ui/icons';
 import type { OAuthModelAliasEntry } from '@/types';
-import type { AuthFileModelItem } from '@/features/authFiles/constants';
+import type { AuthFileModelItem, OAuthConfigLoadState } from '@/features/authFiles/constants';
 import styles from '@/features/authFiles/AuthFilesPage.module.scss';
-
-type UnsupportedError = 'unsupported' | null;
 type ViewMode = 'diagram' | 'list';
 
 export type OAuthModelAliasCardProps = {
   disableControls: boolean;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
+  onRetry: () => void | Promise<void>;
   onAdd: () => void;
   onEditProvider: (provider?: string) => void;
   onDeleteProvider: (provider: string) => void;
-  modelAliasError: UnsupportedError;
+  loadState: OAuthConfigLoadState;
   modelAlias: Record<string, OAuthModelAliasEntry[]>;
   allProviderModels: Record<string, AuthFileModelItem[]>;
   onUpdate: (provider: string, sourceModel: string, newAlias: string) => Promise<void>;
   onDeleteLink: (provider: string, sourceModel: string, alias: string) => void;
-  onToggleFork: (provider: string, sourceModel: string, alias: string, fork: boolean) => Promise<void>;
+  onToggleFork: (
+    provider: string,
+    sourceModel: string,
+    alias: string,
+    fork: boolean
+  ) => Promise<void>;
   onRenameAlias: (oldAlias: string, newAlias: string) => Promise<void>;
   onDeleteAlias: (aliasName: string) => void;
 };
@@ -36,18 +40,20 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
     disableControls,
     viewMode,
     onViewModeChange,
+    onRetry,
     onAdd,
     onEditProvider,
     onDeleteProvider,
-    modelAliasError,
+    loadState,
     modelAlias,
     allProviderModels,
     onUpdate,
     onDeleteLink,
     onToggleFork,
     onRenameAlias,
-    onDeleteAlias
+    onDeleteAlias,
   } = props;
+  const writesDisabled = disableControls || loadState !== 'ready';
 
   return (
     <Card
@@ -59,7 +65,7 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
               variant={viewMode === 'list' ? 'secondary' : 'ghost'}
               size="sm"
               onClick={() => onViewModeChange('list')}
-              disabled={disableControls || modelAliasError === 'unsupported'}
+              disabled={writesDisabled}
             >
               {t('oauth_model_alias.view_mode_list')}
             </Button>
@@ -67,26 +73,33 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
               variant={viewMode === 'diagram' ? 'secondary' : 'ghost'}
               size="sm"
               onClick={() => onViewModeChange('diagram')}
-              disabled={disableControls || modelAliasError === 'unsupported'}
+              disabled={writesDisabled}
             >
               {t('oauth_model_alias.view_mode_diagram')}
             </Button>
           </div>
-          <Button
-            size="sm"
-            onClick={onAdd}
-            disabled={disableControls || modelAliasError === 'unsupported'}
-          >
+          <Button size="sm" onClick={onAdd} disabled={writesDisabled}>
             {t('oauth_model_alias.add')}
           </Button>
         </div>
       }
     >
-      {modelAliasError === 'unsupported' ? (
+      {loadState === 'unsupported' ? (
         <EmptyState
           title={t('oauth_model_alias.upgrade_required_title')}
           description={t('oauth_model_alias.upgrade_required_desc')}
         />
+      ) : loadState === 'error' ? (
+        <EmptyState
+          title={t('notification.refresh_failed')}
+          action={
+            <Button variant="secondary" size="sm" onClick={() => void onRetry()}>
+              {t('common.refresh')}
+            </Button>
+          }
+        />
+      ) : loadState === 'loading' ? (
+        <EmptyState title={t('common.loading')} />
       ) : viewMode === 'diagram' ? (
         Object.keys(modelAlias).length === 0 ? (
           <EmptyState title={t('oauth_model_alias.list_empty_all')} />
@@ -99,7 +112,7 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
                 size="xs"
                 iconOnly
                 onClick={() => diagramRef.current?.collapseAll()}
-                disabled={disableControls || modelAliasError === 'unsupported'}
+                disabled={writesDisabled}
                 title={t('oauth_model_alias.diagram_collapse')}
                 aria-label={t('oauth_model_alias.diagram_collapse')}
               >
@@ -136,10 +149,20 @@ export function OAuthModelAliasCard(props: OAuthModelAliasCardProps) {
                 </div>
               </div>
               <div className={styles.excludedActions}>
-                <Button variant="secondary" size="xs" onClick={() => onEditProvider(provider)}>
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  onClick={() => onEditProvider(provider)}
+                  disabled={writesDisabled}
+                >
                   {t('common.edit')}
                 </Button>
-                <Button variant="danger" size="xs" onClick={() => onDeleteProvider(provider)}>
+                <Button
+                  variant="danger"
+                  size="xs"
+                  onClick={() => onDeleteProvider(provider)}
+                  disabled={writesDisabled}
+                >
                   {t('oauth_model_alias.delete')}
                 </Button>
               </div>

--- a/apps/web/src/features/authFiles/constants.ts
+++ b/apps/web/src/features/authFiles/constants.ts
@@ -25,6 +25,7 @@ export type AuthFileModelItem = {
 export type AuthFileIconAsset = string | { light: string; dark: string };
 
 export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type OAuthConfigLoadState = 'loading' | 'ready' | 'unsupported' | 'error';
 
 export const QUOTA_PROVIDER_TYPES = new Set<QuotaProviderType>([
   'antigravity',
@@ -253,7 +254,7 @@ export const formatModified = (item: AuthFileItem): string => {
   const date =
     Number.isFinite(asNumber) && !Number.isNaN(asNumber)
       ? new Date(asNumber < 1e12 ? asNumber * 1000 : asNumber)
-      : parseTimestamp(raw) ?? new Date(String(raw));
+      : (parseTimestamp(raw) ?? new Date(String(raw)));
   return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
 };
 

--- a/apps/web/src/features/authFiles/hooks/useAuthFilesOauth.tsx
+++ b/apps/web/src/features/authFiles/hooks/useAuthFilesOauth.tsx
@@ -3,17 +3,15 @@ import { Trans, useTranslation } from 'react-i18next';
 import { authFilesApi } from '@/services/api';
 import { useNotificationStore } from '@/stores';
 import type { AuthFileItem, OAuthModelAliasEntry } from '@/types';
-import type { AuthFileModelItem } from '@/features/authFiles/constants';
+import type { AuthFileModelItem, OAuthConfigLoadState } from '@/features/authFiles/constants';
 import { normalizeProviderKey } from '@/features/authFiles/constants';
-
-type UnsupportedError = 'unsupported' | null;
 type ViewMode = 'diagram' | 'list';
 
 export type UseAuthFilesOauthResult = {
   excluded: Record<string, string[]>;
-  excludedError: UnsupportedError;
+  excludedError: OAuthConfigLoadState;
   modelAlias: Record<string, OAuthModelAliasEntry[]>;
-  modelAliasError: UnsupportedError;
+  modelAliasError: OAuthConfigLoadState;
   allProviderModels: Record<string, AuthFileModelItem[]>;
   providerList: string[];
   loadExcluded: () => Promise<void>;
@@ -43,15 +41,29 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
   const { showNotification, showConfirmation } = useNotificationStore();
 
   const [excluded, setExcluded] = useState<Record<string, string[]>>({});
-  const [excludedError, setExcludedError] = useState<UnsupportedError>(null);
+  const [excludedError, setExcludedError] = useState<OAuthConfigLoadState>('loading');
   const [modelAlias, setModelAlias] = useState<Record<string, OAuthModelAliasEntry[]>>({});
-  const [modelAliasError, setModelAliasError] = useState<UnsupportedError>(null);
+  const [modelAliasError, setModelAliasError] = useState<OAuthConfigLoadState>('loading');
   const [allProviderModels, setAllProviderModels] = useState<Record<string, AuthFileModelItem[]>>(
     {}
   );
 
   const excludedUnsupportedRef = useRef(false);
   const mappingsUnsupportedRef = useRef(false);
+  const excludedReadyRef = useRef(false);
+  const modelAliasReadyRef = useRef(false);
+  const excludedLoadRequestRef = useRef(0);
+  const modelAliasLoadRequestRef = useRef(0);
+
+  useEffect(
+    () => () => {
+      excludedReadyRef.current = false;
+      modelAliasReadyRef.current = false;
+      excludedLoadRequestRef.current += 1;
+      modelAliasLoadRequestRef.current += 1;
+    },
+    []
+  );
 
   const providerList = useMemo(() => {
     const providers = new Set<string>();
@@ -116,12 +128,18 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
   }, [providerList, viewMode]);
 
   const loadExcluded = useCallback(async () => {
+    const requestId = ++excludedLoadRequestRef.current;
+    excludedReadyRef.current = false;
+    setExcludedError('loading');
     try {
       const res = await authFilesApi.getOauthExcludedModels();
+      if (requestId !== excludedLoadRequestRef.current) return;
       excludedUnsupportedRef.current = false;
+      excludedReadyRef.current = true;
       setExcluded(res || {});
-      setExcludedError(null);
+      setExcludedError('ready');
     } catch (err: unknown) {
+      if (requestId !== excludedLoadRequestRef.current) return;
       const status =
         typeof err === 'object' && err !== null && 'status' in err
           ? (err as { status?: unknown }).status
@@ -136,17 +154,23 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         }
         return;
       }
-      // 静默失败
+      setExcludedError('error');
     }
   }, [showNotification, t]);
 
   const loadModelAlias = useCallback(async () => {
+    const requestId = ++modelAliasLoadRequestRef.current;
+    modelAliasReadyRef.current = false;
+    setModelAliasError('loading');
     try {
       const res = await authFilesApi.getOauthModelAlias();
+      if (requestId !== modelAliasLoadRequestRef.current) return;
       mappingsUnsupportedRef.current = false;
+      modelAliasReadyRef.current = true;
       setModelAlias(res || {});
-      setModelAliasError(null);
+      setModelAliasError('ready');
     } catch (err: unknown) {
+      if (requestId !== modelAliasLoadRequestRef.current) return;
       const status =
         typeof err === 'object' && err !== null && 'status' in err
           ? (err as { status?: unknown }).status
@@ -161,8 +185,12 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         }
         return;
       }
-      // 静默失败
+      setModelAliasError('error');
     }
+  }, [showNotification, t]);
+
+  const showLoadRequired = useCallback(() => {
+    showNotification(t('notification.refresh_failed'), 'error');
   }, [showNotification, t]);
 
   const deleteExcluded = useCallback(
@@ -174,6 +202,10 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         variant: 'danger',
         confirmText: t('common.confirm'),
         onConfirm: async () => {
+          if (!excludedReadyRef.current) {
+            showLoadRequired();
+            return;
+          }
           const providerKey = normalizeProviderKey(provider);
           if (!providerKey) {
             showNotification(t('oauth_excluded.provider_required'), 'error');
@@ -204,10 +236,10 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
               showNotification(`${t('oauth_excluded.delete_failed')}: ${errorMessage}`, 'error');
             }
           }
-        }
+        },
       });
     },
-    [loadExcluded, showConfirmation, showNotification, t]
+    [loadExcluded, showConfirmation, showLoadRequired, showNotification, t]
   );
 
   const deleteModelAlias = useCallback(
@@ -218,6 +250,10 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         variant: 'danger',
         confirmText: t('common.confirm'),
         onConfirm: async () => {
+          if (!modelAliasReadyRef.current) {
+            showLoadRequired();
+            return;
+          }
           try {
             await authFilesApi.deleteOauthModelAlias(provider);
             await loadModelAlias();
@@ -226,14 +262,18 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
             const errorMessage = err instanceof Error ? err.message : '';
             showNotification(`${t('oauth_model_alias.delete_failed')}: ${errorMessage}`, 'error');
           }
-        }
+        },
       });
     },
-    [loadModelAlias, showConfirmation, showNotification, t]
+    [loadModelAlias, showConfirmation, showLoadRequired, showNotification, t]
   );
 
   const handleMappingUpdate = useCallback(
     async (provider: string, sourceModel: string, newAlias: string) => {
+      if (!modelAliasReadyRef.current) {
+        showLoadRequired();
+        return;
+      }
       if (!provider || !sourceModel || !newAlias) return;
       const normalizedProvider = normalizeProviderKey(provider);
       if (!normalizedProvider) return;
@@ -260,7 +300,7 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
 
       const nextMappings: OAuthModelAliasEntry[] = [
         ...currentMappings,
-        { name: nameTrim, alias: aliasTrim, fork: true }
+        { name: nameTrim, alias: aliasTrim, fork: true },
       ];
 
       try {
@@ -272,7 +312,7 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         showNotification(`${t('oauth_model_alias.save_failed')}: ${errorMessage}`, 'error');
       }
     },
-    [loadModelAlias, modelAlias, showNotification, t]
+    [loadModelAlias, modelAlias, showLoadRequired, showNotification, t]
   );
 
   const handleDeleteLink = useCallback(
@@ -293,6 +333,10 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         variant: 'danger',
         confirmText: t('common.confirm'),
         onConfirm: async () => {
+          if (!modelAliasReadyRef.current) {
+            showLoadRequired();
+            return;
+          }
           const normalizedProvider = normalizeProviderKey(provider);
           const providerKey = Object.keys(modelAlias).find(
             (key) => normalizeProviderKey(key) === normalizedProvider
@@ -319,14 +363,18 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
             const errorMessage = err instanceof Error ? err.message : '';
             showNotification(`${t('oauth_model_alias.save_failed')}: ${errorMessage}`, 'error');
           }
-        }
+        },
       });
     },
-    [loadModelAlias, modelAlias, showConfirmation, showNotification, t]
+    [loadModelAlias, modelAlias, showConfirmation, showLoadRequired, showNotification, t]
   );
 
   const handleToggleFork = useCallback(
     async (provider: string, sourceModel: string, alias: string, fork: boolean) => {
+      if (!modelAliasReadyRef.current) {
+        showLoadRequired();
+        return;
+      }
       const normalizedProvider = normalizeProviderKey(provider);
       if (!normalizedProvider) return;
 
@@ -362,11 +410,15 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         showNotification(`${t('oauth_model_alias.save_failed')}: ${errorMessage}`, 'error');
       }
     },
-    [loadModelAlias, modelAlias, showNotification, t]
+    [loadModelAlias, modelAlias, showLoadRequired, showNotification, t]
   );
 
   const handleRenameAlias = useCallback(
     async (oldAlias: string, newAlias: string) => {
+      if (!modelAliasReadyRef.current) {
+        showLoadRequired();
+        return;
+      }
       const oldTrim = oldAlias.trim();
       const newTrim = newAlias.trim();
       if (!oldTrim || !newTrim || oldTrim === newTrim) return;
@@ -415,7 +467,7 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         showNotification(t('oauth_model_alias.save_success'), 'success');
       }
     },
-    [loadModelAlias, modelAlias, showNotification, t]
+    [loadModelAlias, modelAlias, showLoadRequired, showNotification, t]
   );
 
   const handleDeleteAlias = useCallback(
@@ -441,6 +493,10 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
         variant: 'danger',
         confirmText: t('common.confirm'),
         onConfirm: async () => {
+          if (!modelAliasReadyRef.current) {
+            showLoadRequired();
+            return;
+          }
           let hadFailure = false;
           let failureMessage = '';
 
@@ -480,10 +536,10 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
           } else {
             showNotification(t('oauth_model_alias.delete_success'), 'success');
           }
-        }
+        },
       });
     },
-    [loadModelAlias, modelAlias, showConfirmation, showNotification, t]
+    [loadModelAlias, modelAlias, showConfirmation, showLoadRequired, showNotification, t]
   );
 
   return {
@@ -501,6 +557,6 @@ export function useAuthFilesOauth(options: UseAuthFilesOauthOptions): UseAuthFil
     handleDeleteLink,
     handleToggleFork,
     handleRenameAlias,
-    handleDeleteAlias
+    handleDeleteAlias,
   };
 }


### PR DESCRIPTION
## Summary
Protect OAuth configuration mutations when their server baseline cannot be loaded, and isolate provider request statistics between CPA connections.

These changes prevent empty or stale writes after read failures and avoid showing request data from a previously connected server.

## Scope
- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes
- Add explicit loading, ready, unsupported, and error states for OAuth exclusion and model-alias configuration.
- Disable OAuth mutations until a verified baseline is available and expose retry actions on failure.
- Scope provider recent-request caches to a hash of the API base and management key.
- Keep late in-flight responses attached to the cache for their originating connection.

## User Impact
OAuth configuration controls no longer allow writes after a failed refresh. Switching between CPA connections no longer reuses provider request statistics from the previous connection.

## Compatibility / Runtime Notes
- CPA panel mode: OAuth failure guards and connection-scoped request statistics apply directly in the panel.
- Manager Server mode: The same frontend behavior applies through the existing management proxy.
- Full Docker / native packages: No runtime or packaging changes; embedded frontend behavior is updated.

## Data / Security Notes
No persistent data format changes. The connection cache scope uses a SHA-256 hash of the API base and management key; raw credentials are not used as cache identifiers.

## Risk / Rollback
Risk level: Low

Rollback notes:
- Revert the two commits in this PR to restore the previous loading and cache behavior.

## Verification
- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:
```text
npm run lint
npm run test                     # 102 files, 958 tests passed
npm run build                    # single-file dist/index.html
npm run check:demo-isolation
git diff --check
```

## Screenshots / Recordings
Pending manual verification of the OAuth failure and retry states before merge.

## Docs
- [ ] README updated
- [ ] Wiki updated
- [ ] Release notes needed
- [x] Not needed

## Related
N/A
