### PR TITLE
docs(release): add v1.11.3 notes

### DIFF
--- a/docs/release-notes/v1.11.3-en.md
+++ b/docs/release-notes/v1.11.3-en.md
@@ -1,0 +1,45 @@
+# CPA Manager Plus v1.11.3
+
+> 26 commits · 154 files changed · +10034 / -2403
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.3/docs/release-notes/v1.11.3-zh.md)
+
+## Overview
+
+This release adds complete xAI API key provider management and Claude model-scoped weekly quotas, while fixing paid xAI OAuth quota probing, stale-volume administrator-key mismatches in the installer, client API key copying, and Dashboard token composition. The bilingual documentation has also been reorganized around practical Lightweight Panel and Full Mode workflows.
+
+## Highlights
+
+### Features
+
+- Add complete xAI API key provider management with creation, editing, testing, enable/disable, deletion, priority, and runtime controls. Dashboard, Monitoring, and Usage Analytics now identify xAI sources correctly (`web/providers`, `web/monitoring`).
+- Show Claude model-scoped weekly quotas from the existing usage payload and safely recover five-hour and all-model weekly account limits when top-level values are unavailable. Duplicate, partial, and malformed records are isolated and deduplicated deterministically (`web/quota`).
+
+### Fixes
+
+- When paid xAI OAuth credentials cannot access the Grok CLI billing endpoints, use the read-only official identity endpoint to report a health-only state. The fallback does not invent quota data, invoke a model, or automatically restore accounts, and now provides clearer localized diagnostics (`web/quota`, `manager-server/inspection`).
+- Detect installer upgrade, repair, regeneration, and orphaned Docker-volume states while preserving existing secrets. Stale administrator-key mismatches are repaired through the supported reset flow, and authentication must succeed before installation is reported as complete (`installer`).
+- Allow OAuth exclusion and model-alias changes only after a verified baseline has loaded, preventing empty writes after read failures. Provider recent-request caches are also isolated by CPA connection to prevent cross-session data display (`web/auth-files`, `web/providers`).
+- Copy original configured client API keys from Request Monitoring and Usage Analytics while keeping displayed values masked. Historical, deleted, or unmatched keys do not expose a misleading copy action (`web/monitoring`, `web/usage-analytics`).
+- Correct cached-input and reasoning-output deduplication in Dashboard token composition, and prevent provider key-test error tooltips from being clipped by scrollable tables (`manager-server/dashboard`, `web/ai-providers`).
+
+### Docs
+
+- Reorganize the English and Chinese READMEs and documentation site around Lightweight Panel, Full Mode, and user tasks, with clearer mode selection, quick starts, capability matrices, deployment paths, daily workflows, and troubleshooting (`docs/readme`, `docs/site`).
+- Expand deployment-wide upgrade, backup, rollback, and installer-repair guidance, and add documentation-structure integrity tests to keep implementation details out of primary user paths (`docs/operations`, `tests/docs`).
+
+## Upgrade Notes
+
+- This release introduces no SQLite schema, persistent-format, or required configuration migration.
+- Complete xAI API key management requires CPA to expose `/v0/management/xai-api-key`. Older CPA versions returning `404` are handled safely as zero xAI providers on the Dashboard, but the new management operations will not be available.
+- The paid xAI OAuth identity fallback reports official API reachability only. It does not verify model invocation or provide actual quota and cost data; use the xAI Console for those values.
+- Installer upgrades preserve existing configuration and secrets by default. Back up SQLite files, `data.key`, and installer-managed configuration before using regeneration or recovery operations.
+- This release includes visible xAI provider-management and Claude model-quota changes.
+
+## Acknowledgements
+
+- [@bc19sam-afk](https://github.com/bc19sam-afk) - Contributed Claude model-scoped weekly quotas, `limits[]` account-limit fallback, and robust handling of duplicate and partial records.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.2...v1.11.3

--- a/docs/release-notes/v1.11.3-zh.md
+++ b/docs/release-notes/v1.11.3-zh.md
@@ -1,0 +1,45 @@
+# CPA Manager Plus v1.11.3
+
+> 26 commits · 154 files changed · +10034 / -2403
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.3/docs/release-notes/v1.11.3-en.md)
+
+## Overview
+
+本次发布补齐 xAI API Key Provider 管理与 Claude 模型级周额度展示，并修复付费 xAI OAuth 配额探测、安装器旧卷管理员密钥错配、客户端 API Key 复制和 Dashboard Token 构成等问题。中英文文档也围绕 Lightweight Panel 与 Full Mode 的实际任务完成重组。
+
+## Highlights
+
+### Features
+
+- 新增完整的 xAI API Key Provider 管理，支持新增、编辑、测试、启停、删除、优先级和运行时开关，并在 Dashboard、Monitoring 与 Usage Analytics 中正确识别 xAI 来源（`web/providers`、`web/monitoring`）。
+- Claude 配额卡片支持从现有 usage payload 展示模型级周额度，并在顶层账号额度缺失时安全恢复五小时与全模型周额度；重复、部分和异常记录会被稳定隔离和去重（`web/quota`）。
+
+### Fixes
+
+- 付费 xAI OAuth 凭证无法访问 Grok CLI 账单接口时，可通过只读官方身份接口展示健康状态；该回退不会虚构额度、调用模型或自动恢复账号，并提供更明确的本地化诊断（`web/quota`、`manager-server/inspection`）。
+- 安装器现在能够识别升级、修复、重新生成和孤立 Docker 卷状态，保留现有密钥，并通过受支持的管理员密钥重置流程修复旧卷错配；认证验证通过后才会报告成功（`installer`）。
+- OAuth 排除项和模型别名只有在成功加载基线配置后才能修改，避免读取失败后写入空配置；Provider 最近请求缓存也按 CPA 连接隔离，防止切换连接后展示旧会话数据（`web/auth-files`、`web/providers`）。
+- Request Monitoring 与 Usage Analytics 可以复制仍存在于当前配置中的原始客户端 API Key，同时继续显示脱敏值；历史、已删除或无法匹配的 Key 不提供误导性的复制操作（`web/monitoring`、`web/usage-analytics`）。
+- 修正 Dashboard Token 构成中缓存输入与 reasoning output 的去重归属，并避免 Provider Key 测试错误提示被滚动表格裁切（`manager-server/dashboard`、`web/ai-providers`）。
+
+### Docs
+
+- 中英文 README 与文档站改为围绕 Lightweight Panel、Full Mode 和用户任务组织，新增模式选择、快速开始、能力矩阵以及更清晰的部署、日常使用和故障排查路径（`docs/readme`、`docs/site`）。
+- 完善全部署模式升级、备份、回滚和安装器修复指南，并增加文档结构完整性测试，防止内部实现细节重新进入主要用户路径（`docs/operations`、`tests/docs`）。
+
+## Upgrade Notes
+
+- 本版本没有 SQLite schema、持久化格式或必需配置迁移。
+- 完整的 xAI API Key 管理需要 CPA 提供 `/v0/management/xai-api-key` 接口；旧版 CPA 返回 `404` 时，Dashboard 会安全地将 xAI Provider 数量视为零，但无法使用新增的管理操作。
+- 付费 xAI OAuth 的身份回退只表示官方 API 可达，不代表已验证模型调用，也不提供真实额度或费用；实际用量仍需在 xAI Console 中查看。
+- 安装器升级默认保留现有配置和密钥。执行重新生成或恢复操作前，仍建议备份 SQLite 文件、`data.key` 和安装器管理的配置文件。
+- 本版本包含 xAI Provider 管理与 Claude 模型级额度等可视变化。
+
+## Acknowledgements
+
+- [@bc19sam-afk](https://github.com/bc19sam-afk) - 贡献 Claude 模型级周额度、`limits[]` 账号额度回退及重复和部分记录的稳定处理。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.2...v1.11.3


### PR DESCRIPTION
## Summary

Add the curated Chinese and English release notes for CPA Manager Plus v1.11.3.

The notes summarize xAI API key provider management, Claude model-scoped weekly quotas, installer recovery hardening, quota and monitoring fixes, and the user-focused documentation reorganization.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `docs/release-notes/v1.11.3-zh.md` as the authored Chinese release body.
- Add `docs/release-notes/v1.11.3-en.md` as the matching English translation.
- Use tag-pinned GitHub blob URLs for both language-switch links.
- Document the 26-commit release range, compatibility notes, upgrade guidance, and external contribution.

## User Impact

No application behavior changes in this PR. When tag `v1.11.3` is pushed, the release workflow will use the curated Chinese note as the GitHub Release body, with a pinned link to the English translation.

## Compatibility / Runtime Notes

- CPA panel mode: N/A — release-notes-only change.
- Manager Server mode: N/A — release-notes-only change.
- Full Docker / native packages: The release workflow will package the merged notes with the tagged source and publish the Chinese note as the curated release body.

## Data / Security Notes

N/A. No application data, credentials, configuration, generated artifacts, or runtime behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert the release-note commit before pushing the tag.
- If the tag has already been pushed, correct the notes through a follow-up PR and update the GitHub Release body.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Release version: v1.11.3
Previous tag: v1.11.2
Release range: 26 non-merge commits
Diff statistics: 154 files changed, +10034 / -2403
Preflight branch: main
Local main: 828d4885f95789cd52f9a5cf8fce4a94eecfd3b2
Remote main: 828d4885f95789cd52f9a5cf8fce4a94eecfd3b2
Local/remote divergence: 0 / 0
Worktree: clean
Remote release/v1.11.3 branch and v1.11.3 tag were absent before creation
No existing release PR or v1.11.3 note files were found
Chinese link:
https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.3/docs/release-notes/v1.11.3-en.md
English link:
https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.3/docs/release-notes/v1.11.3-zh.md
```

## Screenshots / Recordings

N/A — release-notes-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: Add versioned Chinese and English release notes so the tag workflow publishes a curated release body instead of the git-log fallback.

## Related

N/A