### PR TITLE
ci(release): notify Telegram after successful releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,3 +233,172 @@ jobs:
           repository: ${{ env.DOCKERHUB_IMAGE }}
           short-description: CPA Manager Plus with Dockerized Manager Server
           readme-filepath: ./README.md
+
+  notify-telegram:
+    name: Notify Telegram
+    needs:
+      - build-and-release
+      - build-and-push-docker
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v4
+
+      - name: Send Telegram release notification
+        shell: bash
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_MESSAGE_THREAD_ID: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}
+        run: |
+          set -euo pipefail
+
+          release_post="docs/release-posts/${GITHUB_REF_NAME}-telegram.html"
+
+          if [ -z "${TELEGRAM_BOT_TOKEN}" ] || [ -z "${TELEGRAM_CHAT_ID}" ]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID is not configured; Telegram notification skipped."
+            exit 0
+          fi
+
+          if [ ! -f "${release_post}" ]; then
+            echo "::warning::Telegram release post ${release_post} was not found; notification skipped."
+            exit 0
+          fi
+
+          validation_error="$(python3 - "${release_post}" <<'PY' 2>&1 || true
+          import sys
+          from html.parser import HTMLParser
+          from pathlib import Path
+          from urllib.parse import urlparse
+
+          path = Path(sys.argv[1])
+          body = path.read_text(encoding="utf-8")
+
+          if not body.strip():
+              raise SystemExit("release post is empty")
+          if len(body) > 3500:
+              raise SystemExit(f"release post is {len(body)} characters; maximum is 3500")
+
+          class TelegramHTMLValidator(HTMLParser):
+              allowed_tags = {"b", "i", "code", "a"}
+
+              def __init__(self):
+                  super().__init__(convert_charrefs=False)
+                  self.stack = []
+
+              def handle_starttag(self, tag, attrs):
+                  if tag not in self.allowed_tags:
+                      raise ValueError(f"unsupported HTML tag: <{tag}>")
+                  if tag == "a":
+                      if len(attrs) != 1 or attrs[0][0] != "href":
+                          raise ValueError("<a> must contain only one href attribute")
+                      url = urlparse(attrs[0][1])
+                      if url.scheme != "https" or not url.netloc:
+                          raise ValueError("<a href> must use an absolute HTTPS URL")
+                  elif attrs:
+                      raise ValueError(f"<{tag}> does not support attributes")
+                  self.stack.append(tag)
+
+              def handle_endtag(self, tag):
+                  if not self.stack or self.stack[-1] != tag:
+                      raise ValueError(f"unbalanced closing tag: </{tag}>")
+                  self.stack.pop()
+
+              def handle_startendtag(self, tag, attrs):
+                  raise ValueError(f"self-closing tag is not supported: <{tag}/>")
+
+          validator = TelegramHTMLValidator()
+          try:
+              validator.feed(body)
+              validator.close()
+              if validator.stack:
+                  raise ValueError(f"unclosed HTML tag: <{validator.stack[-1]}>")
+          except ValueError as error:
+              raise SystemExit(str(error)) from error
+          PY
+          )"
+
+          if [ -n "${validation_error}" ]; then
+            echo "::warning::Telegram release post validation failed: ${validation_error}"
+            exit 0
+          fi
+
+          if [ -n "${TELEGRAM_MESSAGE_THREAD_ID}" ] && ! [[ "${TELEGRAM_MESSAGE_THREAD_ID}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::TELEGRAM_MESSAGE_THREAD_ID must be numeric; Telegram notification skipped."
+            exit 0
+          fi
+
+          release_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}"
+
+          reply_markup="$(python3 - "${release_url}" <<'PY'
+          import json
+          import sys
+
+          print(json.dumps({
+              "inline_keyboard": [
+                  [{"text": "查看 Release", "url": sys.argv[1]}],
+              ]
+          }, ensure_ascii=False, separators=(",", ":")))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          curl_args=(
+            --silent
+            --show-error
+            --retry 3
+            --retry-all-errors
+            --connect-timeout 10
+            --max-time 30
+            --output "${response_file}"
+            --write-out "%{http_code}"
+            --request POST
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage"
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}"
+            --data-urlencode "text@${release_post}"
+            --data-urlencode "parse_mode=HTML"
+            --data-urlencode "disable_web_page_preview=true"
+            --data-urlencode "reply_markup=${reply_markup}"
+          )
+
+          if [ -n "${TELEGRAM_MESSAGE_THREAD_ID}" ]; then
+            curl_args+=(--data-urlencode "message_thread_id=${TELEGRAM_MESSAGE_THREAD_ID}")
+          fi
+
+          set +e
+          http_code="$(curl "${curl_args[@]}")"
+          curl_status=$?
+          set -e
+
+          if [ "${curl_status}" -ne 0 ]; then
+            echo "::warning::Telegram API request failed before receiving an HTTP response."
+            exit 0
+          fi
+
+          if ! [[ "${http_code}" =~ ^2[0-9][0-9]$ ]]; then
+            echo "::warning::Telegram API returned HTTP ${http_code}; release remains successful."
+            exit 0
+          fi
+
+          if ! python3 - "${response_file}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          try:
+              response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+              raise SystemExit(1)
+
+          raise SystemExit(0 if response.get("ok") is True else 1)
+          PY
+          then
+            echo "::warning::Telegram API did not confirm message delivery; release remains successful."
+            exit 0
+          fi
+
+          echo "Telegram release notification sent successfully."

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,6 +10,10 @@ installed as a global cross-project skill.
 `docs/release-notes/` is reserved for versioned release note files only. Do not
 place process documentation or README files inside that directory.
 
+Formal release notes are technical release records. Community-facing release
+copy is authored separately so it can prioritize user value and readability
+without weakening the technical notes.
+
 ## Release Note Files
 
 ```text
@@ -28,6 +32,67 @@ Examples:
 docs/release-notes/v1.0.2-zh.md
 docs/release-notes/v1.0.2-en.md
 ```
+
+## Community Release Post
+
+Each new release must include a reviewed Telegram post:
+
+```text
+docs/release-posts/<tag>-telegram.html
+```
+
+Example:
+
+```text
+docs/release-posts/v1.0.2-telegram.html
+```
+
+The repo-local `/release` workflow drafts this file before confirmation and
+shows the exact message in the release plan. Commit it in the same release PR
+as the Chinese and English release notes. Do not generate or rewrite the post
+inside GitHub Actions.
+
+Write the post for users and community members rather than code reviewers:
+
+- open with one clear release theme and its practical value;
+- select 3-6 high-value highlights;
+- make each bullet express exactly one feature, fix, or user benefit;
+- target 15-28 Chinese characters and never exceed 32 Chinese characters per
+  bullet;
+- do not join changes with semicolons, compound clauses, or long capability
+  lists; split the idea or leave the detail in the GitHub Release;
+- omit commit counts, file counts, internal scopes, module paths, and other
+  technical noise unless users must act on it;
+- include upgrade cautions only when users need to take action or understand a
+  meaningful compatibility, data, security, or behavior change;
+- include acknowledgements only for external contributors and preserve their
+  GitHub profile links;
+- keep claims factual and grounded in the formal release notes;
+- keep the complete HTML body within 3,500 characters.
+
+Telegram posts use a conservative HTML subset supported by the Bot API:
+
+```text
+<b> <i> <code> <a href="https://example.com">...</a>
+```
+
+Escape other HTML characters. Do not include inline keyboard JSON, bot tokens,
+chat IDs, thread IDs, or any other secret in the post file. The release
+workflow adds one `View Release` button at send time.
+
+After both release jobs succeed, `.github/workflows/release.yml` reads the
+tag-matched post and sends it through Telegram Bot API `sendMessage`. Configure
+these repository secrets:
+
+```text
+TELEGRAM_BOT_TOKEN
+TELEGRAM_CHAT_ID
+TELEGRAM_MESSAGE_THREAD_ID  # optional, for a forum topic
+```
+
+Missing configuration or a missing post file skips the notification with an
+Actions warning. Telegram delivery failure must not roll back or invalidate an
+otherwise successful GitHub Release.
 
 ## CI Lookup
 
@@ -68,9 +133,11 @@ curated note body outside that directory.
 ## Highlights
 
 ### Features
+
 - <User-facing capability description> (`<scope>`)
 
 ### Fixes
+
 - <What was fixed and the affected scope>
 
 <Keep only non-empty groups as needed: Performance / Refactor / Docs / Chore / CI / Build. Drop merge commits and noise.>
@@ -92,13 +159,13 @@ curated note body outside that directory.
 
 ## Commit Type Groups
 
-| Type | Group |
-|------|-------|
-| feat | Features |
-| fix | Fixes |
-| perf | Performance |
-| refactor | Refactor |
-| docs | Docs |
-| chore | Chore |
-| ci | CI |
-| build | Build |
+| Type     | Group       |
+| -------- | ----------- |
+| feat     | Features    |
+| fix      | Fixes       |
+| perf     | Performance |
+| refactor | Refactor    |
+| docs     | Docs        |
+| chore    | Chore       |
+| ci       | CI          |
+| build    | Build       |


### PR DESCRIPTION
## Summary

Send a reviewed Telegram community post after both GitHub Release and container publishing complete successfully.
Keep the notification optional and non-blocking while documenting the release-post format and required repository secrets.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Add a post-release Telegram notification job with HTML validation, optional topic support, retry handling, and a single Release button.
- Define reviewed `docs/release-posts/<tag>-telegram.html` copy, concise writing limits, supported markup, and GitHub secret configuration.

## User Impact

Configured releases can publish a concise, reviewed Telegram announcement automatically after the complete release workflow succeeds.
Repositories without Telegram configuration continue releasing normally and receive only an Actions warning.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: Notification runs only after both the GitHub Release and container publishing jobs succeed.

## Data / Security Notes

Telegram credentials remain in GitHub Actions repository secrets and are never written to release posts, logs, or PR content.
The workflow validates the reviewed HTML post before sending it and treats delivery failures as non-blocking.

## Risk / Rollback

Risk level: Low

Rollback notes: Remove the `notify-telegram` job and the community release-post convention. Existing release jobs and artifacts are otherwise unchanged.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
ruby YAML syntax validation for .github/workflows/release.yml
bash -n validation for the embedded notification script
prettier --check .github/workflows/release.yml docs/release.md
git diff --check
mocked Telegram success response and missing-secret skip path
```

## Screenshots / Recordings

N/A — release automation and documentation only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: Updated `docs/release.md` with the reviewed Telegram post contract, concise copy rules, supported HTML, and required repository secrets. No navigation change is required.

## Related

N/A
