### PR TITLE
ci(pr-check): scope jobs by changed paths

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,8 +16,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Scope
+    runs-on: ubuntu-latest
+
+    outputs:
+      frontend: ${{ steps.classify.outputs.frontend }}
+      manager_server: ${{ steps.classify.outputs.manager_server }}
+      windows_sqlite: ${{ steps.classify.outputs.windows_sqlite }}
+      native_control: ${{ steps.classify.outputs.native_control }}
+      docker: ${{ steps.classify.outputs.docker }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="${RUNNER_TEMP}/pr-check-changed-files.txt"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git diff --name-only "${PR_BASE_SHA}...${PR_HEAD_SHA}" > "${changed_files}"
+          elif [ -z "${PUSH_BEFORE_SHA}" ] || [[ "${PUSH_BEFORE_SHA}" =~ ^0+$ ]]; then
+            git show --pretty=format: --name-only "${CURRENT_SHA}" > "${changed_files}"
+          else
+            git diff --name-only "${PUSH_BEFORE_SHA}..${CURRENT_SHA}" > "${changed_files}"
+          fi
+
+          echo "Changed files:"
+          sed 's/^/- /' "${changed_files}"
+          node bin/ci/classify-pr-checks.mjs < "${changed_files}" >> "${GITHUB_OUTPUT}"
+
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -54,6 +98,8 @@ jobs:
 
   manager-server:
     name: Manager Server
+    needs: changes
+    if: needs.changes.outputs.manager_server == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -72,6 +118,8 @@ jobs:
 
   manager-server-windows-sqlite:
     name: Manager Server SQLite (Windows)
+    needs: changes
+    if: needs.changes.outputs.windows_sqlite == 'true'
     runs-on: windows-latest
 
     steps:
@@ -90,6 +138,8 @@ jobs:
 
   native-control:
     name: Native Control (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.native_control == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -119,8 +169,14 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     needs:
+      - changes
       - frontend
       - manager-server
+    if: >-
+      always() &&
+      needs.changes.outputs.docker == 'true' &&
+      (needs.frontend.result == 'success' || needs.frontend.result == 'skipped') &&
+      (needs['manager-server'].result == 'success' || needs['manager-server'].result == 'skipped')
 
     steps:
       - name: Checkout code

--- a/bin/ci/classify-pr-checks.mjs
+++ b/bin/ci/classify-pr-checks.mjs
@@ -1,0 +1,133 @@
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const CHECK_NAMES = ['frontend', 'manager_server', 'windows_sqlite', 'native_control', 'docker'];
+
+const FORBIDDEN_INVISIBLE_CODE_POINTS = new Set([
+  0x200b, 0x200c, 0x200d, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2060, 0x2066,
+  0x2067, 0x2068, 0x2069, 0xfeff,
+]);
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const normalizePath = (filePath) => filePath.trim().replaceAll('\\', '/').replace(/^\.\//, '');
+
+const normalizeChangedFiles = (changedFiles) => [
+  ...new Set(changedFiles.map(normalizePath).filter(Boolean)),
+];
+
+const startsWithPath = (filePath, directory) => filePath.startsWith(`${directory}/`);
+
+const allChecks = (enabled) =>
+  Object.fromEntries(CHECK_NAMES.map((checkName) => [checkName, enabled]));
+
+const triggersAllChecks = (filePath) =>
+  filePath === '.github/workflows/pr-check.yml' ||
+  filePath === 'bin/ci/classify-pr-checks.mjs' ||
+  filePath === 'tests/prCheckClassifier.test.mjs';
+
+const triggersFrontend = (filePath) =>
+  startsWithPath(filePath, 'apps/web') ||
+  startsWithPath(filePath, 'apps/docs') ||
+  startsWithPath(filePath, 'tests') ||
+  filePath === 'README.md' ||
+  filePath === 'README_CN.md' ||
+  filePath === 'package.json' ||
+  filePath === 'package-lock.json' ||
+  filePath === 'eslint.config.js' ||
+  filePath === 'bin/install-cpamp.sh' ||
+  filePath === 'bin/release/check-web-demo-isolation.mjs';
+
+const triggersManagerServer = (filePath) => startsWithPath(filePath, 'apps/manager-server');
+
+const triggersNativeControl = (filePath) =>
+  startsWithPath(filePath, 'bin/native') ||
+  filePath === 'bin/release/package-native.sh' ||
+  filePath === 'tests/nativeControlScripts.test.mjs' ||
+  filePath === 'package.json' ||
+  filePath === 'package-lock.json';
+
+const triggersDocker = (filePath) =>
+  startsWithPath(filePath, 'apps/web') ||
+  startsWithPath(filePath, 'apps/manager-server') ||
+  filePath === 'Dockerfile.manager-server' ||
+  filePath === '.dockerignore' ||
+  filePath === 'package.json' ||
+  filePath === 'package-lock.json';
+
+export const classifyChangedFiles = (changedFiles) => {
+  const files = normalizeChangedFiles(changedFiles);
+  if (files.length === 0 || files.some(triggersAllChecks)) return allChecks(true);
+
+  const frontend = files.some(triggersFrontend);
+  const managerServer = files.some(triggersManagerServer);
+
+  return {
+    frontend,
+    manager_server: managerServer,
+    windows_sqlite: managerServer,
+    native_control: files.some(triggersNativeControl),
+    docker: files.some(triggersDocker),
+  };
+};
+
+export const findForbiddenUnicode = (text) => {
+  const hits = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) continue;
+
+    if (FORBIDDEN_INVISIBLE_CODE_POINTS.has(codePoint)) {
+      hits.push(`U+${codePoint.toString(16).toUpperCase().padStart(4, '0')}`);
+    }
+
+    if (codePoint > 0xffff) index += 1;
+  }
+
+  return hits;
+};
+
+export const scanChangedTextFiles = (changedFiles) => {
+  const violations = [];
+
+  for (const filePath of normalizeChangedFiles(changedFiles)) {
+    const absolutePath = path.resolve(repoRoot, filePath);
+    if (!absolutePath.startsWith(`${repoRoot}${path.sep}`)) {
+      violations.push(`${filePath} resolves outside the repository`);
+      continue;
+    }
+    if (!existsSync(absolutePath)) continue;
+    if (!lstatSync(absolutePath).isFile()) continue;
+
+    const fileBuffer = readFileSync(absolutePath);
+    if (fileBuffer.includes(0)) continue;
+
+    for (const codePoint of findForbiddenUnicode(fileBuffer.toString('utf8'))) {
+      violations.push(`${filePath} contains ${codePoint}`);
+    }
+  }
+
+  return violations;
+};
+
+const runCli = () => {
+  const changedFiles = readFileSync(0, 'utf8').split(/\r?\n/);
+  const violations = scanChangedTextFiles(changedFiles);
+
+  if (violations.length > 0) {
+    console.error('Changed text files contain forbidden invisible Unicode:');
+    for (const violation of violations) console.error(`- ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const classification = classifyChangedFiles(changedFiles);
+  for (const checkName of CHECK_NAMES) {
+    console.log(`${checkName}=${classification[checkName]}`);
+  }
+};
+
+const entryPoint = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : '';
+if (entryPoint === import.meta.url) runCli();

--- a/tests/prCheckClassifier.test.mjs
+++ b/tests/prCheckClassifier.test.mjs
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyChangedFiles,
+  findForbiddenUnicode,
+  scanChangedTextFiles,
+} from '../bin/ci/classify-pr-checks.mjs';
+
+const noChecks = {
+  frontend: false,
+  manager_server: false,
+  windows_sqlite: false,
+  native_control: false,
+  docker: false,
+};
+
+describe('PR check classifier', () => {
+  it('fails closed when no changed files are available', () => {
+    expect(classifyChangedFiles([])).toEqual({
+      frontend: true,
+      manager_server: true,
+      windows_sqlite: true,
+      native_control: true,
+      docker: true,
+    });
+  });
+
+  it('skips application checks for release workflow and ordinary docs changes', () => {
+    expect(classifyChangedFiles(['.github/workflows/release.yml', 'docs/release.md'])).toEqual(
+      noChecks
+    );
+  });
+
+  it('runs frontend and Docker checks for web changes', () => {
+    expect(classifyChangedFiles(['apps/web/src/features/login/LoginPage.tsx'])).toEqual({
+      ...noChecks,
+      frontend: true,
+      docker: true,
+    });
+  });
+
+  it('runs frontend checks for docs-site and README changes', () => {
+    expect(classifyChangedFiles(['apps/docs/index.md', 'README.md'])).toEqual({
+      ...noChecks,
+      frontend: true,
+    });
+  });
+
+  it('runs Linux, Windows SQLite, and Docker checks for manager-server changes', () => {
+    expect(
+      classifyChangedFiles(['apps/manager-server/internal/repository/sqlite/database.go'])
+    ).toEqual({
+      ...noChecks,
+      manager_server: true,
+      windows_sqlite: true,
+      docker: true,
+    });
+  });
+
+  it('runs native checks only for native control changes', () => {
+    expect(classifyChangedFiles(['bin/native/cpa-manager-plusctl.ps1'])).toEqual({
+      ...noChecks,
+      native_control: true,
+    });
+  });
+
+  it('runs Node and Docker checks for root dependency changes', () => {
+    expect(classifyChangedFiles(['package-lock.json'])).toEqual({
+      ...noChecks,
+      frontend: true,
+      native_control: true,
+      docker: true,
+    });
+  });
+
+  it('runs all checks when the classifier or PR workflow changes', () => {
+    for (const filePath of [
+      '.github/workflows/pr-check.yml',
+      'bin/ci/classify-pr-checks.mjs',
+      'tests/prCheckClassifier.test.mjs',
+    ]) {
+      expect(classifyChangedFiles([filePath])).toEqual({
+        frontend: true,
+        manager_server: true,
+        windows_sqlite: true,
+        native_control: true,
+        docker: true,
+      });
+    }
+  });
+
+  it('normalizes CRLF input paths, Windows separators, blanks, and duplicates', () => {
+    expect(
+      classifyChangedFiles([
+        'apps\\web\\src\\App.tsx\r',
+        '',
+        './apps/web/src/App.tsx',
+        'apps/manager-server/cmd/cpa-manager-plus/main.go',
+      ])
+    ).toEqual({
+      ...noChecks,
+      frontend: true,
+      manager_server: true,
+      windows_sqlite: true,
+      docker: true,
+    });
+  });
+
+  it('detects forbidden invisible Unicode code points', () => {
+    expect(findForbiddenUnicode('safe\u200Btext\u202E')).toEqual(['U+200B', 'U+202E']);
+    expect(findForbiddenUnicode('plain text')).toEqual([]);
+  });
+
+  it('rejects changed paths that resolve outside the repository', () => {
+    expect(scanChangedTextFiles(['../../outside.txt'])).toEqual([
+      '../../outside.txt resolves outside the repository',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Scope PR-check jobs to only the parts of the codebase affected by the change. Add a `changes` job that classifies the diff via `bin/ci/classify-pr-checks.mjs` and gates each downstream job behind a per-check output. Also flag invisible Unicode code points in changed text files.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Add a `changes` job that derives changed file paths from the PR base..head range (with push and single-commit fallbacks) and runs `bin/ci/classify-pr-checks.mjs` to emit per-check outputs.
- Gate `frontend`, `manager-server`, `manager-server-windows-sqlite`, and `native-control` on the matching output. The `docker` job also becomes change-aware while still requiring its upstream jobs to succeed or be skipped.
- Teach the classifier to fail-closed (run every check) when no files are available, and to flag zero-width, bidi-override, and BOM code points in changed text files.
- Add a vitest suite under `tests/prCheckClassifier.test.mjs` covering classification rules and the Unicode scan.

## User Impact

No user-facing behaviour change. PR authors and reviewers see faster, more focused CI runs because unrelated PRs no longer pay the cost of every matrix.

## Compatibility / Runtime Notes

- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: N/A

## Data / Security Notes

N/A — CI tooling only.

## Risk / Rollback

Risk level: Medium

Rollback notes: revert this PR. No data, schema, or config migration involved.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run test                                  # 105 files, 968 tests passed
node -e "require('yaml').parse(require('fs').readFileSync('.github/workflows/pr-check.yml','utf8'))"
```

## Screenshots / Recordings

N/A — CI tooling change only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: CI-only change with no user-visible capability surface.

## Related

N/A