### PR TITLE
docs(release): restore community summary title

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -55,7 +55,11 @@ inside GitHub Actions.
 Write the post for users and community members rather than code reviewers:
 
 - use `## <M> 月 <D> 日 v<version>` as the Markdown heading, with `更新内容`,
-  `注意事项`, `发布截图`, and `致谢` sections as applicable;
+  `注意事项`, `发布截图`, and `致谢` sections as applicable; end the Markdown
+  summary and release closeout with the separate title
+  `CPA-Manager-Plus [<M>月<D>日：<primary benefit>，<supporting benefit>]`;
+- make the standalone title reflect the release's main user value, without
+  implementation trivia; it is not part of the date/version heading;
 - list every release-relevant, user-visible semantic change in `更新内容`; do
   not impose a fixed item count, but merge implementation commits that result
   in the same user behavior;
@@ -65,12 +69,41 @@ Write the post for users and community members rather than code reviewers:
 - include `注意事项` only for upgrade, data, compatibility, configuration, or
   meaningful behavior changes that users need to act on or understand;
 - include `发布截图` only when a specific screen or workflow should be shown;
-- keep `发布截图` in the Markdown release summary only; Telegram HTML must omit
-  it because the workflow does not attach media;
+- keep `发布截图` and the standalone community-summary title in the Markdown
+  release summary only; Telegram HTML must omit both because the workflow does
+  not attach media and the title is not part of the message format;
 - include acknowledgements only for external contributors and preserve their
   GitHub profile links;
 - keep claims factual and grounded in the formal release notes;
 - keep the complete HTML body within 3,500 characters.
+
+Markdown community-summary template:
+
+```markdown
+## <M> 月 <D> 日 v<version>
+
+### 更新内容
+
+- <用户可感知的更新>
+
+### 注意事项
+
+- <需要升级、配置或兼容性关注的事项>
+
+### 发布截图
+
+<具体页面或操作路径；没有推荐时省略本节>
+
+### 致谢
+
+- [@contributor](https://github.com/contributor) - <贡献带来的用户价值>
+
+CPA-Manager-Plus [<M>月<D>日：<primary benefit>，<supporting benefit>]
+```
+
+Omit optional sections that have no content. The Telegram HTML mirrors only
+the applicable `更新内容`, `注意事项`, and `致谢` sections; do not append the
+standalone Markdown community-summary title.
 
 Telegram posts use a conservative HTML subset supported by the Bot API:
 


### PR DESCRIPTION
## Summary

Restore the standalone community-summary title used in Markdown release previews and final closeouts. Keep the Telegram release message free of this Markdown-only title.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Document the standalone `CPA-Manager-Plus [...]` title after the Markdown community summary.
- Clarify that Telegram contains only the shared release sections and omits the Markdown title.

## User Impact

Future community Markdown summaries regain the historical descriptive title, while Telegram messages remain concise and unchanged in format.

## Compatibility / Runtime Notes

- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: N/A

## Data / Security Notes

N/A.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this documentation-only commit to restore the prior release-copy guidance.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
git diff --check
Passed with no output.
Markdown and local release-skill templates reviewed for title placement and Telegram exclusion.
```

## Screenshots / Recordings

N/A - documentation-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [x] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: Updated `docs/release.md`; no versioned release notes are needed because this only changes future release-copy guidance.

## Related

N/A