### PR TITLE
fix(usage-analytics): render exact API key trends

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -276,6 +276,27 @@ type CredentialTimelinePoint struct {
 	LatencySamples        int64
 }
 
+type APIKeyTimelinePoint struct {
+	usage.LongContextTokens
+	APIKeyHash          string
+	BucketMS            int64
+	Model               string
+	BillingModel        string
+	ServiceTier         string
+	Calls               int64
+	Tokens              int64
+	Success             int64
+	Failure             int64
+	InputTokens         int64
+	OutputTokens        int64
+	ReasoningTokens     int64
+	CachedTokens        int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	AvgLatencyMS        sql.NullFloat64
+	LatencySamples      int64
+}
+
 type APIKeyModelStat struct {
 	usage.LongContextTokens
 	APIKeyHash           string
@@ -632,6 +653,120 @@ order by timestamp_ms, model`, where)
 		return nil, err
 	}
 	points := make([]TimelinePoint, 0, len(order))
+	for _, mapKey := range order {
+		point := grouped[mapKey]
+		if point.LatencySamples > 0 {
+			point.AvgLatencyMS.Float64 = point.AvgLatencyMS.Float64 / float64(point.LatencySamples)
+			point.AvgLatencyMS.Valid = true
+		}
+		points = append(points, *point)
+	}
+	return points, nil
+}
+
+func (r *repository) APIKeyTimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]APIKeyTimelinePoint, error) {
+	if len(normalizeFilterValues(filter.APIKeyHashes)) == 0 && strings.TrimSpace(filter.SearchAPIKeyHash) == "" {
+		return nil, nil
+	}
+	where, args := analyticsWhere(filter)
+	query := fmt.Sprintf(`select
+	timestamp_ms,
+	coalesce(api_key_hash, ''),
+	model,
+	coalesce(nullif(resolved_model, ''), model) as billing_model,
+	coalesce(service_tier, '') as service_tier,
+	failed,
+	`+normalizedInputExpr+`,
+	output_tokens,
+	reasoning_tokens,
+	`+compatCachedExpr+`,
+	cache_read_tokens,
+	cache_creation_tokens,
+	total_tokens,
+	latency_ms
+from usage_events %s
+order by timestamp_ms, api_key_hash, model`, where)
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type key struct {
+		apiKeyHash   string
+		bucketMS     int64
+		model        string
+		billingModel string
+		serviceTier  string
+	}
+	grouped := map[key]*APIKeyTimelinePoint{}
+	order := make([]key, 0)
+	for rows.Next() {
+		var timestampMS int64
+		var point APIKeyTimelinePoint
+		var failed int
+		var latency sql.NullFloat64
+		var totalTokens int64
+		if err := rows.Scan(
+			&timestampMS,
+			&point.APIKeyHash,
+			&point.Model,
+			&point.BillingModel,
+			&point.ServiceTier,
+			&failed,
+			&point.InputTokens,
+			&point.OutputTokens,
+			&point.ReasoningTokens,
+			&point.CachedTokens,
+			&point.CacheReadTokens,
+			&point.CacheCreationTokens,
+			&totalTokens,
+			&latency,
+		); err != nil {
+			return nil, err
+		}
+		mapKey := key{
+			apiKeyHash:   point.APIKeyHash,
+			bucketMS:     usage.AnalyticsBucketMS(timestampMS, granularity, location),
+			model:        point.Model,
+			billingModel: point.BillingModel,
+			serviceTier:  point.ServiceTier,
+		}
+		entry := grouped[mapKey]
+		if entry == nil {
+			entry = &APIKeyTimelinePoint{
+				APIKeyHash:   point.APIKeyHash,
+				BucketMS:     mapKey.bucketMS,
+				Model:        point.Model,
+				BillingModel: point.BillingModel,
+				ServiceTier:  point.ServiceTier,
+			}
+			grouped[mapKey] = entry
+			order = append(order, mapKey)
+		}
+		entry.Calls += 1
+		entry.Tokens += totalTokens
+		if failed != 0 {
+			entry.Failure += 1
+		} else {
+			entry.Success += 1
+		}
+		entry.InputTokens += point.InputTokens
+		entry.OutputTokens += point.OutputTokens
+		entry.ReasoningTokens += point.ReasoningTokens
+		entry.CachedTokens += point.CachedTokens
+		entry.CacheReadTokens += point.CacheReadTokens
+		entry.CacheCreationTokens += point.CacheCreationTokens
+		entry.AddIfLongContext(point.InputTokens, point.OutputTokens, point.CachedTokens, point.CacheReadTokens, point.CacheCreationTokens)
+		if latency.Valid && latency.Float64 > 0 {
+			entry.AvgLatencyMS.Float64 += latency.Float64
+			entry.LatencySamples += 1
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	points := make([]APIKeyTimelinePoint, 0, len(order))
 	for _, mapKey := range order {
 		point := grouped[mapKey]
 		if point.LatencySamples > 0 {

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -39,6 +39,7 @@ type Repository interface {
 	AccountModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]AccountModelStat, error)
 	CredentialModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]CredentialModelStat, error)
 	CredentialTimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]CredentialTimelinePoint, error)
+	APIKeyTimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]APIKeyTimelinePoint, error)
 	APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error)
 	TaskBucketsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]TaskBucket, error)
 	RecentFailuresWithFilter(ctx context.Context, filter AnalyticsFilter, limit int) ([]RecentFailure, error)

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -151,6 +151,7 @@ type Include struct {
 	AccountStats       bool              `json:"account_stats"`
 	CredentialStats    bool              `json:"credential_stats"`
 	CredentialTimeline bool              `json:"credential_timeline"`
+	APIKeyTimeline     bool              `json:"api_key_timeline"`
 	APIKeyStats        bool              `json:"api_key_stats"`
 	FilterOptions      bool              `json:"filter_options"`
 	FilterSelectors    bool              `json:"filter_selectors"`
@@ -191,6 +192,7 @@ type Response struct {
 	AccountStats       []AccountStatRow          `json:"account_stats,omitempty"`
 	CredentialStats    []CredentialStatRow       `json:"credential_stats,omitempty"`
 	CredentialTimeline []CredentialTimelinePoint `json:"credential_timeline,omitempty"`
+	APIKeyTimeline     []APIKeyTimelinePoint     `json:"api_key_timeline,omitempty"`
 	APIKeyStats        []APIKeyStatRow           `json:"api_key_stats,omitempty"`
 	FilterOptions      *FilterOptions            `json:"filter_options,omitempty"`
 	TaskBuckets        []TaskBucketRow           `json:"task_buckets,omitempty"`
@@ -498,6 +500,27 @@ type CredentialTimelinePoint struct {
 	AvgLatencyMS          *float64 `json:"average_latency_ms"`
 	SuccessRate           float64  `json:"success_rate"`
 	FailureRate           float64  `json:"failure_rate"`
+}
+
+type APIKeyTimelinePoint struct {
+	APIKeyHash          string   `json:"api_key_hash"`
+	BucketMS            int64    `json:"bucket_ms"`
+	BucketLabel         string   `json:"bucket_label"`
+	Calls               int64    `json:"calls"`
+	Tokens              int64    `json:"tokens"`
+	Success             int64    `json:"success"`
+	Failure             int64    `json:"failure"`
+	InputTokens         int64    `json:"input_tokens"`
+	OutputTokens        int64    `json:"output_tokens"`
+	CachedTokens        int64    `json:"cached_tokens"`
+	CacheReadTokens     int64    `json:"cache_read_tokens"`
+	CacheCreationTokens int64    `json:"cache_creation_tokens"`
+	ReasoningTokens     int64    `json:"reasoning_tokens"`
+	TotalTokens         int64    `json:"total_tokens"`
+	Cost                float64  `json:"cost"`
+	AvgLatencyMS        *float64 `json:"average_latency_ms"`
+	SuccessRate         float64  `json:"success_rate"`
+	FailureRate         float64  `json:"failure_rate"`
 }
 
 type AccountModelStatRow struct {
@@ -834,6 +857,15 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 		})
 	}
 
+	var apiKeyTimelinePoints []store.APIKeyTimelinePoint
+	if req.Include.APIKeyTimeline {
+		queries.Go(func(queryCtx context.Context) error {
+			var queryErr error
+			apiKeyTimelinePoints, queryErr = s.store.APIKeyTimelineWithFilter(queryCtx, filter, granularity, location)
+			return queryErr
+		})
+	}
+
 	if req.Include.APIKeyStats {
 		queries.Go(func(queryCtx context.Context) error {
 			var queryErr error
@@ -1057,6 +1089,9 @@ func (s *Service) Analytics(ctx context.Context, req Request) (Response, error) 
 	}
 	if req.Include.CredentialTimeline {
 		response.CredentialTimeline = buildCredentialTimeline(credentialTimelinePoints, granularity, location, prices)
+	}
+	if req.Include.APIKeyTimeline {
+		response.APIKeyTimeline = buildAPIKeyTimeline(apiKeyTimelinePoints, granularity, location, prices)
 	}
 	if req.Include.APIKeyStats {
 		response.APIKeyStats = buildAPIKeyStats(apiKeyStats, prices)
@@ -2224,6 +2259,69 @@ func buildCredentialTimeline(points []store.CredentialTimelinePoint, granularity
 	return result
 }
 
+type apiKeyTimelineAccumulator struct {
+	point          APIKeyTimelinePoint
+	latencySum     float64
+	latencySamples int64
+}
+
+func buildAPIKeyTimeline(points []store.APIKeyTimelinePoint, granularity string, location *time.Location, prices map[string]store.ModelPrice) []APIKeyTimelinePoint {
+	type key struct {
+		apiKeyHash string
+		bucketMS   int64
+	}
+	grouped := map[key]*apiKeyTimelineAccumulator{}
+	order := make([]key, 0, len(points))
+	for _, point := range points {
+		apiKeyHash := strings.TrimSpace(point.APIKeyHash)
+		if apiKeyHash == "" {
+			continue
+		}
+		mapKey := key{apiKeyHash: apiKeyHash, bucketMS: point.BucketMS}
+		entry := grouped[mapKey]
+		if entry == nil {
+			entry = &apiKeyTimelineAccumulator{
+				point: APIKeyTimelinePoint{
+					APIKeyHash:  apiKeyHash,
+					BucketMS:    point.BucketMS,
+					BucketLabel: timelineLabel(point.BucketMS, granularity, location),
+				},
+			}
+			grouped[mapKey] = entry
+			order = append(order, mapKey)
+		}
+		entry.point.Calls += point.Calls
+		entry.point.Tokens += point.Tokens
+		entry.point.TotalTokens += point.Tokens
+		entry.point.Success += point.Success
+		entry.point.Failure += point.Failure
+		entry.point.InputTokens += point.InputTokens
+		entry.point.OutputTokens += point.OutputTokens
+		entry.point.CachedTokens += point.CachedTokens
+		entry.point.CacheReadTokens += point.CacheReadTokens
+		entry.point.CacheCreationTokens += point.CacheCreationTokens
+		entry.point.ReasoningTokens += point.ReasoningTokens
+		entry.point.Cost += costForAPIKeyTimelinePoint(point, prices)
+		if point.AvgLatencyMS.Valid && point.LatencySamples > 0 {
+			entry.latencySum += point.AvgLatencyMS.Float64 * float64(point.LatencySamples)
+			entry.latencySamples += point.LatencySamples
+		}
+	}
+
+	result := make([]APIKeyTimelinePoint, 0, len(order))
+	for _, mapKey := range order {
+		entry := grouped[mapKey]
+		if entry.latencySamples > 0 {
+			value := entry.latencySum / float64(entry.latencySamples)
+			entry.point.AvgLatencyMS = &value
+		}
+		entry.point.SuccessRate = ratio(entry.point.Success, entry.point.Calls)
+		entry.point.FailureRate = ratio(entry.point.Failure, entry.point.Calls)
+		result = append(result, entry.point)
+	}
+	return result
+}
+
 func buildAPIKeyStats(stats []store.APIKeyModelStat, prices map[string]store.ModelPrice) []APIKeyStatRow {
 	grouped := map[string]*apiKeyStatAccumulator{}
 	for _, stat := range stats {
@@ -2993,6 +3091,21 @@ func costForCredentialModelStat(stat store.CredentialModelStat, prices map[strin
 }
 
 func costForCredentialTimelinePoint(point store.CredentialTimelinePoint, prices map[string]store.ModelPrice) float64 {
+	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
+		InputTokens:             point.InputTokens,
+		OutputTokens:            point.OutputTokens,
+		CachedTokens:            point.CachedTokens,
+		CacheReadTokens:         point.CacheReadTokens,
+		CacheCreationTokens:     point.CacheCreationTokens,
+		LongInputTokens:         point.LongInputTokens,
+		LongOutputTokens:        point.LongOutputTokens,
+		LongCachedTokens:        point.LongCachedTokens,
+		LongCacheReadTokens:     point.LongCacheReadTokens,
+		LongCacheCreationTokens: point.LongCacheCreationTokens,
+	}, prices)
+}
+
+func costForAPIKeyTimelinePoint(point store.APIKeyTimelinePoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
 		InputTokens:             point.InputTokens,
 		OutputTokens:            point.OutputTokens,

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -294,6 +294,61 @@ func TestAnalyticsCredentialTimelineBuildsPerCredentialBuckets(t *testing.T) {
 	}
 }
 
+func TestAnalyticsAPIKeyTimelineBuildsExactPerKeyBuckets(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_000_000_000)
+	toMS := fromMS + 3*60*60*1000
+	if err := db.SaveModelPrices(ctx, map[string]store.ModelPrice{
+		"gpt-a": {Prompt: 1},
+	}); err != nil {
+		t.Fatalf("save model prices: %v", err)
+	}
+
+	first := monitoringEvent("api-key-timeline-a1", fromMS+1_000, "gpt-a", "auth-1", "source-a", false, 1_000_000, 0, 0, 0, 1_000_000, nil)
+	second := monitoringEvent("api-key-timeline-a2", fromMS+2_000, "gpt-a", "auth-1", "source-a", true, 2_000_000, 0, 0, 0, 2_000_000, nil)
+	third := monitoringEvent("api-key-timeline-b1", fromMS+60*60*1000+1_000, "gpt-a", "auth-2", "source-b", false, 3_000_000, 0, 0, 0, 3_000_000, nil)
+	excluded := monitoringEvent("api-key-timeline-c1", fromMS+60*60*1000+2_000, "gpt-a", "auth-3", "source-c", false, 4_000_000, 0, 0, 0, 4_000_000, nil)
+	if _, err := db.InsertEvents(ctx, []usage.Event{first, second, third, excluded}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS: fromMS,
+		ToMS:   toMS,
+		Filters: Filters{
+			APIKeyHashes: []string{"api-key-auth-1", "api-key-auth-2"},
+		},
+		Include: Include{
+			APIKeyTimeline: true,
+			Granularity:    "hour",
+		},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if len(resp.APIKeyTimeline) != 2 {
+		t.Fatalf("api key timeline = %#v", resp.APIKeyTimeline)
+	}
+	byKeyBucket := make(map[string]APIKeyTimelinePoint, len(resp.APIKeyTimeline))
+	for _, point := range resp.APIKeyTimeline {
+		byKeyBucket[fmt.Sprintf("%s/%d", point.APIKeyHash, point.BucketMS)] = point
+	}
+	firstBucketMS := time.UnixMilli(fromMS).UTC().Truncate(time.Hour).UnixMilli()
+	secondBucketMS := time.UnixMilli(fromMS + 60*60*1000).UTC().Truncate(time.Hour).UnixMilli()
+	firstBucket := byKeyBucket[fmt.Sprintf("api-key-auth-1/%d", firstBucketMS)]
+	if firstBucket.Calls != 2 || firstBucket.Success != 1 || firstBucket.Failure != 1 || firstBucket.TotalTokens != 3_000_000 {
+		t.Fatalf("first api key bucket = %#v", firstBucket)
+	}
+	if firstBucket.Cost <= 0 {
+		t.Fatalf("first api key bucket cost = %#v", firstBucket)
+	}
+	secondBucket := byKeyBucket[fmt.Sprintf("api-key-auth-2/%d", secondBucketMS)]
+	if secondBucket.Calls != 1 || secondBucket.Success != 1 || secondBucket.Failure != 0 || secondBucket.TotalTokens != 3_000_000 {
+		t.Fatalf("second api key bucket = %#v", secondBucket)
+	}
+}
+
 func TestAnalyticsSummaryComparisonReturnsPreviousPeriod(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -70,6 +70,7 @@ type FailureSourceStat = usageevent.FailureSourceStat
 type AccountModelStat = usageevent.AccountModelStat
 type CredentialModelStat = usageevent.CredentialModelStat
 type CredentialTimelinePoint = usageevent.CredentialTimelinePoint
+type APIKeyTimelinePoint = usageevent.APIKeyTimelinePoint
 type APIKeyModelStat = usageevent.APIKeyModelStat
 type TaskBucket = usageevent.TaskBucket
 type EventPageItem = usageevent.EventPageItem
@@ -524,6 +525,10 @@ func (s *Store) CredentialModelStatsWithFilter(ctx context.Context, filter Analy
 
 func (s *Store) CredentialTimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]CredentialTimelinePoint, error) {
 	return s.UsageEvents.CredentialTimelineWithFilter(ctx, filter, granularity, location)
+}
+
+func (s *Store) APIKeyTimelineWithFilter(ctx context.Context, filter AnalyticsFilter, granularity string, location *time.Location) ([]APIKeyTimelinePoint, error) {
+	return s.UsageEvents.APIKeyTimelineWithFilter(ctx, filter, granularity, location)
 }
 
 func (s *Store) APIKeyModelStatsWithFilter(ctx context.Context, filter AnalyticsFilter) ([]APIKeyModelStat, error) {

--- a/apps/web/src/features/demo/DemoPage.test.tsx
+++ b/apps/web/src/features/demo/DemoPage.test.tsx
@@ -170,6 +170,49 @@ describe('DemoPage', () => {
     );
   });
 
+  it('returns exact API key trend fixtures for selected client keys', () => {
+    const page = getDemoMonitoringAnalytics({
+      from_ms: 1,
+      to_ms: Date.now(),
+      filters: {
+        api_key_hashes: ['hash_research_shared', 'hash_codex_team'],
+      },
+      include: {
+        api_key_timeline: true,
+      },
+    });
+    const timeline = page.timeline;
+    const apiKeyTimeline = page.api_key_timeline;
+    if (!timeline || !apiKeyTimeline) throw new Error('missing demo API key timeline');
+    const firstBucket = timeline[0];
+    const missingCodexBucket = timeline[3];
+    if (!firstBucket || !missingCodexBucket) throw new Error('missing demo timeline buckets');
+
+    expect([...new Set(apiKeyTimeline.map((point) => point.api_key_hash))].sort()).toEqual([
+      'hash_codex_team',
+      'hash_research_shared',
+    ]);
+    expect(apiKeyTimeline).toHaveLength(timeline.length * 2 - 2);
+
+    const firstResearchPoint = apiKeyTimeline.find(
+      (point) =>
+        point.api_key_hash === 'hash_research_shared' && point.bucket_ms === firstBucket.bucket_ms
+    );
+    if (!firstResearchPoint) throw new Error('missing first research API key bucket');
+    expect(firstResearchPoint).toMatchObject({
+      calls: Math.round(firstBucket.calls * 0.36),
+      total_tokens: Math.round(firstBucket.tokens * 0.39),
+    });
+    expect(firstResearchPoint.success + firstResearchPoint.failure).toBe(firstResearchPoint.calls);
+    expect(
+      apiKeyTimeline.some(
+        (point) =>
+          point.api_key_hash === 'hash_codex_team' &&
+          point.bucket_ms === missingCodexBucket.bucket_ms
+      )
+    ).toBe(false);
+  });
+
   it('keeps visible demo dates relative to the current day', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-29T10:00:00+08:00'));

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -2194,6 +2194,78 @@ const buildMonitoringAnalytics = (
     };
   });
 
+  const requestedAPIKeyTimelineHashes = new Set(
+    (request?.filters?.api_key_hashes ?? [])
+      .map((hash) => hash.trim().toLowerCase())
+      .filter(Boolean)
+  );
+  const apiKeyTimelineProfiles = [
+    {
+      apiKeyHash: 'hash_research_shared',
+      callShares: [0.36, 0.14, 0.29, 0.42, 0.19, 0.31, 0.12],
+      tokenShares: [0.39, 0.18, 0.33, 0.46, 0.22, 0.35, 0.15],
+      failureRate: 0.026,
+      averageLatencyMs: 1420,
+      missingBuckets: [],
+    },
+    {
+      apiKeyHash: 'hash_gemini_prod',
+      callShares: [0.16, 0.3, 0.11, 0.25, 0.37, 0.15, 0.28],
+      tokenShares: [0.21, 0.34, 0.14, 0.28, 0.41, 0.18, 0.31],
+      failureRate: 0.018,
+      averageLatencyMs: 1160,
+      missingBuckets: [],
+    },
+    {
+      apiKeyHash: 'hash_codex_team',
+      callShares: [0.22, 0.1, 0.34, 0.17, 0.27, 0.09, 0.23],
+      tokenShares: [0.19, 0.08, 0.29, 0.13, 0.24, 0.07, 0.2],
+      failureRate: 0.012,
+      averageLatencyMs: 1220,
+      missingBuckets: [3, 10],
+    },
+    {
+      apiKeyHash: 'hash_research_batch',
+      callShares: [0.08, 0.19, 0.27, 0.1, 0.16, 0.29, 0.07],
+      tokenShares: [0.11, 0.24, 0.35, 0.14, 0.21, 0.37, 0.09],
+      failureRate: 0.034,
+      averageLatencyMs: 1510,
+      missingBuckets: [],
+    },
+  ];
+  const apiKeyTimeline = timeline
+    .flatMap((point, bucketIndex) =>
+      apiKeyTimelineProfiles.flatMap((profile) => {
+        if (profile.missingBuckets.includes(bucketIndex)) return [];
+        const callShare = profile.callShares[bucketIndex % profile.callShares.length];
+        const tokenShare = profile.tokenShares[bucketIndex % profile.tokenShares.length];
+        const calls = Math.round(point.calls * callShare);
+        const failure = Math.min(calls, Math.round(calls * profile.failureRate));
+        const tokens = Math.round(point.tokens * tokenShare);
+        return [
+          {
+            api_key_hash: profile.apiKeyHash,
+            bucket_ms: point.bucket_ms,
+            bucket_label: point.label,
+            calls,
+            tokens,
+            success: calls - failure,
+            failure,
+            ...splitTokens(tokens),
+            cost: round2(point.cost * tokenShare),
+            average_latency_ms: profile.averageLatencyMs,
+            success_rate: safeRate(calls - failure, calls),
+            failure_rate: safeRate(failure, calls),
+          },
+        ];
+      })
+    )
+    .filter(
+      (point) =>
+        requestedAPIKeyTimelineHashes.size === 0 ||
+        requestedAPIKeyTimelineHashes.has(point.api_key_hash)
+    );
+
   const channelShare = accountStats.map((row) => ({
     auth_index: row.auth_indices?.[0] ?? row.id,
     source: row.sources?.[0],
@@ -2817,6 +2889,9 @@ const buildMonitoringAnalytics = (
     credential_stats: credentialStats,
     credential_timeline: credentialTimeline,
     api_key_stats: apiKeyStats,
+    ...(request?.include?.api_key_timeline && requestedAPIKeyTimelineHashes.size > 0
+      ? { api_key_timeline: apiKeyTimeline }
+      : {}),
     filter_options: {
       account_stats: accountStats,
       api_key_stats: apiKeyStats,

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -4,6 +4,7 @@ import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import type { UsageRankRow } from './usageAnalyticsModel';
 import {
   analyzeUsageBucket,
+  buildApiKeyTrendSeries,
   buildApiKeyRows,
   buildCredentialRows,
   buildSelectedApiKeyTrendSeries,
@@ -25,6 +26,7 @@ import {
   buildUsageHeatmapRangeContext,
   buildUsageHeatmap,
   buildUsageCredentialTimeline,
+  buildUsageApiKeyTimeline,
   buildUsageTimeline,
   computeCacheHitRate,
   computeRowAverageCostPerCall,
@@ -621,6 +623,82 @@ describe('usage analytics adapters', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('abcdef1234567890');
     expect(result[0].points.map((point) => point.value)).toEqual([3, 7]);
+  });
+
+  it('builds overview API key trends from exact per-key buckets', () => {
+    const rows: UsageRankRow[] = [
+      {
+        id: 'key-a',
+        label: 'Key A',
+        apiKeyHash: 'key-a',
+        requestCount: 8,
+        successCount: 8,
+        failureCount: 0,
+        successRate: 1,
+        totalTokens: 800,
+        inputTokens: 800,
+        outputTokens: 0,
+        cachedTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        estimatedCost: 0.8,
+        averageLatencyMs: null,
+        share: 0.8,
+      },
+      {
+        id: 'key-b',
+        label: 'Key B',
+        apiKeyHash: 'key-b',
+        requestCount: 2,
+        successCount: 2,
+        failureCount: 0,
+        successRate: 1,
+        totalTokens: 200,
+        inputTokens: 200,
+        outputTokens: 0,
+        cachedTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        estimatedCost: 0.2,
+        averageLatencyMs: null,
+        share: 0.2,
+      },
+    ];
+    const timeline = buildUsageTimeline(
+      [
+        { bucket_ms: NOW_MS, label: '12:00', calls: 5, tokens: 500, success: 5, failure: 0 },
+        {
+          bucket_ms: NOW_MS + HOUR_MS,
+          label: '13:00',
+          calls: 5,
+          tokens: 500,
+          success: 5,
+          failure: 0,
+        },
+      ],
+      'hour'
+    );
+    const apiKeyTimeline = buildUsageApiKeyTimeline(
+      [
+        { api_key_hash: 'key-a', bucket_ms: NOW_MS, calls: 2, tokens: 200, success: 2, failure: 0 },
+        {
+          api_key_hash: 'key-a',
+          bucket_ms: NOW_MS + HOUR_MS,
+          calls: 6,
+          tokens: 600,
+          success: 6,
+          failure: 0,
+        },
+        { api_key_hash: 'key-b', bucket_ms: NOW_MS, calls: 3, tokens: 300, success: 3, failure: 0 },
+      ],
+      'hour'
+    );
+
+    const result = buildApiKeyTrendSeries(rows, timeline, apiKeyTimeline, 'requestCount');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].points.map((point) => point.value)).toEqual([2, 6]);
+    expect(result[1].points.map((point) => point.value)).toEqual([3, 0]);
   });
 
   it('does not render selected API key trend when the filtered timeline is missing', () => {

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -1,6 +1,7 @@
 import type {
   MonitoringAnalyticsAnomalyPoint,
   MonitoringAnalyticsApiKeyStatRow,
+  MonitoringAnalyticsApiKeyTimelinePoint,
   MonitoringAnalyticsChannelShareRow,
   MonitoringAnalyticsCredentialStatRow,
   MonitoringAnalyticsCredentialTimelinePoint,
@@ -220,6 +221,15 @@ export type UsageEntityTrendSeries = {
 export type UsageCredentialTimelinePoint = {
   id: string;
   label: string;
+  bucketMs: number;
+  bucketLabel: string;
+  requestCount: number;
+  totalTokens: number;
+  estimatedCost: number;
+};
+
+export type UsageApiKeyTimelinePoint = {
+  apiKeyHash: string;
   bucketMs: number;
   bucketLabel: string;
   requestCount: number;
@@ -915,6 +925,22 @@ export const buildUsageCredentialTimeline = (
     return {
       id: point.id || point.auth_file_snapshot || point.auth_index || point.source_hash || '-',
       label: display.label,
+      bucketMs,
+      bucketLabel: point.bucket_label || formatLocalBucketLabel(bucketMs, granularity),
+      requestCount: toNumber(point.calls),
+      totalTokens: toNumber(point.total_tokens ?? point.tokens),
+      estimatedCost: toNumber(point.cost),
+    };
+  });
+
+export const buildUsageApiKeyTimeline = (
+  timeline: MonitoringAnalyticsApiKeyTimelinePoint[] = [],
+  granularity: UsageAnalyticsResolvedGranularity
+): UsageApiKeyTimelinePoint[] =>
+  timeline.map((point) => {
+    const bucketMs = toNumber(point.bucket_ms);
+    return {
+      apiKeyHash: normalizeApiKeyHash(point.api_key_hash),
       bucketMs,
       bucketLabel: point.bucket_label || formatLocalBucketLabel(bucketMs, granularity),
       requestCount: toNumber(point.calls),
@@ -1793,6 +1819,58 @@ export const buildEntityTrendSeries = (
           label: point.label,
           value: point[metric] * share,
         })),
+      };
+    });
+};
+
+const usageApiKeyTimelineMetricValue = (
+  point: UsageApiKeyTimelinePoint,
+  metric: UsageTrendMetricKey
+) => {
+  if (metric === 'estimatedCost') return point.estimatedCost;
+  if (metric === 'totalTokens') return point.totalTokens;
+  return point.requestCount;
+};
+
+export const buildApiKeyTrendSeries = (
+  rows: UsageRankRow[],
+  timeline: UsageTimelinePoint[],
+  apiKeyTimeline: UsageApiKeyTimelinePoint[],
+  metric: UsageTrendMetricKey,
+  limit = 4
+): UsageEntityTrendSeries[] => {
+  const valuesByAPIKey = new Map<string, Map<number, UsageApiKeyTimelinePoint>>();
+  apiKeyTimeline.forEach((point) => {
+    if (!point.apiKeyHash) return;
+    let valuesByBucket = valuesByAPIKey.get(point.apiKeyHash);
+    if (!valuesByBucket) {
+      valuesByBucket = new Map();
+      valuesByAPIKey.set(point.apiKeyHash, valuesByBucket);
+    }
+    valuesByBucket.set(point.bucketMs, point);
+  });
+  const colors = ['#2563eb', '#0ea5a7', '#f59e0b', '#ef4444', '#64748b'];
+  return rows
+    .filter((row) => {
+      const apiKeyHash = normalizeApiKeyHash(row.apiKeyHash || row.id);
+      return apiKeyHash !== '' && usageRankMetricValue(row, metric) > 0;
+    })
+    .slice(0, limit)
+    .map((row, index) => {
+      const apiKeyHash = normalizeApiKeyHash(row.apiKeyHash || row.id);
+      const valuesByBucket = valuesByAPIKey.get(apiKeyHash);
+      return {
+        id: apiKeyHash,
+        label: row.label,
+        color: colors[index % colors.length],
+        points: timeline.map((timelinePoint) => {
+          const value = valuesByBucket?.get(timelinePoint.bucketMs);
+          return {
+            bucketMs: timelinePoint.bucketMs,
+            label: timelinePoint.label,
+            value: value ? usageApiKeyTimelineMetricValue(value, metric) : 0,
+          };
+        }),
       };
     });
 };

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -48,6 +48,7 @@ describe('useUsageAnalytics request orchestration', () => {
     const selectors = Boolean(params.include?.filter_selectors);
     const main = Boolean(params.include?.summary);
     const credentialTimeline = Boolean(params.include?.credential_timeline);
+    const apiKeyTimeline = Boolean(params.include?.api_key_timeline);
     const mainData = params.include?.credential_stats
       ? {
           ...emptyAnalyticsResponse,
@@ -71,7 +72,48 @@ describe('useUsageAnalytics request orchestration', () => {
             },
           ],
         }
-      : emptyAnalyticsResponse;
+      : params.include?.api_key_stats
+        ? {
+            ...emptyAnalyticsResponse,
+            timeline: [
+              {
+                bucket_ms: 1,
+                label: '00:00',
+                calls: 5,
+                tokens: 500,
+                success: 5,
+                failure: 0,
+              },
+              {
+                bucket_ms: 3_600_001,
+                label: '01:00',
+                calls: 5,
+                tokens: 500,
+                success: 5,
+                failure: 0,
+              },
+            ],
+            api_key_stats: [
+              {
+                id: 'key-a',
+                api_key_hash: 'key-a',
+                calls: 6,
+                success_calls: 6,
+                failure_calls: 0,
+                success_rate: 1,
+                input_tokens: 600,
+                output_tokens: 0,
+                cached_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                total_tokens: 600,
+                cost: 0.6,
+                average_latency_ms: null,
+                last_seen_ms: 1,
+              },
+            ],
+          }
+        : emptyAnalyticsResponse;
     return {
       enabled: Boolean(params.fromMs && params.toMs),
       loading: credentialTimeline ? credentialTimelineLoading : false,
@@ -90,22 +132,44 @@ describe('useUsageAnalytics request orchestration', () => {
             }
         : main
           ? mainData
-          : credentialTimeline && !credentialTimelineError && !credentialTimelineLoading
+          : apiKeyTimeline
             ? {
                 ...emptyAnalyticsResponse,
-                credential_timeline: [
+                api_key_timeline: [
                   {
-                    id: 'credential-a.json',
-                    auth_file_snapshot: 'credential-a.json',
+                    api_key_hash: 'key-a',
                     bucket_ms: 1,
-                    calls: 10,
-                    tokens: 150,
-                    success: 9,
-                    failure: 1,
+                    calls: 2,
+                    tokens: 200,
+                    success: 2,
+                    failure: 0,
+                  },
+                  {
+                    api_key_hash: 'key-a',
+                    bucket_ms: 3_600_001,
+                    calls: 4,
+                    tokens: 400,
+                    success: 4,
+                    failure: 0,
                   },
                 ],
               }
-            : null,
+            : credentialTimeline && !credentialTimelineError && !credentialTimelineLoading
+              ? {
+                  ...emptyAnalyticsResponse,
+                  credential_timeline: [
+                    {
+                      id: 'credential-a.json',
+                      auth_file_snapshot: 'credential-a.json',
+                      bucket_ms: 1,
+                      calls: 10,
+                      tokens: 150,
+                      success: 9,
+                      failure: 1,
+                    },
+                  ],
+                }
+              : null,
       dataStale: false,
       lastRefreshedAt: null,
       serviceBase: 'http://manager.local',
@@ -195,6 +259,30 @@ describe('useUsageAnalytics request orchestration', () => {
     });
     expect(JSON.parse(heatmap?.dataScopeKey ?? '{}')).toMatchObject({ activeTab: 'heatmap' });
     expect(selectorsAfterTab?.dataScopeKey).toBe(selectorScope);
+  });
+
+  it('loads exact timeline buckets for the visible client keys on overview and trends', async () => {
+    await renderHook();
+
+    const apiKeyTimeline = lastParams((params) => Boolean(params.include?.api_key_timeline));
+    expect(apiKeyTimeline?.include).toEqual({ granularity: 'hour', api_key_timeline: true });
+    expect(apiKeyTimeline?.filters).toMatchObject({ api_key_hashes: ['key-a'] });
+    expect(JSON.parse(apiKeyTimeline?.dataScopeKey ?? '{}')).toMatchObject({
+      activeTab: 'overview',
+      apiKeyHashes: ['key-a'],
+    });
+    expect(latestResult?.apiKeyTrendSeries[0].points.map((point) => point.value)).toEqual([2, 4]);
+
+    await act(async () => {
+      latestResult?.setActiveTab('trends');
+      await Promise.resolve();
+    });
+
+    const trendsTimeline = lastParams((params) => Boolean(params.include?.api_key_timeline));
+    expect(JSON.parse(trendsTimeline?.dataScopeKey ?? '{}')).toMatchObject({
+      activeTab: 'trends',
+      apiKeyHashes: ['key-a'],
+    });
   });
 
   it('does not couple selector failures to the main page error and refreshes both requests', async () => {

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -15,6 +15,7 @@ import { normalizeAuthIndex } from '@/utils/usage';
 import {
   adaptUsageAnalyticsData,
   analyzeUsageBucket,
+  buildApiKeyTrendSeries,
   buildSelectedApiKeyTrendSeries,
   buildSelectedCredentialTrendSeries,
   buildCredentialQuotaRows,
@@ -29,6 +30,7 @@ import {
   buildUsageMatrix,
   buildUsageSummaryDelta,
   buildUsageCredentialTimeline,
+  buildUsageApiKeyTimeline,
   buildUsageAnalyticsFilters,
   buildUsageAnalyticsFilterSelectorsInclude,
   buildUsageAnalyticsInclude,
@@ -60,6 +62,7 @@ import {
 
 const USAGE_SEARCH_DEBOUNCE_MS = 350;
 const USAGE_HEATMAP_ALL_DATES_KEY = 'all';
+const API_KEY_TREND_SERIES_LIMIT = 4;
 
 type UsageAnalyticsMonitoringMeta = {
   authFiles: AuthFileItem[];
@@ -358,6 +361,71 @@ export function useUsageAnalytics() {
       resolvedGranularity,
     ]
   );
+  const apiKeyTrendHashes = useMemo(() => {
+    if (activeTabState !== 'overview' && activeTabState !== 'trends') return [];
+    return Array.from(
+      new Set(
+        adapted.apiKeyRows
+          .map((row) => row.apiKeyHash || row.id)
+          .filter((value) => value.trim() !== '')
+      )
+    ).slice(0, API_KEY_TREND_SERIES_LIMIT);
+  }, [activeTabState, adapted.apiKeyRows]);
+  const apiKeyTrendFilters = useMemo(
+    () =>
+      apiKeyTrendHashes.length > 0
+        ? { ...analyticsFilters, api_key_hashes: apiKeyTrendHashes }
+        : analyticsFilters,
+    [analyticsFilters, apiKeyTrendHashes]
+  );
+  const apiKeyTrendInclude = useMemo(
+    () => ({
+      granularity: resolvedGranularity,
+      api_key_timeline: true,
+    }),
+    [resolvedGranularity]
+  );
+  const apiKeyTrendDataScopeKey = useMemo(
+    () =>
+      JSON.stringify({
+        activeTab: activeTabState,
+        apiKeyHashes: apiKeyTrendHashes,
+        bounds,
+        filters: apiKeyTrendFilters,
+        granularity: resolvedGranularity,
+        searchQuery: debouncedSearchQuery,
+      }),
+    [
+      activeTabState,
+      apiKeyTrendFilters,
+      apiKeyTrendHashes,
+      bounds,
+      debouncedSearchQuery,
+      resolvedGranularity,
+    ]
+  );
+  const apiKeyTrendAnalytics = useMonitoringAnalytics({
+    fromMs:
+      (activeTabState === 'overview' || activeTabState === 'trends') && apiKeyTrendHashes.length > 0
+        ? bounds?.fromMs
+        : undefined,
+    toMs:
+      (activeTabState === 'overview' || activeTabState === 'trends') && apiKeyTrendHashes.length > 0
+        ? bounds?.toMs
+        : undefined,
+    nowMs,
+    dataScopeKey: apiKeyTrendDataScopeKey,
+    searchQuery: debouncedSearchQuery,
+    filters: apiKeyTrendFilters,
+    include: apiKeyTrendInclude,
+    throttleMs: 0,
+  });
+  const apiKeyTrendData = apiKeyTrendAnalytics.dataStale ? null : apiKeyTrendAnalytics.data;
+  const apiKeyTimeline = useMemo(
+    () => buildUsageApiKeyTimeline(apiKeyTrendData?.api_key_timeline ?? [], resolvedGranularity),
+    [apiKeyTrendData, resolvedGranularity]
+  );
+  const hasExactAPIKeyTimeline = Array.isArray(apiKeyTrendData?.api_key_timeline);
   const heatmapDateData = heatmapDateAnalytics.dataStale ? null : heatmapDateAnalytics.data;
   const heatmapDateRows = useMemo(
     () => buildUsageHeatmap(heatmapDateData?.heatmap ?? [], apiKeyDisplayMap),
@@ -405,8 +473,22 @@ export function useUsageAnalytics() {
     [adapted.modelRows, adapted.timeline, trendMetric]
   );
   const apiKeyTrendSeries = useMemo(
-    () => buildEntityTrendSeries(adapted.apiKeyRows, adapted.timeline, trendMetric, 4),
-    [adapted.apiKeyRows, adapted.timeline, trendMetric]
+    () =>
+      hasExactAPIKeyTimeline
+        ? buildApiKeyTrendSeries(
+            adapted.apiKeyRows,
+            adapted.timeline,
+            apiKeyTimeline,
+            trendMetric,
+            API_KEY_TREND_SERIES_LIMIT
+          )
+        : buildEntityTrendSeries(
+            adapted.apiKeyRows,
+            adapted.timeline,
+            trendMetric,
+            API_KEY_TREND_SERIES_LIMIT
+          ),
+    [adapted.apiKeyRows, adapted.timeline, apiKeyTimeline, hasExactAPIKeyTimeline, trendMetric]
   );
   const selectedApiKeyFilterHash = selectedApiKey?.apiKeyHash || selectedApiKey?.id || '';
   const selectedApiKeyTimelineFilters = useMemo(
@@ -639,6 +721,9 @@ export function useUsageAnalytics() {
     if (selectedApiKeyTimelineAnalytics.enabled) {
       void selectedApiKeyTimelineAnalytics.refresh({ force: true });
     }
+    if (apiKeyTrendAnalytics.enabled) {
+      void apiKeyTrendAnalytics.refresh({ force: true });
+    }
     if (selectedCredentialTimelineAnalytics.enabled) {
       void selectedCredentialTimelineAnalytics.refresh({ force: true });
     }
@@ -647,6 +732,7 @@ export function useUsageAnalytics() {
     }
   }, [
     analytics,
+    apiKeyTrendAnalytics,
     filterSelectorsAnalytics,
     heatmapDateAnalytics,
     loadApiKeyAliases,

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -649,6 +649,7 @@ export interface MonitoringAnalyticsInclude {
   account_stats?: boolean;
   credential_stats?: boolean;
   credential_timeline?: boolean;
+  api_key_timeline?: boolean;
   api_key_stats?: boolean;
   filter_options?: boolean;
   filter_selectors?: boolean;
@@ -920,6 +921,27 @@ export interface MonitoringAnalyticsCredentialTimelinePoint {
   auth_label_snapshot?: string;
   auth_provider_snapshot?: string;
   auth_project_id_snapshot?: string;
+  bucket_ms: number;
+  bucket_label?: string;
+  calls: number;
+  tokens: number;
+  success: number;
+  failure: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  cached_tokens?: number;
+  cache_read_tokens?: number;
+  cache_creation_tokens?: number;
+  reasoning_tokens?: number;
+  total_tokens?: number;
+  cost?: number;
+  average_latency_ms?: number | null;
+  success_rate?: number;
+  failure_rate?: number;
+}
+
+export interface MonitoringAnalyticsApiKeyTimelinePoint {
+  api_key_hash: string;
   bucket_ms: number;
   bucket_label?: string;
   calls: number;
@@ -1225,6 +1247,7 @@ export interface MonitoringAnalyticsResponse {
   account_stats?: MonitoringAnalyticsAccountStatRow[];
   credential_stats?: MonitoringAnalyticsCredentialStatRow[];
   credential_timeline?: MonitoringAnalyticsCredentialTimelinePoint[];
+  api_key_timeline?: MonitoringAnalyticsApiKeyTimelinePoint[];
   api_key_stats?: MonitoringAnalyticsApiKeyStatRow[];
   filter_options?: MonitoringAnalyticsFilterOptions;
   task_buckets?: MonitoringAnalyticsTaskBucketRow[];


### PR DESCRIPTION
## Summary

Fixes #417 by replacing the API-key trend chart global-share approximation with exact per-key time buckets.
The optional analytics response is filtered to selected key hashes, and the panel retains a fallback for older Manager Servers.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add filtered api_key_timeline aggregation with exact calls, tokens, cost, rates, and latency per key and bucket.
- Fetch timeline data for the visible API keys on Overview and Trends, fill absent buckets with zero, and keep the older-server fallback.
- Add regression tests and Demo fixtures with uneven per-key activity.

## User Impact

API-key comparison charts now show integer request counts and the actual per-key time distribution instead of proportional estimates.

## Compatibility / Runtime Notes

- CPA panel mode: Uses the same Manager Server analytics endpoint; the frontend falls back when the optional field is absent.
- Manager Server mode: Existing analytics callers remain unchanged unless they request api_key_timeline.
- Full Docker / native packages: No configuration, data migration, or packaging workflow change is required.

## Data / Security Notes

N/A — this reads existing usage aggregates only. The timeline requires caller-specified API key hashes, preventing an unbounded all-key payload.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the two commits. No schema or persisted-data migration is involved.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

npm run type-check
npm run lint
npm run test (110 files / 1003 tests)
npm run manager-server:test
npm run build
npm run build:demo
npm run check:demo-isolation
git diff --check

## Screenshots / Recordings

No layout change. Demo fixture coverage verifies the visible data path; no separate screenshot was captured.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation update is needed because this corrects an existing analytics visualization and the new API field is optional.

## Related

Fixes #417