### PR TITLE
fix(ai-providers): show complete key test errors

### DIFF
--- a/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx
+++ b/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx
@@ -47,6 +47,37 @@ describe('OpenAIKeyTestStatusIndicator', () => {
     expect(tooltipText.children.join('')).toContain('invalid api key');
   });
 
+  it('preserves multiline response details in the tooltip', () => {
+    const message = '401 Forbidden\n\nBody:\n{\n  "error": {\n    "code": 16\n  }\n}';
+    act(() => {
+      renderer = create(<OpenAIKeyTestStatusIndicator status="error" message={message} />);
+    });
+
+    const trigger = renderer!.root.find(
+      (node) =>
+        typeof node.type === 'string' &&
+        node.type === 'span' &&
+        typeof node.props.className === 'string' &&
+        node.props.className.includes('keyStatusTriggerInteractive')
+    );
+
+    act(() => {
+      trigger.props.onFocus();
+    });
+
+    const tooltip = renderer!.root.findByProps({ role: 'tooltip' });
+    const tooltipText = tooltip.find(
+      (node) =>
+        typeof node.type === 'string' &&
+        node.type === 'span' &&
+        typeof node.props.className === 'string' &&
+        node.props.className.includes('keyStatusTooltipText')
+    );
+    expect(tooltipText.children.join('')).toBe(message);
+    expect(tooltip.props.onMouseEnter).toBeTypeOf('function');
+    expect(tooltip.props.onMouseLeave).toBeTypeOf('function');
+  });
+
   it('keeps the idle icon non-interactive before any test runs', () => {
     act(() => {
       renderer = create(<OpenAIKeyTestStatusIndicator status="idle" message="" />);
@@ -102,6 +133,16 @@ describe('OpenAIKeyTestStatusIndicator', () => {
     expect(position.placement).toBe('above');
     expect(position.style.left).toBe(160);
     expect(position.style.bottom).toBe(46);
-    expect(position.style.maxHeight).toBe(240);
+    expect(position.style.maxHeight).toBe(360);
+  });
+
+  it('uses a readable desktop width for structured errors', () => {
+    const position = resolveOpenAIKeyTestTooltipPosition(
+      { bottom: 120, height: 16, left: 492, top: 104, width: 16 },
+      1024,
+      768
+    );
+
+    expect(position.style.maxWidth).toBe(420);
   });
 });

--- a/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.tsx
+++ b/apps/web/src/components/providers/OpenAIKeyTestStatusIndicator.tsx
@@ -15,8 +15,9 @@ type OpenAIKeyTestStatus = 'idle' | 'loading' | 'success' | 'error';
 
 const TOOLTIP_VIEWPORT_MARGIN = 12;
 const TOOLTIP_OFFSET = 10;
-const TOOLTIP_MAX_WIDTH = 360;
-const TOOLTIP_MAX_HEIGHT = 240;
+const TOOLTIP_MAX_WIDTH = 420;
+const TOOLTIP_MAX_HEIGHT = 360;
+const TOOLTIP_HIDE_DELAY_MS = 120;
 
 type TooltipPlacement = 'above' | 'below';
 
@@ -151,6 +152,7 @@ export function OpenAIKeyTestStatusIndicator({
   const tooltipId = useId();
   const triggerRef = useRef<HTMLSpanElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const hideTimerRef = useRef<number | null>(null);
   const [open, setOpen] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState<OpenAIKeyTestTooltipPosition | null>(null);
   const isBrowser = typeof document !== 'undefined';
@@ -179,12 +181,34 @@ export function OpenAIKeyTestStatusIndicator({
     });
   }, [updateTooltipPosition]);
 
+  const clearHideTimer = useCallback(() => {
+    if (hideTimerRef.current === null || typeof window === 'undefined') return;
+    window.clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = null;
+  }, []);
+
   const showTooltip = useCallback(() => {
+    clearHideTimer();
     updateTooltipPosition();
     setOpen(true);
-  }, [updateTooltipPosition]);
+  }, [clearHideTimer, updateTooltipPosition]);
 
-  const hideTooltip = useCallback(() => setOpen(false), []);
+  const hideTooltip = useCallback(() => {
+    clearHideTimer();
+    setOpen(false);
+  }, [clearHideTimer]);
+
+  const scheduleHideTooltip = useCallback(() => {
+    if (typeof window === 'undefined') {
+      setOpen(false);
+      return;
+    }
+    clearHideTimer();
+    hideTimerRef.current = window.setTimeout(() => {
+      hideTimerRef.current = null;
+      setOpen(false);
+    }, TOOLTIP_HIDE_DELAY_MS);
+  }, [clearHideTimer]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
     if (event.key !== 'Escape') return;
@@ -209,8 +233,9 @@ export function OpenAIKeyTestStatusIndicator({
       if (rafRef.current !== null && typeof window !== 'undefined') {
         window.cancelAnimationFrame(rafRef.current);
       }
+      clearHideTimer();
     },
-    []
+    [clearHideTimer]
   );
 
   const ariaLabel =
@@ -228,6 +253,8 @@ export function OpenAIKeyTestStatusIndicator({
       role="tooltip"
       className={styles.keyStatusTooltip}
       style={isBrowser ? tooltipPosition?.style : undefined}
+      onMouseEnter={clearHideTimer}
+      onMouseLeave={scheduleHideTooltip}
     >
       <span className={styles.keyStatusTooltipText}>{resolvedMessage}</span>
     </span>
@@ -241,7 +268,7 @@ export function OpenAIKeyTestStatusIndicator({
       aria-label={ariaLabel}
       aria-describedby={hasTooltip && open ? tooltipId : undefined}
       onMouseEnter={hasTooltip ? showTooltip : undefined}
-      onMouseLeave={hasTooltip ? hideTooltip : undefined}
+      onMouseLeave={hasTooltip ? scheduleHideTooltip : undefined}
       onFocus={hasTooltip ? showTooltip : undefined}
       onBlur={hasTooltip ? hideTooltip : undefined}
       onKeyDown={hasTooltip ? handleKeyDown : undefined}

--- a/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.tsx
@@ -10,7 +10,7 @@ import { Modal } from '@/components/ui/Modal';
 import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import { OpenAIKeyTestStatusIndicator } from '@/components/providers';
-import { apiCallApi, getApiCallErrorMessage, modelsApi, providersApi } from '@/services/api';
+import { apiCallApi, getApiCallErrorDetails, modelsApi, providersApi } from '@/services/api';
 import { useConfigStore, useNotificationStore } from '@/stores';
 import type { ApiKeyEntry, OpenAIProviderConfig } from '@/types';
 import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
@@ -501,7 +501,7 @@ export function OpenAIEditDrawer({
           { timeout: OPENAI_TEST_TIMEOUT_MS }
         );
         if (result.statusCode < 200 || result.statusCode >= 300)
-          throw new Error(getApiCallErrorMessage(result));
+          throw new Error(getApiCallErrorDetails(result));
         setKeyTestStatuses((prev) => {
           const next = [...prev];
           next[keyIndex] = { status: 'success', message: '' };

--- a/apps/web/src/features/aiProviders/AiProvidersOpenAIEditPage.tsx
+++ b/apps/web/src/features/aiProviders/AiProvidersOpenAIEditPage.tsx
@@ -12,7 +12,7 @@ import { SecondaryScreenShell } from '@/components/common/SecondaryScreenShell';
 import { OpenAIKeyTestStatusIndicator } from '@/components/providers';
 import { useEdgeSwipeBack } from '@/hooks/useEdgeSwipeBack';
 import { useNotificationStore } from '@/stores';
-import { apiCallApi, getApiCallErrorMessage } from '@/services/api';
+import { apiCallApi, getApiCallErrorDetails } from '@/services/api';
 import type { ApiKeyEntry } from '@/types';
 import { normalizeAuthIndex } from '@/utils/authIndex';
 import { buildHeaderObject, hasHeader } from '@/utils/headers';
@@ -183,7 +183,7 @@ export function AiProvidersOpenAIEditPage() {
         );
 
         if (result.statusCode < 200 || result.statusCode >= 300) {
-          throw new Error(getApiCallErrorMessage(result));
+          throw new Error(getApiCallErrorDetails(result));
         }
 
         setDraftKeyTestStatus(keyIndex, { status: 'success', message: '' });

--- a/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
+++ b/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
@@ -819,8 +819,10 @@
 .keyStatusTooltip {
   position: fixed;
   transform: translateX(-50%);
-  width: max-content;
+  box-sizing: border-box;
+  width: min(420px, calc(100vw - 24px));
   padding: 8px 10px;
+  overflow-x: hidden;
   overflow-y: auto;
   background: var(--bg-primary, #fff);
   border: 1px solid var(--border-subtle, #d8e5f2);
@@ -829,14 +831,16 @@
   color: var(--text-primary);
   font-size: 11px;
   line-height: 1.5;
-  pointer-events: none;
-  white-space: normal;
+  pointer-events: auto;
   text-align: left;
-  z-index: $z-dropdown;
+  user-select: text;
+  z-index: $z-modal + 1;
 }
 
 .keyStatusTooltipText {
   display: block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
 }

--- a/apps/web/src/features/demo/demoFixtures.apiCall.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.apiCall.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { apiCallApi, getApiCallErrorDetails, getApiCallErrorMessage } from '@/services/api/apiCall';
+import { getDemoApiCallResult } from './demoFixtures';
+import { setDemoMode } from './demoMode';
+
+afterEach(() => {
+  setDemoMode(false);
+});
+
+describe('API call demo fixtures', () => {
+  it('returns a deterministic upstream 401 for the reserved forbidden host', () => {
+    const result = getDemoApiCallResult({
+      method: 'POST',
+      url: 'https://forbidden.demo.invalid/v1/chat/completions',
+    });
+
+    expect(result).toMatchObject({
+      status_code: 401,
+      has_status_code: true,
+      header: {
+        'access-control-allow-origin': ['*'],
+        'content-type': ['application/json'],
+        'x-request-id': ['demo-forbidden-request'],
+      },
+    });
+    expect(result.body).toBe(JSON.stringify({ error: { code: 16, message: 'Forbidden' } }));
+  });
+
+  it('keeps ordinary API calls successful', () => {
+    const result = getDemoApiCallResult({
+      method: 'POST',
+      url: 'https://api.openai.example/v1/chat/completions',
+    });
+
+    expect(result.status_code).toBe(200);
+    expect(result.has_status_code).toBe(true);
+  });
+
+  it('flows through the demo API client as a displayable 401 error', async () => {
+    setDemoMode(true);
+
+    const result = await apiCallApi.request({
+      method: 'POST',
+      url: 'https://forbidden.demo.invalid/v1/chat/completions',
+    });
+
+    expect(result.statusCode).toBe(401);
+    expect(result.hasStatusCode).toBe(true);
+    expect(result.body).toEqual({ error: { code: 16, message: 'Forbidden' } });
+    expect(getApiCallErrorMessage(result)).toBe('401 Forbidden');
+    expect(getApiCallErrorDetails(result)).toBe(
+      [
+        '401 Forbidden',
+        '',
+        'Body:',
+        '{',
+        '  "error": {',
+        '    "code": 16,',
+        '    "message": "Forbidden"',
+        '  }',
+        '}',
+      ].join('\n')
+    );
+  });
+});

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -3247,10 +3247,35 @@ export const getDemoConfigYaml = () =>
     '  enabled: true',
   ].join('\n');
 
+const DEMO_FORBIDDEN_API_HOST = 'forbidden.demo.invalid';
+
+const isDemoForbiddenApiCall = (requestUrl: string): boolean => {
+  try {
+    return new URL(requestUrl).hostname === DEMO_FORBIDDEN_API_HOST;
+  } catch {
+    return false;
+  }
+};
+
 export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
   const requestUrl = String(payload.url || '');
   const authIndex = String(payload.authIndex || '');
   const isCodexPro20x = authIndex === 'codex-pro-20x-01';
+
+  if (isDemoForbiddenApiCall(requestUrl)) {
+    return {
+      status_code: 401,
+      has_status_code: true,
+      header: {
+        'access-control-allow-origin': ['*'],
+        'content-type': ['application/json'],
+        date: [new Date().toUTCString()],
+        'x-request-id': ['demo-forbidden-request'],
+      },
+      body: JSON.stringify({ error: { code: 16, message: 'Forbidden' } }),
+    };
+  }
+
   let body: unknown = { data: demoProviderModels.map((model) => ({ id: model.name })) };
 
   if (requestUrl.includes('/wham/usage')) {

--- a/apps/web/src/services/api/apiCall.test.ts
+++ b/apps/web/src/services/api/apiCall.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getApiCallErrorDetails, type ApiCallResult } from './apiCall';
+
+const buildResult = (overrides: Partial<ApiCallResult> = {}): ApiCallResult => ({
+  statusCode: 401,
+  hasStatusCode: true,
+  header: {},
+  bodyText: '',
+  body: null,
+  ...overrides,
+});
+
+describe('getApiCallErrorDetails', () => {
+  it('keeps the complete structured response body', () => {
+    const result = buildResult({
+      bodyText: '{"error":{"code":16,"message":"Forbidden"}}',
+      body: { error: { code: 16, message: 'Forbidden' } },
+    });
+
+    expect(getApiCallErrorDetails(result)).toBe(
+      [
+        '401 Forbidden',
+        '',
+        'Body:',
+        '{',
+        '  "error": {',
+        '    "code": 16,',
+        '    "message": "Forbidden"',
+        '  }',
+        '}',
+      ].join('\n')
+    );
+  });
+
+  it('preserves a plain-text response body', () => {
+    const result = buildResult({ bodyText: 'upstream access denied', body: 'upstream access denied' });
+
+    expect(getApiCallErrorDetails(result)).toBe(
+      '401 upstream access denied\n\nBody:\nupstream access denied'
+    );
+  });
+
+  it('returns the summary when the response body is empty', () => {
+    expect(getApiCallErrorDetails(buildResult())).toBe('HTTP 401');
+  });
+});

--- a/apps/web/src/services/api/apiCall.ts
+++ b/apps/web/src/services/api/apiCall.ts
@@ -78,6 +78,36 @@ export const getApiCallErrorMessage = (result: ApiCallResult): string => {
   return message || 'Request failed';
 };
 
+const formatApiCallBody = (result: ApiCallResult): string => {
+  const bodyText = result.bodyText.trim();
+  const body = result.body;
+
+  if (body !== null && typeof body !== 'string') {
+    try {
+      return JSON.stringify(body, null, 2);
+    } catch {
+      // Fall back to the original response text below.
+    }
+  }
+
+  if (bodyText) {
+    try {
+      return JSON.stringify(JSON.parse(bodyText), null, 2);
+    } catch {
+      return bodyText;
+    }
+  }
+
+  return typeof body === 'string' ? body.trim() : '';
+};
+
+export const getApiCallErrorDetails = (result: ApiCallResult): string => {
+  const summary = getApiCallErrorMessage(result);
+  const body = formatApiCallBody(result);
+
+  return body ? `${summary}\n\nBody:\n${body}` : summary;
+};
+
 export const apiCallApi = {
   request: async (
     payload: ApiCallRequest,


### PR DESCRIPTION
## Summary

Fix OpenAI-compatible key test error tooltips that could remain hidden behind provider drawers or lose most of the upstream error response.
The tooltip now presents the complete response body as readable multiline content within the viewport.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Preserve and format complete upstream response bodies for failed OpenAI-compatible key tests in both editor implementations.
- Render structured errors in a responsive, scrollable tooltip above drawer layers while preserving hover, focus, and Escape interactions.
- Add a deterministic Demo 401 fixture and coverage for response formatting, tooltip layout, and the Demo API path.

## User Impact

Users can inspect the full upstream error body, including provider-specific error codes and messages, without horizontal clipping or drawer overlays hiding the tooltip.

## Compatibility / Runtime Notes

- CPA panel mode: Uses the shared frontend behavior; no API or configuration changes.
- Manager Server mode: Uses the same frontend behavior; the manager API contract is unchanged.
- Full Docker / native packages: Frontend-only behavior change when the panel is rebuilt; no packaging changes.

## Data / Security Notes

No error responses are persisted or logged. The existing management UI now displays the complete response body already returned to the authenticated administrator; response headers remain excluded.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `9eaca78b` to restore the previous compact tooltip and error summary behavior.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/services/api/apiCall.test.ts src/components/providers/OpenAIKeyTestStatusIndicator.test.tsx src/features/demo/demoFixtures.apiCall.test.ts
  3 files, 13 tests passed
npm run type-check
npm run lint
npm run test
  112 files, 1008 tests passed
npm run build:demo
Manual Demo acceptance with https://forbidden.demo.invalid/v1
```

## Screenshots / Recordings

N/A — the reporter flow was manually accepted in the local Demo; no screenshot artifact was captured.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a targeted bug fix to existing provider testing behavior. The deterministic Demo fixture and automated coverage document the verification path; user documentation is unchanged.

## Related

Fixes #384
