### PR TITLE
docs(release): prepare v1.11.5

### DIFF
--- a/docs/release-notes/v1.11.5-en.md
+++ b/docs/release-notes/v1.11.5-en.md
@@ -1,0 +1,32 @@
+# CPA Manager Plus v1.11.5
+
+> 14 commits · 63 files changed · +4772 / -330
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.5/docs/release-notes/v1.11.5-zh.md)
+
+## Overview
+
+This release focuses on quota diagnostics, credential-metadata refresh, and accurate analytics. Manager Server now preserves and displays sanitized xAI free-usage exhaustion evidence, Codex users can explicitly refresh cached plan metadata after an account upgrade, and API-key trends and Provider test errors present more accurate and complete information.
+
+## Highlights
+
+### Features
+
+- Parse native xAI `subscription:free-usage-exhausted` responses, persist sanitized actual usage, limits, rolling-window, recovery, trace, and retention evidence, and display the diagnostics in Request Monitoring and Auth Files (`manager-server/quota-cooldown`, `web/monitoring`).
+
+### Fixes
+
+- Add a separate credential-refresh action to Codex auth-file details so CPA can reload runtime metadata after an account plan upgrade without conflating credential refresh with quota refresh (`web/auth-files`).
+- Make Usage Analytics API-key trends use exact per-key time buckets for requests, tokens, cost, success rates, and latency instead of estimating them from global proportions (`manager-server/usage-analytics`, `web/usage-analytics`).
+- Preserve and format complete upstream response bodies from failed OpenAI-compatible Provider key tests. Multiline, scrollable error tooltips now render above drawers without being hidden or truncated (`web/ai-providers`).
+
+## Upgrade Notes
+
+- Manager Server automatically adds the nullable `quota_cooldowns.evidence_json` field and performs a compatible backfill on first startup. No configuration change or manual migration is required.
+- Full Docker and native-package users should still back up their SQLite files and `data.key` before upgrading. The nullable field may safely remain after a rollback.
+- xAI free-usage diagnostics depend on Manager Server and are not available as locally persisted diagnostics in lightweight CPA Panel mode.
+- The Codex credential-refresh action refreshes credential metadata only; it does not refresh quota data.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.4...v1.11.5

--- a/docs/release-notes/v1.11.5-zh.md
+++ b/docs/release-notes/v1.11.5-zh.md
@@ -1,0 +1,32 @@
+# CPA Manager Plus v1.11.5
+
+> 14 commits · 63 files changed · +4772 / -330
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.5/docs/release-notes/v1.11.5-en.md)
+
+## Overview
+
+本次发布聚焦配额诊断、凭据元数据刷新与分析结果准确性。Manager Server 能够保留并展示脱敏的 xAI 免费用量耗尽证据；Codex 账号升级后可主动刷新缓存的套餐元数据；API Key 趋势和 Provider 测试错误也会呈现更准确、完整的信息。
+
+## Highlights
+
+### Features
+
+- Manager Server 解析原生 xAI `subscription:free-usage-exhausted` 响应，持久化脱敏的额度实际值、上限、滚动窗口、恢复时间、追踪与保留策略，并在 Request Monitoring 和 Auth Files 中展示诊断信息（`manager-server/quota-cooldown`、`web/monitoring`）。
+
+### Fixes
+
+- Auth Files 的 Codex 凭据详情新增独立的凭据刷新操作，可在账号套餐升级后触发 CPA 重新读取运行时元数据；该操作与配额刷新保持分离（`web/auth-files`）。
+- Usage Analytics 的 API Key 趋势改为使用逐 Key、逐时间桶的真实请求、Token、成本、成功率和延迟数据，不再按全局占比估算（`manager-server/usage-analytics`、`web/usage-analytics`）。
+- OpenAI 兼容 Provider 的 Key 测试会保留并格式化完整上游响应正文，错误浮层可在抽屉上方以多行、可滚动形式显示，不再被遮挡或截断（`web/ai-providers`）。
+
+## Upgrade Notes
+
+- Manager Server 首次启动会自动新增可空的 `quota_cooldowns.evidence_json` 字段并执行兼容性回填，无需修改配置或手工迁移。
+- Full Docker 和原生包用户升级前仍建议备份 SQLite 文件与 `data.key`；回滚后新增的可空字段可以安全保留。
+- xAI 免费用量诊断依赖 Manager Server，轻量 CPA Panel 模式不提供该本地持久化诊断。
+- Codex“刷新凭据”只刷新凭据元数据，不会同时刷新配额。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.4...v1.11.5

--- a/docs/release-posts/v1.11.5-telegram.html
+++ b/docs/release-posts/v1.11.5-telegram.html
@@ -1,0 +1,14 @@
+🚀 <b>7 月 22 日 · v1.11.5</b>
+
+✨ <b>更新内容</b>
+
+• xAI 免费用量耗尽会展示额度证据、预计恢复时间与保留策略。
+• Codex 账号升级后可在认证文件详情中主动刷新套餐元数据。
+• Usage Analytics 的 API Key 趋势改用真实时间分布与整数请求数。
+• OpenAI 兼容 Provider 的 Key 测试可完整查看上游错误正文。
+
+⚠️ <b>注意事项</b>
+
+• Manager Server 会自动新增可空的 <code>quota_cooldowns.evidence_json</code> 字段；升级前仍建议备份 SQLite 与 <code>data.key</code>，无需手工迁移。
+• xAI 免费用量诊断仅适用于 Full Docker 和 Manager Server，轻量 CPA Panel 不提供该本地诊断。
+• Codex“刷新凭据”只刷新凭据元数据，不会同时刷新配额。


### PR DESCRIPTION
## Summary

Prepare the curated v1.11.5 Chinese and English release notes and the reviewed Telegram community post.
The release covers xAI free-usage diagnostics, Codex credential metadata refresh, exact API-key trends, and complete Provider key-test errors.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add tag-pinned Chinese and English release notes for v1.11.5.
- Add the validated Telegram HTML post for the v1.11.5 release notification.
- Document the automatic quota-cooldown evidence migration and mode-specific behavior.

## User Impact

Users receive curated v1.11.5 release information through GitHub Releases and Telegram.
This release PR itself introduces no application runtime behavior change.

## Compatibility / Runtime Notes

- CPA panel mode: No runtime change from this release documentation PR.
- Manager Server mode: No runtime change from this release documentation PR.
- Full Docker / native packages: The v1.11.5 tag workflow will use these curated notes and the reviewed Telegram post.

## Data / Security Notes

N/A. The release files contain no credentials, Telegram identifiers, tokens, raw response bodies, or other secrets.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this documentation commit before tagging if the release content needs correction.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
main and origin/main resolved to c3a9f9070c9a4973d7d0562927d455832cb3f282
main...origin/main: 0 ahead / 0 behind
Remote release/v1.11.5 branch, v1.11.5 tag, and v1.11.5 Release were absent before creation
v1.11.4...main: 14 commits, 63 files changed, +4772 / -330
Tag-pinned zh/en links and Full Changelog links were checked
Telegram HTML is 437 characters, uses the supported tag subset, and contains no screenshot section or standalone community title
```

## Screenshots / Recordings

N/A - release documentation only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

Curated bilingual release notes and the reviewed Telegram post are included.

## Related

N/A