### PR TITLE
fix(xai): route paid OAuth inference through the official API

### DIFF
--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -345,11 +345,19 @@ func TestRunXAIUsesBillingAndInferenceEndpoints(t *testing.T) {
 
 func TestResolveXAIInferenceURLMatchesRuntimeUsingAPISemantics(t *testing.T) {
 	tests := []struct {
-		name    string
-		file    authFile
-		wantURL string
-		wantCLI bool
+		name          string
+		file          authFile
+		forceOfficial bool
+		wantURL       string
+		wantCLI       bool
 	}{
+		{
+			name:          "verified official identity forces official api",
+			file:          authFile{},
+			forceOfficial: true,
+			wantURL:       xaiOfficialAPIBaseURL + "/responses",
+			wantCLI:       false,
+		},
 		{
 			name:    "missing auth metadata defaults to cli proxy",
 			file:    authFile{},
@@ -389,7 +397,7 @@ func TestResolveXAIInferenceURLMatchesRuntimeUsingAPISemantics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotCLI := resolveXAIInferenceURL(tt.file)
+			gotURL, gotCLI := resolveXAIInferenceURL(tt.file, tt.forceOfficial)
 			if gotURL != tt.wantURL || gotCLI != tt.wantCLI {
 				t.Fatalf("resolveXAIInferenceURL() = %q, %t; want %q, %t", gotURL, gotCLI, tt.wantURL, tt.wantCLI)
 			}
@@ -458,7 +466,7 @@ func TestRunXAIFallsBackToOfficialAPIIdentityHealth(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
-			_, _ = w.Write([]byte(`{"files":[{"name":"paid-xai.json","auth_index":"xai-paid-1","provider":"xai","account":"paid@example.com","disabled":true}]}`))
+			_, _ = w.Write([]byte(`{"files":[{"name":"paid-xai.json","auth_index":"xai-paid-1","provider":"xai","account":"paid@example.com","disabled":true,"user":{"id":"user-1"}}]}`))
 		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
 			var payload struct {
 				Method string            `json:"method"`
@@ -472,6 +480,12 @@ func TestRunXAIFallsBackToOfficialAPIIdentityHealth(t *testing.T) {
 			if strings.HasSuffix(payload.URL, "/responses") {
 				if payload.Method != http.MethodPost {
 					t.Fatalf("xAI inference method = %q, want POST", payload.Method)
+				}
+				if payload.URL != xaiOfficialAPIBaseURL+"/responses" {
+					t.Fatalf("xAI inference URL = %q, want official API", payload.URL)
+				}
+				if payload.Header["x-xai-token-auth"] != "" || payload.Header["x-grok-client-version"] != "" || payload.Header["x-userid"] != "" {
+					t.Fatalf("xAI official inference headers = %#v", payload.Header)
 				}
 				_, _ = w.Write([]byte(xaiCompletedInferenceAPICallResponse))
 				return
@@ -505,7 +519,7 @@ func TestRunXAIFallsBackToOfficialAPIIdentityHealth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run xAI inspection: %v", err)
 	}
-	if len(requestedURLs) != 4 || requestedURLs[2] != xaiOfficialAPIMeURL || !strings.HasSuffix(requestedURLs[3], "/responses") {
+	if len(requestedURLs) != 4 || requestedURLs[2] != xaiOfficialAPIMeURL || requestedURLs[3] != xaiOfficialAPIBaseURL+"/responses" {
 		t.Fatalf("requested URLs = %#v, want billing, identity fallback, and inference", requestedURLs)
 	}
 	if len(result.Results) != 1 {
@@ -715,8 +729,8 @@ func TestRunXAIRejectsInvalidOfficialAPIIdentityPayload(t *testing.T) {
 			if err != nil {
 				t.Fatalf("run xAI inspection: %v", err)
 			}
-			if len(requestedURLs) != 4 || requestedURLs[2] != xaiOfficialAPIMeURL || !strings.HasSuffix(requestedURLs[3], "/responses") {
-				t.Fatalf("requested URLs = %#v, want billing, identity fallback, and inference", requestedURLs)
+			if len(requestedURLs) != 4 || requestedURLs[2] != xaiOfficialAPIMeURL || requestedURLs[3] != xaiCLIChatProxyBaseURL+"/responses" {
+				t.Fatalf("requested URLs = %#v, want billing, rejected identity fallback, and CLI inference", requestedURLs)
 			}
 			if len(result.Results) != 1 || result.Results[0].ErrorKind == "official_api_healthy" {
 				t.Fatalf("invalid official API payload reported healthy: %#v", result.Results)

--- a/apps/manager-server/internal/service/codexinspection/xai_probe.go
+++ b/apps/manager-server/internal/service/codexinspection/xai_probe.go
@@ -114,7 +114,7 @@ func (s *Service) inspectSingleXAIAccount(
 		return base
 	}
 
-	inference := s.requestXAIInferenceWithRetries(ctx, setup, settings, item)
+	inference := s.requestXAIInferenceWithRetries(ctx, setup, settings, item, billing.OfficialAPIHealthy)
 	if inference.Healthy {
 		base.Action = "keep"
 		base.ActionReason = "monitoring.xai_inspection_reason_inference_healthy"
@@ -231,10 +231,11 @@ func (s *Service) requestXAIInferenceWithRetries(
 	setup store.Setup,
 	settings model.ManagerCodexInspectionConfig,
 	item account,
+	forceOfficialAPI bool,
 ) xaiInferenceProbe {
 	var probe xaiInferenceProbe
 	for attempt := 0; attempt <= settings.Retries; attempt++ {
-		probe = s.requestXAIInference(ctx, setup, settings, item)
+		probe = s.requestXAIInference(ctx, setup, settings, item, forceOfficialAPI)
 		if probe.Healthy || probe.Decision == nil || !xaiInferenceShouldRetry(*probe.Decision) {
 			break
 		}
@@ -247,8 +248,9 @@ func (s *Service) requestXAIInference(
 	setup store.Setup,
 	settings model.ManagerCodexInspectionConfig,
 	item account,
+	forceOfficialAPI bool,
 ) xaiInferenceProbe {
-	targetURL, usesCLIChatProxy := resolveXAIInferenceURL(item.File)
+	targetURL, usesCLIChatProxy := resolveXAIInferenceURL(item.File, forceOfficialAPI)
 	header := map[string]string{
 		"Authorization": "Bearer $TOKEN$",
 		"Accept":        "application/json",
@@ -258,9 +260,9 @@ func (s *Service) requestXAIInference(
 	if usesCLIChatProxy {
 		header["x-xai-token-auth"] = "xai-grok-cli"
 		header["x-grok-client-version"] = xaiGrokVersion
-	}
-	if userID := resolveXAIUserID(item.File); userID != "" {
-		header["x-userid"] = userID
+		if userID := resolveXAIUserID(item.File); userID != "" {
+			header["x-userid"] = userID
+		}
 	}
 
 	data, err := json.Marshal(map[string]any{
@@ -349,7 +351,10 @@ func xaiInferenceShouldRetry(decision xaiProbeDecision) bool {
 	}
 }
 
-func resolveXAIInferenceURL(file authFile) (string, bool) {
+func resolveXAIInferenceURL(file authFile, forceOfficialAPI bool) (string, bool) {
+	if forceOfficialAPI {
+		return xaiOfficialAPIBaseURL + "/responses", false
+	}
 	baseURL := strings.TrimSuffix(strings.TrimSpace(readXAIAuthString(file, "base_url", "baseUrl")), "/")
 	usingAPI, hasUsingAPI := readXAIAuthBool(file, "using_api", "usingApi")
 	authKind := strings.ToLower(readXAIAuthString(file, "auth_kind", "authKind"))

--- a/apps/web/src/features/monitoring/model/xaiInspectionProbe.test.ts
+++ b/apps/web/src/features/monitoring/model/xaiInspectionProbe.test.ts
@@ -1,16 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { probeXaiBilling, probeXaiInference, probeXaiQuota } from '@/utils/quota/providerRequests';
+import { probeXaiInference, probeXaiQuota } from '@/utils/quota/providerRequests';
 import { XaiProbeError, classifyXaiProbe, parseXaiErrorEnvelope } from '@/utils/quota/xaiErrors';
 import { DEFAULT_CODEX_INSPECTION_SETTINGS } from './codexInspectionSettings';
 import { inspectSingleXaiAccount } from './xaiInspectionProbe';
 
 vi.mock('@/utils/quota/providerRequests', () => ({
-  probeXaiBilling: vi.fn(),
   probeXaiInference: vi.fn(),
   probeXaiQuota: vi.fn(),
 }));
 
-const mockProbeXaiBilling = vi.mocked(probeXaiBilling);
 const mockProbeXaiInference = vi.mocked(probeXaiInference);
 const mockProbeXaiQuota = vi.mocked(probeXaiQuota);
 const settings = {
@@ -57,6 +55,23 @@ const healthySummary = {
   usedPercent: 40,
 };
 
+const officialApiSummary = {
+  ...healthySummary,
+  periodType: 'unknown' as const,
+  usagePercent: null,
+  productUsage: [],
+  monthlyLimitCents: null,
+  usedCents: null,
+  billingPeriodEnd: undefined,
+  usedPercent: null,
+  officialApiHealth: {
+    source: 'api.x.ai/v1/me' as const,
+    userId: 'user-1',
+    teamId: 'team-1',
+    teamBlocked: false,
+  },
+};
+
 const inferenceError = (statusCode: number, body: unknown) => {
   const envelope = parseXaiErrorEnvelope({ statusCode, body });
   return new XaiProbeError(
@@ -77,15 +92,8 @@ const billingError = (statusCode: number, body: unknown) => {
 
 describe('inspectSingleXaiAccount', () => {
   beforeEach(() => {
-    mockProbeXaiBilling.mockReset();
     mockProbeXaiInference.mockReset();
     mockProbeXaiQuota.mockReset();
-    mockProbeXaiBilling.mockResolvedValue({
-      summary: healthySummary,
-      failures: [],
-      partial: false,
-      statusCode: 200,
-    });
     mockProbeXaiInference.mockResolvedValue({ statusCode: 200 });
     mockProbeXaiQuota.mockResolvedValue({
       summary: healthySummary,
@@ -119,22 +127,7 @@ describe('inspectSingleXaiAccount', () => {
 
   it('normalizes official API identity health to the shared healthy classification', async () => {
     mockProbeXaiQuota.mockResolvedValue({
-      summary: {
-        ...healthySummary,
-        periodType: 'unknown',
-        usagePercent: null,
-        productUsage: [],
-        monthlyLimitCents: null,
-        usedCents: null,
-        billingPeriodEnd: undefined,
-        usedPercent: null,
-        officialApiHealth: {
-          source: 'api.x.ai/v1/me',
-          userId: 'user-1',
-          teamId: 'team-1',
-          teamBlocked: false,
-        },
-      },
+      summary: officialApiSummary,
       failures: [],
       partial: false,
       source: 'official-api',
@@ -251,7 +244,7 @@ describe('inspectSingleXaiAccount', () => {
   it('uses a real inference request as the health authority and keeps billing quota display', async () => {
     const result = await inspectSingleXaiAccount(baseAccount, settings);
 
-    expect(mockProbeXaiBilling).toHaveBeenCalledWith(rawAccount, expect.any(Function), {
+    expect(mockProbeXaiQuota).toHaveBeenCalledWith(rawAccount, expect.any(Function), {
       timeout: settings.timeout,
     });
     expect(mockProbeXaiInference).toHaveBeenCalledWith(
@@ -279,8 +272,39 @@ describe('inspectSingleXaiAccount', () => {
     ]);
   });
 
+  it('routes real inference through the official API after verified identity fallback', async () => {
+    mockProbeXaiQuota.mockResolvedValue({
+      summary: officialApiSummary,
+      failures: [],
+      partial: false,
+      source: 'official-api',
+      statusCode: 200,
+    });
+
+    const result = await inspectSingleXaiAccount(baseAccount, settings);
+
+    expect(mockProbeXaiInference).toHaveBeenCalledWith(
+      rawAccount,
+      expect.any(Function),
+      { timeout: settings.timeout },
+      {
+        model: settings.xaiInferenceModel,
+        prompt: settings.xaiInferencePrompt,
+        userAgent: settings.xaiInferenceUserAgent,
+        routeMode: 'official',
+      }
+    );
+    expect(result).toMatchObject({
+      action: 'keep',
+      statusCode: 200,
+      usedPercent: null,
+      errorKind: 'inference_healthy',
+    });
+    expect(result.quotaWindows).toEqual([]);
+  });
+
   it('does not render a zero-cap on-demand window without usage evidence', async () => {
-    mockProbeXaiBilling.mockResolvedValue({
+    mockProbeXaiQuota.mockResolvedValue({
       summary: {
         ...healthySummary,
         onDemandCapCents: 0,
@@ -289,6 +313,7 @@ describe('inspectSingleXaiAccount', () => {
       },
       failures: [],
       partial: false,
+      source: 'billing',
     });
 
     const result = await inspectSingleXaiAccount(baseAccount, settings);
@@ -297,10 +322,20 @@ describe('inspectSingleXaiAccount', () => {
   });
 
   it('does not treat unavailable billing as an unhealthy credential when inference succeeds', async () => {
-    mockProbeXaiBilling.mockRejectedValue(new Error('billing endpoint unavailable'));
+    mockProbeXaiQuota.mockRejectedValue(new Error('billing endpoint unavailable'));
 
     const result = await inspectSingleXaiAccount(baseAccount, settings);
 
+    expect(mockProbeXaiInference).toHaveBeenCalledWith(
+      rawAccount,
+      expect.any(Function),
+      { timeout: settings.timeout },
+      {
+        model: settings.xaiInferenceModel,
+        prompt: settings.xaiInferencePrompt,
+        userAgent: settings.xaiInferenceUserAgent,
+      }
+    );
     expect(result).toMatchObject({
       action: 'keep',
       statusCode: 200,

--- a/apps/web/src/features/monitoring/model/xaiInspectionProbe.ts
+++ b/apps/web/src/features/monitoring/model/xaiInspectionProbe.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 import type { XaiBillingSummary } from '@/types';
-import { probeXaiBilling, probeXaiInference, probeXaiQuota } from '@/utils/quota/providerRequests';
+import { probeXaiInference, probeXaiQuota } from '@/utils/quota/providerRequests';
 import { formatQuotaResetTime } from '@/utils/quota/formatters';
 import { XaiProbeError } from '@/utils/quota/xaiErrors';
 import { formatXaiProbeIssue } from '@/utils/quota/xaiPresentation';
@@ -224,18 +224,14 @@ export const inspectSingleXaiAccount = async (
   try {
     const billing = await withRetry(
       settings.retries,
-      () =>
-        settings.xaiInferenceEnabled
-          ? probeXaiBilling(account.raw, t, requestConfig)
-          : probeXaiQuota(account.raw, t, requestConfig),
+      () => probeXaiQuota(account.raw, t, requestConfig),
       shouldRetryXaiBilling
     );
     billingSummary = billing.summary;
     billingStatusCode = billing.statusCode ?? null;
     billingPartial = billing.partial;
     billingError = billing.blockingFailure ?? null;
-    billingSource =
-      'source' in billing && billing.source === 'official-api' ? 'official-api' : 'billing';
+    billingSource = billing.source;
   } catch (error) {
     billingError = error;
     // With inference enabled, billing remains supplementary quota evidence.
@@ -296,6 +292,7 @@ export const inspectSingleXaiAccount = async (
           model: settings.xaiInferenceModel,
           prompt: settings.xaiInferencePrompt,
           userAgent: settings.xaiInferenceUserAgent,
+          ...(billingSource === 'official-api' ? { routeMode: 'official' as const } : {}),
         }),
       shouldRetryXaiInference
     );

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -2288,7 +2288,7 @@ describe('probeXaiInference', () => {
         name: 'xai-api.json',
         type: 'xai',
         authIndex: 'xai-api-1',
-        metadata: { auth_kind: 'api_key', using_api: true },
+        metadata: { auth_kind: 'api_key', using_api: true, user_id: 'user-123' },
       },
       t
     );
@@ -2303,6 +2303,44 @@ describe('probeXaiInference', () => {
       },
     });
     expect(mocks.request.mock.calls[0][0].header).not.toHaveProperty('x-xai-token-auth');
+    expect(mocks.request.mock.calls[0][0].header).not.toHaveProperty('x-grok-client-version');
+    expect(mocks.request.mock.calls[0][0].header).not.toHaveProperty('x-userid');
+  });
+
+  it('forces the official endpoint after verified official identity fallback', async () => {
+    const body = completedXaiInferenceResponse();
+    mocks.request.mockResolvedValue({
+      statusCode: 200,
+      hasStatusCode: true,
+      header: {},
+      bodyText: JSON.stringify(body),
+      body,
+    });
+
+    await probeXaiInference(
+      {
+        name: 'xai-paid-oauth.json',
+        type: 'xai',
+        authIndex: 'xai-paid-oauth-1',
+        metadata: { user_id: 'user-123' },
+      },
+      t,
+      undefined,
+      { routeMode: 'official' }
+    );
+
+    expect(mocks.request.mock.calls[0][0]).toMatchObject({
+      url: `${XAI_OFFICIAL_API_BASE_URL}/responses`,
+      header: {
+        Authorization: 'Bearer $TOKEN$',
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': XAI_INFERENCE_USER_AGENT,
+      },
+    });
+    expect(mocks.request.mock.calls[0][0].header).not.toHaveProperty('x-xai-token-auth');
+    expect(mocks.request.mock.calls[0][0].header).not.toHaveProperty('x-grok-client-version');
+    expect(mocks.request.mock.calls[0][0].header).not.toHaveProperty('x-userid');
   });
 
   it('uses the configured model and prompt in the real inference request', async () => {

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -1142,7 +1142,13 @@ const readXaiAuthBoolean = (file: AuthFileItem, ...keys: string[]): boolean | nu
 const sameXaiBaseUrl = (left: string, right: string) =>
   left.trim().replace(/\/+$/, '').toLowerCase() === right.trim().replace(/\/+$/, '').toLowerCase();
 
-const resolveXaiInferenceRequest = (file: AuthFileItem, userAgent?: string) => {
+export type XaiInferenceRouteMode = 'auto' | 'official';
+
+const resolveXaiInferenceRequest = (
+  file: AuthFileItem,
+  userAgent?: string,
+  routeMode: XaiInferenceRouteMode = 'auto'
+) => {
   const configuredBaseUrl = readXaiAuthString(file, 'base_url', 'baseUrl').replace(/\/+$/, '');
   const usingApi = readXaiAuthBoolean(file, 'using_api', 'usingApi');
   const authKind = readXaiAuthString(file, 'auth_kind', 'authKind').toLowerCase();
@@ -1151,23 +1157,29 @@ const resolveXaiInferenceRequest = (file: AuthFileItem, userAgent?: string) => {
   // API credentials must opt in explicitly with using_api=true or api_key.
   const resolvedUsingApi = usingApi ?? (authKind ? authKind !== 'oauth' : false);
   const usesCliChatProxy =
+    routeMode !== 'official' &&
     !resolvedUsingApi &&
     (!configuredBaseUrl || sameXaiBaseUrl(configuredBaseUrl, XAI_OFFICIAL_API_BASE_URL));
-  const baseUrl = usesCliChatProxy
-    ? XAI_CLI_CHAT_PROXY_BASE_URL
-    : configuredBaseUrl || XAI_OFFICIAL_API_BASE_URL;
+  const baseUrl =
+    routeMode === 'official'
+      ? XAI_OFFICIAL_API_BASE_URL
+      : usesCliChatProxy
+        ? XAI_CLI_CHAT_PROXY_BASE_URL
+        : configuredBaseUrl || XAI_OFFICIAL_API_BASE_URL;
   const header: Record<string, string> = {
     Authorization: 'Bearer $TOKEN$',
     Accept: 'application/json',
     'Content-Type': 'application/json',
     'User-Agent': normalizeStringValue(userAgent) || XAI_INFERENCE_USER_AGENT,
   };
-  if (usesCliChatProxy || sameXaiBaseUrl(baseUrl, XAI_CLI_CHAT_PROXY_BASE_URL)) {
+  const targetsCliChatProxy =
+    usesCliChatProxy || sameXaiBaseUrl(baseUrl, XAI_CLI_CHAT_PROXY_BASE_URL);
+  if (targetsCliChatProxy) {
     header['x-xai-token-auth'] = 'xai-grok-cli';
     header['x-grok-client-version'] = XAI_GROK_CLIENT_VERSION;
+    const userId = resolveXaiUserId(file);
+    if (userId) header['x-userid'] = userId;
   }
-  const userId = resolveXaiUserId(file);
-  if (userId) header['x-userid'] = userId;
   return { url: `${baseUrl}/responses`, header };
 };
 
@@ -1363,6 +1375,7 @@ export interface XaiInferenceProbeOptions {
   model?: string;
   prompt?: string;
   userAgent?: string;
+  routeMode?: XaiInferenceRouteMode;
 }
 
 const hasCompletedXaiInferenceOutput = (value: unknown): boolean => {
@@ -1393,7 +1406,7 @@ export const probeXaiInference = async (
   options?: XaiInferenceProbeOptions
 ): Promise<XaiInferenceProbeResult> => {
   const authIndex = resolveXaiProbeAuthIndex(file, t);
-  const { url, header } = resolveXaiInferenceRequest(file, options?.userAgent);
+  const { url, header } = resolveXaiInferenceRequest(file, options?.userAgent, options?.routeMode);
   const result = await apiCallApi.request(
     {
       authIndex,


### PR DESCRIPTION
## Summary

Route explicit xAI OAuth credential inference through the official Responses API when a guarded quota and identity probe verifies paid OAuth identity. This keeps frontend and Manager Server health checks aligned for verified paid credentials.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Run a guarded quota and identity probe before frontend xAI inference.
- Route verified paid xAI OAuth requests to https://api.x.ai/v1/responses.
- Add xAI CLI identity headers only for CLI targets.
- Align frontend and Manager Server tests and failure handling.

## User Impact

Verified paid xAI OAuth credentials now use the official API for health inference, correcting false inference failures. There are no visual, configuration, or copy changes.

## Compatibility / Runtime Notes

- CPA panel mode: applies the guarded frontend route selection without configuration changes.
- Manager Server mode: applies the same verified paid OAuth route selection on the server.
- Full Docker / native packages: no migration, packaging, or configuration changes; Full Docker receives the Manager Server behavior.

## Data / Security Notes

No schema or raw authentication data changes. CPA token substitution remains unchanged. Official and custom API routes exclude xAI CLI identity headers; those headers are limited to CLI targets.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert commits 61223e03 and 38701b00 to restore the previous routing behavior.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

- Focused frontend tests: 81 passed.
- npm run type-check: passed.
- npm run lint: passed.
- npm run test: 122 files and 1093 tests passed.
- npm run manager-server:test: passed.
- go vet ./...: passed.
- git diff --check origin/main...HEAD: passed.
- Build and manual UI checks were not run because this change has no visual UI surface.

## Screenshots / Recordings

N/A — no visual UI changes.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: No documentation changes are needed because this corrects internal credential-health routing without changing configuration, UI copy, or user workflows.

## Related

N/A