### PR TITLE
fix(web): prevent drawer close on text drag

### DIFF
--- a/apps/web/src/components/ui/Drawer.test.tsx
+++ b/apps/web/src/components/ui/Drawer.test.tsx
@@ -41,13 +41,23 @@ import { Drawer } from './Drawer';
 
 const CLOSE_ANIMATION_DURATION = 280;
 
-const createPointerEvent = (target: unknown, currentTarget: unknown, button = 0) => ({
+const createPointerEvent = (
+  target: unknown,
+  currentTarget: unknown,
+  options: { button?: number; pointerId?: number } = {}
+) => ({
   target,
   currentTarget,
-  button,
+  button: options.button ?? 0,
+  pointerId: options.pointerId ?? 1,
 });
 
 const installMinimalDom = () => {
+  const previousHTMLElement = Object.getOwnPropertyDescriptor(globalThis, 'HTMLElement');
+  const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const installedWindow = typeof globalThis.window === 'undefined';
+
   const bodyStyle = { overflow: '' };
   const htmlStyle = { overflow: '' };
   const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
@@ -80,29 +90,57 @@ const installMinimalDom = () => {
     value: documentMock,
   });
 
-  if (typeof globalThis.window === 'undefined') {
+  if (installedWindow) {
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
       writable: true,
       value: globalThis,
     });
   }
+
+  return () => {
+    if (previousHTMLElement) {
+      Object.defineProperty(globalThis, 'HTMLElement', previousHTMLElement);
+    } else {
+      Reflect.deleteProperty(globalThis, 'HTMLElement');
+    }
+
+    if (previousDocument) {
+      Object.defineProperty(globalThis, 'document', previousDocument);
+    } else {
+      Reflect.deleteProperty(globalThis, 'document');
+    }
+
+    if (installedWindow) {
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
+  };
 };
 
 describe('Drawer overlay close guard', () => {
+  let renderer: ReactTestRenderer | undefined;
+  let restoreDom: (() => void) | undefined;
+
   beforeEach(() => {
     vi.useFakeTimers();
-    installMinimalDom();
+    restoreDom = installMinimalDom();
   });
 
   afterEach(() => {
+    act(() => {
+      renderer?.unmount();
+    });
+    renderer = undefined;
+    restoreDom?.();
+    restoreDom = undefined;
     vi.useRealTimers();
   });
 
-  it('closes when pointer starts and ends on overlay', async () => {
-    const onClose = vi.fn();
-    let renderer: ReactTestRenderer;
-
+  const mountDrawer = async (onClose: ReturnType<typeof vi.fn>) => {
     await act(async () => {
       renderer = create(
         <Drawer open title="Test drawer" onClose={onClose}>
@@ -116,13 +154,20 @@ describe('Drawer overlay close guard', () => {
       await Promise.resolve();
     });
 
-    const overlay = renderer!.root.find((node) =>
-      String(node.props.className ?? '').includes('overlay')
-    );
+    return renderer!;
+  };
+
+  const findOverlay = (root: ReactTestRenderer) =>
+    root.root.find((node) => String(node.props.className ?? '').includes('overlay'));
+
+  it('closes when pointer starts and ends on overlay', async () => {
+    const onClose = vi.fn();
+    const mounted = await mountDrawer(onClose);
+    const overlay = findOverlay(mounted);
 
     await act(async () => {
-      overlay.props.onPointerDown(createPointerEvent(overlay, overlay));
-      overlay.props.onPointerUp(createPointerEvent(overlay, overlay));
+      overlay.props.onPointerDown(createPointerEvent(overlay, overlay, { pointerId: 1 }));
+      overlay.props.onPointerUp(createPointerEvent(overlay, overlay, { pointerId: 1 }));
     });
 
     expect(onClose).not.toHaveBeenCalled();
@@ -136,29 +181,14 @@ describe('Drawer overlay close guard', () => {
 
   it('does not close when pointer starts inside drawer and ends on overlay', async () => {
     const onClose = vi.fn();
-    let renderer: ReactTestRenderer;
-
-    await act(async () => {
-      renderer = create(
-        <Drawer open title="Test drawer" onClose={onClose}>
-          <input aria-label="field" />
-        </Drawer>
-      );
-    });
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    const overlay = renderer!.root.find((node) =>
-      String(node.props.className ?? '').includes('overlay')
-    );
-    const panel = renderer!.root.findByProps({ role: 'dialog' });
+    const mounted = await mountDrawer(onClose);
+    const overlay = findOverlay(mounted);
+    const panel = mounted.root.findByProps({ role: 'dialog' });
 
     await act(async () => {
       // 模拟：在面板内按下，在遮罩上释放（拖选文字场景）
-      overlay.props.onPointerDown(createPointerEvent(panel, overlay));
-      overlay.props.onPointerUp(createPointerEvent(overlay, overlay));
+      overlay.props.onPointerDown(createPointerEvent(panel, overlay, { pointerId: 1 }));
+      overlay.props.onPointerUp(createPointerEvent(overlay, overlay, { pointerId: 1 }));
     });
 
     await act(async () => {
@@ -170,28 +200,33 @@ describe('Drawer overlay close guard', () => {
 
   it('does not close when pointer starts on overlay and ends inside drawer', async () => {
     const onClose = vi.fn();
-    let renderer: ReactTestRenderer;
+    const mounted = await mountDrawer(onClose);
+    const overlay = findOverlay(mounted);
+    const panel = mounted.root.findByProps({ role: 'dialog' });
 
     await act(async () => {
-      renderer = create(
-        <Drawer open title="Test drawer" onClose={onClose}>
-          <input aria-label="field" />
-        </Drawer>
-      );
+      overlay.props.onPointerDown(createPointerEvent(overlay, overlay, { pointerId: 1 }));
+      overlay.props.onPointerUp(createPointerEvent(panel, overlay, { pointerId: 1 }));
     });
 
     await act(async () => {
-      await Promise.resolve();
+      vi.advanceTimersByTime(CLOSE_ANIMATION_DURATION);
     });
 
-    const overlay = renderer!.root.find((node) =>
-      String(node.props.className ?? '').includes('overlay')
-    );
-    const panel = renderer!.root.findByProps({ role: 'dialog' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close when interleaved pointers mix panel and overlay starts', async () => {
+    const onClose = vi.fn();
+    const mounted = await mountDrawer(onClose);
+    const overlay = findOverlay(mounted);
+    const panel = mounted.root.findByProps({ role: 'dialog' });
 
     await act(async () => {
-      overlay.props.onPointerDown(createPointerEvent(overlay, overlay));
-      overlay.props.onPointerUp(createPointerEvent(panel, overlay));
+      // 指针 1：面板内按下；指针 2：遮罩上按下；释放指针 1 在遮罩上 → 不应关闭
+      overlay.props.onPointerDown(createPointerEvent(panel, overlay, { pointerId: 1 }));
+      overlay.props.onPointerDown(createPointerEvent(overlay, overlay, { pointerId: 2 }));
+      overlay.props.onPointerUp(createPointerEvent(overlay, overlay, { pointerId: 1 }));
     });
 
     await act(async () => {

--- a/apps/web/src/components/ui/Drawer.test.tsx
+++ b/apps/web/src/components/ui/Drawer.test.tsx
@@ -140,7 +140,7 @@ describe('Drawer overlay close guard', () => {
     vi.useRealTimers();
   });
 
-  const mountDrawer = async (onClose: ReturnType<typeof vi.fn>) => {
+  const mountDrawer = async (onClose: () => void) => {
     await act(async () => {
       renderer = create(
         <Drawer open title="Test drawer" onClose={onClose}>

--- a/apps/web/src/components/ui/Drawer.test.tsx
+++ b/apps/web/src/components/ui/Drawer.test.tsx
@@ -1,0 +1,203 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom');
+  return {
+    ...actual,
+    createPortal: (children: unknown) => children,
+  };
+});
+
+vi.mock('./Drawer.module.scss', () => ({
+  default: {
+    overlay: 'overlay',
+    overlayClosing: 'overlayClosing',
+    overlayEntering: 'overlayEntering',
+    panel: 'panel',
+    panelClosing: 'panelClosing',
+    panelEntering: 'panelEntering',
+    header: 'header',
+    title: 'title',
+    closeButton: 'closeButton',
+    body: 'body',
+    footer: 'footer',
+  },
+}));
+
+vi.mock('./icons', () => ({
+  IconX: () => null,
+}));
+
+import { Drawer } from './Drawer';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const CLOSE_ANIMATION_DURATION = 280;
+
+const createPointerEvent = (target: unknown, currentTarget: unknown, button = 0) => ({
+  target,
+  currentTarget,
+  button,
+});
+
+const installMinimalDom = () => {
+  const bodyStyle = { overflow: '' };
+  const htmlStyle = { overflow: '' };
+  const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+
+  class HTMLElementMock {}
+
+  const documentMock = {
+    body: { style: bodyStyle },
+    documentElement: { style: htmlStyle },
+    activeElement: null as unknown,
+    addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      listeners.get(type)?.delete(listener);
+    },
+  };
+
+  Object.defineProperty(globalThis, 'HTMLElement', {
+    configurable: true,
+    writable: true,
+    value: HTMLElementMock,
+  });
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    writable: true,
+    value: documentMock,
+  });
+
+  if (typeof globalThis.window === 'undefined') {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: globalThis,
+    });
+  }
+};
+
+describe('Drawer overlay close guard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installMinimalDom();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('closes when pointer starts and ends on overlay', async () => {
+    const onClose = vi.fn();
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <Drawer open title="Test drawer" onClose={onClose}>
+          <input aria-label="field" />
+        </Drawer>
+      );
+    });
+
+    // open effect 通过 queueMicrotask 切换可见态
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const overlay = renderer!.root.find((node) =>
+      String(node.props.className ?? '').includes('overlay')
+    );
+
+    await act(async () => {
+      overlay.props.onPointerDown(createPointerEvent(overlay, overlay));
+      overlay.props.onPointerUp(createPointerEvent(overlay, overlay));
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(CLOSE_ANIMATION_DURATION);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close when pointer starts inside drawer and ends on overlay', async () => {
+    const onClose = vi.fn();
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <Drawer open title="Test drawer" onClose={onClose}>
+          <input aria-label="field" />
+        </Drawer>
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const overlay = renderer!.root.find((node) =>
+      String(node.props.className ?? '').includes('overlay')
+    );
+    const panel = renderer!.root.findByProps({ role: 'dialog' });
+
+    await act(async () => {
+      // 模拟：在面板内按下，在遮罩上释放（拖选文字场景）
+      overlay.props.onPointerDown(createPointerEvent(panel, overlay));
+      overlay.props.onPointerUp(createPointerEvent(overlay, overlay));
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(CLOSE_ANIMATION_DURATION);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close when pointer starts on overlay and ends inside drawer', async () => {
+    const onClose = vi.fn();
+    let renderer: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <Drawer open title="Test drawer" onClose={onClose}>
+          <input aria-label="field" />
+        </Drawer>
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const overlay = renderer!.root.find((node) =>
+      String(node.props.className ?? '').includes('overlay')
+    );
+    const panel = renderer!.root.findByProps({ role: 'dialog' });
+
+    await act(async () => {
+      overlay.props.onPointerDown(createPointerEvent(overlay, overlay));
+      overlay.props.onPointerUp(createPointerEvent(panel, overlay));
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(CLOSE_ANIMATION_DURATION);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -64,7 +64,7 @@ export function Drawer({
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
-  const overlayPointerStartedRef = useRef(false);
+  const overlayPointerIdsRef = useRef<Set<number>>(new Set());
 
   const startClose = useCallback(
     (notifyParent: boolean) => {
@@ -119,29 +119,33 @@ export function Drawer({
     startClose(true);
   }, [startClose]);
 
-  // 仅当按下与释放都发生在遮罩本身时才关闭，避免「面板内拖选到遮罩释放」误关。
+  // 按 pointerId 配对：仅当同一指针在遮罩上按下且在遮罩上释放时才关闭。
+  // 避免「面板内拖选到遮罩释放」与多指针交错状态互相覆盖。
   const handleOverlayPointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    overlayPointerStartedRef.current = event.target === event.currentTarget;
+    if (event.target === event.currentTarget && event.button === 0) {
+      overlayPointerIdsRef.current.add(event.pointerId);
+    } else {
+      overlayPointerIdsRef.current.delete(event.pointerId);
+    }
   }, []);
 
   const handleOverlayPointerUp = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
-      const shouldClose =
-        overlayPointerStartedRef.current &&
+      const startedOnOverlay = overlayPointerIdsRef.current.delete(event.pointerId);
+
+      if (
+        startedOnOverlay &&
         event.target === event.currentTarget &&
-        event.button === 0;
-
-      overlayPointerStartedRef.current = false;
-
-      if (shouldClose) {
+        event.button === 0
+      ) {
         handleClose();
       }
     },
     [handleClose]
   );
 
-  const handleOverlayPointerCancel = useCallback(() => {
-    overlayPointerStartedRef.current = false;
+  const handleOverlayPointerCancel = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    overlayPointerIdsRef.current.delete(event.pointerId);
   }, []);
 
   const shouldLockScroll = open || isVisible;

--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -4,6 +4,7 @@ import {
   useId,
   useRef,
   useState,
+  type PointerEvent as ReactPointerEvent,
   type PropsWithChildren,
   type ReactNode,
 } from 'react';
@@ -63,6 +64,7 @@ export function Drawer({
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const overlayPointerStartedRef = useRef(false);
 
   const startClose = useCallback(
     (notifyParent: boolean) => {
@@ -116,6 +118,31 @@ export function Drawer({
   const handleClose = useCallback(() => {
     startClose(true);
   }, [startClose]);
+
+  // 仅当按下与释放都发生在遮罩本身时才关闭，避免「面板内拖选到遮罩释放」误关。
+  const handleOverlayPointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    overlayPointerStartedRef.current = event.target === event.currentTarget;
+  }, []);
+
+  const handleOverlayPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const shouldClose =
+        overlayPointerStartedRef.current &&
+        event.target === event.currentTarget &&
+        event.button === 0;
+
+      overlayPointerStartedRef.current = false;
+
+      if (shouldClose) {
+        handleClose();
+      }
+    },
+    [handleClose]
+  );
+
+  const handleOverlayPointerCancel = useCallback(() => {
+    overlayPointerStartedRef.current = false;
+  }, []);
 
   const shouldLockScroll = open || isVisible;
 
@@ -173,7 +200,12 @@ export function Drawer({
     .join(' ');
 
   const drawerContent = (
-    <div className={overlayClass} onClick={handleClose}>
+    <div
+      className={overlayClass}
+      onPointerDown={handleOverlayPointerDown}
+      onPointerUp={handleOverlayPointerUp}
+      onPointerCancel={handleOverlayPointerCancel}
+    >
       <div
         ref={panelRef}
         className={panelClass}


### PR DESCRIPTION
## Summary

Fix Drawer overlay false close when users drag-select text from inputs onto the mask. Only close when pointer down and up both land on the overlay itself, and add unit coverage for the three press/release paths.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Replace Drawer overlay `onClick` close with pointer down/up pairing
- Keep close button and Esc behavior unchanged
- Add Drawer unit tests for overlay press/release vs drag-out cases

## User Impact

Provider edit drawers and other Drawer consumers no longer close accidentally when users drag-select text from inputs onto the overlay. Intentional overlay click-to-close still works.

## Compatibility / Runtime Notes

- CPA panel mode: frontend-only Drawer behavior; no CPA runtime/API change
- Manager Server mode: frontend-only; no server contract change
- Full Docker / native packages: same embedded frontend behavior after rebuild/release

## Data / Security Notes

N/A — no SQLite, credential, auth file, log, raw usage data, or plugin changes.

## Risk / Rollback

Risk level: Low

Rollback notes:
- Revert this PR to restore previous overlay `onClick` close behavior
- No data migration or config change required

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/components/ui/Drawer.test.tsx
# Test Files  1 passed (1)
# Tests  3 passed (3)
```

## Screenshots / Recordings

N/A — interaction fix only; no visual layout change. Recommended manual check:
1. Open provider edit drawer
2. Drag-select text from an input onto the overlay → drawer stays open
3. Click overlay background → drawer still closes

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:
Bugfix for existing Drawer close interaction; no new capability, config surface, or docs path change.

## Related

Closes #437