### PR TITLE
fix(sqlite): prevent rollup snapshot lock failures

### DIFF
--- a/apps/manager-server/internal/repository/sqlite/db.go
+++ b/apps/manager-server/internal/repository/sqlite/db.go
@@ -46,6 +46,7 @@ func dataSourceName(path string) string {
 		Path:   uriPath,
 	}
 	query := dsn.Query()
+	query.Add("_txlock", "immediate")
 	query.Add("_pragma", "busy_timeout(5000)")
 	query.Add("_pragma", "foreign_keys(1)")
 	query.Add("_pragma", "synchronous(FULL)")

--- a/apps/manager-server/internal/repository/sqlite/db_test.go
+++ b/apps/manager-server/internal/repository/sqlite/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 )
 
 func TestDataSourceNameEncodesWindowsDrivePath(t *testing.T) {
@@ -32,6 +33,9 @@ func TestDataSourceNameEncodesWindowsDrivePath(t *testing.T) {
 	}
 	if pragmas := parsed.Query()["_pragma"]; !slices.Equal(pragmas, wantPragmas) {
 		t.Fatalf("pragmas = %q, want %q", pragmas, wantPragmas)
+	}
+	if txLock := parsed.Query().Get("_txlock"); txLock != "immediate" {
+		t.Fatalf("txlock = %q, want immediate", txLock)
 	}
 }
 
@@ -89,6 +93,54 @@ func TestOpenWithOptionsAppliesConnectionDefaults(t *testing.T) {
 	}
 	if stats.MaxIdleClosed != int64(defaultMaxOpenConns-defaultMaxIdleConns) {
 		t.Fatalf("MaxIdleClosed = %d, want %d", stats.MaxIdleClosed, defaultMaxOpenConns-defaultMaxIdleConns)
+	}
+}
+
+func TestOpenWithOptionsBeginsWriteTransactionsImmediately(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	if _, err := db.Exec(`create table write_lock_test (id integer primary key)`); err != nil {
+		t.Fatalf("create write lock fixture: %v", err)
+	}
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin write transaction: %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	started := make(chan struct{})
+	writeResult := make(chan error, 1)
+	go func() {
+		close(started)
+		_, err := db.Exec(`insert into write_lock_test (id) values (1)`)
+		writeResult <- err
+	}()
+	<-started
+
+	select {
+	case err := <-writeResult:
+		t.Fatalf("competing write completed before transaction release: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback write transaction: %v", err)
+	}
+	select {
+	case err := <-writeResult:
+		if err != nil {
+			t.Fatalf("competing write after transaction release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("competing write did not resume after transaction release")
 	}
 }
 

--- a/apps/manager-server/internal/repository/usagerollup/repository_test.go
+++ b/apps/manager-server/internal/repository/usagerollup/repository_test.go
@@ -237,6 +237,77 @@ func TestCatchUpAccountHistorySerializesConcurrentCalls(t *testing.T) {
 	}
 }
 
+func TestCatchUpAccountHistoryWaitsForConcurrentWriter(t *testing.T) {
+	db := newRollupTestDB(t)
+	ctx := context.Background()
+	events := usageevent.New(db)
+	repo := New(db)
+
+	if _, err := events.InsertBatch(ctx, []usage.Event{
+		rollupTestEvent("rollup-lock-contention", 1_700_000_001_000, "gpt-a", "", "lock-test-account", "", "auth-a", false, 1, 2, 0, 0, 0, 0, 3),
+	}); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	latestEventID, err := repo.LatestEventID(ctx)
+	if err != nil {
+		t.Fatalf("latest event id: %v", err)
+	}
+	if _, err := db.Exec(`create table rollup_write_lock_test (id integer primary key)`); err != nil {
+		t.Fatalf("create write lock fixture: %v", err)
+	}
+
+	lockingTx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin competing write: %v", err)
+	}
+	defer func() {
+		_ = lockingTx.Rollback()
+	}()
+	if _, err := lockingTx.Exec(`insert into rollup_write_lock_test (id) values (1)`); err != nil {
+		t.Fatalf("hold competing write lock: %v", err)
+	}
+
+	type catchUpOutcome struct {
+		result CatchUpResult
+		err    error
+	}
+	catchUpResult := make(chan catchUpOutcome, 1)
+	go func() {
+		result, err := repo.CatchUpAccountHistory(ctx, 10, 1_700_000_010_000)
+		catchUpResult <- catchUpOutcome{result: result, err: err}
+	}()
+
+	select {
+	case outcome := <-catchUpResult:
+		t.Fatalf("catch-up completed before competing writer released: result=%#v err=%v", outcome.result, outcome.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := lockingTx.Commit(); err != nil {
+		t.Fatalf("commit competing write: %v", err)
+	}
+
+	var outcome catchUpOutcome
+	select {
+	case outcome = <-catchUpResult:
+	case <-time.After(time.Second):
+		t.Fatal("catch-up did not resume after competing writer released")
+	}
+	if outcome.err != nil {
+		t.Fatalf("catch-up after competing writer released: %v", outcome.err)
+	}
+	if outcome.result.Processed != 1 || outcome.result.LastEventID != latestEventID || outcome.result.Pending {
+		t.Fatalf("catch-up result = %#v, latest event id = %d", outcome.result, latestEventID)
+	}
+
+	rows, err := repo.AccountHistoryRows(ctx, []string{"lock-test-account"})
+	if err != nil {
+		t.Fatalf("query account history rows: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Calls != 1 || rows[0].TotalTokens != 3 {
+		t.Fatalf("account history rows = %#v", rows)
+	}
+}
+
 func newRollupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))


### PR DESCRIPTION
## Summary

Prevent SQLite write-intent transactions from upgrading stale WAL read snapshots during rollup catch-up.
Use immediate write transactions with the existing busy timeout so transient writers are handled before checkpoint reads begin.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Configure SQLite write-intent transactions to use `BEGIN IMMEDIATE`.
- Add connection-level and account-history rollup contention regression coverage.

## User Impact

Account-history rollup catch-up no longer remains permanently behind when usage ingestion writes concurrently to SQLite.

## Compatibility / Runtime Notes

- CPA panel mode: Manager Server rollups use the same transaction behavior; APIs are unchanged.
- Manager Server mode: Write transactions wait for the writer slot using the existing 5-second busy timeout.
- Full Docker / native packages: No environment, schema, or migration changes are required.

## Data / Security Notes

No raw usage data, credentials, keys, or schema are changed. `usage_events` remains the source of truth.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert the commit and redeploy the previous Manager Server binary. No data rollback is required.

## Verification

- [ ] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
go test -count=20 ./internal/repository/sqlite ./internal/repository/usagerollup
go test ./...
go test -race ./...
go vet ./...
go build -o /tmp/cpamp-issue-447 ./cmd/cpa-manager-plus
git diff --check
```

Runtime validation used the compiled Manager Server with 3,400 legacy events and 500ms concurrent SQLite writes. Migration completed, the account-history checkpoint reached all 3,430 events with zero lag, and no SQLITE_BUSY/517 errors occurred.

## Screenshots / Recordings

N/A. Backend-only SQLite transaction behavior change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: No public configuration or API behavior changed.

## Related

Fixes #447
Refs #435