### PR TITLE
[codex] fix nested plugin management caller auth

### DIFF
--- a/apps/manager-server/internal/http/controller/proxy/handler.go
+++ b/apps/manager-server/internal/http/controller/proxy/handler.go
@@ -20,14 +20,14 @@ func (h *Handler) Management(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if ok {
-		if proxysvc.IsCPAPluginManagementPath(r.URL.Path) {
+		if proxysvc.IsCPAPluginManagementRequest(r.Method, r.URL.Path) {
 			h.App.ProxyService.ProxyPluginManagement(w, r, response.Error)
 			return
 		}
 		h.App.ProxyService.ProxyManagement(w, r, response.Error)
 		return
 	}
-	if !proxysvc.IsCPAPluginManagementPath(r.URL.Path) {
+	if !proxysvc.IsCPAPluginManagementRequest(r.Method, r.URL.Path) {
 		response.Error(w, http.StatusUnauthorized, errors.New("invalid admin key"))
 		return
 	}

--- a/apps/manager-server/internal/httpapi/server_compat_test.go
+++ b/apps/manager-server/internal/httpapi/server_compat_test.go
@@ -841,6 +841,37 @@ func TestServerCompatPluginProxyRoutes(t *testing.T) {
 		body:          `{"refresh":true}`,
 	})
 
+	pluginNestedManagementRR := requestWithHeaders(
+		http.MethodGet,
+		"/v0/management/plugins/codex-pat/status",
+		"",
+		"plugin-management-key",
+		nil,
+	)
+	testutil.RequireStatus(t, pluginNestedManagementRR, http.StatusOK)
+	assertObserved("/v0/management/plugins/codex-pat/status", observedRequest{
+		method:        http.MethodGet,
+		path:          "/v0/management/plugins/codex-pat/status",
+		authorization: "Bearer plugin-management-key",
+	})
+
+	pluginBuiltinConfigRR := requestWithHeaders(
+		http.MethodGet,
+		"/v0/management/plugins/codex-pat/config",
+		"",
+		"plugin-management-key",
+		nil,
+	)
+	testutil.RequireStatus(t, pluginBuiltinConfigRR, http.StatusUnauthorized)
+	if !strings.Contains(pluginBuiltinConfigRR.Body.String(), `"code":"invalid_admin_key"`) {
+		t.Fatalf("plugin config body = %s", pluginBuiltinConfigRR.Body.String())
+	}
+	select {
+	case got := <-observed:
+		t.Fatalf("CPA upstream received rejected built-in plugin request: %#v", got)
+	default:
+	}
+
 	pluginDynamicManagementRR := requestWithHeaders(
 		http.MethodGet,
 		"/v0/management/codex-invite/accounts",

--- a/apps/manager-server/internal/service/proxy/service.go
+++ b/apps/manager-server/internal/service/proxy/service.go
@@ -70,7 +70,7 @@ func (s *Service) ProxyManagement(w http.ResponseWriter, r *http.Request, writeE
 }
 
 func (s *Service) ProxyPluginManagement(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
-	if !IsCPAPluginManagementPath(r.URL.Path) {
+	if !IsCPAPluginManagementRequest(r.Method, r.URL.Path) {
 		writeError(w, http.StatusNotFound, errors.New("proxy path must be a CPA plugin management path"))
 		return
 	}
@@ -78,7 +78,7 @@ func (s *Service) ProxyPluginManagement(w http.ResponseWriter, r *http.Request, 
 }
 
 func (s *Service) ProxyPluginManagementWithCallerAuth(w http.ResponseWriter, r *http.Request, writeError func(http.ResponseWriter, int, error)) {
-	if !IsCPAPluginManagementPath(r.URL.Path) {
+	if !IsCPAPluginManagementRequest(r.Method, r.URL.Path) {
 		writeError(w, http.StatusNotFound, errors.New("proxy path must be a CPA plugin management path"))
 		return
 	}
@@ -520,18 +520,43 @@ func isStrictManagementPath(path string) bool {
 	return path == "/v0/management" || strings.HasPrefix(path, "/v0/management/")
 }
 
-func IsCPAPluginManagementPath(path string) bool {
+func IsCPAPluginManagementRequest(method string, path string) bool {
 	cleaned := strings.TrimRight(path, "/")
 	if !strings.HasPrefix(cleaned, cpaManagementPrefix+"/") {
 		return false
 	}
 	rest := strings.TrimPrefix(cleaned, cpaManagementPrefix+"/")
-	head, _, _ := strings.Cut(rest, "/")
+	head, tail, _ := strings.Cut(rest, "/")
 	if head == "" {
 		return false
 	}
+	if head == "plugins" {
+		return !isCPABuiltinPluginManagementRequest(method, tail)
+	}
 	_, reserved := cpaBuiltinManagementPathHeads[head]
 	return !reserved
+}
+
+func isCPABuiltinPluginManagementRequest(method string, path string) bool {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 1 && parts[0] == "" {
+		return method == http.MethodGet
+	}
+	if len(parts) == 1 {
+		return method == http.MethodDelete
+	}
+	if len(parts) != 2 {
+		return false
+	}
+	switch parts[1] {
+	case "enabled":
+		return method == http.MethodPatch
+	case "config":
+		return method == http.MethodGet || method == http.MethodPut || method == http.MethodPatch
+	default:
+		return false
+	}
 }
 
 func IsCPAPluginResourcePath(path string) bool {

--- a/apps/manager-server/internal/service/proxy/service_test.go
+++ b/apps/manager-server/internal/service/proxy/service_test.go
@@ -258,29 +258,43 @@ func TestIsModelListPath(t *testing.T) {
 	}
 }
 
-func TestIsCPAPluginManagementPath(t *testing.T) {
+func TestIsCPAPluginManagementRequest(t *testing.T) {
 	tests := []struct {
-		path string
-		want bool
+		method string
+		path   string
+		want   bool
 	}{
-		{path: "/v0/management/codex-invite/accounts", want: true},
-		{path: "/v0/management/sample-plugin/custom/action", want: true},
-		{path: "/v0/management/accounts", want: false},
-		{path: "/v0/management/accounts/", want: false},
-		{path: "/v0/management/config", want: false},
-		{path: "/v0/management/reload", want: false},
-		{path: "/v0/management/plugins/demo/custom", want: false},
-		{path: "/v0/management/plugin-store/demo/install", want: false},
-		{path: "/v0/management/usage", want: false},
-		{path: "/v0/resource/plugins/codex-invite/invite", want: false},
-		{path: "/v0/management", want: false},
-		{path: "/v0/management/", want: false},
+		{method: http.MethodGet, path: "/v0/management/codex-invite/accounts", want: true},
+		{method: http.MethodPost, path: "/v0/management/sample-plugin/custom/action", want: true},
+		{method: http.MethodGet, path: "/v0/management/accounts", want: false},
+		{method: http.MethodGet, path: "/v0/management/accounts/", want: false},
+		{method: http.MethodGet, path: "/v0/management/config", want: false},
+		{method: http.MethodPost, path: "/v0/management/reload", want: false},
+		{method: http.MethodGet, path: "/v0/management/plugins", want: false},
+		{method: http.MethodPost, path: "/v0/management/plugins", want: true},
+		{method: http.MethodDelete, path: "/v0/management/plugins/demo", want: false},
+		{method: http.MethodGet, path: "/v0/management/plugins/demo", want: true},
+		{method: http.MethodPatch, path: "/v0/management/plugins/demo/enabled", want: false},
+		{method: http.MethodGet, path: "/v0/management/plugins/demo/enabled", want: true},
+		{method: http.MethodGet, path: "/v0/management/plugins/demo/config", want: false},
+		{method: http.MethodPut, path: "/v0/management/plugins/demo/config", want: false},
+		{method: http.MethodPatch, path: "/v0/management/plugins/demo/config", want: false},
+		{method: http.MethodPost, path: "/v0/management/plugins/demo/config", want: true},
+		{method: http.MethodGet, path: "/v0/management/plugins/codex-pat/status", want: true},
+		{method: http.MethodPost, path: "/v0/management/plugins/codex-pat/import", want: true},
+		{method: http.MethodPost, path: "/v0/management/plugins/codex-pat/revalidate", want: true},
+		{method: http.MethodPatch, path: "/v0/management/plugins/demo/custom", want: true},
+		{method: http.MethodPost, path: "/v0/management/plugin-store/demo/install", want: false},
+		{method: http.MethodGet, path: "/v0/management/usage", want: false},
+		{method: http.MethodGet, path: "/v0/resource/plugins/codex-invite/invite", want: false},
+		{method: http.MethodGet, path: "/v0/management", want: false},
+		{method: http.MethodGet, path: "/v0/management/", want: false},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			if got := IsCPAPluginManagementPath(tt.path); got != tt.want {
-				t.Fatalf("IsCPAPluginManagementPath(%q) = %v, want %v", tt.path, got, tt.want)
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			if got := IsCPAPluginManagementRequest(tt.method, tt.path); got != tt.want {
+				t.Fatalf("IsCPAPluginManagementRequest(%q, %q) = %v, want %v", tt.method, tt.path, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fix Manager Server caller-auth proxying for plugin-owned routes nested under
`/v0/management/plugins/:id/`.

The proxy now classifies these requests using the HTTP method and full route
shape, matching CPA's built-in plugin management route boundaries.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Preserve caller-provided CPA authorization for nested plugin routes such as
  `/plugins/codex-pat/status`, `/import`, and `/revalidate`.
- Keep CPA built-in plugin list, deletion, enablement, and configuration routes
  protected by the CPAMP Admin Key.
- Add unit and HTTP compatibility coverage for both allowed plugin routes and
  rejected built-in routes.

## User Impact

Plugin resource pages accessed through Manager Server can call nested plugin
management endpoints with a valid CPA Management Key instead of receiving
`invalid_admin_key`.

## Compatibility / Runtime Notes

- CPA panel mode: No behavior change; plugin requests already go directly to CPA.
- Manager Server mode: Nested plugin-owned management routes preserve caller auth.
- Full Docker / native packages: Full Docker mode receives the Manager Server fix.

## Data / Security Notes

CPA built-in plugin management routes remain protected by the CPAMP Admin Key.
Caller auth is preserved only when the method and route do not match a built-in
CPA plugin management endpoint.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert the commit to restore the previous path-head
classification.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
cd apps/manager-server
go test ./internal/service/proxy ./internal/http/controller/proxy ./internal/httpapi
go test ./...
git diff --check
go build -trimpath -o /tmp/cpamp-real-smoke/cpa-manager-plus ./cmd/cpa-manager-plus
```

Runtime smoke used a real CPA v7.2.102 process with the native codex-pat v0.1.4
plugin loaded, plus a Manager Server binary built from this branch:

```text
GET CPA    /v0/management/plugins/codex-pat/status with CPA key -> 200
GET CPAMP  /v0/management/plugins/codex-pat/status with CPA key -> 200
GET CPAMP  /v0/management/plugins/codex-pat/config with CPA key -> 401 invalid_admin_key
GET CPAMP  /v0/resource/plugins/codex-pat/manage without auth -> 200
```

## Screenshots / Recordings

N/A. Backend proxy behavior only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed - compatibility bug fix with no configuration changes

Docs decision: No documentation changes are required because this restores
existing plugin proxy behavior without adding configuration or a new capability.

## Related

Refs #173

Follow-up to #176
