### PR TITLE
fix(manager-server): drop priced models from sync feedback

### DIFF
--- a/apps/manager-server/internal/service/modelprice/service.go
+++ b/apps/manager-server/internal/service/modelprice/service.go
@@ -147,6 +147,7 @@ func (s *Service) Sync(ctx context.Context, req SyncRequest) (SyncResult, error)
 	if err != nil {
 		return SyncResult{}, err
 	}
+	selection = filterSelectionFeedback(selection, prices)
 	return SyncResult{
 		Source:        syncResultSource(sources),
 		Sources:       sources,
@@ -823,4 +824,30 @@ func readString(entry map[string]any, key string) string {
 	default:
 		return ""
 	}
+}
+
+// filterSelectionFeedback drops candidate and unmatched entries for models that
+// already have a stored price. Sync feedback should only report models the user
+// can still act on; the prices page intentionally hides priced rows from the
+// pending-confirmation filter to protect manually configured prices, so reporting
+// them here only produces misleading counts.
+func filterSelectionFeedback(selection priceSelectionResult, prices map[string]store.ModelPrice) priceSelectionResult {
+	if len(selection.Candidates) == 0 && len(selection.Unmatched) == 0 {
+		return selection
+	}
+	candidates := make([]SyncCandidateSet, 0, len(selection.Candidates))
+	for _, set := range selection.Candidates {
+		if _, priced := prices[set.Model]; !priced {
+			candidates = append(candidates, set)
+		}
+	}
+	unmatched := make([]string, 0, len(selection.Unmatched))
+	for _, model := range selection.Unmatched {
+		if _, priced := prices[model]; !priced {
+			unmatched = append(unmatched, model)
+		}
+	}
+	selection.Candidates = candidates
+	selection.Unmatched = unmatched
+	return selection
 }

--- a/apps/manager-server/internal/service/modelprice/service_test.go
+++ b/apps/manager-server/internal/service/modelprice/service_test.go
@@ -209,3 +209,53 @@ func closePrice(left float64, right float64) bool {
 	}
 	return right-left < 0.0000001
 }
+
+func TestFilterSelectionFeedbackDropsPricedModels(t *testing.T) {
+	selection := priceSelectionResult{
+		Prices:  map[string]store.ModelPrice{},
+		Matched: map[string]store.ModelPrice{},
+		Candidates: []SyncCandidateSet{
+			{
+				Model: "priced-ambiguous",
+				Candidates: []SyncCandidate{
+					{SourceModelID: "vendor/priced-ambiguous", Score: 0.9, Price: store.ModelPrice{Prompt: 1, Completion: 2}},
+				},
+			},
+			{
+				Model: "unpriced-ambiguous",
+				Candidates: []SyncCandidate{
+					{SourceModelID: "vendor/unpriced-ambiguous", Score: 0.9, Price: store.ModelPrice{Prompt: 3, Completion: 4}},
+				},
+			},
+		},
+		Unmatched: []string{"priced-unmatched", "unpriced-unmatched"},
+	}
+	stored := map[string]store.ModelPrice{
+		"priced-ambiguous": {Prompt: 5, Completion: 6},
+		"priced-unmatched": {Prompt: 7, Completion: 8},
+	}
+
+	filtered := filterSelectionFeedback(selection, stored)
+
+	if len(filtered.Candidates) != 1 || filtered.Candidates[0].Model != "unpriced-ambiguous" {
+		t.Fatalf("candidates = %#v", filtered.Candidates)
+	}
+	if len(filtered.Unmatched) != 1 || filtered.Unmatched[0] != "unpriced-unmatched" {
+		t.Fatalf("unmatched = %#v", filtered.Unmatched)
+	}
+}
+
+func TestFilterSelectionFeedbackKeepsEverythingWithoutStoredPrices(t *testing.T) {
+	selection := priceSelectionResult{
+		Candidates: []SyncCandidateSet{
+			{Model: "unpriced-ambiguous", Candidates: []SyncCandidate{{SourceModelID: "vendor/x", Score: 0.9}}},
+		},
+		Unmatched: []string{"unpriced-unmatched"},
+	}
+
+	filtered := filterSelectionFeedback(selection, nil)
+
+	if len(filtered.Candidates) != 1 || len(filtered.Unmatched) != 1 {
+		t.Fatalf("filtered = %#v", filtered)
+	}
+}


### PR DESCRIPTION
## Summary

Sync no longer reports pending-candidate or unmatched entries for models that
already have a stored price, so the notification counts match what the model
prices page can actually act on.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Filter `candidates` and `unmatched` in `Service.Sync` against the stored
  price table before returning the sync result (reuses the already-loaded
  price map; no extra queries).
- Add unit coverage for the filter: priced vs unpriced candidates/unmatched.

## User Impact

The "Sync complete: imported X, pending Y, unmatched Z" notification now only
counts models without a stored price — the same set shown under the "Pending"
filter on the model prices page. Previously, already-priced models (e.g.
manually configured custom models) were counted as pending on every sync while
the UI intentionally hides them to protect manual prices, so the notification
permanently reported actionable-looking counts with no matching rows.

## Compatibility / Runtime Notes

- CPA panel mode: N/A (Manager Server sync endpoint only).
- Manager Server mode: Sync response `candidates`/`unmatched` now only include
  models without a stored price. `matched`, `imported`, `skipped`, and price
  upsert behavior are unchanged.
- Full Docker / native packages: Same as Manager Server mode.

## Data / Security Notes

N/A — no schema, key, or stored-data changes; the filter reuses the price map
already loaded by `Service.Sync`.

## Risk / Rollback

Low. Response-only filtering; no persistence changes. Revert restores the
previous counts.
