### PR TITLE
docs(release): publish v1.11.11 release notes

### DIFF
--- a/docs/release-notes/v1.11.11-en.md
+++ b/docs/release-notes/v1.11.11-en.md
@@ -1,0 +1,30 @@
+# CPA Manager Plus v1.11.11
+
+> 2 commits · 2 files changed · +65 / -14
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.11/docs/release-notes/v1.11.11-zh.md)
+
+## Overview
+
+This security patch fixes an authentication privilege-escalation path in the Manager Server plugin resource proxy. Plugin resource requests that do not pass CPAMP Admin Key verification no longer implicitly borrow the server's saved CPA Management Key; caller Authorization is preserved, and requests without Authorization remain subject to the upstream CPA or plugin public-resource policy.
+
+## Highlights
+
+### Fixes
+
+- `/v0/resource/plugins/*` now uses the saved CPA Management Key only after a request carries a valid CPAMP Admin Key. Unauthenticated GET/HEAD requests can no longer access upstream plugin resources with elevated management privileges (`manager-server/plugin-resource-proxy`).
+- All supported plugin resource HTTP methods now enforce the same authorization boundary: plugin caller Authorization is forwarded unchanged, while unauthenticated requests remain subject to the upstream CPA or plugin public-resource policy (`manager-server/plugin-resource-proxy`).
+
+## Upgrade Notes
+
+- Releases `v1.5.0` through `v1.11.10` are affected. Upgrade promptly if the Manager Server was reachable by untrusted clients.
+- Affected deployments include Manager Server, Full Docker, and native Manager Server installations configured with a CPA upstream and saved CPA Management Key. CPA Panel direct mode is unaffected.
+- No configuration or database migration is required. If the instance was exposed to an untrusted network, inspect relevant access and plugin logs; rotate affected plugin-side tokens or API keys where an installed plugin resource endpoint may have exposed sensitive data or credentials.
+
+## Acknowledgements
+
+- [@Cec1c](https://github.com/Cec1c) - Reported and contributed the fix for this privilege-escalation issue.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.10...v1.11.11

--- a/docs/release-notes/v1.11.11-zh.md
+++ b/docs/release-notes/v1.11.11-zh.md
@@ -1,0 +1,30 @@
+# CPA Manager Plus v1.11.11
+
+> 2 commits · 2 files changed · +65 / -14
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.11/docs/release-notes/v1.11.11-en.md)
+
+## Overview
+
+本安全补丁修复了 Manager Server 插件资源代理中的认证权限提升路径。未通过 CPAMP Admin Key 验证的插件资源请求不再隐式借用服务器已保存的 CPA Management Key；调用方自身的 Authorization 会保留转发，未提供认证时则由上游 CPA 或插件的公开资源策略决定。
+
+## Highlights
+
+### Fixes
+
+- `/v0/resource/plugins/*` 仅在请求携带有效的 CPAMP Admin Key 后才使用保存的 CPA Management Key；无认证的 GET/HEAD 请求不会再以管理权限访问上游插件资源（`manager-server/plugin-resource-proxy`）。
+- 所有已支持的插件资源 HTTP 方法现在遵循相同的权限边界：插件调用方携带的 Authorization 会原样转发，而无认证请求仍受上游 CPA 或插件的公开资源策略约束（`manager-server/plugin-resource-proxy`）。
+
+## Upgrade Notes
+
+- `v1.5.0` 至 `v1.11.10` 受影响。若 Manager Server 曾可被不可信客户端访问，请尽快升级。
+- 影响范围包括 Manager Server、Full Docker，以及配置了 CPA upstream 和保存 CPA Management Key 的原生 Manager Server 安装；CPA Panel 直接模式不受影响。
+- 无需配置或数据库迁移。若实例曾暴露给不可信网络，请检查相关访问和插件日志；仅当已安装插件的资源接口可能返回敏感数据或凭据时，按排查结果轮换相应插件侧 Token 或 API Key。
+
+## Acknowledgements
+
+- [@Cec1c](https://github.com/Cec1c) - 报告并贡献修复了该权限提升问题。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.10...v1.11.11

--- a/docs/release-posts/v1.11.11-telegram.html
+++ b/docs/release-posts/v1.11.11-telegram.html
@@ -1,0 +1,16 @@
+🚀 <b>7 月 31 日 v1.11.11</b>
+
+✨ <b>更新内容</b>
+
+• Manager Server 插件资源代理只有在验证 CPAMP Admin Key 后才使用已保存的 CPA Management Key，未认证请求不再被提升为管理权限。
+• 插件自身携带的 Authorization 会继续原样转发，公开插件资源仍由 CPA 或插件的现有访问策略决定。
+
+⚠️ <b>注意事项</b>
+
+• v1.5.0 至 v1.11.10 的 Manager Server、Full Docker 和原生 Manager Server 部署建议尽快升级；CPA Panel 直接模式不受影响。
+• 如 Manager Server 曾暴露给不可信网络，请检查相关访问和插件日志；如插件资源可能返回敏感凭据，请按排查结果轮换相关 Token 或 API Key。
+• 本次无需配置或数据库迁移。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/Cec1c">@Cec1c</a> - 报告并修复了该权限提升问题。


### PR DESCRIPTION
## Summary

Prepare the v1.11.11 patch-release records for the merged Manager Server plugin resource authorization fix. This PR adds the bilingual, tag-pinned release notes and the reviewed Telegram notification body before the release tag is created.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add Chinese and English v1.11.11 release notes covering the Manager Server plugin resource authorization fix, affected versions, scope, and upgrade guidance.
- Add the validated Telegram HTML release post, including the external contributor acknowledgement.

## User Impact

Users receive clear upgrade guidance for the security fix: unauthenticated plugin resource requests can no longer be elevated with the saved CPA Management Key, while plugin caller-auth and public-resource behavior remain compatible.

## Compatibility / Runtime Notes

- CPA panel mode: Unchanged and unaffected.
- Manager Server mode: The previously merged fix uses the saved CPA Management Key only after valid CPAMP admin authentication.
- Full Docker / native packages: Upgrade includes the fix; no configuration or database migration is required.

## Data / Security Notes

This documents a security fix for the Manager Server plugin resource proxy. No secrets, credentials, or tokens are added to the release files, logs, or PR body. The release notes advise users with formerly untrusted exposure to inspect relevant logs and rotate plugin-side secrets only where warranted.

## Risk / Rollback

Risk level: Low

Rollback notes:

This is a release-notes-only PR. Before tagging, it can be reverted normally. Do not roll back the merged authorization fix on externally reachable Manager Server deployments.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Release range: v1.11.10..842eec791377ddcbea5cd639bc065eaa4801d656
Range statistics: 2 commits, 2 files changed, +65 / -14
git diff --check v1.11.10..main: PASS
PR #463 checks: Scope, PR Template, Manager Server, Manager Server SQLite (Windows), and Docker Build: PASS
PR #463 Frontend and Native Control checks: expected scope skips
Release-note language links are tag-pinned to v1.11.11 paths.
Telegram HTML uses only allowed tags and is 486 characters.
```

## Screenshots / Recordings

N/A — release documentation and notification copy only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

This PR adds the required Chinese and English release records plus the Telegram post. No separate user-guide or UI documentation change is needed for this backend security fix.

## Related

Refs #462, #463
