### PR TITLE
📚 docs(release): require dev promotion before tags

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -14,6 +14,36 @@ Formal release notes are technical release records. Community-facing release
 copy is authored separately so it can prioritize user value and readability
 without weakening the technical notes.
 
+## Release Branch Flow
+
+`main` is the stable default branch. `dev` is the integration branch. Every
+release follows this sequence:
+
+```text
+release/<version> -> dev -> main -> v<version> tag -> GitHub Release
+```
+
+1. Freeze the intended release scope on `dev`; do not merge unrelated work
+   until the tag is created.
+2. Create `release/<version>` from `dev`, add the two release-note files and
+   the Telegram post, then merge its release PR into `dev`.
+3. Record the resulting `dev` commit from that release PR as the release SHA.
+   Before promotion, confirm that `dev` still points to that exact SHA.
+4. Open a same-repository `dev -> main` promotion PR. It must pass the normal
+   PR checks and the `Verify dev promotion source` gate before merging.
+5. Reconfirm that the resulting `main` commit contains the recorded release
+   `dev` SHA, then create the tag from that exact `main` commit.
+
+Do not open a release PR directly to `main`: branch protection permits only
+the repository's `dev` branch to promote into `main`.
+
+`main` can contain a prior `dev -> main` merge commit that is not an ancestor
+of the current `dev` ref. This is normal. Before a new release, require that
+`main` has no non-merge commits absent from `dev`; investigate and stop if it
+does. The release scope is still invalid if `dev` advances after the release PR
+is merged: refresh the notes and repeat the release preflight rather than
+including unreviewed changes in the tag.
+
 ## Release Note Files
 
 ```text


### PR DESCRIPTION
## Summary

Document the protected release path so release preparation enters `dev`, is promoted through `dev → main`, and is tagged only from the verified stable merge. The repo-local `$release` skill now enforces the same sequence.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Define `release/<version> → dev → main → tag` as the mandatory release branch flow.
- Require a frozen, recorded `dev` SHA between the merged release PR and the promotion PR.
- Explain the protected-branch merge topology and stop condition for release-scope drift.

## User Impact

Release preparation now has an explicit, reproducible integration and promotion gate before a tag can publish packages or a GitHub Release.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: No runtime or packaging behavior changes; the release procedure is clarified.

## Data / Security Notes

No credentials, runtime configuration, database data, or release secrets are changed. The documented source gate uses the existing same-repository `dev → main` policy.

## Risk / Rollback

Risk level: Low

Rollback notes:

Revert this documentation commit and restore the previous release procedure if the branch model changes.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
git diff --check
git rev-list --no-merges origin/dev..origin/main  # no output
git merge-base --is-ancestor origin/dev origin/main  # success
```

## Screenshots / Recordings

N/A — release-process documentation only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [x] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — this governs the release workflow itself and does not change a product capability.

Docs decision:

`docs/release.md` is the canonical repository release-process reference.

## Related

Refs #468