### PR TITLE
🔧 ci: add stable required-check gate

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -203,3 +203,51 @@ jobs:
           push: false
           build-args: |
             VERSION=ci
+
+  required:
+    name: Required checks
+    needs:
+      - changes
+      - frontend
+      - manager-server
+      - manager-server-windows-sqlite
+      - native-control
+      - docker-build
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify applicable checks
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          MANAGER_SERVER_RESULT: ${{ needs['manager-server'].result }}
+          WINDOWS_SQLITE_RESULT: ${{ needs['manager-server-windows-sqlite'].result }}
+          NATIVE_CONTROL_RESULT: ${{ needs['native-control'].result }}
+          DOCKER_BUILD_RESULT: ${{ needs['docker-build'].result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          results=(
+            "Scope:${CHANGES_RESULT}"
+            "Frontend:${FRONTEND_RESULT}"
+            "Manager Server:${MANAGER_SERVER_RESULT}"
+            "Manager Server SQLite (Windows):${WINDOWS_SQLITE_RESULT}"
+            "Native Control:${NATIVE_CONTROL_RESULT}"
+            "Docker Build:${DOCKER_BUILD_RESULT}"
+          )
+
+          for check in "${results[@]}"; do
+            name="${check%%:*}"
+            result="${check#*:}"
+            case "${result}" in
+              success|skipped)
+                echo "${name}: ${result}"
+                ;;
+              *)
+                echo "${name} did not complete successfully: ${result:-missing}" >&2
+                exit 1
+                ;;
+            esac
+          done


### PR DESCRIPTION
## Summary

Add one stable aggregate check for branch protection. It preserves path-selective CI while preventing docs-only or skipped matrix jobs from leaving required check contexts permanently expected.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Add the always-run `Required checks` job after all path-selected PR jobs.
- Treat successful and intentionally skipped checks as valid.
- Fail the aggregate whenever an applicable prerequisite fails, is cancelled, or has no result.

## User Impact

Contributors can merge docs-only and other narrow PRs after the applicable CI completes, while failed frontend, backend, native, or Docker checks still block protected branches.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: CI gating only; no runtime behavior changes.

## Data / Security Notes

No credentials, runtime configuration, database data, or release secrets are changed.

## Risk / Rollback

Risk level: Low

Rollback notes:

Revert this workflow commit and restore the previous required-check configuration if the aggregate gate behaves unexpectedly.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-check.yml")'
git diff --check
bash -n bin/release/package-native.sh
```

## Screenshots / Recordings

N/A — CI workflow only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — internal CI gate behavior only.

Docs decision:

No user-facing documentation changes are required.

## Related

Refs #469