### PR TITLE
chore(release): promote dev to main

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -203,3 +203,51 @@ jobs:
           push: false
           build-args: |
             VERSION=ci
+
+  required:
+    name: Required checks
+    needs:
+      - changes
+      - frontend
+      - manager-server
+      - manager-server-windows-sqlite
+      - native-control
+      - docker-build
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify applicable checks
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          MANAGER_SERVER_RESULT: ${{ needs['manager-server'].result }}
+          WINDOWS_SQLITE_RESULT: ${{ needs['manager-server-windows-sqlite'].result }}
+          NATIVE_CONTROL_RESULT: ${{ needs['native-control'].result }}
+          DOCKER_BUILD_RESULT: ${{ needs['docker-build'].result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          results=(
+            "Scope:${CHANGES_RESULT}"
+            "Frontend:${FRONTEND_RESULT}"
+            "Manager Server:${MANAGER_SERVER_RESULT}"
+            "Manager Server SQLite (Windows):${WINDOWS_SQLITE_RESULT}"
+            "Native Control:${NATIVE_CONTROL_RESULT}"
+            "Docker Build:${DOCKER_BUILD_RESULT}"
+          )
+
+          for check in "${results[@]}"; do
+            name="${check%%:*}"
+            result="${check#*:}"
+            case "${result}" in
+              success|skipped)
+                echo "${name}: ${result}"
+                ;;
+              *)
+                echo "${name} did not complete successfully: ${result:-missing}" >&2
+                exit 1
+                ;;
+            esac
+          done

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,6 +14,36 @@ Formal release notes are technical release records. Community-facing release
 copy is authored separately so it can prioritize user value and readability
 without weakening the technical notes.
 
+## Release Branch Flow
+
+`main` is the stable default branch. `dev` is the integration branch. Every
+release follows this sequence:
+
+```text
+release/<version> -> dev -> main -> v<version> tag -> GitHub Release
+```
+
+1. Freeze the intended release scope on `dev`; do not merge unrelated work
+   until the tag is created.
+2. Create `release/<version>` from `dev`, add the two release-note files and
+   the Telegram post, then merge its release PR into `dev`.
+3. Record the resulting `dev` commit from that release PR as the release SHA.
+   Before promotion, confirm that `dev` still points to that exact SHA.
+4. Open a same-repository `dev -> main` promotion PR. It must pass the normal
+   PR checks and the `Verify dev promotion source` gate before merging.
+5. Reconfirm that the resulting `main` commit contains the recorded release
+   `dev` SHA, then create the tag from that exact `main` commit.
+
+Do not open a release PR directly to `main`: branch protection permits only
+the repository's `dev` branch to promote into `main`.
+
+`main` can contain a prior `dev -> main` merge commit that is not an ancestor
+of the current `dev` ref. This is normal. Before a new release, require that
+`main` has no non-merge commits absent from `dev`; investigate and stop if it
+does. The release scope is still invalid if `dev` advances after the release PR
+is merged: refresh the notes and repeat the release preflight rather than
+including unreviewed changes in the tag.
+
 ## Release Note Files
 
 ```text

--- a/tests/nativeControlScripts.test.mjs
+++ b/tests/nativeControlScripts.test.mjs
@@ -455,7 +455,7 @@ describe('native control scripts', () => {
         'if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }',
       ].join('; '),
     ]);
-  });
+  }, 10_000);
 
   it('starts Windows processes with custom paths, private files, logs, and stop', () => {
     if (process.platform !== 'win32') {


### PR DESCRIPTION
## Summary

Promote the verified integration branch `dev` to the protected stable branch `main`. This carries the release-flow documentation and the stable aggregate CI gate introduced by PRs #469 and #470.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Publish the required `release/<version> → dev → main → tag` release-promotion process.
- Use the stable `Required checks` aggregate gate so path-skipped CI jobs satisfy the protected-branch policy deterministically.
- Promote only the same repository's current `dev` branch into `main`.

## User Impact

No product runtime behavior changes. Maintainers and community contributors now have a consistent PR target and a reliable protected-branch gate for docs-only and scoped changes.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: No runtime, packaging, or release asset changes; this promotion governs the release process and CI gate.

## Data / Security Notes

No credentials, runtime configuration, database data, or release secrets are changed. The existing same-repository `dev → main` source restriction remains enforced.

## Risk / Rollback

Risk level: Low

Rollback notes:

Revert this promotion through a new protected `dev → main` PR if the branch model or aggregate-gate policy needs to change.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
PR #469: Scope, PR Template, and Required checks succeeded.
dev commit 00c26e0: Scope and Required checks succeeded; path-scoped build jobs skipped as designed.
```

## Screenshots / Recordings

N/A — documentation and CI policy only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [x] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — this promotion documents and enforces the release workflow; no product release is created.

Docs decision:

`docs/release.md` is the canonical release-process reference. No tag or GitHub Release is included in this PR.

## Related

Refs #469
Refs #470