### PR TITLE
test(native): extend Windows parser timeout

### DIFF
--- a/tests/nativeControlScripts.test.mjs
+++ b/tests/nativeControlScripts.test.mjs
@@ -455,7 +455,7 @@ describe('native control scripts', () => {
         'if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }',
       ].join('; '),
     ]);
-  });
+  }, 10_000);
 
   it('starts Windows processes with custom paths, private files, logs, and stop', () => {
     if (process.platform !== 'win32') {


### PR DESCRIPTION
## Summary

Increase the timeout for the Windows-only PowerShell syntax parser test. The test exceeded Vitest's default 5-second limit on GitHub-hosted Windows runners even though the parser completed successfully.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Set a 10-second timeout only for the Windows PowerShell control-script parsing test.
- Preserve the parser-error assertion and all native-control test coverage.

## User Impact

No user-facing behavior change. This removes a Windows CI timing false negative that blocks protected-branch promotions.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: Native package scripts are unchanged; only the test timeout is adjusted.

## Data / Security Notes

No credentials, runtime configuration, database data, or security behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes:

Revert this one-line test timeout adjustment if Windows runner performance makes a different test strategy necessary.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npx vitest run tests/nativeControlScripts.test.mjs --reporter=dot
git diff --check
Observed failure on PR #471: Windows PowerShell parse completed in 5.6s, exceeding the default 5s timeout.
```

## Screenshots / Recordings

N/A — test-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — test-only timing correction with no product behavior change.

Docs decision:

No documentation update is needed.

## Related

Refs #471