### PR TITLE
chore(release): promote dev to main

### DIFF
--- a/docs/release-notes/v1.11.12-en.md
+++ b/docs/release-notes/v1.11.12-en.md
@@ -1,0 +1,52 @@
+# CPA Manager Plus v1.11.12
+
+> 16 commits · 71 files changed · +9754 / -872
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.12/docs/release-notes/v1.11.12-zh.md)
+
+## Overview
+
+This release focuses on large-usage monitoring performance, SQLite/WAL observability, and a protected release flow. Manager Server adds recoverable derived data and background catch-up for long-window monitoring, while SQLite storage status is now centralized in System Info with responsive desktop, tablet, and mobile layouts; releases now require verified `dev` integration, `main` promotion, and provenance checks before a tag is created.
+
+## Highlights
+
+### Features
+
+- System Info now provides a SQLite storage status module showing database, WAL, SHM, total footprint, and checkpoint status in responsive desktop, tablet, and mobile layouts (`web/system-info`).
+- Dashboard no longer contains the SQLite storage card and restores its original four-column data layout (`web/dashboard`).
+
+### Performance
+
+- 7-day and 30-day monitoring analytics use recoverable SQLite readers once derived coverage is available, reducing scans over large `usage_events` tables (`manager-server/monitoring`).
+- Model, account, API-key statistics, selectors, event search and paging, and header snapshots use derived data when coverage is available, while retaining raw edge and tail fallback (`manager-server/monitoring`).
+- Concurrent header-snapshot loads are coalesced, and monitoring endpoints avoid unnecessary response payloads (`manager-server/monitoring`).
+- SQLite WAL maintenance uses non-blocking bounded checkpoints, a 256 MiB journal-size target, and truncation only after a fully caught-up checkpoint, while exposing database, WAL, and checkpoint status (`manager-server/sqlite`).
+
+### Fixes
+
+- Manager Server detects incomplete monitoring-derived state at startup and rebuilds only damaged derived data without rewriting raw usage events (`manager-server/monitoring`).
+
+### CI
+
+- PR workflows now provide a stable Required checks aggregate and fail closed when required workflows are missing, skipped, or failed (`ci/pr-check`).
+- Release validation now checks tag format, the three versioned release files, reciprocal language links, `dev`-to-`main` provenance, and the absence of unrelated release-commit changes (`ci/release`).
+- Windows native control parser tests use a larger timeout budget to reduce false failures on slow runners (`tests/nativeControlScripts`).
+
+### Docs
+
+- README, README_CN, contributor, and release documentation now describe the `dev` integration flow, backup requirements, release prerequisites, and recovery boundaries (`docs/release`, `contributing`).
+
+### Chore
+
+- Legacy Chinese issue forms were removed, and community and maintenance changes are now governed through `dev` branch integration (`github`, `contributing`).
+
+## Upgrade Notes
+
+- Manager Server upgrades automatically create additive SQLite tables and indexes and backfill historical monitoring state in the existing background derived-data worker; no manual database or configuration migration is required. Large databases may temporarily use more CPU, disk I/O, and storage after the first upgrade.
+- `usage_events` remains the raw source of truth and derived data is rebuildable. Back up `usage.sqlite`, `usage.sqlite-wal`, `usage.sqlite-shm`, and `data.key` together before upgrading; do not manually delete a live WAL.
+- The 256 MiB value is a post-checkpoint journal-size target, not a hard cap while a long transaction or reader prevents progress. WAL maintenance avoids waiting for active readers and writers and attempts truncation only after the checkpoint is fully caught up.
+- API response shapes, CPA Panel authentication and management-key ownership, and collector queue semantics remain unchanged. A pure CPA Panel deployment without Manager Server does not render this Manager SQLite status module.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.11...v1.11.12

--- a/docs/release-notes/v1.11.12-zh.md
+++ b/docs/release-notes/v1.11.12-zh.md
@@ -1,0 +1,52 @@
+# CPA Manager Plus v1.11.12
+
+> 16 commits · 71 files changed · +9754 / -872
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.11.12/docs/release-notes/v1.11.12-en.md)
+
+## Overview
+
+本版本聚焦大规模用量监控的查询性能、SQLite/WAL 状态可观测性和受保护的发布流程。Manager Server 为长窗口监控增加可恢复的派生数据与后台补齐机制，SQLite 存储状态现集中在系统信息页并适配桌面、平板和移动端；发布流程要求完成 `dev` 集成、`main` 晋级和来源校验后才创建标签。
+
+## Highlights
+
+### Features
+
+- 系统信息页提供 SQLite 存储状态模块，展示数据库、WAL、SHM、总占用和检查点状态，并采用桌面、平板和移动端响应式布局（`web/system-info`）。
+- Dashboard 移除 SQLite 存储卡片并恢复原有四列数据布局（`web/dashboard`）。
+
+### Performance
+
+- 7 天和 30 天监控分析会在派生数据覆盖后使用可恢复的 SQLite 读取路径，减少对大型 `usage_events` 原始表的扫描（`manager-server/monitoring`）。
+- 模型、账户、API Key 统计、筛选器、事件搜索与分页、Header 快照等监控读取会在覆盖可用时使用派生数据，并保留原始边缘数据和尾部数据回退（`manager-server/monitoring`）。
+- Header 快照加载会合并并发请求，监控接口同时减少不必要的响应负载（`manager-server/monitoring`）。
+- SQLite WAL 维护使用非阻塞的有界检查点、256 MiB 日志大小目标，并仅在检查点完全追平后尝试截断，同时提供数据库/WAL/检查点状态（`manager-server/sqlite`）。
+
+### Fixes
+
+- Manager Server 启动时会检测不完整的监控派生状态，只重建受损的派生数据，不重写原始用量事件（`manager-server/monitoring`）。
+
+### CI
+
+- PR 流程新增稳定的 Required checks 汇总，并对缺失、跳过或失败的必需工作流采取 fail-closed 处理（`ci/pr-check`）。
+- 发布校验现在验证标签格式、三份版本化发布文件、双语互链、`dev` 到 `main` 的来源拓扑，以及发布提交不能包含额外变更（`ci/release`）。
+- Windows 原生控制解析器测试使用更充足的超时预算，减少慢速运行器上的误报（`tests/nativeControlScripts`）。
+
+### Docs
+
+- README、README_CN、贡献指南和发布文档补充 `dev` 集成流程、备份要求、发布前置条件和恢复边界（`docs/release`、`contributing`）。
+
+### Chore
+
+- 移除旧版中文 Issue 表单，并将社区与维护类变更纳入 `dev` 分支集成治理（`github`、`contributing`）。
+
+## Upgrade Notes
+
+- Manager Server 升级时会自动创建新增的 SQLite 表和索引，并在现有后台派生数据 worker 中补齐历史监控状态；无需手动执行数据库或配置迁移。大型数据库首次升级后可能暂时增加 CPU、磁盘 I/O 和额外存储占用。
+- `usage_events` 仍是原始事实来源，派生数据可重建。升级前请将 `usage.sqlite`、`usage.sqlite-wal`、`usage.sqlite-shm` 和 `data.key` 一起备份；不要手动删除正在使用的 WAL。
+- 256 MiB 是检查点完成后的日志大小目标，不是长事务或长期读者存在时的硬上限；WAL 维护会避免等待活跃读写，并只在检查点完全追平后尝试截断。
+- API 响应形状、CPA Panel 的认证与管理密钥归属、以及采集队列语义保持不变。纯 CPA Panel 直连且未运行 Manager Server 时不会显示该 Manager SQLite 状态模块。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.11...v1.11.12

--- a/docs/release-posts/v1.11.12-telegram.html
+++ b/docs/release-posts/v1.11.12-telegram.html
@@ -1,0 +1,15 @@
+🚀 <b>8 月 7 日 v1.11.12</b>
+
+✨ <b>更新内容</b>
+
+• 7 天和 30 天监控分析、模型/账户/API Key 统计、筛选器和事件搜索在派生数据覆盖后使用更快的 SQLite 读取路径。
+• 监控历史会在后台补齐，派生数据异常时可自动恢复，原始用量事件不受影响。
+• SQLite WAL 检查点维护采用非阻塞、有界策略，降低长期运行中的 WAL 膨胀风险。
+• SQLite 存储和检查点状态现位于系统信息页，并适配桌面、平板与移动端。
+• Dashboard 移除 SQLite 存储卡片并恢复原有四列数据布局。
+
+⚠️ <b>注意事项</b>
+
+• 升级后 Manager Server 会在后台补齐历史监控派生数据；大型数据库首次运行可能暂时增加 CPU、磁盘 I/O 和额外存储，无需手动执行迁移。
+• 请将 <code>usage.sqlite</code>、<code>usage.sqlite-wal</code>、<code>usage.sqlite-shm</code> 与 <code>data.key</code> 一起备份；不要手动删除正在使用的 WAL，256 MiB 只是检查点完成后的目标。
+• SQLite 状态模块依赖 Manager Server；纯 CPA Panel 直连且未运行 Manager Server 时不会显示该模块。


### PR DESCRIPTION
## Summary

Promote the verified v1.11.12 release scope from `dev` to stable `main`.

This promotion includes release PR #486, the long-window monitoring and SQLite/WAL work already integrated into `dev`, and the System Info relocation of the SQLite storage status card.

> Community and maintenance PRs must target `dev`. `main` accepts only a
> promotion PR whose source is this repository's `dev` branch.

## Scope

<!-- Check all areas touched by this PR. -->

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [x] CI / build / tooling

## Changes

<!-- List concrete changes, not implementation trivia. -->

- Promote the current repository `dev` tip, including the verified v1.11.12 release content from PR #486.
- Include the monitoring derived-data and WAL maintenance improvements, the System Info SQLite storage layout, and the restored Dashboard four-column data layout.

## User Impact

Users receive the v1.11.12 monitoring performance improvements and SQLite/WAL status visibility. SQLite storage and checkpoint health is found under System Info, while Dashboard retains its original four-column data layout.

## Compatibility / Runtime Notes

- CPA panel mode: Authentication, management-key ownership, and collector queue semantics remain unchanged. A pure CPA Panel deployment without Manager Server does not render the Manager SQLite status module.
- Manager Server mode: Additive monitoring-derived SQLite state is backfilled in the background and API response shapes remain compatible.
- Full Docker / native packages: No new configuration is required. Large databases may temporarily use more CPU, disk I/O, and storage during the first background catch-up.

## Data / Security Notes

No credentials or raw failure bodies are added to the release content. The documented upgrade path keeps `usage_events` authoritative, requires backing up `usage.sqlite`, `usage.sqlite-wal`, `usage.sqlite-shm`, and `data.key` together, and prohibits manually deleting a live WAL.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert the promotion merge before creating the release tag if promotion checks fail or the release scope needs correction. After tagging, follow immutable-tag recovery rules and use a new version for substantive corrections.

## Verification

<!-- Check what was actually done. Keep skipped items unchecked and explain when needed. -->

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Promotion source: repository dev branch
Release dev SHA after PR #486: 132af35ff0dac028013bc33a0ed6aeefdcb32087
Previous stable main SHA: 51991ae168f97f15e389046a4f0d1e77d6f46f22
PR #482 checks passed for the monitoring and WAL implementation.
PR #484 checks passed for the System Info relocation and restored Dashboard layout.
PR #486 checks passed: Release Content, Required checks, PR Template, and Scope.
PR #486 adds exactly the three v1.11.12 release files.
Manual UI verification covered System Info desktop, tablet, and mobile layouts and the restored Dashboard four-column data row.
```

## Screenshots / Recordings

Manual UI verification is recorded in PR #484:
- System Info desktop: four storage summary columns and five checkpoint detail columns.
- System Info tablet: two storage summary columns and three checkpoint detail columns.
- System Info mobile: single-column layout without horizontal overflow.
- Dashboard: the original four-column data layout is restored.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — this is a branch promotion; release notes and tagging are handled by the release workflow.

Docs decision:

The versioned release notes and Telegram post are already included in PR #486. This PR only promotes the verified `dev` tree to `main`.

## Related

Refs #482
Refs #484
Refs #486
