### PR TITLE
fix(monitoring): realtime TPS font size and raw reasoning tokens

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -1528,7 +1528,6 @@
   display: inline-block;
   min-width: 48px;
   color: var(--monitor-ink);
-  font-size: 12px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   line-height: 1.25;

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -733,7 +733,7 @@ const buildRealtimeTokenUsageDetails = (row: MonitoringEventRow, t: TFunction) =
     { label: t('monitoring.realtime_usage_output_label'), value: formatCompactNumber(row.outputTokens) },
     {
       label: t('monitoring.realtime_usage_reasoning_label'),
-      value: formatCompactNumber(row.reasoningTokens),
+      value: String(row.reasoningTokens),
     },
     { label: t('monitoring.realtime_usage_cached_label'), value: formatCompactNumber(row.cachedTokens) },
     {


### PR DESCRIPTION
## Summary

Two small realtime monitoring UI tweaks: the realtime list TPS column now matches the adjacent total-calls column font size, and the realtime usage tooltip shows the raw reasoning token count instead of a compacted value.

> Community and maintenance PRs must target `dev`. `main` accepts only a promotion PR whose source is this repository's `dev` branch.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Removed the explicit `font-size: 12px` on `.realtimeTpsCell` so the realtime list TPS column inherits the table base font size, matching the total-calls column to its left.
- In `buildRealtimeTokenUsageDetails`, replaced `formatCompactNumber(row.reasoningTokens)` with `String(row.reasoningTokens)` so the realtime usage tooltip shows the exact reasoning token count rather than a compacted form (e.g. `1.2k`).

## User Impact

Realtime monitoring list: the TPS value now visually matches the total-calls value in size. Realtime usage tooltip: reasoning tokens are shown as their exact integer value. No other token fields changed.

## Compatibility / Runtime Notes

- CPA panel mode: N/A (frontend-only).
- Manager Server mode: N/A.
- Full Docker / native packages: N/A (frontend-only; management.html is regenerated by the web build).

## Data / Security Notes

N/A — display-only changes, no data shape, persistence, or auth impact.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert both commits; no schema, API, or state changes.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- --run src/features/monitoring/components/RealtimeEventsPanel.test.tsx
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

## Screenshots / Recordings

N/A — minor styling/value-display tweaks; visible in the realtime monitoring table and usage tooltip.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: Display-only refinements, no user-visible capability change.

## Related

Fixes #249 