### PR TITLE
chore(release): promote v1.12.0-beta2 to main

### DIFF
--- a/docs/release-notes/v1.12.0-beta2-en.md
+++ b/docs/release-notes/v1.12.0-beta2-en.md
@@ -1,0 +1,28 @@
+# CPA Manager Plus v1.12.0-beta2
+
+> 7 commits · 12 files changed · +505 / -130
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-beta2/docs/release-notes/v1.12.0-beta2-zh.md)
+
+## Overview
+
+This is the second beta of v1.12.0, focused on fresher quota evidence and clearer realtime monitoring. Accounts and Monitoring now share and refresh passive usage-response Header evidence while Provider quota refresh remains explicitly manual; realtime monitoring improves TPS typography and reasoning-token precision.
+
+## Highlights
+
+### Fixes
+
+- Refresh Codex quota state in Accounts and Monitoring from usage-response Header evidence scoped to the active Manager connection without implicitly calling Provider quota endpoints (`web/accounts`, `web/monitoring`).
+- Load and refresh passive Header evidence when Accounts opens, remains visible, or is explicitly refreshed, and requery selected-account usage when its evidence revision changes while keeping Provider quota refresh manual (`web/accounts`, `web/quota`).
+- Match the realtime TPS column font size to total calls and display the exact reasoning-token count in the usage tooltip (`web/monitoring`).
+
+## Upgrade Notes
+
+- This is a prerelease. Stable Docker tags and `latest` are not updated; use the explicit `v1.12.0-beta2` image or release assets.
+- No SQLite schema, API, or configuration migration is required. Header evidence is session-only and scoped to the active Manager connection.
+- Provider quota endpoints remain manual; opening Accounts, Monitoring, or refreshing the workspace reads passive Header evidence only.
+- Manager-backed quota evidence continues to follow the existing CPA Panel and Full Docker capability boundaries.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-beta1...v1.12.0-beta2

--- a/docs/release-notes/v1.12.0-beta2-zh.md
+++ b/docs/release-notes/v1.12.0-beta2-zh.md
@@ -1,0 +1,28 @@
+# CPA Manager Plus v1.12.0-beta2
+
+> 7 commits · 12 files changed · +505 / -130
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-beta2/docs/release-notes/v1.12.0-beta2-en.md)
+
+## Overview
+
+这是 v1.12.0 的第二个 beta 版本，聚焦被动额度证据的新鲜度和实时监控的可读性。Accounts 与 Monitoring 现在会共享并刷新 usage-response Header 额度证据，同时保持 Provider 额度刷新为显式手动操作；实时监控改进 TPS 与推理 Token 的展示。
+
+## Highlights
+
+### Fixes
+
+- 从当前 Manager 连接范围内的 usage-response Header 证据更新 Accounts 与 Monitoring 的 Codex 额度状态，并避免隐式请求 Provider 额度端点（`web/accounts`、`web/monitoring`）。
+- Accounts 工作区在打开、保持可见及执行工作区刷新时更新被动 Header 证据，并仅在选中凭证的证据版本变化时重新查询其用量；Provider 额度刷新仍为手动操作（`web/accounts`、`web/quota`）。
+- 实时监控的 TPS 列与总调用数使用一致的字号，并在用量提示中显示精确的推理 Token 数量（`web/monitoring`）。
+
+## Upgrade Notes
+
+- 这是预发布版本。稳定 Docker 标签和 `latest` 不会更新，请显式使用 `v1.12.0-beta2` 对应的镜像或发布资产。
+- 本次无 SQLite schema、API 或配置迁移；Header 证据仅保存在当前浏览器会话，并按当前 Manager 连接范围隔离。
+- Provider 额度端点仍只由用户主动刷新调用；打开 Accounts、Monitoring 或刷新工作区只读取被动 Header 证据。
+- 依赖 Manager 连接的额度证据继续遵循现有 CPA Panel 与 Full Docker 能力边界。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-beta1...v1.12.0-beta2

--- a/docs/release-posts/v1.12.0-beta2-telegram.html
+++ b/docs/release-posts/v1.12.0-beta2-telegram.html
@@ -1,0 +1,12 @@
+🚀 <b>8 月 10 日 · v1.12.0-beta2</b>
+
+✨ <b>更新内容</b>
+
+• Accounts 与 Monitoring 会读取当前 Manager 连接范围内的被动 Header 额度证据，让 Codex 额度状态更及时。
+• Accounts 工作区会在打开、可见期间和工作区刷新时更新额度证据，同时保持 Provider 额度刷新为手动操作。
+• 实时监控的 TPS 列与总调用数字号一致，实时用量提示展示精确的推理 Token 数量。
+
+⚠️ <b>注意事项</b>
+
+• 这是预发布版本；稳定 Docker 标签和 <code>latest</code> 不会更新，请使用 <code>v1.12.0-beta2</code> 对应的镜像或发布资产。
+• Provider 额度仍需手动刷新；本次被动 Header 证据仅保存在当前浏览器会话，不新增数据库或配置迁移。


### PR DESCRIPTION
## Summary

Promote the exact v1.12.0-beta2 release merge from the protected `dev` branch into `main`.

The release source is `dev@33ed644d405d90a14b343aa6a720a4c8c5277bd2`, merged from release PR #496 with the three required versioned release files.

> Community and maintenance PRs must target `dev`. `main` accepts only a
> promotion PR whose source is this repository's `dev` branch.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Promote the v1.12.0-beta2 release notes and Telegram post from `dev` to `main`.
- Preserve the exact release merge topology and source SHA required by release preflight.
- Prepare the verified `main` merge as the sole source for the v1.12.0-beta2 tag.

## User Impact

This promotion publishes the reviewed v1.12.0-beta2 release content, covering fresher passive Header quota evidence and clearer realtime monitoring presentation.

## Compatibility / Runtime Notes

- CPA panel mode: Existing Manager connection and management-key scope remain unchanged.
- Manager Server mode: No backend, API, SQLite, or configuration changes are introduced by the release content.
- Full Docker / native packages: The verified `main` merge will be used to build the prerelease assets and explicit Docker image tag.

## Data / Security Notes

The release content contains no credentials, management keys, raw provider responses, or persisted runtime data. Header evidence remains session-only and connection-scoped.

## Risk / Rollback

Risk level: Low

Rollback notes: Do not rewrite or retarget the release tag. If the promotion is invalid, use a corrective protected PR and a new release version before tagging.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Release PR: #496
Recorded release dev SHA: 33ed644d405d90a14b343aa6a720a4c8c5277bd2
Release content validation: passed before PR #496
Required promotion checks, including Verify dev promotion source, must pass before merge.
After merge, main must be verified as a two-parent promotion whose second parent is the recorded dev SHA.
```

## Screenshots / Recordings

N/A — protected release promotion; no new UI implementation is introduced.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

The versioned release notes and Telegram post were added and validated in PR #496; this PR promotes them without additional documentation changes.

## Related

Refs #496