### PR TITLE
🐛 fix(accounts): preserve quota usage across cycle activation

### DIFF
--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -861,28 +861,41 @@ func reconcileCycle(
 		}
 		return active.ID, 0, false, nil
 	}
+	if isProvisionalZeroAPIBoundary(*snapshot) {
+		// A zero-use Codex API response whose calculated start follows the query
+		// time is not proof that a provider cycle has started. Keep the evidence,
+		// but do not let it establish, split, or reset lifecycle state. Marking the
+		// persisted boundary unknown also prevents consumers from deriving usage
+		// ranges from this snapshot when there is no confirmed active cycle yet.
+		snapshot.BoundaryAccuracy = "unknown"
+		return 0, 0, false, nil
+	}
 	if errors.Is(activeErr, sql.ErrNoRows) {
 		id, restoreErr := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
 		return id, 0, false, restoreErr
 	}
 	cycleMatches := cycleMatchesSnapshot(active, *snapshot)
-	if !cycleMatches && isReliableLifecycleHeaderFixedBoundary(*snapshot) {
-		provisional, err := activeCycleHasOnlyProvisionalZeroBoundaries(ctx, tx, active.ID)
-		if err != nil {
+	if active.ScheduledEndMS != nil && *snapshot.CycleStartMS >= *active.ScheduledEndMS {
+		actualEndMS := *active.ScheduledEndMS
+		if actualEndMS < active.ActualStartMS {
+			actualEndMS = active.ActualStartMS
+		}
+		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
+			state = 'closed', actual_end_ms = ?, end_reason = 'scheduled',
+			last_observation_id = ?, updated_at_ms = ? where id = ?`,
+			actualEndMS, observationID, snapshot.CreatedAtMS, active.ID); err != nil {
 			return 0, 0, false, err
 		}
-		cycleMatches = provisional && provisionalBoundaryFallsWithinCycle(active, *snapshot)
+		id, err := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
+		return id, active.ID, false, err
 	}
-	if cycleMatches {
+	if isConfirmedLifecycleBoundary(*snapshot) {
 		counterReset, err := quotaCounterResetDetected(ctx, tx, active, *snapshot)
 		if err != nil {
 			return 0, 0, false, err
 		}
 		if counterReset {
-			transitionMS := snapshot.ObservedAtMS
-			if transitionMS < active.ActualStartMS {
-				transitionMS = active.ActualStartMS
-			}
+			transitionMS := confirmedResetTransitionMS(active, *snapshot, cycleMatches)
 			if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 				state = 'closed', actual_end_ms = ?, end_reason = 'early_reset',
 				last_observation_id = ?, updated_at_ms = ? where id = ?`,
@@ -892,6 +905,8 @@ func reconcileCycle(
 			id, err := insertCounterResetCycle(ctx, tx, activationID, observationID, transitionMS, *snapshot)
 			return id, active.ID, true, err
 		}
+	}
+	if cycleMatches {
 		if cycleBoundaryShouldUpgrade(active, *snapshot) {
 			if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 				scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
@@ -918,42 +933,64 @@ func reconcileCycle(
 		}
 		return active.ID, 0, false, nil
 	}
-
-	transitionMS := *snapshot.CycleStartMS
-	actualEndMS := transitionMS
-	endReason := "unknown"
-	if active.ScheduledEndMS != nil {
-		delta := transitionMS - *active.ScheduledEndMS
-		switch {
-		case absInt64(delta) <= quotaBoundaryJitterMS:
-			actualEndMS = transitionMS
-			endReason = "scheduled"
-		case transitionMS < *active.ScheduledEndMS:
-			actualEndMS = transitionMS
-			endReason = "early_reset"
-		default:
-			actualEndMS = *active.ScheduledEndMS
-			endReason = "scheduled"
+	if isConfirmedLifecycleBoundary(*snapshot) && cycleBoundaryShouldUpgrade(active, *snapshot) {
+		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
+			scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
+			duration_seconds = ?, boundary_accuracy = ?, last_observation_id = ?, updated_at_ms = ?
+			where id = ?`,
+			snapshot.CycleStartMS,
+			snapshot.CycleEndMS,
+			*snapshot.CycleStartMS,
+			snapshot.DurationSeconds,
+			snapshot.BoundaryAccuracy,
+			observationID,
+			snapshot.CreatedAtMS,
+			active.ID,
+		); err != nil {
+			return 0, 0, false, err
 		}
+		return active.ID, 0, false, nil
 	}
-	if actualEndMS < active.ActualStartMS {
-		actualEndMS = active.ActualStartMS
-		endReason = "unknown"
-	}
+
+	// A boundary change before the confirmed scheduled end is not sufficient
+	// evidence of a reset. Preserve the confirmed cycle until a counter reset,
+	// scheduled rollover, or stronger boundary correction proves otherwise.
+	applyActiveCycleBoundary(snapshot, active)
 	if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
-		state = 'closed', actual_end_ms = ?, end_reason = ?, last_observation_id = ?, updated_at_ms = ?
-		where id = ?`, actualEndMS, endReason, observationID, snapshot.CreatedAtMS, active.ID); err != nil {
+		last_observation_id = ?, updated_at_ms = ? where id = ?`,
+		observationID, snapshot.CreatedAtMS, active.ID); err != nil {
 		return 0, 0, false, err
 	}
-	id, err := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
-	return id, active.ID, endReason == "early_reset", err
+	return active.ID, 0, false, nil
 }
 
-func isReliableLifecycleHeaderFixedBoundary(snapshot model.AccountQuotaSnapshot) bool {
-	return snapshot.Source == "response_header" &&
-		snapshot.WindowMode == "fixed" &&
+func isConfirmedLifecycleBoundary(snapshot model.AccountQuotaSnapshot) bool {
+	return !isProvisionalZeroAPIBoundary(snapshot) &&
+		(snapshot.Source == "response_header" || snapshot.Source == "api_query" || snapshot.Source == "inspection") &&
+		(snapshot.WindowMode == "fixed" || snapshot.WindowMode == "calendar") &&
 		(snapshot.BoundaryAccuracy == "exact" || snapshot.BoundaryAccuracy == "derived") &&
 		snapshot.CycleStartMS != nil && snapshot.CycleEndMS != nil && snapshot.DurationSeconds != nil
+}
+
+func isProvisionalZeroAPIBoundary(snapshot model.AccountQuotaSnapshot) bool {
+	return snapshot.Provider == "codex" &&
+		snapshot.Source == "api_query" &&
+		snapshot.WindowMode == "fixed" &&
+		(snapshot.BoundaryAccuracy == "exact" || snapshot.BoundaryAccuracy == "derived") &&
+		snapshot.UsedPercent != nil && *snapshot.UsedPercent == 0 &&
+		snapshot.CycleStartMS != nil && snapshot.CycleEndMS != nil && snapshot.DurationSeconds != nil &&
+		absInt64(*snapshot.CycleStartMS-snapshot.ObservedAtMS) <= quotaProvisionalStartJitterMS
+}
+
+func confirmedResetTransitionMS(cycle model.AccountQuotaCycle, snapshot model.AccountQuotaSnapshot, sameBoundary bool) int64 {
+	transitionMS := *snapshot.CycleStartMS
+	if sameBoundary {
+		transitionMS = snapshot.ObservedAtMS
+	}
+	if transitionMS < cycle.ActualStartMS {
+		transitionMS = cycle.ActualStartMS
+	}
+	return transitionMS
 }
 
 func cycleBoundaryShouldUpgrade(cycle model.AccountQuotaCycle, snapshot model.AccountQuotaSnapshot) bool {
@@ -984,14 +1021,16 @@ func quotaCounterResetDetected(
 		return false, err
 	}
 	current := *snapshot.UsedPercent
+	return quotaCounterResetValues(previous, current), nil
+}
+
+func quotaCounterResetValues(previous, current float64) bool {
 	if previous < quotaResetMinimumPriorPercent || current >= previous {
-		return false, nil
+		return false
 	}
 	drop := previous - current
-	if current <= quotaResetNearZeroPercent {
-		return true, nil
-	}
-	return drop >= quotaResetLargeDropPercent && current <= previous/2, nil
+	return current <= quotaResetNearZeroPercent ||
+		(drop >= quotaResetLargeDropPercent && current <= previous/2)
 }
 
 func boundaryAccuracyValue(value string) int {
@@ -1071,53 +1110,6 @@ func matchingClosedCycle(
 		quotaBoundaryJitterMS,
 		cycleKey,
 	))
-}
-
-func isProvisionalZeroHeaderBoundary(snapshot model.AccountQuotaSnapshot) bool {
-	return snapshot.Source == "response_header" &&
-		snapshot.WindowMode == "fixed" &&
-		snapshot.BoundaryAccuracy == "derived" &&
-		snapshot.UsedPercent != nil && *snapshot.UsedPercent == 0 &&
-		snapshot.CycleStartMS != nil && snapshot.DurationSeconds != nil &&
-		absInt64(*snapshot.CycleStartMS-snapshot.ObservedAtMS) <= quotaProvisionalStartJitterMS
-}
-
-func activeCycleHasOnlyProvisionalZeroBoundaries(
-	ctx context.Context,
-	tx *sql.Tx,
-	cycleID int64,
-) (bool, error) {
-	var total, provisional int
-	if err := tx.QueryRowContext(ctx, `select count(*), coalesce(sum(case
-		when source = 'response_header' and window_mode = 'fixed'
-			and boundary_accuracy = 'derived' and used_percent = 0
-			and cycle_start_ms is not null
-			and abs(cycle_start_ms - observed_at_ms) <= ?
-		then 1 else 0 end), 0)
-		from account_quota_snapshots where cycle_id = ?`,
-		quotaProvisionalStartJitterMS,
-		cycleID,
-	).Scan(&total, &provisional); err != nil {
-		return false, err
-	}
-	return total > 0 && total == provisional, nil
-}
-
-func provisionalBoundaryFallsWithinCycle(
-	cycle model.AccountQuotaCycle,
-	snapshot model.AccountQuotaSnapshot,
-) bool {
-	if cycle.DurationSeconds == nil || snapshot.DurationSeconds == nil ||
-		*cycle.DurationSeconds != *snapshot.DurationSeconds {
-		return false
-	}
-	if snapshot.ObservedAtMS+quotaBoundaryJitterMS < cycle.ActualStartMS {
-		return false
-	}
-	if cycle.ScheduledEndMS != nil {
-		return snapshot.ObservedAtMS < *cycle.ScheduledEndMS
-	}
-	return snapshot.ObservedAtMS-cycle.ActualStartMS < *cycle.DurationSeconds*1000
 }
 
 func applyActiveCycleBoundary(snapshot *model.AccountQuotaSnapshot, cycle model.AccountQuotaCycle) {
@@ -1642,6 +1634,7 @@ func (r *repository) ListWindowStates(ctx context.Context, accountKey, provider 
 	if err := rows.Close(); err != nil {
 		return nil, err
 	}
+	cycleAliases := make(map[int64]int64)
 	for index := range states {
 		state := &states[index]
 		activationID, err := latestActivationID(ctx, r.db, state.ID, state.Generation)
@@ -1655,18 +1648,34 @@ func (r *repository) ListWindowStates(ctx context.Context, accountKey, provider 
 				return nil, currentErr
 			}
 			if currentErr == nil {
-				state.CurrentCycle = &current
-				previous, previousErr := previousCycle(ctx, r.db, activationID, current.ActualStartMS)
-				if previousErr != nil && !errors.Is(previousErr, sql.ErrNoRows) {
-					return nil, previousErr
+				normalizedCurrent, normalizedPrevious, aliases, normalizeErr := normalizeCycleView(ctx, r.db, activationID, current)
+				if normalizeErr != nil {
+					return nil, normalizeErr
 				}
-				if previousErr == nil {
-					state.PreviousCycle = &previous
+				for cycleID, canonicalID := range aliases {
+					cycleAliases[cycleID] = canonicalID
 				}
+				state.CurrentCycle = &normalizedCurrent
+				state.PreviousCycle = normalizedPrevious
 			}
 		}
 	}
+	for index := range states {
+		applyCycleParentAliases(states[index].CurrentCycle, cycleAliases)
+		applyCycleParentAliases(states[index].PreviousCycle, cycleAliases)
+	}
 	return states, nil
+}
+
+func applyCycleParentAliases(cycle *model.AccountQuotaCycle, aliases map[int64]int64) {
+	if cycle == nil || cycle.ParentCycleID == nil {
+		return
+	}
+	canonicalID, ok := aliases[*cycle.ParentCycleID]
+	if !ok {
+		return
+	}
+	cycle.ParentCycleID = &canonicalID
 }
 
 func latestActivationID(ctx context.Context, db *sql.DB, windowID int64, generation int) (int64, error) {
@@ -1687,6 +1696,256 @@ func previousCycle(ctx context.Context, db *sql.DB, activationID, currentStartMS
 			and actual_start_ms < ? and abs(actual_end_ms - ?) <= ?
 		order by actual_end_ms desc, id desc limit 1`,
 		activationID, currentStartMS, currentStartMS, quotaBoundaryJitterMS))
+}
+
+type quotaCycleEvidence struct {
+	firstObservedAtMS  int64
+	firstUsedPercent   *float64
+	lastUsedPercent    *float64
+	confirmed          bool
+	confirmedAtMS      int64
+	onlyProvisionalAPI bool
+}
+
+func normalizeCycleView(
+	ctx context.Context,
+	db *sql.DB,
+	activationID int64,
+	current model.AccountQuotaCycle,
+) (model.AccountQuotaCycle, *model.AccountQuotaCycle, map[int64]int64, error) {
+	currentOnlyProvisionalAPI, err := cycleHasOnlyProvisionalZeroAPIBoundaries(ctx, db, current.ID)
+	if err != nil {
+		return model.AccountQuotaCycle{}, nil, nil, err
+	}
+
+	canonical := current
+	canonicalEvidence := quotaCycleEvidence{onlyProvisionalAPI: currentOnlyProvisionalAPI}
+	next := current
+	var nextEvidence quotaCycleEvidence
+	evidenceLoaded := false
+	lookupStartMS := current.ActualStartMS
+	collapsed := false
+	collapsedCycleIDs := []int64{current.ID}
+	var previousResult *model.AccountQuotaCycle
+	for {
+		previous, previousErr := previousCycle(ctx, db, activationID, lookupStartMS)
+		if errors.Is(previousErr, sql.ErrNoRows) {
+			break
+		}
+		if previousErr != nil {
+			return model.AccountQuotaCycle{}, nil, nil, previousErr
+		}
+		if !structurallyCollapsibleEarlyResetFragment(previous, next) {
+			previousResult = &previous
+			break
+		}
+		if !evidenceLoaded {
+			currentEvidence, evidenceErr := loadQuotaCycleEvidence(ctx, db, current.ID)
+			if evidenceErr != nil {
+				return model.AccountQuotaCycle{}, nil, nil, evidenceErr
+			}
+			canonicalEvidence = currentEvidence
+			nextEvidence = currentEvidence
+			evidenceLoaded = true
+		}
+		previousEvidence, evidenceErr := loadQuotaCycleEvidence(ctx, db, previous.ID)
+		if evidenceErr != nil {
+			return model.AccountQuotaCycle{}, nil, nil, evidenceErr
+		}
+		if !collapsibleEarlyResetFragment(previous, next, previousEvidence, nextEvidence) {
+			previousResult = &previous
+			break
+		}
+		collapsed = true
+		collapsedCycleIDs = append(collapsedCycleIDs, previous.ID)
+		if quotaCycleEvidencePreferred(previous, previousEvidence, canonical, canonicalEvidence) {
+			canonical = previous
+			canonicalEvidence = previousEvidence
+		}
+		lookupStartMS = previous.ActualStartMS
+		next = previous
+		nextEvidence = previousEvidence
+	}
+
+	if canonical.ID != current.ID {
+		current.ID = canonical.ID
+		current.ActivationID = canonical.ActivationID
+		current.ProviderCycleKey = canonical.ProviderCycleKey
+		current.ScheduledStartMS = copyInt64(canonical.ScheduledStartMS)
+		current.ScheduledEndMS = copyInt64(canonical.ScheduledEndMS)
+		current.ActualStartMS = canonical.ActualStartMS
+		current.DurationSeconds = copyInt64(canonical.DurationSeconds)
+		current.BoundaryAccuracy = canonical.BoundaryAccuracy
+		current.FirstObservationID = copyInt64(canonical.FirstObservationID)
+		current.ParentCycleID = copyInt64(canonical.ParentCycleID)
+		current.CreatedAtMS = canonical.CreatedAtMS
+	}
+	if canonicalEvidence.onlyProvisionalAPI {
+		current.State = "provisional"
+		current.BoundaryAccuracy = "unknown"
+	}
+	if collapsed && previousResult != nil && previousResult.ActualEndMS != nil {
+		actualEndMS := current.ActualStartMS
+		previousResult.ActualEndMS = &actualEndMS
+	}
+	aliases := make(map[int64]int64)
+	if collapsed {
+		for _, cycleID := range collapsedCycleIDs {
+			if cycleID != canonical.ID {
+				aliases[cycleID] = canonical.ID
+			}
+		}
+	}
+	return current, previousResult, aliases, nil
+}
+
+func cycleHasOnlyProvisionalZeroAPIBoundaries(ctx context.Context, db *sql.DB, cycleID int64) (bool, error) {
+	var hasSnapshots, hasNonProvisional int
+	err := db.QueryRowContext(ctx, `select
+		exists(select 1 from account_quota_snapshots where cycle_id = ? limit 1),
+		exists(select 1 from account_quota_snapshots where cycle_id = ? and coalesce((
+			provider = 'codex' and source = 'api_query' and window_mode = 'fixed'
+			and boundary_accuracy in ('exact', 'derived') and used_percent = 0
+			and cycle_start_ms is not null and cycle_end_ms is not null
+			and duration_seconds is not null
+			and abs(cycle_start_ms - observed_at_ms) <= ?
+		), 0) = 0 limit 1)`,
+		cycleID,
+		cycleID,
+		quotaProvisionalStartJitterMS,
+	).Scan(&hasSnapshots, &hasNonProvisional)
+	if err != nil {
+		return false, err
+	}
+	return hasSnapshots != 0 && hasNonProvisional == 0, nil
+}
+
+func loadQuotaCycleEvidence(ctx context.Context, db *sql.DB, cycleID int64) (quotaCycleEvidence, error) {
+	rows, err := db.QueryContext(ctx, `select
+		provider, source, window_mode, boundary_accuracy, cycle_start_ms, cycle_end_ms,
+		duration_seconds, used_percent, observed_at_ms
+		from account_quota_snapshots where cycle_id = ?
+		order by observed_at_ms asc, id asc`, cycleID)
+	if err != nil {
+		return quotaCycleEvidence{}, err
+	}
+	defer func() { _ = rows.Close() }()
+	evidence := quotaCycleEvidence{onlyProvisionalAPI: true}
+	total := 0
+	for rows.Next() {
+		var snapshot model.AccountQuotaSnapshot
+		var cycleStart, cycleEnd, duration sql.NullInt64
+		var used sql.NullFloat64
+		if err := rows.Scan(
+			&snapshot.Provider,
+			&snapshot.Source,
+			&snapshot.WindowMode,
+			&snapshot.BoundaryAccuracy,
+			&cycleStart,
+			&cycleEnd,
+			&duration,
+			&used,
+			&snapshot.ObservedAtMS,
+		); err != nil {
+			return quotaCycleEvidence{}, err
+		}
+		snapshot.CycleStartMS = int64Pointer(cycleStart)
+		snapshot.CycleEndMS = int64Pointer(cycleEnd)
+		snapshot.DurationSeconds = int64Pointer(duration)
+		if used.Valid {
+			value := used.Float64
+			snapshot.UsedPercent = &value
+			if evidence.firstUsedPercent == nil {
+				evidence.firstUsedPercent = copyFloat64(snapshot.UsedPercent)
+			}
+			evidence.lastUsedPercent = copyFloat64(snapshot.UsedPercent)
+		}
+		if total == 0 {
+			evidence.firstObservedAtMS = snapshot.ObservedAtMS
+		}
+		total++
+		provisional := isProvisionalZeroAPIBoundary(snapshot)
+		evidence.onlyProvisionalAPI = evidence.onlyProvisionalAPI && provisional
+		if isConfirmedLifecycleBoundary(snapshot) {
+			evidence.confirmed = true
+			if evidence.confirmedAtMS == 0 || snapshot.ObservedAtMS < evidence.confirmedAtMS {
+				evidence.confirmedAtMS = snapshot.ObservedAtMS
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return quotaCycleEvidence{}, err
+	}
+	evidence.onlyProvisionalAPI = total > 0 && evidence.onlyProvisionalAPI
+	return evidence, nil
+}
+
+func collapsibleEarlyResetFragment(
+	previous model.AccountQuotaCycle,
+	next model.AccountQuotaCycle,
+	previousEvidence quotaCycleEvidence,
+	nextEvidence quotaCycleEvidence,
+) bool {
+	if !structurallyCollapsibleEarlyResetFragment(previous, next) ||
+		previousEvidence.firstObservedAtMS == 0 || nextEvidence.firstObservedAtMS == 0 ||
+		previousEvidence.lastUsedPercent == nil || nextEvidence.firstUsedPercent == nil {
+		return false
+	}
+	startShiftMS := *next.ScheduledStartMS - *previous.ScheduledStartMS
+	endShiftMS := *next.ScheduledEndMS - *previous.ScheduledEndMS
+	observationShiftMS := nextEvidence.firstObservedAtMS - previousEvidence.firstObservedAtMS
+	if absInt64(startShiftMS-endShiftMS) > quotaBoundaryJitterMS ||
+		absInt64(startShiftMS-observationShiftMS) > quotaBoundaryJitterMS {
+		return false
+	}
+	return !quotaCounterResetValues(*previousEvidence.lastUsedPercent, *nextEvidence.firstUsedPercent)
+}
+
+func structurallyCollapsibleEarlyResetFragment(previous, next model.AccountQuotaCycle) bool {
+	return previous.EndReason == "early_reset" && previous.ActualEndMS != nil &&
+		absInt64(*previous.ActualEndMS-next.ActualStartMS) <= quotaBoundaryJitterMS &&
+		previous.ScheduledStartMS != nil && previous.ScheduledEndMS != nil &&
+		next.ScheduledStartMS != nil && next.ScheduledEndMS != nil &&
+		previous.DurationSeconds != nil && next.DurationSeconds != nil &&
+		*previous.DurationSeconds == *next.DurationSeconds &&
+		next.ActualStartMS < *previous.ScheduledEndMS
+}
+
+func quotaCycleEvidencePreferred(
+	candidate model.AccountQuotaCycle,
+	candidateEvidence quotaCycleEvidence,
+	current model.AccountQuotaCycle,
+	currentEvidence quotaCycleEvidence,
+) bool {
+	if candidateEvidence.confirmed != currentEvidence.confirmed {
+		return candidateEvidence.confirmed
+	}
+	if candidateEvidence.onlyProvisionalAPI != currentEvidence.onlyProvisionalAPI {
+		return !candidateEvidence.onlyProvisionalAPI
+	}
+	candidateAccuracy := boundaryAccuracyValue(candidate.BoundaryAccuracy)
+	currentAccuracy := boundaryAccuracyValue(current.BoundaryAccuracy)
+	if candidateAccuracy != currentAccuracy {
+		return candidateAccuracy > currentAccuracy
+	}
+	if candidateEvidence.confirmedAtMS != currentEvidence.confirmedAtMS {
+		if candidateEvidence.confirmedAtMS == 0 {
+			return false
+		}
+		if currentEvidence.confirmedAtMS == 0 {
+			return true
+		}
+		return candidateEvidence.confirmedAtMS < currentEvidence.confirmedAtMS
+	}
+	return candidate.ActualStartMS < current.ActualStartMS
+}
+
+func copyFloat64(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
 }
 
 func activationStart(snapshot model.AccountQuotaSnapshot, fallback int64) int64 {

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -1770,6 +1770,7 @@ func ensureQuotaSnapshotLifecycleColumns(db *sql.DB) error {
 	for _, statement := range []string{
 		`create index if not exists idx_quota_snapshots_observation on account_quota_snapshots(observation_id)`,
 		`create index if not exists idx_quota_snapshots_window_cycle on account_quota_snapshots(logical_window_id, cycle_id, observed_at_ms desc)`,
+		`create index if not exists idx_quota_snapshots_cycle_evidence on account_quota_snapshots(cycle_id, observed_at_ms, id)`,
 	} {
 		if _, err := db.Exec(statement); err != nil {
 			return err

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -170,6 +170,7 @@ func TestMigrateCreatesAccountQuotaSnapshotSchema(t *testing.T) {
 		"idx_quota_snapshots_latest",
 		"idx_quota_snapshots_observation",
 		"idx_quota_snapshots_window_cycle",
+		"idx_quota_snapshots_cycle_evidence",
 	} {
 		if !indexes[name] {
 			t.Fatalf("account quota snapshot indexes = %#v, missing %s", indexes, name)

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -2619,6 +2619,265 @@ func TestQuotaLifecycleDoesNotSplitCycleForSmallQuotaCorrection(t *testing.T) {
 	}
 }
 
+func TestQuotaLifecycleDetectsCalendarCounterReset(t *testing.T) {
+	resetAtMS := quotaLifecycleBaseMS + 3*quotaLifecycleHourMS
+	service := newQuotaSnapshotTestService(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
+	beforeReset := quotaLifecycleFixedWindow("calendar-week", "weekly", quotaLifecycleBaseMS, 7*24*60*60, 65)
+	beforeReset.WindowMode = "calendar"
+	writeQuotaLifecycleObservation(
+		t,
+		service,
+		"complete",
+		resetAtMS-quotaLifecycleHourMS,
+		[]WindowInput{beforeReset},
+	)
+
+	afterReset := quotaLifecycleFixedWindow("calendar-week", "weekly", quotaLifecycleBaseMS, 7*24*60*60, 1)
+	afterReset.WindowMode = "calendar"
+	writeQuotaLifecycleObservation(t, service, "complete", resetAtMS, []WindowInput{afterReset})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["calendar-week"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != resetAtMS ||
+		window.PreviousCycle == nil || window.PreviousCycle.ActualEndMS == nil ||
+		*window.PreviousCycle.ActualEndMS != resetAtMS ||
+		window.PreviousCycle.EndReason != "early_reset" || window.PreviousCycle.ForecastEligible {
+		t.Fatalf("calendar counter reset lifecycle = %#v", window)
+	}
+}
+
+func TestQuotaLifecycleActivatesCodexCycleFromConfirmedCallAfterProvisionalAPI(t *testing.T) {
+	location := time.FixedZone("UTC+8", 8*60*60)
+	at := func(day, hour, minute int) int64 {
+		return time.Date(2026, time.August, day, hour, minute, 0, 0, location).UnixMilli()
+	}
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	oldStartMS := at(9, 8, 28)
+	oldEndMS := at(16, 8, 28)
+	provisionalAtMS := at(11, 9, 24)
+	confirmedAtMS := at(11, 9, 27)
+	confirmedStartMS := at(11, 8, 0)
+	confirmedEndMS := confirmedStartMS + durationSeconds*1000
+	driftAtMS := at(11, 9, 30)
+	service, path := newQuotaSnapshotTestServiceWithPath(t, at(12, 8, 0))
+
+	oldCycle := quotaLifecycleFixedWindow("weekly", "weekly", oldStartMS, durationSeconds, 65)
+	writeQuotaLifecycleObservation(t, service, "complete", at(10, 8, 30), []WindowInput{oldCycle})
+
+	provisional := quotaLifecycleFixedWindow("weekly", "weekly", provisionalAtMS, durationSeconds, 0)
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-provisional", "codex:quota-windows",
+			provisionalAtMS, []WindowInput{provisional},
+		),
+	}}); err != nil {
+		t.Fatalf("write provisional API boundary: %v", err)
+	}
+
+	beforeCall := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if beforeCall.CurrentCycle == nil || beforeCall.CurrentCycle.ActualStartMS != oldStartMS ||
+		beforeCall.PreviousCycle != nil {
+		t.Fatalf("provisional API boundary changed lifecycle = %#v", beforeCall)
+	}
+
+	confirmed := quotaLifecycleFixedWindow("weekly", "weekly", confirmedStartMS, durationSeconds, 0)
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"partial", "response_header", "header-first-call", "codex:quota-windows",
+			confirmedAtMS, []WindowInput{confirmed},
+		),
+	}}); err != nil {
+		t.Fatalf("write confirmed Header boundary: %v", err)
+	}
+
+	drift := quotaLifecycleFixedWindow("weekly", "weekly", driftAtMS, durationSeconds, 0)
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-after-confirmation", "codex:quota-windows",
+			driftAtMS, []WindowInput{drift},
+		),
+	}}); err != nil {
+		t.Fatalf("write API drift after confirmation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != confirmedStartMS ||
+		window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != confirmedStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != confirmedEndMS ||
+		window.PreviousCycle == nil || window.PreviousCycle.ScheduledStartMS == nil ||
+		*window.PreviousCycle.ScheduledStartMS != oldStartMS || window.PreviousCycle.ScheduledEndMS == nil ||
+		*window.PreviousCycle.ScheduledEndMS != oldEndMS || window.PreviousCycle.ActualEndMS == nil ||
+		*window.PreviousCycle.ActualEndMS != confirmedStartMS {
+		t.Fatalf("confirmed Codex lifecycle = %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open lifecycle database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount, unassignedProvisionalCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count confirmed lifecycle cycles: %v", err)
+	}
+	if err := db.QueryRow(`select count(*) from account_quota_snapshots
+		where source = 'api_query' and source_observation_id in ('api-provisional', 'api-after-confirmation')
+			and cycle_id is null and boundary_accuracy = 'unknown'`).Scan(&unassignedProvisionalCount); err != nil {
+		t.Fatalf("count unassigned provisional snapshots: %v", err)
+	}
+	if cycleCount != 2 || unassignedProvisionalCount != 2 {
+		t.Fatalf("cycle_count=%d unassigned_provisional_count=%d, want 2 and 2", cycleCount, unassignedProvisionalCount)
+	}
+}
+
+func TestQuotaLifecycleTreatsZeroUseResponseHeaderAsConfirmedCallEvidence(t *testing.T) {
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	oldStartMS := quotaLifecycleBaseMS
+	firstCallAtMS := oldStartMS + 2*quotaLifecycleDayMS
+	service := newQuotaSnapshotTestService(t, firstCallAtMS+quotaLifecycleDayMS)
+	oldCycle := quotaLifecycleFixedWindow("weekly", "weekly", oldStartMS, durationSeconds, 65)
+	writeQuotaLifecycleObservation(t, service, "complete", oldStartMS+quotaLifecycleHourMS, []WindowInput{oldCycle})
+
+	firstCall := quotaLifecycleFixedWindow("weekly", "weekly", firstCallAtMS, durationSeconds, 0)
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"partial", "response_header", "header-zero-first-call", "codex:quota-windows",
+			firstCallAtMS, []WindowInput{firstCall},
+		),
+	}}); err != nil {
+		t.Fatalf("write zero-use Header call evidence: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != firstCallAtMS ||
+		window.CurrentCycle.State != "active" || window.PreviousCycle == nil ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != firstCallAtMS {
+		t.Fatalf("zero-use Header call lifecycle = %#v", window)
+	}
+}
+
+func TestQuotaLifecycleNormalizesStoredProvisionalDriftChainWithoutDeletingRows(t *testing.T) {
+	location := time.FixedZone("UTC+8", 8*60*60)
+	at := func(day, hour, minute int) int64 {
+		return time.Date(2026, time.August, day, hour, minute, 0, 0, location).UnixMilli()
+	}
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	oldStartMS := at(9, 8, 28)
+	oldEndMS := at(16, 8, 28)
+	provisionalStartMS := at(11, 9, 24)
+	confirmedStartMS := at(11, 9, 27)
+	service, path := newQuotaSnapshotTestServiceWithPath(t, at(12, 8, 0))
+	oldCycle := quotaLifecycleFixedWindow("weekly", "weekly", oldStartMS, durationSeconds, 65)
+	writeQuotaLifecycleObservation(t, service, "complete", at(10, 8, 30), []WindowInput{oldCycle})
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy lifecycle database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var activationID, oldCycleID int64
+	if err := db.QueryRow(`select activation_id, id from account_quota_cycles
+		where actual_end_ms is null limit 1`).Scan(&activationID, &oldCycleID); err != nil {
+		t.Fatalf("read active lifecycle IDs: %v", err)
+	}
+	if _, err := db.Exec(`update account_quota_cycles set
+		state = 'closed', actual_end_ms = ?, end_reason = 'early_reset' where id = ?`,
+		provisionalStartMS, oldCycleID); err != nil {
+		t.Fatalf("close original legacy cycle: %v", err)
+	}
+	insertCycle := func(key, state string, startMS int64, endMS *int64, endReason string) int64 {
+		t.Helper()
+		result, insertErr := db.Exec(`insert into account_quota_cycles (
+			activation_id, provider_cycle_key, state, scheduled_start_ms, scheduled_end_ms,
+			actual_start_ms, actual_end_ms, duration_seconds, boundary_accuracy, end_reason,
+			created_at_ms, updated_at_ms
+		) values (?, ?, ?, ?, ?, ?, ?, ?, 'exact', ?, ?, ?)`,
+			activationID, key, state, startMS, startMS+durationSeconds*1000,
+			startMS, endMS, durationSeconds, endReason, startMS, startMS,
+		)
+		if insertErr != nil {
+			t.Fatalf("insert legacy cycle %s: %v", key, insertErr)
+		}
+		id, insertErr := result.LastInsertId()
+		if insertErr != nil {
+			t.Fatalf("read legacy cycle %s ID: %v", key, insertErr)
+		}
+		return id
+	}
+	provisionalEndMS := confirmedStartMS
+	confirmedCycleID := insertCycle("legacy-confirmed", "closed", provisionalStartMS, &provisionalEndMS, "early_reset")
+	provisionalCycleID := insertCycle("legacy-provisional", "active", confirmedStartMS, nil, "")
+
+	insertSnapshot := func(cycleID int64, source, sourceID string, observedAtMS, startMS int64, usedPercent float64) {
+		t.Helper()
+		_, insertErr := db.Exec(`insert into account_quota_snapshots (
+			logical_window_id, activation_id, cycle_id, account_key, provider,
+			provider_window_id, window_kind, window_mode, model_scope_kind,
+			scope_fingerprint, content_hash, source, source_observation_id,
+			observed_at_ms, boundary_accuracy, cycle_start_ms, cycle_end_ms,
+			duration_seconds, used_percent, created_at_ms
+		) select logical_window_id, activation_id, ?, account_key, provider,
+			provider_window_id, window_kind, window_mode, model_scope_kind,
+			scope_fingerprint, ?, ?, ?, ?, 'exact', ?, ?, ?, ?, ?
+			from account_quota_snapshots where cycle_id = ? limit 1`,
+			cycleID, sourceID, source, sourceID, observedAtMS,
+			startMS, startMS+durationSeconds*1000, durationSeconds, usedPercent, observedAtMS,
+			oldCycleID,
+		)
+		if insertErr != nil {
+			t.Fatalf("insert legacy snapshot %s: %v", sourceID, insertErr)
+		}
+	}
+	insertSnapshot(confirmedCycleID, "response_header", "legacy-header-0924", provisionalStartMS, provisionalStartMS, 0)
+	insertSnapshot(provisionalCycleID, "api_query", "legacy-api-0927", confirmedStartMS, confirmedStartMS, 0)
+	child := quotaLifecycleFixedWindow("five-hour", "five_hour", confirmedStartMS, 5*60*60, 0)
+	child.RelationshipKind = "concurrent_subwindow"
+	child.ContainerWindowID = "weekly"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"partial", "response_header", "legacy-child-header", "codex:quota-windows",
+			at(11, 9, 28), []WindowInput{child},
+		),
+	}}); err != nil {
+		t.Fatalf("write legacy child cycle: %v", err)
+	}
+	var storedParentCycleID int64
+	if err := db.QueryRow(`select c.parent_cycle_id
+		from account_quota_cycles c
+		join account_quota_window_activations a on a.id = c.activation_id
+		join account_quota_windows w on w.id = a.window_id
+		where w.provider_window_id = 'five-hour' and c.actual_end_ms is null`).Scan(&storedParentCycleID); err != nil {
+		t.Fatalf("read stored legacy child parent: %v", err)
+	}
+	if storedParentCycleID != provisionalCycleID {
+		t.Fatalf("stored child parent cycle = %d, want provisional cycle %d", storedParentCycleID, provisionalCycleID)
+	}
+
+	windows := queryQuotaLifecycleWindows(t, service, false)
+	window := windows["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != provisionalStartMS ||
+		window.CurrentCycle.ID != confirmedCycleID || window.CurrentCycle.State != "active" ||
+		window.CurrentCycle.ScheduledStartMS == nil ||
+		*window.CurrentCycle.ScheduledStartMS != provisionalStartMS ||
+		window.PreviousCycle == nil || window.PreviousCycle.ID != oldCycleID ||
+		window.PreviousCycle.ScheduledStartMS == nil || *window.PreviousCycle.ScheduledStartMS != oldStartMS ||
+		window.PreviousCycle.ScheduledEndMS == nil || *window.PreviousCycle.ScheduledEndMS != oldEndMS ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != provisionalStartMS {
+		t.Fatalf("normalized legacy lifecycle = %#v", window)
+	}
+	childWindow := windows["five-hour"]
+	if childWindow.CurrentCycle == nil || childWindow.CurrentCycle.ParentCycleID == nil ||
+		*childWindow.CurrentCycle.ParentCycleID != window.CurrentCycle.ID {
+		t.Fatalf("normalized child parent cycle: child=%#v weekly=%#v", childWindow, window)
+	}
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles where activation_id = ?`, activationID).Scan(&cycleCount); err != nil {
+		t.Fatalf("count stored legacy cycles: %v", err)
+	}
+	if cycleCount != 3 {
+		t.Fatalf("stored legacy cycle count = %d, want 3", cycleCount)
+	}
+}
+
 func TestQuotaLifecycleRequiresConfirmedAbsenceAndReopensNewGeneration(t *testing.T) {
 	service := newQuotaSnapshotTestService(t, quotaLifecycleBaseMS+2*quotaLifecycleDayMS)
 	weekly := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, 7*24*60*60, 10)

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -4851,6 +4851,63 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaFetch).not.toHaveBeenCalled();
   });
 
+  it('reloads lifecycle and window usage after detail quota refresh without loading history', async () => {
+    const file = makeCodexFile('codex-refresh.json', 'auth-refresh', 'refresh@example.com');
+    mocks.files = [file];
+    mocks.location = {
+      pathname: '/accounts',
+      search: '?account=codex-refresh.json%00auth-refresh&tab=quota',
+    };
+    mocks.panelFeatureAvailability = {
+      checking: false,
+      managerServiceBase: 'http://manager.local:18317',
+      requestMonitoringAvailable: true,
+      serverCodexInspectionAvailable: false,
+    };
+    const resetAtMs = Date.now() + 5 * 60 * 60 * 1000;
+    mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(file, {
+      status: 'success',
+      quotaInventoryObserved: true,
+      fetchedAtMs: Date.now(),
+      windows: [
+        {
+          id: 'five-hour',
+          label: 'Five hours',
+          usedPercent: 10,
+          resetAtMs,
+          resetLabel: new Date(resetAtMs).toISOString(),
+          resetAccuracy: 'exact',
+          limitWindowSeconds: 5 * 60 * 60,
+        },
+      ],
+    });
+    const quotaFetch = vi.spyOn(CODEX_CONFIG, 'fetchQuota').mockResolvedValue(makeCodexQuotaData());
+
+    const renderer = await renderAccountsPage();
+    await flushPromises();
+    await flushPromises();
+    expect(accountQuotaSnapshotApi.query).toHaveBeenCalledTimes(1);
+    expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(1);
+    mocks.getAccountHistory.mockClear();
+
+    await act(async () => {
+      const detailRefreshButton = renderer.root
+        .findByType(Drawer)
+        .findAllByType(Button)
+        .find((node) => readText(node.props.children).includes('accounts.refresh_quota'));
+      if (!detailRefreshButton) throw new Error('Detail quota refresh button not found');
+      detailRefreshButton.props.onClick();
+      await Promise.resolve();
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(quotaFetch).toHaveBeenCalledTimes(1);
+    expect(accountQuotaSnapshotApi.query).toHaveBeenCalledTimes(2);
+    expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(2);
+    expect(mocks.getAccountHistory).not.toHaveBeenCalled();
+  });
+
   it('loads history for a deep-linked credential outside the visible page', async () => {
     mocks.files = Array.from({ length: 11 }, (_, index) =>
       makeCodexFile(

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -464,6 +464,7 @@ export function AccountsPage() {
   const [quotaRefreshing, setQuotaRefreshing] = useState(false);
   const [historyRefreshing, setHistoryRefreshing] = useState(false);
   const [accountHistoryRefreshRevision, setAccountHistoryRefreshRevision] = useState(0);
+  const [accountQuotaRefreshRevision, setAccountQuotaRefreshRevision] = useState(0);
   const [statusUpdating, setStatusUpdating] = useState(false);
   const [selectedRowKey, setSelectedRowKey] = useState<string | null>(
     () => initialWorkspaceUrlState.current.account
@@ -1690,9 +1691,11 @@ export function AccountsPage() {
         selectedRowKey: selectedRow?.selectionKey ?? selectedRowKey,
         selectedHeaderSnapshotRevision,
         historyRevision: accountHistoryRefreshRevision,
+        quotaRevision: accountQuotaRefreshRevision,
       }),
     [
       accountHistoryRefreshRevision,
+      accountQuotaRefreshRevision,
       featureAvailability.checking,
       featureAvailability.managerServiceBase,
       featureAvailability.requestMonitoringAvailable,
@@ -2713,7 +2716,12 @@ export function AccountsPage() {
   );
 
   const refreshAccountQuota = useCallback(
-    (row: AccountRow) => refreshQuotaRows([row]),
+    async (row: AccountRow): Promise<void> => {
+      await refreshQuotaRows([row]);
+      if (selectedRowKeyRef.current === row.selectionKey) {
+        setAccountQuotaRefreshRevision((current) => current + 1);
+      }
+    },
     [refreshQuotaRows]
   );
 

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
@@ -128,8 +128,7 @@ describe('QuotaWindowCard', () => {
     const renderer = renderCard(makeWindow());
     const current = renderer.root.findByProps({ 'data-quota-usage-period': 'current' });
     const icons = current.findAll(
-      (node) =>
-        typeof node.props.className === 'string' && node.props.className.includes('rowIcon')
+      (node) => typeof node.props.className === 'string' && node.props.className.includes('rowIcon')
     );
 
     expect(icons).toHaveLength(4);
@@ -147,8 +146,7 @@ describe('QuotaWindowCard', () => {
     )[0];
     if (!forecast) throw new Error('forecast column not found');
     const forecastIcons = forecast.findAll(
-      (node) =>
-        typeof node.props.className === 'string' && node.props.className.includes('rowIcon')
+      (node) => typeof node.props.className === 'string' && node.props.className.includes('rowIcon')
     );
     expect(forecastIcons.map((node) => node.props.className)).toEqual([
       expect.stringContaining('rowIconBlue'),
@@ -175,6 +173,42 @@ describe('QuotaWindowCard', () => {
 
       expect(currentText).toContain(formatDisplayRange(cycleStartMs, cycleEndMs));
       expect(currentText).not.toContain(formatDisplayRange(cycleStartMs, dataEndMs));
+    }
+  });
+
+  it('shows scheduled previous-cycle bounds while retaining actual usage bounds', () => {
+    const scheduledStartMs = Date.parse('2026-08-09T00:28:00Z');
+    const scheduledEndMs = Date.parse('2026-08-16T00:28:00Z');
+    const actualEndMs = Date.parse('2026-08-11T00:00:00Z');
+    const window = makeWindow({
+      previousCycle: {
+        id: 1,
+        activationId: 1,
+        state: 'closed',
+        scheduledStartMs,
+        scheduledEndMs,
+        actualStartMs: scheduledStartMs,
+        actualEndMs,
+        durationSeconds: 7 * 24 * 60 * 60,
+        boundaryAccuracy: 'exact',
+        endReason: 'early_reset',
+        parentCycleId: null,
+        forecastEligible: false,
+      },
+      previousUsage: usage({ fromMs: scheduledStartMs, toMs: actualEndMs }),
+    });
+
+    for (const mode of ['standard', 'model'] as const) {
+      const renderer = renderCard(window, mode);
+      const previous = renderer.root.findByProps({ 'data-quota-usage-period': 'previous' });
+      const previousText = readText(previous);
+
+      expect(previousText).toContain(formatDisplayRange(scheduledStartMs, scheduledEndMs));
+      expect(previousText).not.toContain(formatDisplayRange(scheduledStartMs, actualEndMs));
+      expect(window.previousUsage).toMatchObject({
+        fromMs: scheduledStartMs,
+        toMs: actualEndMs,
+      });
     }
   });
 

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
@@ -102,6 +102,26 @@ const formatCurrentWindowRange = (
   return formatRange(usage?.fromMs, usage?.toMs, locale);
 };
 
+const formatPreviousWindowRange = (
+  window: AccountDetailQuotaWindow,
+  usage: AccountDetailWindowUsageSummary | null | undefined,
+  locale: string
+): string => {
+  const scheduledStartMs = window.previousCycle?.scheduledStartMs;
+  const scheduledEndMs = window.previousCycle?.scheduledEndMs;
+  if (
+    (window.windowMode === 'fixed' || window.windowMode === 'calendar') &&
+    typeof scheduledStartMs === 'number' &&
+    Number.isFinite(scheduledStartMs) &&
+    typeof scheduledEndMs === 'number' &&
+    Number.isFinite(scheduledEndMs) &&
+    scheduledStartMs < scheduledEndMs
+  ) {
+    return formatRange(scheduledStartMs, scheduledEndMs, locale);
+  }
+  return formatRange(usage?.fromMs, usage?.toMs, locale);
+};
+
 const formatObservedAt = (value: number, locale: string): string =>
   new Intl.DateTimeFormat(locale, {
     month: '2-digit',
@@ -622,7 +642,7 @@ export const QuotaWindowCard = ({
                   ? t('accounts.detail_previous_equal_range', { defaultValue: '前一等长区间' })
                   : t('accounts.detail_previous_usage', { defaultValue: '上个窗口用量' })
               }
-              subtitle={formatRange(previousUsage?.fromMs, previousUsage?.toMs, resolvedLocale)}
+              subtitle={formatPreviousWindowRange(q, previousUsage, resolvedLocale)}
               period="previous"
               usage={previousUsage}
               labels={usageLabels}
@@ -677,7 +697,7 @@ export const QuotaWindowCard = ({
               ? t('accounts.detail_previous_equal_range', { defaultValue: '前一等长区间' })
               : t('accounts.detail_previous_usage', { defaultValue: '上个窗口用量' })
           }
-          subtitle={formatRange(previousUsage?.fromMs, previousUsage?.toMs, resolvedLocale)}
+          subtitle={formatPreviousWindowRange(q, previousUsage, resolvedLocale)}
           period="previous"
           usage={previousUsage}
           labels={usageLabels}


### PR DESCRIPTION
## Summary

Fix quota-cycle activation and previous-window visibility when a provider resets before the scheduled cycle end. Confirmed boundaries now preserve canonical lifecycle evidence, and manual quota refreshes update the account detail view.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Treat confirmed fixed/calendar/API boundaries consistently, while keeping provisional zero-use Codex responses from establishing lifecycle state.
- Normalize early-reset fragments and parent-cycle aliases so usage remains attributable to the canonical quota cycle.
- Add a SQLite cycle-evidence index and refresh account quota details after manual quota refreshes.
- Render scheduled bounds for previous fixed/calendar cycles while retaining actual observed usage query bounds.

## User Impact

Previous-cycle usage remains visible after an early provider reset, including after quota and history refreshes. Displayed cycle labels use the provider's scheduled interval without changing the actual usage aggregation interval.

## Compatibility / Runtime Notes

- CPA panel mode: Uses the same corrected quota lifecycle and detail rendering; no authentication or configuration contract changes.
- Manager Server mode: Applies lifecycle normalization and the additive SQLite index migration.
- Full Docker / native packages: Full Docker uses the same embedded panel behavior; native package contents and runtime configuration are unchanged.

## Data / Security Notes

The SQLite change adds a non-destructive lookup index only. No credential, admin-key, raw usage payload, or external data contract is changed.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert the PR commits if necessary. The added SQLite index is additive and harmless if retained while running a previous application version.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
go test ./internal/service/quotasnapshot ./internal/repository/sqlite
go test ./...
npm run manager-server:test
Frontend and repository tests: 1959/1959
Focused Accounts tests: 142/142
npm run type-check
npm run lint
Prettier check, gofmt -d, and git diff --check
```

## Screenshots / Recordings

N/A — no browser recording was captured; visible behavior is covered by component regression tests.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

This is a correctness fix with no new setup, configuration, or API capability.

## Related

N/A
