### PR TITLE
🐛 fix(accounts): restore quota usage after drawer reopen

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -4944,7 +4944,7 @@ describe('AccountsPage replacement flows', () => {
     expect(request.accounts).toContainEqual(expect.objectContaining({ row_key: targetKey }));
   });
 
-  it('keeps rolling window usage visible across snapshot rerenders and history refreshes', async () => {
+  it('keeps rolling window usage visible across refreshes and detail drawer reopen', async () => {
     let currentTimeMs = 2_000_000_000_000;
     vi.spyOn(Date, 'now').mockImplementation(() => {
       currentTimeMs += 1_000;
@@ -5000,8 +5000,9 @@ describe('AccountsPage replacement flows', () => {
     let usageRequestCount = 0;
     mocks.getAccountWindowUsage.mockImplementation(async (_base, _managementKey, request) => {
       usageRequestCount += 1;
-      const totalRequests = usageRequestCount === 1 ? 4 : 5;
-      const totalTokens = usageRequestCount === 1 ? 9_939 : 12_460;
+      const totalRequests = usageRequestCount === 1 ? 4 : usageRequestCount === 2 ? 5 : 6;
+      const totalTokens =
+        usageRequestCount === 1 ? 9_939 : usageRequestCount === 2 ? 12_460 : 14_981;
       const windows = request.windows as Array<{
         request_key: string;
         row_key: string;
@@ -5083,6 +5084,45 @@ describe('AccountsPage replacement flows', () => {
       toMs: refreshedCurrentTarget?.to_ms,
       totalRequests: 5,
       totalTokens: 12_460,
+    });
+
+    await act(async () => {
+      renderer.root.findByType(Drawer).props.onClose();
+    });
+    await flushPromises();
+
+    expect(renderer.root.findAllByType(AccountQuotaTab)).toHaveLength(0);
+
+    await act(async () => {
+      findDetailButtonByName(renderer, 'xai-ops.json').props.onClick();
+    });
+    await flushPromises();
+    await act(async () => {
+      findHostButtonByText(renderer, 'accounts.detail_tab_quota').props.onClick();
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(3);
+    const reopenedWindowUsageRequest = mocks.getAccountWindowUsage.mock.calls[2]?.[2] as
+      | AccountWindowUsageRequestForTest
+      | undefined;
+    const reopenedCurrentTarget = (
+      reopenedWindowUsageRequest?.windows as Array<{
+        period: string;
+        from_ms: number;
+        to_ms: number;
+      }>
+    ).find((window) => window.period === 'current');
+    expect(reopenedCurrentTarget?.from_ms).toBeGreaterThan(refreshedCurrentTarget?.from_ms ?? 0);
+    expect(reopenedCurrentTarget?.to_ms).toBeGreaterThan(refreshedCurrentTarget?.to_ms ?? 0);
+    expect(
+      renderer.root.findByType(AccountQuotaTab).props.detailView.quota.windows[0].currentUsage
+    ).toMatchObject({
+      fromMs: reopenedCurrentTarget?.from_ms,
+      toMs: reopenedCurrentTarget?.to_ms,
+      totalRequests: 6,
+      totalTokens: 14_981,
     });
   });
 

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -2119,6 +2119,7 @@ export function AccountsPage() {
     setHistoryRefreshing(false);
     usageValuesRequestIdRef.current += 1;
     usageValuesAutoLoadKeyRef.current = null;
+    accountWindowUsageAutoLoadKeyRef.current = null;
     setAccountWindowUsageQueryContext(null);
     detailEventsRequestIdRef.current += 1;
     detailEventsAutoLoadKeyRef.current = null;


### PR DESCRIPTION
## Summary

Fix quota usage disappearing after closing and reopening the same credential detail drawer.

The fix invalidates the completed quota-window auto-load key when the selected credential changes, allowing the reopened drawer to fetch a fresh query context.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Clear the quota-window auto-load deduplication key with the existing selected-credential lifecycle invalidation.
- Add regression coverage for closing and reopening the same credential detail drawer.
- Preserve strict rolling-window bounds and avoid provider quota refreshes.

## User Impact

Quota usage remains visible when a credential detail drawer is closed and reopened during the same Accounts page session.

## Compatibility / Runtime Notes

- CPA panel mode: No protocol or runtime change.
- Manager Server mode: Uses the existing account-window-usage request path; no backend change.
- Full Docker / native packages: No packaging or deployment change.

## Data / Security Notes

N/A. No database, credential, admin key, raw usage data, or security contract changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit eb7d9b3e. The change is isolated to AccountsPage lifecycle invalidation and its regression test.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/features/accounts/AccountsPage.test.tsx
  124/124 tests passed

npm run type-check
  passed

npm run lint
  0 errors; one pre-existing react-refresh warning in AccountHealthBadge.tsx

npm run test
  184 test files, 1959 tests passed

npm --workspace apps/web exec prettier -- --check src/features/accounts/AccountsPage.tsx src/features/accounts/AccountsPage.test.tsx
  passed

git diff --check
  passed
```

The repository PR workflow will run the frontend build and applicable CI checks.

## Screenshots / Recordings

N/A — no layout or visual styling changed; the regression is covered by the automated drawer lifecycle test.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a localized Accounts state-lifecycle bug fix and does not change documented behavior or configuration.

## Related

N/A