### PR TITLE
🐛 fix(auth-files): resolve stale reauth candidates after re-authentication

### DIFF
--- a/apps/manager-server/internal/http/controller/accountaction/handler.go
+++ b/apps/manager-server/internal/http/controller/accountaction/handler.go
@@ -1,6 +1,7 @@
 package accountaction
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -24,6 +25,11 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimRight(r.URL.Path, "/")
 	if path == "/v0/management/account-action-candidates" {
 		h.handleList(w, r)
+		return
+	}
+
+	if path == "/v0/management/account-action-candidates/resolve-reauth-by-auth-file" {
+		h.handleResolveReauthByAuthFile(w, r)
 		return
 	}
 
@@ -94,6 +100,30 @@ func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response.JSON(w, http.StatusOK, result)
+}
+
+func (h *Handler) handleResolveReauthByAuthFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.MethodNotAllowed(w)
+		return
+	}
+	var body struct {
+		FileName string `json:"fileName"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.Error(w, http.StatusBadRequest, errors.New("invalid body"))
+		return
+	}
+	if strings.TrimSpace(body.FileName) == "" {
+		response.Error(w, http.StatusBadRequest, errors.New("auth file name is required"))
+		return
+	}
+	resolved, err := h.App.AccountActionService.ResolveReauthByAuthFileName(r.Context(), body.FileName)
+	if err != nil {
+		response.Error(w, http.StatusInternalServerError, err)
+		return
+	}
+	response.JSON(w, http.StatusOK, map[string]any{"resolved": resolved})
 }
 
 func (h *Handler) writeCandidateResult(w http.ResponseWriter, item any, err error) {

--- a/apps/manager-server/internal/repository/accountaction/repository.go
+++ b/apps/manager-server/internal/repository/accountaction/repository.go
@@ -19,6 +19,7 @@ type Repository interface {
 	Get(ctx context.Context, id int64) (model.AccountActionCandidate, bool, error)
 	UpdateStatus(ctx context.Context, id int64, status string) (model.AccountActionCandidate, error)
 	UpdatePendingStatus(ctx context.Context, id int64, status string) (model.AccountActionCandidate, error)
+	ResolvePendingReauthByAuthFileName(ctx context.Context, authFileName string) (int64, error)
 	RecordFailure(ctx context.Context, id int64, reason string) error
 	MarkAutoDisabled(ctx context.Context, id int64, disabledAtMS int64) error
 }
@@ -329,6 +330,21 @@ func (r *repository) updateStatus(ctx context.Context, id int64, status string, 
 		return model.AccountActionCandidate{}, sql.ErrNoRows
 	}
 	return r.mustGet(ctx, id)
+}
+
+func (r *repository) ResolvePendingReauthByAuthFileName(ctx context.Context, authFileName string) (int64, error) {
+	authFileName = strings.TrimSpace(authFileName)
+	if authFileName == "" {
+		return 0, errors.New("auth file name is required")
+	}
+	res, err := r.db.ExecContext(ctx, `update account_action_candidates set status = ?, last_error = null, updated_at_ms = ?
+		where status = ? and action_type = ? and auth_file_name = ?`,
+		model.AccountActionStatusResolved, time.Now().UnixMilli(),
+		model.AccountActionStatusPending, model.AccountActionTypeReauth, authFileName)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 func (r *repository) RecordFailure(ctx context.Context, id int64, reason string) error {

--- a/apps/manager-server/internal/repository/accountaction/repository_test.go
+++ b/apps/manager-server/internal/repository/accountaction/repository_test.go
@@ -283,3 +283,68 @@ func TestUpsertUpgradesFallbackIdentityWhenStableLocatorAppears(t *testing.T) {
 		t.Fatalf("upgraded candidate = %#v, first = %#v", upgraded, first)
 	}
 }
+
+func TestResolvePendingReauthByAuthFileName(t *testing.T) {
+	ctx := context.Background()
+	st := testutil.NewStore(t, testutil.NewConfig(t))
+	repo := st.AccountActions
+
+	upsert := func(actionType, fileName, reasonCode string) model.AccountActionCandidate {
+		t.Helper()
+		item, err := repo.Upsert(ctx, model.AccountActionCandidateUpsert{
+			ActionType:   actionType,
+			Provider:     "codex",
+			AuthFileName: fileName,
+			ReasonCode:   reasonCode,
+			Reason:       "test",
+			SeenAtMS:     1000,
+		})
+		if err != nil {
+			t.Fatalf("upsert %s/%s: %v", actionType, fileName, err)
+		}
+		return item
+	}
+
+	targetA := upsert(model.AccountActionTypeReauth, "codex-a.json", "token_revoked")
+	targetB := upsert(model.AccountActionTypeReauth, "codex-a.json", "auth_expired")
+	otherFile := upsert(model.AccountActionTypeReauth, "codex-b.json", "token_revoked")
+	otherAction := upsert(model.AccountActionTypeReview, "codex-a.json", "rate_limited")
+
+	resolved, err := repo.ResolvePendingReauthByAuthFileName(ctx, "codex-a.json")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resolved != 2 {
+		t.Fatalf("resolved = %d, want 2", resolved)
+	}
+
+	for _, item := range []model.AccountActionCandidate{targetA, targetB} {
+		current, ok, err := repo.Get(ctx, item.ID)
+		if err != nil || !ok {
+			t.Fatalf("get candidate %d: ok=%v err=%v", item.ID, ok, err)
+		}
+		if current.Status != model.AccountActionStatusResolved {
+			t.Fatalf("candidate %d status = %q, want resolved", item.ID, current.Status)
+		}
+	}
+	otherFileCurrent, ok, err := repo.Get(ctx, otherFile.ID)
+	if err != nil || !ok || otherFileCurrent.Status != model.AccountActionStatusPending {
+		t.Fatalf("other file candidate = %#v ok=%v err=%v, want still pending", otherFileCurrent, ok, err)
+	}
+	otherActionCurrent, ok, err := repo.Get(ctx, otherAction.ID)
+	if err != nil || !ok || otherActionCurrent.Status != model.AccountActionStatusPending {
+		t.Fatalf("other action candidate = %#v ok=%v err=%v, want still pending", otherActionCurrent, ok, err)
+	}
+
+	again, err := repo.ResolvePendingReauthByAuthFileName(ctx, "codex-a.json")
+	if err != nil {
+		t.Fatalf("resolve again: %v", err)
+	}
+	if again != 0 {
+		t.Fatalf("second resolve affected = %d, want 0", again)
+	}
+
+	if _, err := repo.ResolvePendingReauthByAuthFileName(ctx, "  "); err == nil {
+		t.Fatal("empty auth file name should error")
+	}
+}

--- a/apps/manager-server/internal/service/accountaction/service.go
+++ b/apps/manager-server/internal/service/accountaction/service.go
@@ -91,6 +91,12 @@ func (s *Service) Resolve(ctx context.Context, id int64) (model.AccountActionCan
 	return s.updatePendingStatus(ctx, id, model.AccountActionStatusResolved)
 }
 
+// ResolveReauthByAuthFileName marks all pending reauth candidates for an auth
+// file as resolved, e.g. after the user re-authenticates that credential.
+func (s *Service) ResolveReauthByAuthFileName(ctx context.Context, authFileName string) (int64, error) {
+	return s.store.ResolvePendingReauthAccountActionCandidatesByAuthFileName(ctx, strings.TrimSpace(authFileName))
+}
+
 func (s *Service) Enable(ctx context.Context, id int64) (model.AccountActionCandidate, error) {
 	unlock := s.lockCandidateAction(id)
 	defer unlock()

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -289,6 +289,10 @@ func (s *Store) UpdatePendingAccountActionCandidateStatus(ctx context.Context, i
 	return s.AccountActions.UpdatePendingStatus(ctx, id, status)
 }
 
+func (s *Store) ResolvePendingReauthAccountActionCandidatesByAuthFileName(ctx context.Context, authFileName string) (int64, error) {
+	return s.AccountActions.ResolvePendingReauthByAuthFileName(ctx, authFileName)
+}
+
 func (s *Store) RecordAccountActionCandidateFailure(ctx context.Context, id int64, reason string) error {
 	return s.AccountActions.RecordFailure(ctx, id, reason)
 }

--- a/apps/web/src/features/authFiles/AuthFilesPage.tsx
+++ b/apps/web/src/features/authFiles/AuthFilesPage.tsx
@@ -1359,6 +1359,19 @@ export function AuthFilesPage() {
     await loadCodexInspectionSnapshots();
     if (!target?.fileName) return;
 
+    if (managerServiceBase) {
+      try {
+        await usageServiceApi.resolveAccountActionCandidatesByAuthFile(
+          managerServiceBase,
+          managementKey,
+          target.fileName
+        );
+      } catch {
+        // Best-effort cleanup; the 60s candidate poll stays as a fallback.
+      }
+      await loadAccountActionCandidates();
+    }
+
     const targetKey = getAuthFileCodexInspectionKeyForIdentity({
       fileName: target.fileName,
       runtimeId: target.runtimeId,
@@ -1373,7 +1386,14 @@ export function AuthFilesPage() {
         return itemKey !== targetKey || !isStaleCodexReauthSnapshot(item);
       })
     );
-  }, [codexReauthTarget, loadCodexInspectionSnapshots, loadFiles]);
+  }, [
+    codexReauthTarget,
+    loadAccountActionCandidates,
+    loadCodexInspectionSnapshots,
+    loadFiles,
+    managementKey,
+    managerServiceBase,
+  ]);
 
   const openExcludedEditor = useCallback(
     (provider?: string) => {

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -3046,6 +3046,31 @@ export const usageServiceApi = {
     });
   },
 
+  resolveAccountActionCandidatesByAuthFile: async (
+    base: string,
+    managementKey: string | undefined,
+    fileName: string
+  ): Promise<{ resolved: number }> => {
+    if (__DEMO_SITE__ && isDemoMode()) {
+      return { resolved: 0 };
+    }
+
+    return withUsageServiceError(async () => {
+      const response = await axios.post<{ resolved: number }>(
+        buildUrl(
+          base,
+          '/v0/management/account-action-candidates/resolve-reauth-by-auth-file'
+        ),
+        { fileName },
+        {
+          timeout: USAGE_SERVICE_TIMEOUT_MS,
+          headers: authHeaders(managementKey),
+        }
+      );
+      return response.data;
+    });
+  },
+
   enableAccountActionCandidate: async (
     base: string,
     managementKey: string | undefined,


### PR DESCRIPTION
## 背景

Closes #479

手动删除并重新 OAuth 认证后，账号已恢复可用，但认证文件页仍显示黄色【需重新登录】标签且永不消失。

## 根因

`account_action_candidates` 表中的 pending `reauth` 候选由认证失败事件 upsert 产生（`worker/account_action_candidate.go`），但**重新认证成功后没有任何机制清理该候选**。前端按 `authFileKey` + `fileName` 匹配候选渲染黄标，且 60s 轮询（`AuthFilesPage.tsx`）持续拉回该旧记录，导致黄标永不消失。

## 修复

1. **后端**：新增按 auth file 名称批量 resolve pending reauth 候选的能力
   - `repository/accountaction`：`ResolvePendingReauthByAuthFileName`（仅影响 `status=pending AND action_type=reauth` 的候选）
   - `service/accountaction`：`ResolveReauthByAuthFileName`
   - 新端点 `POST /v0/management/account-action-candidates/resolve-reauth-by-auth-file`（body: `{"fileName": "..."}`）
2. **前端**：`handleCodexReauthSuccess`（Codex 重新认证成功回调）中调用该 API 并刷新候选列表，黄标随即消失

## 测试

- 后端：`go test ./internal/repository/accountaction/ ./internal/service/accountaction/ ./internal/store/` 全部通过；新增 `TestResolvePendingReauthByAuthFileName` 覆盖同文件多候选、不同文件、不同 actionType、重复调用、空文件名
- 前端：`npm run type-check`、`npm run lint` 通过（无新增告警）；`npm test` 184 个文件 / 1957 个用例全部通过

## 已知局限

xAI 走 `/oauth` 页面重新登录：OAuth 状态接口不返回对应 auth file 名称，前端无法精确关联；且 xAI 重新登录通常会生成新文件名、旧候选自然失效，故本次未覆盖该路径。如需要，可后续在巡检（inspection）检测到认证恢复时自动清理，作为独立改进。
