### PR TITLE
🐛 fix(accounts): harden quota lifecycle rollover and loading

### DIFF
--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -861,6 +861,21 @@ func reconcileCycle(
 		}
 		return active.ID, 0, false, nil
 	}
+	if activeErr == nil && isReliableLifecycleBoundary(*snapshot) && active.ScheduledEndMS != nil &&
+		*snapshot.CycleStartMS >= *active.ScheduledEndMS {
+		actualEndMS := *active.ScheduledEndMS
+		if actualEndMS < active.ActualStartMS {
+			actualEndMS = active.ActualStartMS
+		}
+		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
+			state = 'closed', actual_end_ms = ?, end_reason = 'scheduled',
+			last_observation_id = ?, updated_at_ms = ? where id = ?`,
+			actualEndMS, observationID, snapshot.CreatedAtMS, active.ID); err != nil {
+			return 0, 0, false, err
+		}
+		id, err := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
+		return id, active.ID, false, err
+	}
 	if isProvisionalZeroAPIBoundary(*snapshot) {
 		// A zero-use Codex API response whose calculated start follows the query
 		// time is not proof that a provider cycle has started. Keep the evidence,
@@ -875,20 +890,6 @@ func reconcileCycle(
 		return id, 0, false, restoreErr
 	}
 	cycleMatches := cycleMatchesSnapshot(active, *snapshot)
-	if active.ScheduledEndMS != nil && *snapshot.CycleStartMS >= *active.ScheduledEndMS {
-		actualEndMS := *active.ScheduledEndMS
-		if actualEndMS < active.ActualStartMS {
-			actualEndMS = active.ActualStartMS
-		}
-		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
-			state = 'closed', actual_end_ms = ?, end_reason = 'scheduled',
-			last_observation_id = ?, updated_at_ms = ? where id = ?`,
-			actualEndMS, observationID, snapshot.CreatedAtMS, active.ID); err != nil {
-			return 0, 0, false, err
-		}
-		id, err := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
-		return id, active.ID, false, err
-	}
 	if isConfirmedLifecycleBoundary(*snapshot) {
 		counterReset, err := quotaCounterResetDetected(ctx, tx, active, *snapshot)
 		if err != nil {
@@ -965,8 +966,11 @@ func reconcileCycle(
 }
 
 func isConfirmedLifecycleBoundary(snapshot model.AccountQuotaSnapshot) bool {
-	return !isProvisionalZeroAPIBoundary(snapshot) &&
-		(snapshot.Source == "response_header" || snapshot.Source == "api_query" || snapshot.Source == "inspection") &&
+	return isReliableLifecycleBoundary(snapshot) && !isProvisionalZeroAPIBoundary(snapshot)
+}
+
+func isReliableLifecycleBoundary(snapshot model.AccountQuotaSnapshot) bool {
+	return (snapshot.Source == "response_header" || snapshot.Source == "api_query" || snapshot.Source == "inspection") &&
 		(snapshot.WindowMode == "fixed" || snapshot.WindowMode == "calendar") &&
 		(snapshot.BoundaryAccuracy == "exact" || snapshot.BoundaryAccuracy == "derived") &&
 		snapshot.CycleStartMS != nil && snapshot.CycleEndMS != nil && snapshot.DurationSeconds != nil
@@ -1800,7 +1804,7 @@ func normalizeCycleView(
 }
 
 func cycleHasOnlyProvisionalZeroAPIBoundaries(ctx context.Context, db *sql.DB, cycleID int64) (bool, error) {
-	var hasSnapshots, hasNonProvisional int
+	var hasSnapshots, hasNonProvisional, hasScheduledPredecessor int
 	err := db.QueryRowContext(ctx, `select
 		exists(select 1 from account_quota_snapshots where cycle_id = ? limit 1),
 		exists(select 1 from account_quota_snapshots where cycle_id = ? and coalesce((
@@ -1809,15 +1813,26 @@ func cycleHasOnlyProvisionalZeroAPIBoundaries(ctx context.Context, db *sql.DB, c
 			and cycle_start_ms is not null and cycle_end_ms is not null
 			and duration_seconds is not null
 			and abs(cycle_start_ms - observed_at_ms) <= ?
-		), 0) = 0 limit 1)`,
+		), 0) = 0 limit 1),
+		exists(select 1
+			from account_quota_cycles current
+			join account_quota_cycles previous
+				on previous.activation_id = current.activation_id
+				and previous.actual_start_ms < current.actual_start_ms
+			where current.id = ? and previous.end_reason = 'scheduled'
+				and previous.actual_end_ms is not null
+				and abs(previous.actual_end_ms - current.actual_start_ms) <= ?
+			limit 1)`,
 		cycleID,
 		cycleID,
 		quotaProvisionalStartJitterMS,
-	).Scan(&hasSnapshots, &hasNonProvisional)
+		cycleID,
+		quotaBoundaryJitterMS,
+	).Scan(&hasSnapshots, &hasNonProvisional, &hasScheduledPredecessor)
 	if err != nil {
 		return false, err
 	}
-	return hasSnapshots != 0 && hasNonProvisional == 0, nil
+	return hasSnapshots != 0 && hasNonProvisional == 0 && hasScheduledPredecessor == 0, nil
 }
 
 func loadQuotaCycleEvidence(ctx context.Context, db *sql.DB, cycleID int64) (quotaCycleEvidence, error) {

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3026,6 +3026,51 @@ func TestQuotaLifecycleScheduledPreviousCycleRemainsForecastEligible(t *testing.
 	}
 }
 
+func TestQuotaLifecycleAcceptsZeroUseAPIBoundaryAtScheduledRollover(t *testing.T) {
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	rolloverAtMS := quotaLifecycleBaseMS + durationSeconds*1000
+	service := newQuotaSnapshotTestService(t, rolloverAtMS+quotaLifecycleDayMS)
+	first := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, durationSeconds, 80)
+	writeQuotaLifecycleObservation(t, service, "complete", rolloverAtMS-quotaLifecycleHourMS, []WindowInput{first})
+
+	second := quotaLifecycleFixedWindow("weekly", "weekly", rolloverAtMS, durationSeconds, 0)
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-scheduled-rollover", "codex:quota-windows",
+			rolloverAtMS+1_000, []WindowInput{second},
+		),
+	}}); err != nil {
+		t.Fatalf("write zero-use API scheduled rollover: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != rolloverAtMS ||
+		window.CurrentCycle.State != "active" || window.PreviousCycle == nil ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != rolloverAtMS ||
+		window.PreviousCycle.EndReason != "scheduled" {
+		t.Fatalf("zero-use API scheduled rollover lifecycle = %#v", window)
+	}
+}
+
+func TestQuotaLifecycleRejectsUnreliableScheduledRolloverBoundary(t *testing.T) {
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	rolloverAtMS := quotaLifecycleBaseMS + durationSeconds*1000
+	service := newQuotaSnapshotTestService(t, rolloverAtMS+quotaLifecycleDayMS)
+	first := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, durationSeconds, 80)
+	writeQuotaLifecycleObservation(t, service, "complete", rolloverAtMS-quotaLifecycleHourMS, []WindowInput{first})
+
+	unreliable := quotaLifecycleFixedWindow("weekly", "weekly", rolloverAtMS, durationSeconds, 10)
+	unreliable.BoundaryAccuracy = "estimated"
+	writeQuotaLifecycleObservation(t, service, "complete", rolloverAtMS+1_000, []WindowInput{unreliable})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != quotaLifecycleBaseMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != rolloverAtMS ||
+		window.PreviousCycle != nil {
+		t.Fatalf("unreliable scheduled rollover changed lifecycle = %#v", window)
+	}
+}
+
 func quotaLifecycleFixedWindow(id, kind string, startMS, durationSeconds int64, usedPercent float64) WindowInput {
 	endMS := startMS + durationSeconds*1000
 	return WindowInput{

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -284,6 +284,7 @@ const { mocks } = vi.hoisted(() => {
   return {
     mocks: {
       files: [codexFile] as AuthFileItem[],
+      authFilesLoading: false,
       selectedFiles: new Set<string>(),
       selectionCount: 0,
       batchFieldsUpdating: false,
@@ -469,7 +470,7 @@ vi.mock('@/features/authFiles/hooks/useAuthFilesData', () => ({
     files: mocks.files,
     selectedFiles: mocks.selectedFiles,
     selectionCount: mocks.selectionCount,
-    loading: false,
+    loading: mocks.authFilesLoading,
     error: '',
     uploading: false,
     authJsonPasteSaving: false,
@@ -945,6 +946,7 @@ describe('AccountsPage replacement flows', () => {
       window.location.hash = '';
     }
     mocks.files = [makeCodexFile('codex.json', 'auth-1', 'codex@example.com')];
+    mocks.authFilesLoading = false;
     useUsageHeaderSnapshotStore.setState({
       scopeKey: '',
       items: [],
@@ -4849,6 +4851,78 @@ describe('AccountsPage replacement flows', () => {
     expect(mocks.getHeaderSnapshots).toHaveBeenCalledTimes(2);
     expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(1);
     expect(quotaFetch).not.toHaveBeenCalled();
+  });
+
+  it('loads quota lifecycle after a deep-linked credential resolves asynchronously', async () => {
+    const target = {
+      name: 'xai-delayed.json',
+      type: 'xai',
+      provider: 'xai',
+      authIndex: 'xai-delayed-01',
+      account: 'delayed@example.com',
+      disabled: true,
+    } as AuthFileItem;
+    const rowKey = getAuthFileSelectionKey(target);
+    mocks.files = [
+      makeCodexFile('placeholder.json', 'placeholder-auth', 'placeholder@example.com'),
+    ];
+    mocks.authFilesLoading = true;
+    mocks.location = {
+      pathname: '/accounts',
+      search: `?account=${encodeURIComponent(rowKey)}&tab=quota`,
+    };
+    mocks.panelFeatureAvailability = {
+      checking: false,
+      managerServiceBase: 'http://manager.local:18317',
+      requestMonitoringAvailable: true,
+      serverCodexInspectionAvailable: false,
+    };
+    vi.mocked(accountQuotaSnapshotApi.query).mockResolvedValue({
+      generated_at_ms: 1,
+      items: [
+        {
+          row_key: rowKey,
+          account_key: rowKey,
+          provider: 'xai',
+          windows: [
+            {
+              provider_window_id: 'included-free-rolling-24h',
+              window_kind: 'rolling_24h',
+              window_mode: 'rolling',
+              model_scope_kind: 'models',
+              model_scope_key: 'grok-4.5-build-free',
+              model_ids: ['grok-4.5-build-free'],
+              source: 'response_body',
+              observed_at_ms: 1,
+              boundary_accuracy: 'estimated',
+              duration_seconds: 24 * 60 * 60,
+              used_percent: 100,
+              remaining_percent: 0,
+              stale: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    await flushPromises();
+
+    expect(accountQuotaSnapshotApi.query).not.toHaveBeenCalled();
+    expect(mocks.getAccountWindowUsage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mocks.files = [target];
+      mocks.authFilesLoading = false;
+      renderer.update(<AccountsPage />);
+      await Promise.resolve();
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+    expect(accountQuotaSnapshotApi.query).toHaveBeenCalledTimes(1);
+    expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(1);
   });
 
   it('reloads lifecycle and window usage after detail quota refresh without loading history', async () => {

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -2788,12 +2788,12 @@ export function AccountsPage() {
   );
 
   useEffect(() => {
-    if (activeView !== 'accounts' || detailTab !== 'quota' || !selectedRowKey) {
+    if (activeView !== 'accounts' || detailTab !== 'quota' || !selectedRowKey || !selectedRow) {
       const hadInFlightRequest = accountWindowUsageAbortRef.current !== null;
       accountWindowUsageReqIdRef.current += 1;
       accountWindowUsageAbortRef.current?.abort();
       accountWindowUsageAbortRef.current = null;
-      if (hadInFlightRequest) {
+      if (hadInFlightRequest || !selectedRow) {
         accountWindowUsageAutoLoadKeyRef.current = null;
       }
       return;


### PR DESCRIPTION
## Summary

Fix follow-up review findings from #504 and #505 in quota lifecycle rollover handling and account detail loading.
Accept reliable scheduled reset evidence while preventing unreliable or provisional boundaries from splitting cycles, and reload usage after asynchronous deep-linked credential resolution.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Accept zero-use API evidence when it aligns with a reliable scheduled rollover.
- Reject estimated or unknown boundaries before closing an active quota cycle.
- Preserve scheduled rollover cycles during provisional evidence normalization.
- Defer automatic usage loading until a deep-linked credential row resolves.
- Add backend lifecycle and frontend asynchronous-loading regression coverage.

## User Impact

Users see the correct active and previous quota cycles after scheduled resets, and quota lifecycle usage loads after asynchronously resolved deep links instead of remaining empty.

## Compatibility / Runtime Notes

- CPA panel mode: No behavior change; lifecycle usage storage requires Manager Server.
- Manager Server mode: Updates quota lifecycle persistence, read normalization, and account usage loading.
- Full Docker / native packages: No configuration change; the fix applies when using Manager Server storage.

## Data / Security Notes

- Uses the existing SQLite lifecycle schema; there is no migration or bulk data rewrite.
- No changes to authentication data, key storage, log exposure, or raw usage export contracts.

## Risk / Rollback

Risk level: Medium

Rollback notes:

Revert the two commits in this PR. No schema or configuration rollback is required.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test
npm run build
npm run manager-server:test
go test ./internal/service/quotasnapshot ./internal/repository/sqlite -count=1
git diff --check
```

`npm run test` passed 184 test files and 1960 tests. Lint passed with one existing React Refresh warning in an unchanged file.

## Screenshots / Recordings

N/A — no visual layout changes; the behavior is covered by AccountsPage component tests.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation changes are needed because this is a regression fix without capability, configuration, or API contract changes.

## Related

Refs #504 and #505