### PR TITLE
perf(manager-server): prevent compatible usage exports from pinning SQLite WAL

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/stream.go
+++ b/apps/manager-server/internal/repository/usageevent/stream.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -16,65 +17,26 @@ import (
 )
 
 const (
-	defaultUsageStreamLimit = 50000
-	usageStreamBufferSize   = 64 * 1024
-	usageExportBatchSize    = 512
+	defaultUsageStreamLimit        = 50000
+	maxCompatibleUsageStreamLimit  = 50000
+	usageStreamBufferSize          = 64 * 1024
+	usageExportBatchSize           = 512
+	compatibleUsageDetailBatchSize = 1024
 )
 
-type usageSnapshot struct {
-	maxID             int64
-	cutoffTimestampMS int64
-	cutoffID          int64
-	empty             bool
-}
+const compatibleUsageOrderedIDsQuery = `select id
+	from usage_events
+	where id <= ? and (
+		timestamp_ms > ? or (timestamp_ms = ? and id >= ?)
+	)
+	order by
+		coalesce(nullif(endpoint, ''), '-') asc,
+		coalesce(nullif(model, ''), '-') asc,
+		timestamp_ms desc,
+		id desc`
 
-type compatibleUsageTotals struct {
-	totalRequests int64
-	successCount  int64
-	failureCount  int64
-	totalTokens   int64
-}
-
-type rawMetadataDetail struct {
-	usage.Detail
-	ResponseMetadata json.RawMessage `json:"response_metadata,omitempty"`
-}
-
-type exportRow struct {
-	id               int64
-	timestampMS      int64
-	event            model.UsageEvent
-	responseMetadata json.RawMessage
-}
-
-type rawMetadataEvent struct {
-	usage.Event
-	ResponseMetadata json.RawMessage `json:"response_metadata,omitempty"`
-}
-
-func (r *repository) WriteCompatibleUsage(ctx context.Context, writer io.Writer, limit int) error {
-	limit = normalizeUsageStreamLimit(limit)
-	snapshot, err := r.captureUsageSnapshot(ctx, limit)
-	if err != nil {
-		return err
-	}
-	totals, err := r.compatibleUsageTotals(ctx, snapshot)
-	if err != nil {
-		return err
-	}
-
-	buffer := bufio.NewWriterSize(writer, usageStreamBufferSize)
-	if err := writeCompatibleUsageHeader(buffer, totals); err != nil {
-		return err
-	}
-	if snapshot.empty {
-		if _, err := io.WriteString(buffer, "}}\n"); err != nil {
-			return err
-		}
-		return buffer.Flush()
-	}
-
-	rows, err := r.db.QueryContext(ctx, `select
+const compatibleUsageDetailQueryPrefix = `select
+		id,
 		coalesce(nullif(endpoint, ''), '-') as group_endpoint,
 		coalesce(nullif(model, ''), '-') as group_model,
 		timestamp,
@@ -109,118 +71,290 @@ func (r *repository) WriteCompatibleUsage(ctx context.Context, writer io.Writer,
 		coalesce(fail_summary, ''),
 		coalesce(response_metadata_json, '')
 	from usage_events
-	where id <= ? and (
-		timestamp_ms > ? or (timestamp_ms = ? and id >= ?)
-	)
-	order by group_endpoint asc, group_model asc, timestamp_ms desc, id desc`,
+	where id in (`
+
+type usageSnapshot struct {
+	maxID             int64
+	cutoffTimestampMS int64
+	cutoffID          int64
+	empty             bool
+}
+
+type compatibleUsageTotals struct {
+	totalRequests int64
+	successCount  int64
+	failureCount  int64
+	totalTokens   int64
+}
+
+type rawMetadataDetail struct {
+	usage.Detail
+	ResponseMetadata json.RawMessage `json:"response_metadata,omitempty"`
+}
+
+type compatibleExportRow struct {
+	id       int64
+	endpoint string
+	model    string
+	detail   rawMetadataDetail
+}
+
+type compatibleStreamState struct {
+	currentEndpoint string
+	currentModel    string
+	endpointOpen    bool
+	modelOpen       bool
+	firstEndpoint   bool
+	firstModel      bool
+	firstDetail     bool
+}
+
+type exportRow struct {
+	id               int64
+	timestampMS      int64
+	event            model.UsageEvent
+	responseMetadata json.RawMessage
+}
+
+type rawMetadataEvent struct {
+	usage.Event
+	ResponseMetadata json.RawMessage `json:"response_metadata,omitempty"`
+}
+
+func (r *repository) WriteCompatibleUsage(ctx context.Context, writer io.Writer, limit int) error {
+	limit = normalizeCompatibleUsageStreamLimit(limit)
+	snapshot, err := r.captureUsageSnapshot(ctx, limit)
+	if err != nil {
+		return err
+	}
+	totals, err := r.compatibleUsageTotals(ctx, snapshot)
+	if err != nil {
+		return err
+	}
+
+	var orderedIDs []int64
+	if !snapshot.empty {
+		orderedIDs, err = r.compatibleOrderedIDs(ctx, snapshot, int(totals.totalRequests))
+		if err != nil {
+			return err
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	buffer := bufio.NewWriterSize(writer, usageStreamBufferSize)
+	if err := writeCompatibleUsageHeader(buffer, totals); err != nil {
+		return err
+	}
+	if snapshot.empty {
+		if _, err := io.WriteString(buffer, "}}\n"); err != nil {
+			return err
+		}
+		return buffer.Flush()
+	}
+
+	state := newCompatibleStreamState()
+	for start := 0; start < len(orderedIDs); start += compatibleUsageDetailBatchSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(start+compatibleUsageDetailBatchSize, len(orderedIDs))
+		batchIDs := orderedIDs[start:end]
+		rowsByID, err := r.compatibleRowsByIDs(ctx, batchIDs)
+		if err != nil {
+			return err
+		}
+
+		// Do not write to the HTTP writer while sql.Rows is still active.
+		// Network backpressure across an open SQLite reader can pin the WAL.
+		if err := writeCompatibleRows(ctx, buffer, batchIDs, rowsByID, &state); err != nil {
+			return err
+		}
+	}
+	if err := finishCompatibleStream(buffer, &state); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return buffer.Flush()
+}
+
+func (r *repository) compatibleOrderedIDs(ctx context.Context, snapshot usageSnapshot, expectedCount int) ([]int64, error) {
+	rows, err := r.db.QueryContext(
+		ctx,
+		compatibleUsageOrderedIDsQuery,
 		snapshot.maxID,
 		snapshot.cutoffTimestampMS,
 		snapshot.cutoffTimestampMS,
 		snapshot.cutoffID,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer rows.Close()
 
-	var currentEndpoint string
-	var currentModel string
-	endpointOpen := false
-	modelOpen := false
-	firstEndpoint := true
-	firstModel := true
-	firstDetail := true
-
+	orderedIDs := make([]int64, 0, expectedCount)
 	for rows.Next() {
-		endpoint, modelName, detail, err := scanCompatibleDetail(rows)
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		orderedIDs = append(orderedIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return orderedIDs, nil
+}
+
+func (r *repository) compatibleRowsByIDs(ctx context.Context, ids []int64) (map[int64]compatibleExportRow, error) {
+	if len(ids) == 0 {
+		return map[int64]compatibleExportRow{}, nil
+	}
+
+	args := make([]any, len(ids))
+	for index, id := range ids {
+		args[index] = id
+	}
+	rows, err := r.db.QueryContext(ctx, compatibleUsageDetailQuery(len(ids)), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	rowsByID := make(map[int64]compatibleExportRow, len(ids))
+	for rows.Next() {
+		row, err := scanCompatibleDetail(rows)
 		if err != nil {
+			return nil, err
+		}
+		rowsByID[row.id] = row
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	for _, id := range ids {
+		if _, ok := rowsByID[id]; !ok {
+			return nil, fmt.Errorf("compatible usage snapshot row disappeared: id=%d", id)
+		}
+	}
+	return rowsByID, nil
+}
+
+func compatibleUsageDetailQuery(count int) string {
+	return compatibleUsageDetailQueryPrefix + strings.TrimSuffix(strings.Repeat("?,", count), ",") + ")"
+}
+
+func newCompatibleStreamState() compatibleStreamState {
+	return compatibleStreamState{
+		firstEndpoint: true,
+		firstModel:    true,
+		firstDetail:   true,
+	}
+}
+
+func writeCompatibleRows(ctx context.Context, buffer *bufio.Writer, orderedIDs []int64, rowsByID map[int64]compatibleExportRow, state *compatibleStreamState) error {
+	for _, id := range orderedIDs {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
+		row, ok := rowsByID[id]
+		if !ok {
+			return fmt.Errorf("compatible usage snapshot row disappeared: id=%d", id)
+		}
 
-		if !endpointOpen || endpoint != currentEndpoint {
-			if modelOpen {
+		if !state.endpointOpen || row.endpoint != state.currentEndpoint {
+			if state.modelOpen {
 				if _, err := io.WriteString(buffer, "]}"); err != nil {
 					return err
 				}
-				modelOpen = false
+				state.modelOpen = false
 			}
-			if endpointOpen {
+			if state.endpointOpen {
 				if _, err := io.WriteString(buffer, "}}"); err != nil {
 					return err
 				}
 			}
-			if !firstEndpoint {
+			if !state.firstEndpoint {
 				if err := buffer.WriteByte(','); err != nil {
 					return err
 				}
 			}
-			if err := writeJSONString(buffer, endpoint); err != nil {
+			if err := writeJSONString(buffer, row.endpoint); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(buffer, `:{"models":{`); err != nil {
 				return err
 			}
-			currentEndpoint = endpoint
-			currentModel = ""
-			endpointOpen = true
-			firstEndpoint = false
-			firstModel = true
+			state.currentEndpoint = row.endpoint
+			state.currentModel = ""
+			state.endpointOpen = true
+			state.firstEndpoint = false
+			state.firstModel = true
 		}
 
-		if !modelOpen || modelName != currentModel {
-			if modelOpen {
+		if !state.modelOpen || row.model != state.currentModel {
+			if state.modelOpen {
 				if _, err := io.WriteString(buffer, "]}"); err != nil {
 					return err
 				}
 			}
-			if !firstModel {
+			if !state.firstModel {
 				if err := buffer.WriteByte(','); err != nil {
 					return err
 				}
 			}
-			if err := writeJSONString(buffer, modelName); err != nil {
+			if err := writeJSONString(buffer, row.model); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(buffer, `:{"details":[`); err != nil {
 				return err
 			}
-			currentModel = modelName
-			modelOpen = true
-			firstModel = false
-			firstDetail = true
+			state.currentModel = row.model
+			state.modelOpen = true
+			state.firstModel = false
+			state.firstDetail = true
 		}
 
-		if !firstDetail {
+		if !state.firstDetail {
 			if err := buffer.WriteByte(','); err != nil {
 				return err
 			}
 		}
-		encoded, err := json.Marshal(detail)
+		encoded, err := json.Marshal(row.detail)
 		if err != nil {
 			return err
 		}
 		if _, err := buffer.Write(encoded); err != nil {
 			return err
 		}
-		firstDetail = false
+		state.firstDetail = false
 	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	if modelOpen {
+	return nil
+}
+
+func finishCompatibleStream(buffer *bufio.Writer, state *compatibleStreamState) error {
+	if state.modelOpen {
 		if _, err := io.WriteString(buffer, "]}"); err != nil {
 			return err
 		}
 	}
-	if endpointOpen {
+	if state.endpointOpen {
 		if _, err := io.WriteString(buffer, "}}"); err != nil {
 			return err
 		}
 	}
-	if _, err := io.WriteString(buffer, "}}\n"); err != nil {
-		return err
-	}
-	return buffer.Flush()
+	_, err := io.WriteString(buffer, "}}\n")
+	return err
 }
 
 func (r *repository) WriteExportJSONL(ctx context.Context, writer io.Writer, limit int) error {
@@ -376,9 +510,8 @@ func (r *repository) exportBatch(ctx context.Context, snapshot usageSnapshot, cu
 	return batch, nil
 }
 
-func scanCompatibleDetail(rows *sql.Rows) (string, string, rawMetadataDetail, error) {
-	var endpoint string
-	var modelName string
+func scanCompatibleDetail(rows *sql.Rows) (compatibleExportRow, error) {
+	var row compatibleExportRow
 	var detail usage.Detail
 	var authSnapshotAt sql.NullInt64
 	var latency sql.NullInt64
@@ -390,8 +523,9 @@ func scanCompatibleDetail(rows *sql.Rows) (string, string, rawMetadataDetail, er
 	var cacheTokens int64
 
 	err := rows.Scan(
-		&endpoint,
-		&modelName,
+		&row.id,
+		&row.endpoint,
+		&row.model,
 		&detail.Timestamp,
 		&detail.Source,
 		&detail.AuthIndex,
@@ -425,7 +559,7 @@ func scanCompatibleDetail(rows *sql.Rows) (string, string, rawMetadataDetail, er
 		&responseMetadataJSON,
 	)
 	if err != nil {
-		return "", "", rawMetadataDetail{}, err
+		return compatibleExportRow{}, err
 	}
 	if authSnapshotAt.Valid {
 		detail.AuthSnapshotAtMS = authSnapshotAt.Int64
@@ -450,10 +584,11 @@ func scanCompatibleDetail(rows *sql.Rows) (string, string, rawMetadataDetail, er
 	)
 	detail.Tokens.CachedTokens = compatibleCachedTokens
 	detail.Tokens.CacheTokens = compatibleCachedTokens
-	return endpoint, modelName, rawMetadataDetail{
+	row.detail = rawMetadataDetail{
 		Detail:           detail,
 		ResponseMetadata: validatedMetadataJSON(responseMetadataJSON),
-	}, nil
+	}
+	return row, nil
 }
 
 func scanExportRow(rows *sql.Rows) (exportRow, error) {
@@ -585,6 +720,17 @@ func validatedMetadataJSON(raw string) json.RawMessage {
 func normalizeUsageStreamLimit(limit int) int {
 	if limit <= 0 {
 		return defaultUsageStreamLimit
+	}
+	return limit
+}
+
+func normalizeCompatibleUsageStreamLimit(limit int) int {
+	limit = normalizeUsageStreamLimit(limit)
+	// Compatible usage retains one ordered int64 ID per exported row so the
+	// SQLite reader can close before HTTP output starts. Keep that snapshot
+	// bounded without changing the independently streamed JSONL export limit.
+	if limit > maxCompatibleUsageStreamLimit {
+		return maxCompatibleUsageStreamLimit
 	}
 	return limit
 }

--- a/apps/manager-server/internal/repository/usageevent/stream_benchmark_test.go
+++ b/apps/manager-server/internal/repository/usageevent/stream_benchmark_test.go
@@ -1,0 +1,195 @@
+package usageevent
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+)
+
+const compatibleUsageBenchmarkBaseTimestampMS = int64(1_700_000_000_000)
+
+type compatibleUsageBenchmarkWriter struct {
+	bytes int64
+}
+
+func (w *compatibleUsageBenchmarkWriter) Write(p []byte) (int, error) {
+	w.bytes += int64(len(p))
+	return len(p), nil
+}
+
+func BenchmarkWriteCompatibleUsage(b *testing.B) {
+	tests := []struct {
+		name         string
+		databaseRows int
+		exportLimit  int
+	}{
+		{name: "db_50000_export_50000", databaseRows: 50_000, exportLimit: 50_000},
+		{name: "db_500000_export_50000", databaseRows: 500_000, exportLimit: 50_000},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			ctx := context.Background()
+			db := openCompatibleUsageBenchmarkDB(b)
+			seedCompatibleUsageBenchmark(b, ctx, db, test.databaseRows)
+			checkpointCompatibleUsageBenchmark(b, db)
+			repo := New(db)
+
+			b.ReportAllocs()
+			var totalOutputBytes int64
+			b.ResetTimer()
+			for iteration := 0; iteration < b.N; iteration++ {
+				writer := &compatibleUsageBenchmarkWriter{}
+				if err := repo.WriteCompatibleUsage(ctx, writer, test.exportLimit); err != nil {
+					b.Fatalf("write compatible usage: %v", err)
+				}
+				totalOutputBytes += writer.bytes
+			}
+			b.StopTimer()
+
+			if totalOutputBytes == 0 {
+				b.Fatal("compatible usage benchmark produced no output")
+			}
+			outputBytesPerOperation := totalOutputBytes / int64(b.N)
+			b.SetBytes(outputBytesPerOperation)
+			b.ReportMetric(float64(outputBytesPerOperation), "output-bytes/op")
+			effectiveLimit := normalizeCompatibleUsageStreamLimit(test.exportLimit)
+			expectedQueryCount := 4 + (effectiveLimit+compatibleUsageDetailBatchSize-1)/compatibleUsageDetailBatchSize
+			b.ReportMetric(float64(expectedQueryCount), "expected-queries/op")
+		})
+	}
+}
+
+func openCompatibleUsageBenchmarkDB(b *testing.B) *sql.DB {
+	b.Helper()
+	db, err := sqliterepo.Open(filepath.Join(b.TempDir(), "usage.sqlite"))
+	if err != nil {
+		b.Fatalf("open benchmark database: %v", err)
+	}
+	b.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}
+
+func seedCompatibleUsageBenchmark(b *testing.B, ctx context.Context, db *sql.DB, count int) {
+	b.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		b.Fatalf("begin benchmark seed transaction: %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, `insert into usage_events (
+		event_hash,
+		timestamp_ms,
+		timestamp,
+		model,
+		endpoint,
+		source,
+		auth_index,
+		account_snapshot,
+		resolved_model,
+		input_tokens,
+		output_tokens,
+		reasoning_tokens,
+		cached_tokens,
+		cache_tokens,
+		cache_read_tokens,
+		cache_creation_tokens,
+		total_tokens,
+		failed,
+		fail_status_code,
+		fail_summary,
+		response_metadata_json,
+		created_at_ms
+	) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		b.Fatalf("prepare benchmark seed: %v", err)
+	}
+	defer stmt.Close()
+
+	endpoints := make([]string, 24)
+	for index := range endpoints {
+		endpoints[index] = fmt.Sprintf("POST /v1/responses/%02d", index)
+	}
+	models := make([]string, 96)
+	for index := range models {
+		models[index] = fmt.Sprintf("benchmark-model-%03d", index)
+	}
+
+	for index := 1; index <= count; index++ {
+		timestampMS := compatibleUsageBenchmarkBaseTimestampMS + int64(index/2)
+		endpoint := endpoints[index%len(endpoints)]
+		model := models[index%len(models)]
+		if index%211 == 0 {
+			endpoint = ""
+		}
+		if index%223 == 0 {
+			model = ""
+		}
+		failed := index%19 == 0
+		var failStatusCode any
+		failSummary := ""
+		if failed {
+			failStatusCode = 429
+			failSummary = "benchmark rate limit"
+		}
+		responseMetadataJSON := ""
+		if index%29 == 0 {
+			responseMetadataJSON = `{"trace":{"primary_trace_id":"benchmark-trace"}}`
+		}
+
+		if _, err := stmt.ExecContext(
+			ctx,
+			"benchmark-"+strconv.Itoa(index),
+			timestampMS,
+			strconv.FormatInt(timestampMS, 10),
+			model,
+			endpoint,
+			"benchmark-source",
+			fmt.Sprintf("auth-%03d", index%128),
+			fmt.Sprintf("account-%04d@example.com", index%1024),
+			model,
+			100+index%31,
+			40+index%17,
+			index%11,
+			index%7,
+			index%7,
+			index%5,
+			index%3,
+			160+index%47,
+			failed,
+			failStatusCode,
+			failSummary,
+			responseMetadataJSON,
+			timestampMS,
+		); err != nil {
+			b.Fatalf("insert benchmark row %d: %v", index, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit benchmark seed: %v", err)
+	}
+}
+
+func checkpointCompatibleUsageBenchmark(b *testing.B, db *sql.DB) {
+	b.Helper()
+	var busy int64
+	var logFrames int64
+	var checkpointedFrames int64
+	if err := db.QueryRow(`pragma wal_checkpoint(truncate)`).Scan(&busy, &logFrames, &checkpointedFrames); err != nil {
+		b.Fatalf("checkpoint benchmark database: %v", err)
+	}
+	if busy != 0 {
+		b.Fatalf("benchmark checkpoint busy = %d", busy)
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/stream_test.go
+++ b/apps/manager-server/internal/repository/usageevent/stream_test.go
@@ -3,12 +3,16 @@ package usageevent
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
@@ -63,6 +67,402 @@ func TestWriteCompatibleUsageMatchesBuildPayload(t *testing.T) {
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("streamed payload mismatch\nactual: %#v\nexpected: %#v", actual, expected)
+	}
+}
+
+func TestNormalizeCompatibleUsageStreamLimit(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{name: "negative defaults", limit: -1, want: defaultUsageStreamLimit},
+		{name: "zero defaults", limit: 0, want: defaultUsageStreamLimit},
+		{name: "below maximum", limit: 1024, want: 1024},
+		{name: "at maximum", limit: maxCompatibleUsageStreamLimit, want: maxCompatibleUsageStreamLimit},
+		{name: "above maximum", limit: maxCompatibleUsageStreamLimit + 1, want: maxCompatibleUsageStreamLimit},
+		{name: "maximum integer", limit: maxInt, want: maxCompatibleUsageStreamLimit},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := normalizeCompatibleUsageStreamLimit(test.limit); got != test.want {
+				t.Fatalf("normalize compatible usage limit %d = %d, want %d", test.limit, got, test.want)
+			}
+		})
+	}
+
+	exportLimit := maxCompatibleUsageStreamLimit + 1
+	if got := normalizeUsageStreamLimit(exportLimit); got != exportLimit {
+		t.Fatalf("normalize JSONL export limit %d = %d, want unchanged", exportLimit, got)
+	}
+}
+
+func TestWriteCompatibleUsageMatchesBuildPayloadAcrossDetailBatchSizes(t *testing.T) {
+	_, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+
+	endpoints := []string{"", "GET /v1/models", "POST /v1/chat/completions", "POST /v1/responses"}
+	models := []string{"", "gpt-a", "gpt-b", "gpt-c", "gpt-d"}
+	events := make([]usage.Event, 0, 2049)
+	for index := 1; index <= 2049; index++ {
+		event := streamTestEvent(
+			fmt.Sprintf("compatible-size-%04d", index),
+			int64(index/2),
+			endpoints[index%len(endpoints)],
+			models[(index/3)%len(models)],
+		)
+		event.Source = fmt.Sprintf("source-%04d", index)
+		events = append(events, event)
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	for _, limit := range []int{1, 1023, 1024, 1025, 2049} {
+		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+			recent, err := repo.ListRecent(ctx, limit)
+			if err != nil {
+				t.Fatalf("list recent: %v", err)
+			}
+			expected := usage.BuildPayload(recent)
+			actual := writeAndDecodeCompatibleUsage(t, ctx, repo, limit)
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("payload mismatch for limit %d", limit)
+			}
+		})
+	}
+}
+
+func TestWriteCompatibleUsagePreservesGroupingAcrossDetailBatchBoundaries(t *testing.T) {
+	_, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+
+	groups := []struct {
+		endpoint string
+		model    string
+		count    int
+	}{
+		{endpoint: "endpoint-a", model: "model-a", count: 1023},
+		{endpoint: "endpoint-a", model: "model-b", count: 1025},
+		{endpoint: "endpoint-b", model: "model-a", count: 1},
+	}
+	events := make([]usage.Event, 0, 2049)
+	sequence := 0
+	for _, group := range groups {
+		for offset := 0; offset < group.count; offset++ {
+			sequence++
+			event := streamTestEvent(
+				fmt.Sprintf("compatible-group-%04d", sequence),
+				int64(sequence),
+				group.endpoint,
+				group.model,
+			)
+			event.Source = fmt.Sprintf("group-source-%04d", sequence)
+			events = append(events, event)
+		}
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	recent, err := repo.ListRecent(ctx, len(events))
+	if err != nil {
+		t.Fatalf("list recent: %v", err)
+	}
+	expected := usage.BuildPayload(recent)
+	actual := writeAndDecodeCompatibleUsage(t, ctx, repo, len(events))
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatal("payload mismatch across detail batch grouping boundaries")
+	}
+	if got := len(actual.APIs["endpoint-a"].Models["model-a"].Details); got != 1023 {
+		t.Fatalf("endpoint-a/model-a details = %d, want 1023", got)
+	}
+	if got := len(actual.APIs["endpoint-a"].Models["model-b"].Details); got != 1025 {
+		t.Fatalf("endpoint-a/model-b details = %d, want 1025", got)
+	}
+	if got := len(actual.APIs["endpoint-b"].Models["model-a"].Details); got != 1 {
+		t.Fatalf("endpoint-b/model-a details = %d, want 1", got)
+	}
+}
+
+func TestWriteCompatibleUsagePreservesIDDescendingTieBreaker(t *testing.T) {
+	_, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+
+	events := make([]usage.Event, 0, 5)
+	for index := 1; index <= 5; index++ {
+		event := streamTestEvent(
+			fmt.Sprintf("compatible-tie-%d", index),
+			100,
+			"POST /v1/responses",
+			"gpt-tie",
+		)
+		event.Source = fmt.Sprintf("source-%d", index)
+		events = append(events, event)
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	actual := writeAndDecodeCompatibleUsage(t, ctx, repo, len(events))
+	details := actual.APIs["POST /v1/responses"].Models["gpt-tie"].Details
+	if len(details) != len(events) {
+		t.Fatalf("details = %d, want %d", len(details), len(events))
+	}
+	for index, detail := range details {
+		want := fmt.Sprintf("source-%d", len(events)-index)
+		if detail.Source != want {
+			t.Fatalf("detail %d source = %q, want %q", index, detail.Source, want)
+		}
+	}
+}
+
+func TestWriteCompatibleUsagePreservesEndpointAndModelJSONKeyOrder(t *testing.T) {
+	_, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+	events := []usage.Event{
+		streamTestEvent("compatible-order-z-b", 100, "endpoint-z", "model-b"),
+		streamTestEvent("compatible-order-a-c", 200, "endpoint-a", "model-c"),
+		streamTestEvent("compatible-order-empty", 300, "", ""),
+		streamTestEvent("compatible-order-z-a", 400, "endpoint-z", "model-a"),
+		streamTestEvent("compatible-order-a-a", 500, "endpoint-a", "model-a"),
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	var output bytes.Buffer
+	if err := repo.WriteCompatibleUsage(ctx, &output, len(events)); err != nil {
+		t.Fatalf("write compatible usage: %v", err)
+	}
+	endpointOrder, modelOrder := compatibleUsageJSONKeyOrder(t, output.Bytes())
+	if want := []string{"-", "endpoint-a", "endpoint-z"}; !reflect.DeepEqual(endpointOrder, want) {
+		t.Fatalf("endpoint JSON key order = %q, want %q", endpointOrder, want)
+	}
+	wantModels := map[string][]string{
+		"-":          {"-"},
+		"endpoint-a": {"model-a", "model-c"},
+		"endpoint-z": {"model-a", "model-b"},
+	}
+	if !reflect.DeepEqual(modelOrder, wantModels) {
+		t.Fatalf("model JSON key order = %#v, want %#v", modelOrder, wantModels)
+	}
+}
+
+func TestCompatibleRowsByIDsFailsWhenSnapshotRowDisappears(t *testing.T) {
+	db, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+	events := []usage.Event{
+		streamTestEvent("compatible-present", 100, "endpoint", "model"),
+		streamTestEvent("compatible-disappears", 200, "endpoint", "model"),
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	snapshot, err := repo.captureUsageSnapshot(ctx, len(events))
+	if err != nil {
+		t.Fatalf("capture snapshot: %v", err)
+	}
+	orderedIDs, err := repo.compatibleOrderedIDs(ctx, snapshot, len(events))
+	if err != nil {
+		t.Fatalf("ordered ids: %v", err)
+	}
+	missingID := orderedIDs[0]
+	if _, err := db.ExecContext(ctx, "delete from usage_events where id = ?", missingID); err != nil {
+		t.Fatalf("delete snapshot row: %v", err)
+	}
+
+	_, err = repo.compatibleRowsByIDs(ctx, orderedIDs)
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("snapshot row disappeared: id=%d", missingID)) {
+		t.Fatalf("missing row error = %v", err)
+	}
+}
+
+func TestWriteCompatibleUsageSnapshotExcludesConcurrentInsert(t *testing.T) {
+	_, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+
+	events := make([]usage.Event, 0, 1500)
+	for index := 1; index <= cap(events); index++ {
+		events = append(events, streamTestEvent(
+			fmt.Sprintf("compatible-snapshot-%04d", index),
+			int64(index),
+			"POST /v1/responses",
+			"gpt-snapshot",
+		))
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	writer, errCh := startBlockedCompatibleUsageExport(t, ctx, repo, len(events))
+	waitForCompatibleUsageWriterBlock(t, writer)
+	concurrent := streamTestEvent(
+		"compatible-concurrent-insert",
+		int64(len(events)+1),
+		"CONCURRENT /new",
+		"gpt-concurrent",
+	)
+	if _, err := repo.InsertBatch(ctx, []usage.Event{concurrent}); err != nil {
+		t.Fatalf("insert concurrent event: %v", err)
+	}
+	if err := finishBlockedCompatibleUsageExport(t, writer, errCh); err != nil {
+		t.Fatalf("write compatible usage: %v", err)
+	}
+
+	actual := decodeCompatibleUsageBytes(t, writer.Bytes())
+	if actual.TotalRequests != int64(len(events)) {
+		t.Fatalf("total requests = %d, want %d", actual.TotalRequests, len(events))
+	}
+	if _, ok := actual.APIs[concurrent.Endpoint]; ok {
+		t.Fatalf("concurrent endpoint %q entered the captured response", concurrent.Endpoint)
+	}
+}
+
+func TestWriteCompatibleUsageReleasesReaderBeforeSlowWriter(t *testing.T) {
+	db, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+
+	events := make([]usage.Event, 0, 1500)
+	for index := 1; index <= cap(events); index++ {
+		events = append(events, streamTestEvent(
+			fmt.Sprintf("compatible-wal-%04d", index),
+			int64(index),
+			"POST /v1/responses",
+			"gpt-wal",
+		))
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	busy, _, _ := runCompatibleUsageCheckpoint(t, db, "truncate")
+	if busy != 0 {
+		t.Fatalf("initial truncate checkpoint busy = %d", busy)
+	}
+
+	writer, errCh := startBlockedCompatibleUsageExport(t, ctx, repo, len(events))
+	waitForCompatibleUsageWriterBlock(t, writer)
+	inUse := db.Stats().InUse
+	t.Logf("database connections in use while HTTP writer is blocked: %d", inUse)
+	if inUse != 0 {
+		t.Fatalf("database connections in use while HTTP writer is blocked = %d, want 0", inUse)
+	}
+
+	appended := make([]usage.Event, 0, 32)
+	for index := 1; index <= cap(appended); index++ {
+		appended = append(appended, streamTestEvent(
+			fmt.Sprintf("compatible-wal-appended-%02d", index),
+			int64(len(events)+index),
+			"POST /v1/responses",
+			"gpt-wal-appended",
+		))
+	}
+	if _, err := repo.InsertBatch(ctx, appended); err != nil {
+		t.Fatalf("append WAL events: %v", err)
+	}
+	busy, logFrames, checkpointedFrames := runCompatibleUsageCheckpoint(t, db, "passive")
+	t.Logf(
+		"passive checkpoint while HTTP writer is blocked: busy=%d log_frames=%d checkpointed_frames=%d",
+		busy,
+		logFrames,
+		checkpointedFrames,
+	)
+	if busy != 0 {
+		t.Fatalf("passive checkpoint busy = %d", busy)
+	}
+	if logFrames <= 0 {
+		t.Fatalf("passive checkpoint log frames = %d, want positive", logFrames)
+	}
+	if checkpointedFrames != logFrames {
+		t.Fatalf(
+			"passive checkpoint frames = %d/%d, want checkpoint to catch up while writer is blocked",
+			checkpointedFrames,
+			logFrames,
+		)
+	}
+
+	if err := finishBlockedCompatibleUsageExport(t, writer, errCh); err != nil {
+		t.Fatalf("write compatible usage: %v", err)
+	}
+	if !json.Valid(writer.Bytes()) {
+		t.Fatal("compatible usage output is not valid JSON")
+	}
+}
+
+func TestWriteCompatibleUsageStopsAfterContextCancellation(t *testing.T) {
+	_, repo := openCompatibleUsageStreamTestRepository(t)
+	events := make([]usage.Event, 0, compatibleUsageDetailBatchSize+100)
+	for index := 1; index <= cap(events); index++ {
+		events = append(events, streamTestEvent(
+			fmt.Sprintf("compatible-cancel-%04d", index),
+			int64(index),
+			"POST /v1/responses",
+			"gpt-cancel",
+		))
+	}
+	if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	writer := &cancelCompatibleUsageWriter{cancel: cancel}
+	err := repo.WriteCompatibleUsage(ctx, writer, len(events))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("write error = %v, want context canceled", err)
+	}
+}
+
+func TestCompatibleUsageQueryPlans(t *testing.T) {
+	db, repo := openCompatibleUsageStreamTestRepository(t)
+	ctx := context.Background()
+	events := []usage.Event{
+		streamTestEvent("compatible-plan-a", 100, "endpoint-a", "model-a"),
+		streamTestEvent("compatible-plan-b", 200, "endpoint-a", "model-b"),
+		streamTestEvent("compatible-plan-c", 300, "endpoint-b", "model-a"),
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	snapshot, err := repo.captureUsageSnapshot(ctx, len(events))
+	if err != nil {
+		t.Fatalf("capture snapshot: %v", err)
+	}
+	orderedIDs, err := repo.compatibleOrderedIDs(ctx, snapshot, len(events))
+	if err != nil {
+		t.Fatalf("ordered ids: %v", err)
+	}
+
+	orderedPlan := explainCompatibleUsageQueryPlan(
+		t,
+		db,
+		compatibleUsageOrderedIDsQuery,
+		snapshot.maxID,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffTimestampMS,
+		snapshot.cutoffID,
+	)
+	detailArgs := make([]any, len(orderedIDs))
+	for index, id := range orderedIDs {
+		detailArgs[index] = id
+	}
+	detailPlan := explainCompatibleUsageQueryPlan(
+		t,
+		db,
+		compatibleUsageDetailQuery(len(orderedIDs)),
+		detailArgs...,
+	)
+	t.Logf("ordered ID query plan:\n%s", strings.Join(orderedPlan, "\n"))
+	t.Logf("detail batch query plan:\n%s", strings.Join(detailPlan, "\n"))
+
+	detailPlanText := strings.Join(detailPlan, "\n")
+	if !strings.Contains(detailPlanText, "USING INTEGER PRIMARY KEY") {
+		t.Fatalf("detail query does not use INTEGER PRIMARY KEY:\n%s", detailPlanText)
+	}
+	if strings.Contains(detailPlanText, "USE TEMP B-TREE") {
+		t.Fatalf("detail query performs a temporary sort:\n%s", detailPlanText)
 	}
 }
 
@@ -165,6 +565,240 @@ func TestValidatedMetadataJSONRequiresJSONObject(t *testing.T) {
 	if metadata := validatedMetadataJSON(`{"trace":{"primary_trace_id":"trace"}}`); metadata == nil {
 		t.Fatal("valid metadata was rejected")
 	}
+}
+
+func openCompatibleUsageStreamTestRepository(t *testing.T) (*sql.DB, *repository) {
+	t.Helper()
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db, &repository{db: db}
+}
+
+func writeAndDecodeCompatibleUsage(t *testing.T, ctx context.Context, repo *repository, limit int) usage.Payload {
+	t.Helper()
+	var output bytes.Buffer
+	if err := repo.WriteCompatibleUsage(ctx, &output, limit); err != nil {
+		t.Fatalf("write compatible usage: %v", err)
+	}
+	return decodeCompatibleUsageBytes(t, output.Bytes())
+}
+
+func decodeCompatibleUsageBytes(t *testing.T, output []byte) usage.Payload {
+	t.Helper()
+	if !json.Valid(output) {
+		t.Fatalf("invalid compatible usage JSON: %s", output)
+	}
+	var payload usage.Payload
+	if err := json.Unmarshal(output, &payload); err != nil {
+		t.Fatalf("decode compatible usage: %v", err)
+	}
+	return payload
+}
+
+func compatibleUsageJSONKeyOrder(t *testing.T, output []byte) ([]string, map[string][]string) {
+	t.Helper()
+	if !json.Valid(output) {
+		t.Fatalf("invalid compatible usage JSON: %s", output)
+	}
+	var root struct {
+		APIs json.RawMessage `json:"apis"`
+	}
+	if err := json.Unmarshal(output, &root); err != nil {
+		t.Fatalf("decode compatible usage root: %v", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(root.APIs))
+	if token, err := decoder.Token(); err != nil || token != json.Delim('{') {
+		t.Fatalf("decode APIs object start: token=%v err=%v", token, err)
+	}
+	endpointOrder := make([]string, 0)
+	modelOrder := make(map[string][]string)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			t.Fatalf("decode endpoint key: %v", err)
+		}
+		endpoint, ok := token.(string)
+		if !ok {
+			t.Fatalf("endpoint key token = %T, want string", token)
+		}
+		var endpointPayload struct {
+			Models json.RawMessage `json:"models"`
+		}
+		if err := decoder.Decode(&endpointPayload); err != nil {
+			t.Fatalf("decode endpoint %q payload: %v", endpoint, err)
+		}
+		endpointOrder = append(endpointOrder, endpoint)
+		modelOrder[endpoint] = jsonObjectKeyOrder(t, endpointPayload.Models)
+	}
+	if token, err := decoder.Token(); err != nil || token != json.Delim('}') {
+		t.Fatalf("decode APIs object end: token=%v err=%v", token, err)
+	}
+	return endpointOrder, modelOrder
+}
+
+func jsonObjectKeyOrder(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if token, err := decoder.Token(); err != nil || token != json.Delim('{') {
+		t.Fatalf("decode JSON object start: token=%v err=%v", token, err)
+	}
+	keys := make([]string, 0)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			t.Fatalf("decode JSON object key: %v", err)
+		}
+		key, ok := token.(string)
+		if !ok {
+			t.Fatalf("JSON object key token = %T, want string", token)
+		}
+		keys = append(keys, key)
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			t.Fatalf("decode JSON object value for %q: %v", key, err)
+		}
+	}
+	if token, err := decoder.Token(); err != nil || token != json.Delim('}') {
+		t.Fatalf("decode JSON object end: token=%v err=%v", token, err)
+	}
+	return keys
+}
+
+type blockingCompatibleUsageWriter struct {
+	mu          sync.Mutex
+	buffer      bytes.Buffer
+	blocked     chan struct{}
+	release     chan struct{}
+	blockOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingCompatibleUsageWriter() *blockingCompatibleUsageWriter {
+	return &blockingCompatibleUsageWriter{
+		blocked: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (w *blockingCompatibleUsageWriter) Write(p []byte) (int, error) {
+	w.blockOnce.Do(func() {
+		close(w.blocked)
+		<-w.release
+	})
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buffer.Write(p)
+}
+
+func (w *blockingCompatibleUsageWriter) Unblock() {
+	w.releaseOnce.Do(func() {
+		close(w.release)
+	})
+}
+
+func (w *blockingCompatibleUsageWriter) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.buffer.Bytes()...)
+}
+
+func startBlockedCompatibleUsageExport(t *testing.T, ctx context.Context, repo *repository, limit int) (*blockingCompatibleUsageWriter, <-chan error) {
+	t.Helper()
+	writer := newBlockingCompatibleUsageWriter()
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		errCh <- repo.WriteCompatibleUsage(ctx, writer, limit)
+	}()
+	t.Cleanup(func() {
+		writer.Unblock()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("compatible usage export did not finish during cleanup")
+		}
+	})
+	return writer, errCh
+}
+
+func waitForCompatibleUsageWriterBlock(t *testing.T, writer *blockingCompatibleUsageWriter) {
+	t.Helper()
+	select {
+	case <-writer.blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("compatible usage writer did not block")
+	}
+}
+
+func finishBlockedCompatibleUsageExport(t *testing.T, writer *blockingCompatibleUsageWriter, errCh <-chan error) error {
+	t.Helper()
+	writer.Unblock()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("compatible usage export did not finish")
+		return nil
+	}
+}
+
+type cancelCompatibleUsageWriter struct {
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (w *cancelCompatibleUsageWriter) Write(p []byte) (int, error) {
+	w.once.Do(w.cancel)
+	return len(p), nil
+}
+
+func runCompatibleUsageCheckpoint(t *testing.T, db *sql.DB, mode string) (busy, logFrames, checkpointedFrames int64) {
+	t.Helper()
+	var query string
+	switch mode {
+	case "passive":
+		query = "pragma wal_checkpoint(passive)"
+	case "truncate":
+		query = "pragma wal_checkpoint(truncate)"
+	default:
+		t.Fatalf("unsupported checkpoint mode %q", mode)
+	}
+	if err := db.QueryRow(query).Scan(&busy, &logFrames, &checkpointedFrames); err != nil {
+		t.Fatalf("run %s checkpoint: %v", mode, err)
+	}
+	return busy, logFrames, checkpointedFrames
+}
+
+func explainCompatibleUsageQueryPlan(t *testing.T, db *sql.DB, query string, args ...any) []string {
+	t.Helper()
+	rows, err := db.Query("explain query plan "+query, args...)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	defer rows.Close()
+
+	plan := make([]string, 0)
+	for rows.Next() {
+		var id int
+		var parent int
+		var unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read query plan: %v", err)
+	}
+	return plan
 }
 
 func streamTestEvent(hash string, timestampMS int64, endpoint, model string) usage.Event {


### PR DESCRIPTION
## Summary

Decouple compatible usage JSON streaming from SQLite reader lifetimes by snapshotting ordered row IDs once and loading details in bounded primary-key batches.
This lets WAL checkpoints progress while slow clients receive `GET /v0/management/usage`, without changing the payload shape or JSONL export path.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Execute the compatible global `ORDER BY` once for an ID-only snapshot, then load full rows in 1,024-row primary-key batches after closing each SQLite reader.
- Preserve endpoint/model/detail ordering across batch boundaries, fail closed when a snapshot row disappears, and cap compatible ID snapshots at 50,000 rows while leaving JSONL export limits unchanged.
- Add payload compatibility, batch-boundary, raw JSON ordering, concurrent-insert, cancellation, query-plan, slow-writer WAL, and focused benchmark coverage.

## User Impact

Slow compatible usage downloads no longer keep a SQLite reader open for the lifetime of HTTP backpressure, allowing WAL checkpoints to catch up.

The API shape and normal 50,000-row behavior remain unchanged. Configurations above 50,000 now return the latest 50,000 rows from the compatible endpoint; `/v0/management/usage/export` continues to honor the configured limit.

## Compatibility / Runtime Notes

- CPA panel mode: No authentication, frontend, or payload-shape changes.
- Manager Server mode: Compatible export uses one ordered ID snapshot and bounded primary-key detail batches; JSONL export remains unchanged.
- Full Docker / native packages: No deployment, environment-variable, or configuration changes.

## Data / Security Notes

This changes only the SQLite read pattern for compatible usage exports.

- No schema, index, or migration changes.
- No collector or WAL maintenance changes.
- No changes to raw usage sanitization or sensitive-field exposure.
- No changes to stored usage data.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert the single PR commit to restore the previous compatible export reader behavior.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
go test ./...
go test -race ./...
go vet ./...
go build ./...
go test ./internal/repository/usageevent -run Compatible -count=1 -v
go test ./internal/repository/usageevent -run NONE -bench BenchmarkWriteCompatibleUsage -benchmem -count=3
gofmt -d internal/repository/usageevent/stream.go internal/repository/usageevent/stream_test.go internal/repository/usageevent/stream_benchmark_test.go
git diff --check

Slow-writer checkpoint:
database connections in use: 0
busy=0 log_frames=62 checkpointed_frames=62

Benchmark comparison:
50k DB / 50k export: 1.245x wall time, 1.006x peak RSS
500k DB / 50k export: 1.166x wall time, 1.008x peak RSS
```

## Screenshots / Recordings

N/A — backend-only SQLite/export change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

No README or manual change is required because the API shape, configuration, and schema remain unchanged. Include the WAL reader-lifetime fix and compatible 50,000-row cap in the next release notes.

## Related

Fixes #503