### PR TITLE
ci(pr): automatically retarget pull requests to dev

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,10 @@
 
 <!-- What changed and why. Keep it short, 2-4 lines. -->
 
-> Community and maintenance PRs must target `dev`. `main` accepts only a
-> promotion PR whose source is this repository's `dev` branch.
+> Community and maintenance PRs must target `dev`. Repository automation
+> retargets other pull requests to `dev`; this can change the diff and make
+> existing review comments outdated. `main` accepts only a promotion PR whose
+> source is this repository's `dev` branch.
 
 ## Scope
 

--- a/.github/workflows/main-promotion.yml
+++ b/.github/workflows/main-promotion.yml
@@ -1,4 +1,4 @@
-name: Main Promotion
+name: PR Target Policy
 
 on:
   pull_request:
@@ -10,13 +10,101 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  pull_request_target:
+    branches-ignore:
+      - dev
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: read
 
 jobs:
+  retarget:
+    name: Retarget pull request to dev
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.base.ref != 'dev' &&
+      (github.event.pull_request.base.ref != 'main' ||
+       github.event.pull_request.head.repo.full_name != github.repository ||
+       github.event.pull_request.head.ref != 'dev')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify retargeting credentials
+        env:
+          APP_ID: ${{ vars.PR_TARGET_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.PR_TARGET_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${APP_ID}" ]; then
+            echo "Repository variable PR_TARGET_APP_ID is required to retarget pull requests." >&2
+            exit 1
+          fi
+
+          if [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "Repository secret PR_TARGET_PRIVATE_KEY is required to retarget pull requests." >&2
+            exit 1
+          fi
+
+      - name: Create pull request retargeting token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.PR_TARGET_APP_ID }}
+          private-key: ${{ secrets.PR_TARGET_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Retarget pull request to dev
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const repository = `${owner}/${repo}`;
+
+            const { data: current } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number
+            });
+
+            const targetsDev = current.base.ref === "dev";
+            const isDevPromotion =
+              current.base.ref === "main" &&
+              current.head.repo?.full_name === repository &&
+              current.head.ref === "dev";
+
+            if (targetsDev || isDevPromotion) {
+              core.info("Pull request target already satisfies the dev integration policy.");
+              return;
+            }
+
+            const previousBase = current.base.ref;
+            const { data: updated } = await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number,
+              base: "dev"
+            });
+
+            if (updated.base.ref !== "dev") {
+              core.setFailed(`Expected pull request base dev, received ${updated.base.ref}.`);
+              return;
+            }
+
+            core.notice(`Retargeted pull request #${pull_number} from ${previousBase} to dev.`);
+
   verify-source:
     name: Verify dev promotion source
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - dev
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
   push:
     branches:
       - main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,11 @@ work is integrated through `dev` before it is promoted to `main`.
 5. A maintainer promotes the tested repository `dev` branch to `main`.
 
 Do not open a feature or fix pull request directly to `main`. `main` accepts
-only a pull request from this repository's `dev` branch.
+only a pull request from this repository's `dev` branch. If a community or
+maintenance pull request targets another branch, repository automation changes
+its base to `dev`. Changing the base can alter the displayed diff and make
+existing review comments outdated, so select `dev` when opening the pull
+request instead of relying on the correction.
 
 ```bash
 git remote add upstream https://github.com/seakee/CPA-Manager-Plus.git

--- a/tests/ciWorkflowIntegrity.test.mjs
+++ b/tests/ciWorkflowIntegrity.test.mjs
@@ -39,6 +39,47 @@ describe('GitHub Actions workflow integrity', () => {
     }
   });
 
+  it('retargets non-dev pull requests without executing contributor code', () => {
+    const workflow = readWorkflow('main-promotion.yml');
+    const targetJob = jobBlock(workflow, 'retarget');
+
+    expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain('branches-ignore:');
+    expect(workflow).toContain("github.event.pull_request.base.ref != 'dev'");
+    expect(workflow).toContain(
+      'github.event.pull_request.head.repo.full_name != github.repository'
+    );
+    expect(targetJob).toContain('PR_TARGET_APP_ID');
+    expect(targetJob).toContain('PR_TARGET_PRIVATE_KEY');
+    expect(targetJob).toContain('permission-pull-requests: write');
+    expect(targetJob).toContain('github.rest.pulls.update');
+    expect(targetJob).toContain('base: "dev"');
+    expect(targetJob).not.toContain('actions/checkout@');
+    expect(targetJob).not.toContain('github.event.pull_request.head.sha');
+  });
+
+  it('keeps the main promotion check on the pull request merge commit', () => {
+    const workflow = readWorkflow('main-promotion.yml');
+    const promotionJob = jobBlock(workflow, 'verify-source');
+
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('- main');
+    expect(promotionJob).toContain('name: Verify dev promotion source');
+    expect(promotionJob).toContain("if: github.event_name == 'pull_request'");
+    expect(promotionJob).toContain('HEAD_REPOSITORY');
+    expect(promotionJob).toContain('HEAD_REF');
+    expect(promotionJob).toContain('main accepts promotions only from');
+  });
+
+  it('reruns pull request checks after an automated base change', () => {
+    const workflow = readWorkflow('pr-check.yml');
+    const trigger = workflow.slice(0, workflow.indexOf('\npermissions:'));
+
+    expect(trigger).toContain('pull_request:');
+    expect(trigger).toContain('types:');
+    expect(trigger).toContain('- edited');
+  });
+
   it('keeps Demo and Docs inside the stable required-check aggregate', () => {
     const workflow = readWorkflow('pr-check.yml');
     const demoJob = jobBlock(workflow, 'demo-docs');


### PR DESCRIPTION
## Summary

Automatically retarget ordinary pull requests to `dev` while preserving same-repository `dev` to `main` promotion pull requests.

The privileged workflow authenticates through the repository GitHub App and does not check out or execute contributor-controlled code.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [x] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Add a `pull_request_target` job that uses `PR_TARGET_APP_ID` and `PR_TARGET_PRIVATE_KEY` to change non-promotion PR bases to `dev`.
- Require both the `dev` head branch and the same repository for valid `dev` to `main` promotions, and rerun normal PR checks after base edits.
- Document the contribution target and automatic retargeting behavior in the PR template and contribution guide.
- Add workflow integrity coverage for triggers, permissions, pinned Actions, and the no-checkout privileged boundary.

## User Impact

Contributors who accidentally open a pull request against `main` will have its base changed automatically to `dev`. This can update the displayed diff and may make existing review comments outdated.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: N/A.
- Repository configuration: requires variable `PR_TARGET_APP_ID` and secret `PR_TARGET_PRIVATE_KEY` for a GitHub App installed on this repository with pull-request read/write permission.

## Data / Security Notes

The `pull_request_target` job has pull-request write access only. It uses pinned official Actions, does not check out the pull request, and does not execute contributor-controlled code. No application data, credentials, or runtime storage formats change.

## Risk / Rollback

Risk level: Low

Rollback notes: revert the two commits to remove automatic retargeting and restore the previous documentation. The GitHub App variable, secret, and installation can then be removed separately if no longer needed.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run test -- --run tests/ciWorkflowIntegrity.test.mjs
Test Files 192 passed (192)
Tests 2170 passed (2170)

All GitHub Actions YAML files parsed successfully.
Modified workflows, tests, and PR template passed Prettier validation.
git diff --check
```

## Screenshots / Recordings

N/A — CI governance and documentation only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: The contributor-facing behavior is documented in `CONTRIBUTING.md` and the pull request template. Product documentation and release notes are not required.

## Related

N/A