### PR TITLE
ci(release): support immutable release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,12 @@ jobs:
       - build_release_assets
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       publish: ${{ steps.release_state.outputs.publish }}
+      finalize: ${{ steps.release_state.outputs.finalize }}
+      release_id: ${{ steps.prepared_release.outputs.release_id }}
+      state: ${{ steps.release_state.outputs.state }}
       upload_files: ${{ steps.release_state.outputs.upload_files }}
     env:
       RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
@@ -204,6 +207,10 @@ jobs:
 
           if [ "${DRY_RUN}" = "true" ]; then
             echo "publish=false" >> "${GITHUB_OUTPUT}"
+            echo "finalize=false" >> "${GITHUB_OUTPUT}"
+            echo "release_id=" >> "${GITHUB_OUTPUT}"
+            echo "state=none" >> "${GITHUB_OUTPUT}"
+            echo "upload_files=" >> "${GITHUB_OUTPUT}"
             echo "Dry-run does not inspect or publish a GitHub Release." >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
@@ -234,10 +241,58 @@ jobs:
             --header "X-GitHub-Api-Version: 2022-11-28" \
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
 
+          if [ "${http_code}" = "404" ]; then
+            release_list_json="${RUNNER_TEMP}/release-list.json"
+            release_list_code="$(curl \
+              --silent \
+              --show-error \
+              --output "${release_list_json}" \
+              --write-out "%{http_code}" \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases?per_page=100")"
+            case "${release_list_code}" in
+              200)
+                matching_release_count="$(jq --arg tag "${RELEASE_TAG}" \
+                  'map(select(.tag_name == $tag)) | length' \
+                  "${release_list_json}")"
+                if [ "${matching_release_count}" -gt 1 ]; then
+                  echo "GitHub Release list contains multiple entries for ${RELEASE_TAG}." >&2
+                  exit 1
+                fi
+                jq -c --arg tag "${RELEASE_TAG}" \
+                  'map(select(.tag_name == $tag)) | if length == 1 then .[0] else empty end' \
+                  "${release_list_json}" > "${release_json}"
+                if [ -s "${release_json}" ]; then
+                  http_code=200
+                fi
+                ;;
+              *)
+                echo "GitHub Release list lookup failed with HTTP ${release_list_code}." >&2
+                exit 1
+                ;;
+            esac
+          fi
+
           case "${http_code}" in
             200)
+              release_id="$(jq -r '.id' "${release_json}")"
+              if ! [[ "${release_id}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "GitHub Release response has an invalid id: ${release_id}." >&2
+                exit 1
+              fi
+              echo "release_id=${release_id}" >> "${GITHUB_OUTPUT}"
+              is_draft="$(jq -r '.draft' "${release_json}")"
+              verification_mode=artifact
+              if [ "${is_draft}" = "true" ]; then
+                verification_mode=draft
+              elif [ "${is_draft}" != "false" ]; then
+                echo "GitHub Release response has an invalid draft value: ${is_draft}." >&2
+                exit 1
+              fi
               allow_missing=false
-              if [ "${RUN_ATTEMPT}" -gt 1 ]; then
+              if [ "${verification_mode}" = "draft" ] || [ "${RUN_ATTEMPT}" -gt 1 ]; then
                 allow_missing=true
               fi
               verification_json="${RUNNER_TEMP}/release-verification.json"
@@ -247,6 +302,7 @@ jobs:
                 --body-path dist/release/release-notes.md \
                 --release-json "${release_json}" \
                 --prerelease "${EXPECTED_PRERELEASE}" \
+                --mode "${verification_mode}" \
                 --allow-missing-assets "${allow_missing}" \
                 --result-path "${verification_json}"
               complete="$(node --input-type=module - "${verification_json}" <<'NODE'
@@ -256,9 +312,22 @@ jobs:
               process.stdout.write(String(result.complete));
               NODE
               )"
+              echo "state=${verification_mode}" >> "${GITHUB_OUTPUT}"
+              if [ "${verification_mode}" = "draft" ]; then
+                echo "finalize=true" >> "${GITHUB_OUTPUT}"
+              else
+                echo "finalize=false" >> "${GITHUB_OUTPUT}"
+              fi
               if [ "${complete}" = "true" ]; then
-                echo "publish=false" >> "${GITHUB_OUTPUT}"
-                echo "Existing GitHub Release matches the checked payload; upload skipped." >> "${GITHUB_STEP_SUMMARY}"
+                if [ "${verification_mode}" = "draft" ]; then
+                  echo "publish=true" >> "${GITHUB_OUTPUT}"
+                  echo "upload_files=" >> "${GITHUB_OUTPUT}"
+                  echo "A complete draft GitHub Release is ready for publication." >> "${GITHUB_STEP_SUMMARY}"
+                else
+                  echo "publish=false" >> "${GITHUB_OUTPUT}"
+                  echo "upload_files=" >> "${GITHUB_OUTPUT}"
+                  echo "Existing GitHub Release matches the checked payload; upload skipped." >> "${GITHUB_STEP_SUMMARY}"
+                fi
               else
                 missing_upload_files="$(node --input-type=module - "${verification_json}" <<'NODE'
                 import { readFileSync } from 'node:fs';
@@ -269,11 +338,18 @@ jobs:
                 )"
                 echo "publish=true" >> "${GITHUB_OUTPUT}"
                 write_upload_files "${missing_upload_files}"
-                echo "Existing matching assets will be preserved; only missing assets will be uploaded." >> "${GITHUB_STEP_SUMMARY}"
+                if [ "${verification_mode}" = "draft" ]; then
+                  echo "Existing draft assets will be preserved; only missing assets will be uploaded before publication." >> "${GITHUB_STEP_SUMMARY}"
+                else
+                  echo "Existing matching assets will be preserved; only missing assets will be uploaded." >> "${GITHUB_STEP_SUMMARY}"
+                fi
               fi
               ;;
             404)
               echo "publish=true" >> "${GITHUB_OUTPUT}"
+              echo "finalize=true" >> "${GITHUB_OUTPUT}"
+              echo "release_id=" >> "${GITHUB_OUTPUT}"
+              echo "state=missing" >> "${GITHUB_OUTPUT}"
               write_upload_files "${all_upload_files}"
               ;;
             *)
@@ -281,6 +357,130 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Create or update draft GitHub Release
+        id: draft_release
+        if: env.DRY_RUN != 'true' && steps.release_state.outputs.finalize == 'true' && steps.release_state.outputs.upload_files != ''
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ needs.preflight.outputs.release_tag }}
+          files: ${{ steps.release_state.outputs.upload_files }}
+          body_path: dist/release/release-notes.md
+          draft: true
+          prerelease: ${{ needs.preflight.outputs.prerelease == 'true' }}
+          overwrite_files: false
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload missing assets to existing mutable Release
+        id: published_release
+        if: env.DRY_RUN != 'true' && steps.release_state.outputs.state == 'artifact' && steps.release_state.outputs.upload_files != ''
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ needs.preflight.outputs.release_tag }}
+          files: ${{ steps.release_state.outputs.upload_files }}
+          body_path: dist/release/release-notes.md
+          draft: false
+          prerelease: ${{ needs.preflight.outputs.prerelease == 'true' }}
+          overwrite_files: false
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve prepared GitHub Release id
+        id: prepared_release
+        if: env.DRY_RUN != 'true'
+        shell: bash
+        env:
+          DRAFT_RELEASE_ID: ${{ steps.draft_release.outputs.id }}
+          EXISTING_RELEASE_ID: ${{ steps.release_state.outputs.release_id }}
+          PUBLISHED_RELEASE_ID: ${{ steps.published_release.outputs.id }}
+        run: |
+          set -euo pipefail
+          release_id=""
+          for candidate in "${EXISTING_RELEASE_ID}" "${DRAFT_RELEASE_ID}" "${PUBLISHED_RELEASE_ID}"; do
+            if [ -z "${candidate}" ]; then
+              continue
+            fi
+            if ! [[ "${candidate}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "GitHub Release action returned an invalid id: ${candidate}." >&2
+              exit 1
+            fi
+            if [ -n "${release_id}" ] && [ "${release_id}" != "${candidate}" ]; then
+              echo "GitHub Release id changed during preparation: ${release_id} -> ${candidate}." >&2
+              exit 1
+            fi
+            release_id="${candidate}"
+          done
+          if [ -z "${release_id}" ]; then
+            echo "Prepared GitHub Release id is missing." >&2
+            exit 1
+          fi
+          echo "release_id=${release_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify prepared draft Release
+        if: env.DRY_RUN != 'true' && steps.release_state.outputs.finalize == 'true'
+        shell: bash
+        env:
+          EXPECTED_PRERELEASE: ${{ needs.preflight.outputs.prerelease }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.prepared_release.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          release_json="${RUNNER_TEMP}/prepared-draft-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "GitHub Release lookup after draft upload failed with HTTP ${http_code} for id ${RELEASE_ID}." >&2
+            exit 1
+          fi
+          node bin/release/verify-published-release.mjs \
+            --tag "${RELEASE_TAG}" \
+            --assets-dir dist/release \
+            --body-path dist/release/release-notes.md \
+            --release-json "${release_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}" \
+            --mode draft \
+            --allow-missing-assets false
+
+      - name: Verify completed mutable Release upload
+        if: env.DRY_RUN != 'true' && steps.release_state.outputs.state == 'artifact' && steps.release_state.outputs.upload_files != ''
+        shell: bash
+        env:
+          EXPECTED_PRERELEASE: ${{ needs.preflight.outputs.prerelease }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.prepared_release.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          release_json="${RUNNER_TEMP}/prepared-published-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "GitHub Release lookup after asset upload failed with HTTP ${http_code} for id ${RELEASE_ID}." >&2
+            exit 1
+          fi
+          node bin/release/verify-published-release.mjs \
+            --tag "${RELEASE_TAG}" \
+            --assets-dir dist/release \
+            --body-path dist/release/release-notes.md \
+            --release-json "${release_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}" \
+            --allow-missing-assets false
 
   build_and_push_docker:
     name: Build and publish Docker images
@@ -434,19 +634,103 @@ jobs:
         if: needs.inspect_github_release.outputs.publish != 'true'
         run: echo "Existing GitHub Release already matches the checked payload." >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Create Release
-        if: needs.inspect_github_release.outputs.publish == 'true'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ needs.preflight.outputs.release_tag }}
-          files: ${{ needs.inspect_github_release.outputs.upload_files }}
-          body_path: dist/release/release-notes.md
-          draft: false
-          prerelease: ${{ needs.preflight.outputs.prerelease == 'true' }}
-          overwrite_files: false
-          fail_on_unmatched_files: true
+      - name: Publish verified draft GitHub Release
+        if: needs.inspect_github_release.outputs.publish == 'true' && needs.inspect_github_release.outputs.finalize == 'true'
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_PRERELEASE: ${{ needs.preflight.outputs.prerelease }}
+          RELEASE_ID: ${{ needs.inspect_github_release.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          release_json="${RUNNER_TEMP}/draft-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "Draft GitHub Release lookup failed with HTTP ${http_code} for id ${RELEASE_ID}." >&2
+            exit 1
+          fi
+
+          node bin/release/verify-published-release.mjs \
+            --tag "${RELEASE_TAG}" \
+            --assets-dir dist/release \
+            --body-path dist/release/release-notes.md \
+            --release-json "${release_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}" \
+            --mode draft \
+            --allow-missing-assets false
+
+          release_id="$(jq -r '.id' "${release_json}")"
+          if [ "${release_id}" != "${RELEASE_ID}" ]; then
+            echo "Draft GitHub Release id changed during publication: ${RELEASE_ID} -> ${release_id}." >&2
+            exit 1
+          fi
+          publish_payload="$(jq -cn --argjson prerelease "${EXPECTED_PRERELEASE}" '{draft: false, prerelease: $prerelease}')"
+          publish_json="${RUNNER_TEMP}/published-release.json"
+          publish_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${publish_json}" \
+            --write-out "%{http_code}" \
+            --request PATCH \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --header "Content-Type: application/json" \
+            --data "${publish_payload}" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${release_id}")"
+          if [ "${publish_code}" != "200" ]; then
+            echo "Publishing the verified draft GitHub Release failed with HTTP ${publish_code}." >&2
+            exit 1
+          fi
+
+          node bin/release/verify-published-release.mjs \
+            --tag "${RELEASE_TAG}" \
+            --assets-dir dist/release \
+            --body-path dist/release/release-notes.md \
+            --release-json "${publish_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}" \
+            --allow-missing-assets false
+
+          echo "Verified draft GitHub Release published after all assets were uploaded." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Verify existing published GitHub Release
+        if: needs.inspect_github_release.outputs.publish == 'true' && needs.inspect_github_release.outputs.finalize != 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_PRERELEASE: ${{ needs.preflight.outputs.prerelease }}
+          RELEASE_ID: ${{ needs.inspect_github_release.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          release_json="${RUNNER_TEMP}/published-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "Published GitHub Release lookup failed with HTTP ${http_code} for id ${RELEASE_ID}." >&2
+            exit 1
+          fi
+          node bin/release/verify-published-release.mjs \
+            --tag "${RELEASE_TAG}" \
+            --assets-dir dist/release \
+            --body-path dist/release/release-notes.md \
+            --release-json "${release_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}" \
+            --allow-missing-assets false
 
   notify_telegram:
     name: Notify Telegram

--- a/bin/release/verify-published-release.mjs
+++ b/bin/release/verify-published-release.mjs
@@ -66,19 +66,27 @@ export const buildExpectedReleaseAssets = (assetsDir, tag) => {
   return assets;
 };
 
-const verifyReleaseIdentity = ({ release, tag, prerelease, body }) => {
+const verifyReleaseIdentity = ({ release, tag, prerelease, body, draft }) => {
   parseReleaseTag(tag);
   if (!release || typeof release !== 'object') fail('GitHub Release response must be an object');
   if (release.tag_name !== tag) {
     fail(`Existing GitHub Release tag mismatch: expected ${tag}, received ${release.tag_name}`);
   }
-  if (release.draft !== false) fail(`Existing GitHub Release ${tag} is still a draft`);
+  if (release.draft !== draft) {
+    fail(
+      `Existing GitHub Release ${tag} draft mismatch: expected ${draft}, received ${release.draft}`
+    );
+  }
   if (release.prerelease !== prerelease) {
     fail(
       `Existing GitHub Release prerelease mismatch: expected ${prerelease}, received ${release.prerelease}`
     );
   }
-  if (typeof release.published_at !== 'string' || release.published_at.trim() === '') {
+  if (draft) {
+    if (release.published_at !== null) {
+      fail(`Existing GitHub Release ${tag} draft has an unexpected published_at value`);
+    }
+  } else if (typeof release.published_at !== 'string' || release.published_at.trim() === '') {
     fail(`Existing GitHub Release ${tag} is not published`);
   }
   if (normalizeBody(release.body) !== normalizeBody(body)) {
@@ -111,15 +119,7 @@ const verifyUploadedAssetMetadata = (asset) => {
   }
 };
 
-export const verifyPublishedRelease = ({
-  release,
-  tag,
-  prerelease,
-  body,
-  assets,
-  allowMissingAssets = false,
-}) => {
-  verifyReleaseIdentity({ release, tag, prerelease, body });
+const verifyReleaseAssets = ({ release, tag, assets, allowMissingAssets }) => {
   const actualAssets = sortedPublishedAssets(release);
   const expectedByName = new Map(assets.map((asset) => [asset.name, asset]));
 
@@ -161,8 +161,37 @@ export const verifyPublishedRelease = ({
   };
 };
 
+export const verifyPublishedRelease = ({
+  release,
+  tag,
+  prerelease,
+  body,
+  assets,
+  allowMissingAssets = false,
+}) => {
+  verifyReleaseIdentity({ release, tag, prerelease, body, draft: false });
+  return verifyReleaseAssets({ release, tag, assets, allowMissingAssets });
+};
+
+export const verifyDraftRelease = ({
+  release,
+  tag,
+  prerelease,
+  body,
+  assets,
+  allowMissingAssets = false,
+}) => {
+  verifyReleaseIdentity({ release, tag, prerelease, body, draft: true });
+  return verifyReleaseAssets({
+    release,
+    tag,
+    assets,
+    allowMissingAssets,
+  });
+};
+
 export const verifyPublishedReleaseMetadata = ({ release, tag, prerelease, body }) => {
-  verifyReleaseIdentity({ release, tag, prerelease, body });
+  verifyReleaseIdentity({ release, tag, prerelease, body, draft: false });
   const actualAssets = sortedPublishedAssets(release);
   const expectedNames = expectedReleaseAssetNames(tag);
   if (actualAssets.length !== expectedNames.length) {
@@ -235,21 +264,32 @@ const runCli = () => {
   const releaseJsonPath = requiredOption(options, 'release-json');
   const prerelease = booleanOption(options, 'prerelease');
   const mode = options.mode || 'artifact';
-  if (mode !== 'artifact' && mode !== 'metadata') fail('--mode must be artifact or metadata');
+  if (mode !== 'artifact' && mode !== 'draft' && mode !== 'metadata') {
+    fail('--mode must be artifact, draft, or metadata');
+  }
 
   const release = JSON.parse(readFileSync(releaseJsonPath, 'utf8'));
   const body = readFileSync(bodyPath, 'utf8');
   const result =
     mode === 'metadata'
       ? verifyPublishedReleaseMetadata({ release, tag, prerelease, body })
-      : verifyPublishedRelease({
-          release,
-          tag,
-          prerelease,
-          body,
-          assets: buildExpectedReleaseAssets(requiredOption(options, 'assets-dir'), tag),
-          allowMissingAssets: booleanOption(options, 'allow-missing-assets'),
-        });
+      : mode === 'draft'
+        ? verifyDraftRelease({
+            release,
+            tag,
+            prerelease,
+            body,
+            assets: buildExpectedReleaseAssets(requiredOption(options, 'assets-dir'), tag),
+            allowMissingAssets: booleanOption(options, 'allow-missing-assets'),
+          })
+        : verifyPublishedRelease({
+            release,
+            tag,
+            prerelease,
+            body,
+            assets: buildExpectedReleaseAssets(requiredOption(options, 'assets-dir'), tag),
+            allowMissingAssets: booleanOption(options, 'allow-missing-assets'),
+          });
 
   if (options['result-path']) {
     writeFileSync(options['result-path'], `${JSON.stringify(result, null, 2)}\n`);

--- a/tests/ciWorkflowIntegrity.test.mjs
+++ b/tests/ciWorkflowIntegrity.test.mjs
@@ -168,13 +168,47 @@ describe('GitHub Actions workflow integrity', () => {
     expect(inspectJob).toContain('bin/release/verify-published-release.mjs');
     expect(inspectJob).toContain('--allow-missing-assets "${allow_missing}"');
     expect(inspectJob).toContain('only missing assets will be uploaded');
+    expect(inspectJob).toContain('matching_release_count');
+    expect(inspectJob).toContain('multiple entries for ${RELEASE_TAG}');
     expect(dockerJob).toContain('- inspect_github_release');
     expect(publishJob).toContain('- inspect_github_release');
     expect(publishJob).toContain("if: needs.inspect_github_release.outputs.publish == 'true'");
     expect(workflow.indexOf('  inspect_github_release:')).toBeLessThan(
       workflow.indexOf('  build_and_push_docker:')
     );
-    expect(publishJob).toContain('overwrite_files: false');
+    expect(inspectJob).toContain('overwrite_files: false');
+  });
+
+  it('uploads every new Release as a draft and publishes only after verification', () => {
+    const workflow = readWorkflow('release.yml');
+    const inspectJob = jobBlock(workflow, 'inspect_github_release');
+    const publishJob = jobBlock(workflow, 'publish_github_release');
+
+    expect(inspectJob).toContain('contents: write');
+    expect(inspectJob).toContain('verification_mode=draft');
+    expect(inspectJob).toContain('draft: true');
+    expect(inspectJob).toContain('Resolve prepared GitHub Release id');
+    expect(inspectJob).toContain('release_id: ${{ steps.prepared_release.outputs.release_id }}');
+    expect(inspectJob).toContain('Verify prepared draft Release');
+    expect(inspectJob).toContain('/releases/${RELEASE_ID}');
+    expect(publishJob).toContain('Publish verified draft GitHub Release');
+    expect(publishJob).toContain(
+      "if: needs.inspect_github_release.outputs.publish == 'true' && needs.inspect_github_release.outputs.finalize == 'true'"
+    );
+    expect(publishJob).toContain('--request PATCH');
+    expect(publishJob).toContain(
+      'RELEASE_ID: ${{ needs.inspect_github_release.outputs.release_id }}'
+    );
+    expect(publishJob).toContain(
+      '"${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"'
+    );
+    expect(publishJob).not.toContain('/releases/tags/${RELEASE_TAG}');
+    expect(publishJob).toContain('draft: false');
+    expect(publishJob).toContain(
+      'Verified draft GitHub Release published after all assets were uploaded.'
+    );
+    expect(inspectJob).toContain('echo "state=${verification_mode}"');
+    expect(inspectJob).toContain('echo "state=missing"');
   });
 
   it('prevents automatic Telegram delivery on workflow reruns', () => {

--- a/tests/releasePublishedState.test.mjs
+++ b/tests/releasePublishedState.test.mjs
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildExpectedReleaseAssets,
   expectedReleaseAssetNames,
+  verifyDraftRelease,
   verifyPublishedRelease,
   verifyPublishedReleaseMetadata,
 } from '../bin/release/verify-published-release.mjs';
@@ -46,6 +47,17 @@ const makePublishedRelease = ({ assets, overrides = {} }) => ({
   ...overrides,
 });
 
+const makeDraftRelease = ({ assets, overrides = {} }) => ({
+  tag_name: tag,
+  draft: true,
+  prerelease: true,
+  immutable: false,
+  published_at: null,
+  body: '# Release\n',
+  assets: assets.map(publishedAsset),
+  ...overrides,
+});
+
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
@@ -71,6 +83,58 @@ describe('published release verification', () => {
       missingAssets: [],
       complete: true,
       immutable: true,
+    });
+  });
+
+  it('accepts a complete draft Release before final publication', () => {
+    const assets = buildExpectedReleaseAssets(makeReleaseFixture(), tag);
+
+    expect(
+      verifyDraftRelease({
+        release: makeDraftRelease({ assets }),
+        tag,
+        prerelease: true,
+        body: '# Release\n',
+        assets,
+      })
+    ).toEqual({
+      expectedAssets: 8,
+      publishedAssets: 8,
+      missingAssets: [],
+      complete: true,
+      immutable: false,
+    });
+  });
+
+  it('allows a draft with matching missing assets to be completed', () => {
+    const assets = buildExpectedReleaseAssets(makeReleaseFixture(), tag);
+    const release = makeDraftRelease({ assets: assets.slice(1) });
+
+    expect(() =>
+      verifyDraftRelease({
+        release,
+        tag,
+        prerelease: true,
+        body: '# Release\n',
+        assets,
+      })
+    ).toThrow('asset count mismatch');
+
+    expect(
+      verifyDraftRelease({
+        release,
+        tag,
+        prerelease: true,
+        body: '# Release\n',
+        assets,
+        allowMissingAssets: true,
+      })
+    ).toMatchObject({
+      expectedAssets: 8,
+      publishedAssets: 7,
+      missingAssets: [{ name: assets[0].name, filePath: assets[0].filePath }],
+      complete: false,
+      immutable: false,
     });
   });
 
@@ -174,7 +238,7 @@ describe('published release verification', () => {
       makePublishedRelease({ assets, overrides: { body: '# Other' } }),
       'body differs'
     );
-    assertRejected(makePublishedRelease({ assets, overrides: { draft: true } }), 'still a draft');
+    assertRejected(makePublishedRelease({ assets, overrides: { draft: true } }), 'draft mismatch');
     assertRejected(
       makePublishedRelease({ assets, overrides: { prerelease: false } }),
       'prerelease mismatch'
@@ -183,6 +247,16 @@ describe('published release verification', () => {
       makePublishedRelease({ assets, overrides: { published_at: null } }),
       'is not published'
     );
+
+    expect(() =>
+      verifyDraftRelease({
+        release: makeDraftRelease({ assets, overrides: { published_at: '2026-08-12T00:00:00Z' } }),
+        tag,
+        prerelease: true,
+        body: '# Release',
+        assets,
+      })
+    ).toThrow('draft has an unexpected published_at value');
   });
 
   it('requires a complete healthy asset set for Telegram recovery', () => {


### PR DESCRIPTION
## Summary

Make the release workflow compatible with GitHub Immutable Releases by preparing the complete asset set in a draft Release and publishing it only after verification.

Preserve fail-closed rerun behavior for existing published Releases while allowing incomplete mutable drafts to resume safely.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Create or resume a draft GitHub Release, upload only missing verified assets, and publish it explicitly through the Releases API after the complete payload is revalidated.
- Keep published Release reruns idempotent, reject incomplete immutable Releases and duplicate tag matches, and verify all subsequent operations by Release ID.
- Add draft-state verification and workflow integrity regression coverage.

## User Impact

No product UI or runtime behavior change. Release publication can now complete when GitHub Immutable Releases is enabled without attempting to upload assets after publication.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: Release packaging outputs are unchanged; only GitHub Release publication ordering and verification change.

## Data / Security Notes

No application data, credentials, auth files, logs, or secret handling changes. The workflow continues to use the scoped GitHub Actions token and validates Release metadata and SHA-256 asset digests before publication.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert commit `b5b9ce54` to restore the previous direct publication workflow. Do not rerun a partially published tag without first inspecting the existing GitHub Release and registry state.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm test
  185 test files passed
  2219 tests passed

focused Vitest
  tests/releasePublishedState.test.mjs
  tests/ciWorkflowIntegrity.test.mjs
  2 test files passed
  23 tests passed

Prettier check passed for the changed JavaScript files.
release.yml parsed successfully as YAML.
All bash workflow blocks passed bash -n.
node --check bin/release/verify-published-release.mjs passed.
git diff --check passed.
```

## Screenshots / Recordings

N/A — CI and release workflow change only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: The release process contract is unchanged for operators; this PR changes the workflow implementation required by the repository's Immutable Releases setting.

## Related

Pre-release prerequisite for `v1.12.0-rc.1`.
