### PR TITLE
docs(release): prepare v1.12.0-rc.1

### DIFF
--- a/docs/release-notes/v1.12.0-rc.1-en.md
+++ b/docs/release-notes/v1.12.0-rc.1-en.md
@@ -1,0 +1,46 @@
+# CPA Manager Plus v1.12.0-rc.1
+
+> 23 commits · 275 files changed · +21969 / -6576
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-rc.1/docs/release-notes/v1.12.0-rc.1-zh.md)
+
+## Overview
+
+This is the first release candidate of v1.12.0. It completes the unified Accounts credential-management workflow, improves credential-health synchronization, adds weighted credential routing and monitoring request metadata, and retires the standalone Auth Files and Quota management surfaces. Server inspection, quota refreshes, and Codex reauthorization now synchronize back into Accounts instead of leaving stale limited or re-login states visible.
+
+## Highlights
+
+### Features
+
+- Monitoring can display normalized and bounded client IP, unverified X-Forwarded-For, and User-Agent metadata in full display mode while remaining absent-safe for older CPA payloads.
+- Add weighted round-robin credential routing and show effective and default weights in supported provider credential details.
+- Use Accounts as the unified workflow for credentials, quota, inspection, and reauthorization, replacing the standalone Auth Files and Quota pages.
+
+### Fixes
+
+- Derive Accounts health from the newest qualified request, credential, quota, and inspection evidence so HTTP 499, client cancellation, and stale asynchronous results no longer restore incorrect abnormal or re-login labels.
+- Synchronize credential status, quota, and action evidence into Accounts after server inspection, manual quota refresh, and completed Codex OAuth reauthorization.
+- Scope reauthorization flows to the active connection and session so late results from superseded attempts cannot overwrite the current credential state.
+- Preserve empty quota-window observations and retryable quota-snapshot synchronization failures instead of leaving Accounts with stale limited evidence.
+- Normalize request metadata at ingestion and presentation boundaries while keeping full and masked display behavior separate.
+
+### Docs
+
+- Align Chinese and English documentation, navigation, and deployment guidance around Accounts credential management, and remove the retired Auth Files and standalone Quota manuals.
+
+### CI / Build
+
+- Prepare and verify a complete Draft Release before explicitly publishing it, making the workflow compatible with Immutable Releases.
+- Keep release reruns idempotent and fail-closed, with approved recovery support for incomplete mutable Releases.
+
+## Upgrade Notes
+
+- This is a prerelease. Stable Docker tags and `latest` are not updated; use the explicit `v1.12.0-rc.1` release assets or image.
+- Use Accounts for credential management, quota, inspection, and reauthorization. The standalone Auth Files and Quota pages and routes have been removed, while compatibility APIs remain available to Accounts.
+- Weighted round robin requires a CPA runtime that supports the routing strategy and credential weight fields. Existing routing is unchanged unless the strategy is enabled.
+- Request metadata may contain sensitive client information. It is available only in full display mode and is excluded from compatible usage and JSONL exports.
+- Manager Server handles the additive compatibility fields automatically; no manual database rebuild or credential re-import is required.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-beta3...v1.12.0-rc.1

--- a/docs/release-notes/v1.12.0-rc.1-zh.md
+++ b/docs/release-notes/v1.12.0-rc.1-zh.md
@@ -1,0 +1,46 @@
+# CPA Manager Plus v1.12.0-rc.1
+
+> 23 commits · 275 files changed · +21969 / -6576
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-rc.1/docs/release-notes/v1.12.0-rc.1-en.md)
+
+## Overview
+
+这是 v1.12.0 的第一个 release candidate，重点完善统一的 Accounts 凭证管理、凭证健康状态同步、加权凭证路由和监控请求元数据，同时移除旧版独立 Auth Files 与 Quota 管理入口。服务端巡检、额度刷新和 Codex 重新登录后的结果现在会同步回 Accounts，避免继续显示过期的限额或需要重新登录状态。
+
+## Highlights
+
+### Features
+
+- Monitoring 在完整显示模式下支持查看经规范化和限制长度的客户端 IP、未验证的 X-Forwarded-For 与 User-Agent；旧 CPA 数据缺少这些字段时仍可正常工作。
+- 支持在凭证路由中使用 weighted round robin，并在支持的提供商凭证详情中展示有效权重和默认权重。
+- Accounts 统一承载凭证、额度、巡检和重新登录工作流，替代旧版独立 Auth Files 与 Quota 页面。
+
+### Fixes
+
+- Accounts 统一按最新的有效请求、凭证、额度和巡检证据计算状态，HTTP 499、客户端取消和过期异步结果不再恢复错误的异常或重新登录标签。
+- 服务端巡检启用凭证、手动刷新额度以及 Codex OAuth 重新登录完成后，Accounts 会重新同步凭证状态、额度和操作证据。
+- 凭证重新登录流程绑定当前连接和会话，旧连接或旧会话的延迟结果不会覆盖新的凭证状态。
+- 空额度窗口和额度快照同步失败会被作为有效或可重试证据处理，避免 Accounts 长时间保留陈旧的限额状态。
+- 用量请求元数据在写入和展示边界进行规范化，并保持完整显示与脱敏显示的隔离。
+
+### Docs
+
+- 中英文文档、导航和部署说明统一指向 Accounts 凭证管理流程，并移除旧 Auth Files 与独立 Quota 手册。
+
+### CI / Build
+
+- 发布流程先创建并校验 Draft Release，在完整资产、大小、摘要和内容验证通过后再显式发布，以兼容 Immutable Releases。
+- 发布重跑继续保持幂等和 fail-closed，并支持经过批准的可变不完整 Release 恢复。
+
+## Upgrade Notes
+
+- 这是预发布版本；稳定 Docker 标签和 `latest` 不会更新，请显式使用 `v1.12.0-rc.1` 对应的发布资产或镜像。
+- 凭证管理、额度查看、巡检和重新登录请使用 Accounts 页面；旧版 Auth Files 与独立 Quota 页面和路由已移除，内部兼容 API 仍由 Accounts 使用。
+- weighted round robin 需要 CPA 运行时支持对应的路由和凭证权重字段；未启用该策略时，现有路由行为不变。
+- 请求元数据可能包含敏感的客户端信息，仅在完整显示模式下提供，并且不会进入兼容用量导出或 JSONL 导出。
+- Manager Server 会自动处理新增的兼容字段，无需手工重建数据库或重新导入凭证。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-beta3...v1.12.0-rc.1

--- a/docs/release-posts/v1.12.0-rc.1-telegram.html
+++ b/docs/release-posts/v1.12.0-rc.1-telegram.html
@@ -1,0 +1,17 @@
+🚀 <b>8 月 13 日 · v1.12.0-rc.1</b>
+
+✨ <b>更新内容</b>
+
+• Accounts 统一承载凭证、额度、巡检和重新登录工作流，旧版 Auth Files 与独立 Quota 页面已移除。
+• 服务端巡检、额度刷新和 Codex 重新登录完成后，Accounts 会同步最新凭证状态和额度证据。
+• 过期异步结果、HTTP 499 和客户端取消不再恢复错误的限额或重新登录状态。
+• 支持 weighted round robin，并在凭证详情中展示有效权重和默认权重。
+• Monitoring 完整显示模式支持查看受限的客户端请求元数据。
+• 中英文文档和导航统一指向 Accounts 凭证管理流程。
+• 发布流程先验证 Draft Release 的完整资产，再显式发布以兼容 Immutable Releases。
+
+⚠️ <b>注意事项</b>
+
+• 这是预发布版本；稳定 Docker 标签和 <code>latest</code> 不会更新，请使用 <code>v1.12.0-rc.1</code> 对应的发布资产或镜像。
+• weighted round robin 需要兼容的 CPA 运行时；未启用时现有路由行为不变。
+• 请求元数据可能包含敏感信息，仅在完整显示模式下提供，不进入用量导出。


### PR DESCRIPTION
## Summary

Prepare the reviewed release notes and Telegram announcement for CPA Manager Plus v1.12.0-rc.1.

This release candidate documents the unified Accounts credential workflow, state synchronization after inspection/quota refresh/Codex reauthorization, weighted routing, monitoring request metadata, retired legacy surfaces, and immutable-release publication behavior.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.0-rc.1 release notes with reciprocal tag-pinned links.
- Add the reviewed Telegram HTML announcement for the release workflow.
- Document upgrade guidance for Accounts, weighted round robin, request metadata, and prerelease channels.

## User Impact

Users receive a complete technical and community-facing description of the v1.12.0-rc.1 changes and upgrade considerations. This PR does not change runtime behavior by itself.

## Compatibility / Runtime Notes

- CPA panel mode: No runtime change in this PR; the release notes describe the Accounts migration and compatible CPA requirements.
- Manager Server mode: No runtime change in this PR; additive compatibility behavior is documented.
- Full Docker / native packages: The RC remains a prerelease and does not update stable or `latest` tags.

## Data / Security Notes

No data, credential, key, database, or runtime configuration changes are introduced by this documentation-only PR. The notes warn that full-display request metadata may contain sensitive client information.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this release documentation commit before promotion or tagging if the frozen release scope changes.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
npm run release:validate -- --tag v1.12.0-rc.1 --content-only
Result: ok=true, prerelease=true; both reciprocal note links and Telegram HTML validated.

git diff --check
Result: passed.

SHA-256:
77339baa4ead08e1a125777f19bc9ca1fa7a3206db2f538188fc406b77e2cb9e  docs/release-notes/v1.12.0-rc.1-zh.md
917754f17ce1bcb37a4f855a5565c62d68f2e9d3e0323da9cc33c7afa5090ac0  docs/release-notes/v1.12.0-rc.1-en.md
9eb41776501229e831b625827ca3d571a4eb008a7e85960a32b7258921278573  docs/release-posts/v1.12.0-rc.1-telegram.html
```

## Screenshots / Recordings

N/A — documentation-only release preparation.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: This PR adds the versioned bilingual release notes and Telegram announcement required by the release workflow. Product documentation changes are already part of the frozen release scope.

## Related

Refs #479, #527, #528
