### PR TITLE
chore(release): promote rc.1 publication recovery to main

### DIFF
--- a/.github/workflows/release-publish-recovery.yml
+++ b/.github/workflows/release-publish-recovery.yml
@@ -1,0 +1,1298 @@
+name: Recover Release Publication
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing release tag to recover, for example v1.12.0-rc.1'
+        required: true
+        type: string
+      failed_run_id:
+        description: 'Exact failed Build and Release workflow run ID that produced the artifact'
+        required: true
+        type: string
+      artifact_id:
+        description: 'Exact release-assets artifact ID from the failed run'
+        required: true
+        type: string
+      confirm_publish:
+        description: 'I verified the tag, failed run, artifact, and registry state and authorize publication'
+        required: true
+        default: false
+        type: boolean
+      confirm_telegram:
+        description: 'After publication, send the release notification to Telegram'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  prepare_release:
+    name: Validate and prepare GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      dispatch_sha: ${{ steps.source.outputs.dispatch_sha }}
+      release_sha: ${{ steps.source.outputs.release_sha }}
+      release_dev_sha: ${{ steps.source.outputs.release_dev_sha }}
+      prerelease: ${{ steps.source.outputs.prerelease }}
+      release_version: ${{ steps.source.outputs.release_version }}
+      asset_manifest: ${{ steps.artifact.outputs.asset_manifest }}
+      release_id: ${{ steps.prepared_release.outputs.release_id }}
+      release_state: ${{ steps.prepared_release.outputs.release_state }}
+      needs_publish: ${{ steps.prepared_release.outputs.needs_publish }}
+
+    steps:
+      - name: Require main dispatch and explicit publication authorization
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          CONFIRM_PUBLISH: ${{ inputs.confirm_publish }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          FAILED_RUN_ID: ${{ inputs.failed_run_id }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_REF}" != "refs/heads/main" ]; then
+            echo "Release recovery must be dispatched from main; received ${EVENT_REF}." >&2
+            exit 1
+          fi
+          if [ "${CONFIRM_PUBLISH}" != "true" ]; then
+            echo "Release recovery requires explicit publication confirmation." >&2
+            exit 1
+          fi
+          if ! [[ "${FAILED_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "failed_run_id must be a positive decimal integer." >&2
+            exit 1
+          fi
+          if ! [[ "${ARTIFACT_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "artifact_id must be a positive decimal integer." >&2
+            exit 1
+          fi
+
+      - name: Checkout recovery source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Validate immutable tag and failed source run
+        id: source
+        shell: bash
+        env:
+          DISPATCH_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          FAILED_RUN_ID: ${{ inputs.failed_run_id }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          prerelease="$(node --input-type=module -e '
+            import { parseReleaseTag } from "./bin/release/validate-release.mjs";
+            try {
+              process.stdout.write(String(parseReleaseTag(process.argv[1]).prerelease));
+            } catch (error) {
+              console.error(error instanceof Error ? error.message : String(error));
+              process.exit(1);
+            }
+          ' "${RELEASE_TAG}")"
+
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/dev:refs/remotes/origin/dev
+          git fetch --tags origin
+
+          current_main_sha="$(git rev-parse --verify origin/main^{commit})"
+          if [ "${current_main_sha}" != "${DISPATCH_SHA}" ]; then
+            echo "main advanced after dispatch: expected ${DISPATCH_SHA}, received ${current_main_sha}." >&2
+            exit 1
+          fi
+
+          release_sha="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          release_dev_sha="$(git rev-parse --verify "${release_sha}^2")"
+
+          if ! git merge-base --is-ancestor "${release_sha}" origin/main; then
+            echo "Release commit ${release_sha} is not contained in current origin/main." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${release_dev_sha}" origin/dev; then
+            echo "Release dev commit ${release_dev_sha} is not contained in current origin/dev." >&2
+            exit 1
+          fi
+
+          for release_path in \
+            "docs/release-notes/${RELEASE_TAG}-zh.md" \
+            "docs/release-notes/${RELEASE_TAG}-en.md" \
+            "docs/release-posts/${RELEASE_TAG}-telegram.html"; do
+            if ! git diff --quiet "${release_sha}" origin/main -- "${release_path}"; then
+              echo "Current main differs from the tagged release content at ${release_path}." >&2
+              exit 1
+            fi
+          done
+
+          npm run --silent release:validate -- \
+            --tag "${RELEASE_TAG}" \
+            --sha "${release_sha}" \
+            --main-ref "${release_sha}" \
+            --dev-ref "${release_dev_sha}"
+
+          run_json="${RUNNER_TEMP}/failed-release-run.json"
+          run_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${run_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${FAILED_RUN_ID}")"
+          if [ "${run_code}" != "200" ]; then
+            echo "Failed source run lookup returned HTTP ${run_code}." >&2
+            exit 1
+          fi
+
+          run_path="$(jq -r '.path // empty' "${run_json}")"
+          run_name="$(jq -r '.name // empty' "${run_json}")"
+          run_event="$(jq -r '.event // empty' "${run_json}")"
+          run_status="$(jq -r '.status // empty' "${run_json}")"
+          run_conclusion="$(jq -r '.conclusion // empty' "${run_json}")"
+          run_head_sha="$(jq -r '.head_sha // empty' "${run_json}")"
+          run_head_branch="$(jq -r '.head_branch // empty' "${run_json}")"
+          run_attempt="$(jq -r '.run_attempt // empty' "${run_json}")"
+          run_workflow_id="$(jq -r '.workflow_id // empty | tostring' "${run_json}")"
+          run_repository="$(jq -r '.repository.full_name // empty' "${run_json}")"
+          run_head_repository="$(jq -r '.head_repository.full_name // empty' "${run_json}")"
+          if [ "${run_path}" != ".github/workflows/release.yml" ] ||
+            [ "${run_name}" != "Build and Release" ] ||
+            [ "${run_event}" != "push" ] ||
+            [ "${run_status}" != "completed" ] ||
+            [ "${run_conclusion}" != "failure" ] ||
+            [ "${run_head_sha}" != "${release_sha}" ] ||
+            { [ -n "${run_head_branch}" ] && [ "${run_head_branch}" != "${RELEASE_TAG}" ]; } ||
+            ! [[ "${run_attempt}" =~ ^[1-9][0-9]*$ ]] ||
+            ! [[ "${run_workflow_id}" =~ ^[1-9][0-9]*$ ]] ||
+            [ "${run_repository}" != "${GITHUB_REPOSITORY}" ] ||
+            [ "${run_head_repository}" != "${GITHUB_REPOSITORY}" ]; then
+            echo "The supplied run is not the expected failed tagged release run." >&2
+            exit 1
+          fi
+
+          workflow_json="${RUNNER_TEMP}/failed-release-workflow.json"
+          workflow_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${workflow_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/${run_workflow_id}")"
+          if [ "${workflow_code}" != "200" ] ||
+            [ "$(jq -r '.path // empty' "${workflow_json}")" != ".github/workflows/release.yml" ] ||
+            [ "$(jq -r '.name // empty' "${workflow_json}")" != "Build and Release" ] ||
+            [ "$(jq -r '.state // empty' "${workflow_json}")" != "active" ]; then
+            echo "The source run is not bound to the expected release workflow identity." >&2
+            exit 1
+          fi
+
+          jobs_json="${RUNNER_TEMP}/failed-release-jobs.json"
+          jobs_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${jobs_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${FAILED_RUN_ID}/jobs?per_page=100")"
+          if [ "${jobs_code}" != "200" ]; then
+            echo "Failed source run job lookup returned HTTP ${jobs_code}." >&2
+            exit 1
+          fi
+          build_job_result="$(jq -r '[.jobs[] | select(.name == "Build release assets") | .conclusion] | if length == 1 then .[0] else "missing" end' "${jobs_json}")"
+          inspect_job_result="$(jq -r '[.jobs[] | select(.name == "Inspect GitHub Release state") | .conclusion] | if length == 1 then .[0] else "missing" end' "${jobs_json}")"
+          docker_job_result="$(jq -r '[.jobs[] | select(.name == "Build and publish Docker images") | .conclusion] | if length == 1 then .[0] else "missing" end' "${jobs_json}")"
+          publish_job_result="$(jq -r '[.jobs[] | select(.name == "Publish GitHub Release") | .conclusion] | if length == 1 then .[0] else "missing" end' "${jobs_json}")"
+          telegram_job_result="$(jq -r '[.jobs[] | select(.name == "Notify Telegram") | .conclusion] | if length == 1 then .[0] else "missing" end' "${jobs_json}")"
+          if [ "${build_job_result}" != "success" ] ||
+            [ "${inspect_job_result}" != "failure" ] ||
+            [ "${docker_job_result}" != "skipped" ] ||
+            [ "${publish_job_result}" != "skipped" ] ||
+            [ "${telegram_job_result}" != "skipped" ]; then
+            echo "The supplied run did not produce a successful release artifact before the expected Release inspection failure." >&2
+            exit 1
+          fi
+
+          artifact_list_json="${RUNNER_TEMP}/failed-release-artifacts.json"
+          artifact_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${artifact_list_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${FAILED_RUN_ID}/artifacts?per_page=100")"
+          if [ "${artifact_code}" != "200" ]; then
+            echo "Failed source run artifact lookup returned HTTP ${artifact_code}." >&2
+            exit 1
+          fi
+
+          artifact_matches="$(jq --arg artifact_id "${ARTIFACT_ID}" --arg artifact_name "release-assets-${RELEASE_TAG}" '
+            [.artifacts[] | select((.id | tostring) == $artifact_id and .name == $artifact_name)] | length
+          ' "${artifact_list_json}")"
+          if [ "${artifact_matches}" != "1" ]; then
+            echo "The supplied artifact ID is not the unique exact release artifact for the failed run." >&2
+            exit 1
+          fi
+          artifact_list_size="$(jq -r --arg artifact_id "${ARTIFACT_ID}" '[.artifacts[] | select((.id | tostring) == $artifact_id)][0].size_in_bytes // empty' "${artifact_list_json}")"
+          artifact_json="${RUNNER_TEMP}/failed-release-artifact.json"
+          artifact_detail_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${artifact_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          if [ "${artifact_detail_code}" != "200" ]; then
+            echo "Exact artifact lookup returned HTTP ${artifact_detail_code}." >&2
+            exit 1
+          fi
+          artifact_name="$(jq -r '.name // empty' "${artifact_json}")"
+          artifact_expired="$(jq -r '.expired // empty' "${artifact_json}")"
+          artifact_size="$(jq -r '.size_in_bytes // empty' "${artifact_json}")"
+          artifact_head_sha="$(jq -r '.workflow_run.head_sha // empty' "${artifact_json}")"
+          artifact_run_id="$(jq -r '.workflow_run.id // empty | tostring' "${artifact_json}")"
+          if [ "${artifact_name}" != "release-assets-${RELEASE_TAG}" ] ||
+            [ "${artifact_expired}" != "false" ] || ! [[ "${artifact_size}" =~ ^[1-9][0-9]*$ ]] ||
+            [ "${artifact_size}" != "${artifact_list_size}" ] ||
+            [ "${artifact_head_sha}" != "${release_sha}" ] ||
+            [ "${artifact_run_id}" != "${FAILED_RUN_ID}" ]; then
+            echo "The supplied release artifact failed immutable provenance checks." >&2
+            exit 1
+          fi
+
+          {
+            echo "dispatch_sha=${DISPATCH_SHA}"
+            echo "release_sha=${release_sha}"
+            echo "release_dev_sha=${release_dev_sha}"
+            echo "prerelease=${prerelease}"
+            echo "release_version=${RELEASE_TAG#v}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Download and verify the exact release artifact
+        id: artifact
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_SHA: ${{ steps.source.outputs.release_sha }}
+          FAILED_RUN_ID: ${{ inputs.failed_run_id }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          artifact_zip="${RUNNER_TEMP}/release-artifact.zip"
+          curl \
+            --silent \
+            --show-error \
+            --fail \
+            --location \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --output "${artifact_zip}" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip"
+
+          extract_dir="${RUNNER_TEMP}/release-artifact"
+          mkdir -p "${extract_dir}"
+          archive_paths="${RUNNER_TEMP}/release-artifact-paths.txt"
+          unzip -Z1 "${artifact_zip}" > "${archive_paths}"
+          if [ ! -s "${archive_paths}" ] ||
+            grep -Eq '(^[\\/]|^[A-Za-z]:[\\/]|(^|[\\/])\.\.($|[\\/]))' "${archive_paths}" ||
+            [ -n "$(sort "${archive_paths}" | uniq -d | head -n 1)" ]; then
+            echo "The release artifact contains an unsafe archive path." >&2
+            exit 1
+          fi
+          if zipinfo -l "${artifact_zip}" | grep -Eq '^l'; then
+            echo "The release artifact contains a symbolic-link entry and is rejected." >&2
+            exit 1
+          fi
+          unzip -q "${artifact_zip}" -d "${extract_dir}"
+
+          artifact_root="${extract_dir}"
+          if [ ! -f "${artifact_root}/management.html" ] && [ -f "${extract_dir}/dist/release/management.html" ]; then
+            artifact_root="${extract_dir}/dist/release"
+          fi
+          if [ ! -f "${artifact_root}/management.html" ]; then
+            echo "The exact artifact does not contain management.html at the expected root." >&2
+            exit 1
+          fi
+          if find "${artifact_root}" -type l -print -quit | grep -q .; then
+            echo "The release artifact contains a symbolic link and is rejected." >&2
+            exit 1
+          fi
+
+          rm -rf dist/release
+          mkdir -p dist/release
+          cp -R "${artifact_root}/." dist/release/
+
+          asset_names="$(node --input-type=module -e '
+            import { expectedReleaseAssetNames } from "./bin/release/verify-published-release.mjs";
+            process.stdout.write(expectedReleaseAssetNames(process.argv[1]).filter((name) => name !== "management.html").join("\n"));
+          ' "${RELEASE_TAG}")"
+          if grep -q '^$' <<< "${asset_names}"; then
+            echo "Expected release asset names contain an empty entry." >&2
+            exit 1
+          fi
+          expected_files="$(
+            {
+              echo "management.html"
+              echo "release-notes.md"
+              while IFS= read -r asset_name; do
+                printf 'native/%s\n' "${asset_name}"
+              done <<< "${asset_names}"
+            } | sort
+          )"
+          actual_files="$(find "${artifact_root}" -type f -print | sed "s#^${artifact_root}/##" | sort)"
+          if [ "${actual_files}" != "${expected_files}" ]; then
+            echo "The exact release artifact file set does not match the checked release payload." >&2
+            diff -u <(printf '%s\n' "${expected_files}") <(printf '%s\n' "${actual_files}") || true
+            exit 1
+          fi
+
+          tagged_notes="${RUNNER_TEMP}/${RELEASE_TAG}-zh.md"
+          git show "${RELEASE_SHA}:docs/release-notes/${RELEASE_TAG}-zh.md" > "${tagged_notes}"
+          if ! cmp -s "${tagged_notes}" "${artifact_root}/release-notes.md"; then
+            echo "Artifact release-notes.md differs from the immutable tag content." >&2
+            exit 1
+          fi
+          (
+            cd "${artifact_root}/native"
+            sha256sum --check checksums.txt
+          )
+          expected_checksum_targets="$(printf '%s\n' "${asset_names}" | grep -v '^checksums.txt$' | sort)"
+          actual_checksum_targets="$(awk '{name=$2; sub(/^\*/, "", name); sub(/^\.\//, "", name); print name}' "${artifact_root}/native/checksums.txt" | sort)"
+          if [ "${actual_checksum_targets}" != "${expected_checksum_targets}" ]; then
+            echo "Artifact checksums.txt does not cover the exact expected native asset set." >&2
+            exit 1
+          fi
+
+          asset_manifest="$(node --input-type=module -e '
+            import { buildExpectedReleaseAssets } from "./bin/release/verify-published-release.mjs";
+            const assets = buildExpectedReleaseAssets(process.argv[1], process.argv[2]);
+            process.stdout.write(JSON.stringify(assets.map(({ name, size, digest }) => ({ name, size, digest }))));
+          ' "${artifact_root}" "${RELEASE_TAG}")"
+          echo "asset_manifest=${asset_manifest}" >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "Verified artifact ${ARTIFACT_ID} from failed run ${FAILED_RUN_ID}."
+            echo "Artifact file set, release-note content, sizes, names, and SHA-256 digests match ${RELEASE_TAG}."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Resolve existing GitHub Release state
+        id: release_state
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          EXPECTED_PRERELEASE: ${{ steps.source.outputs.prerelease }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          all_upload_files="$(node --input-type=module -e '
+            import { buildExpectedReleaseAssets } from "./bin/release/verify-published-release.mjs";
+            const assets = buildExpectedReleaseAssets("dist/release", process.argv[1]);
+            process.stdout.write(assets.map(({ filePath }) => filePath).join("\n"));
+          ' "${RELEASE_TAG}")"
+          release_json="${RUNNER_TEMP}/existing-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+
+          if [ "${http_code}" = "404" ]; then
+            release_list_json="${RUNNER_TEMP}/release-list.json"
+            release_list_code=200
+            page=1
+            printf '[]\n' > "${release_list_json}"
+            while [ "${page}" -le 10 ]; do
+              release_page_json="${RUNNER_TEMP}/release-list-${page}.json"
+              release_list_code="$(curl \
+                --silent \
+                --show-error \
+                --output "${release_page_json}" \
+                --write-out "%{http_code}" \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases?per_page=100&page=${page}")"
+              if [ "${release_list_code}" != "200" ]; then
+                echo "GitHub Release list lookup failed with HTTP ${release_list_code}." >&2
+                exit 1
+              fi
+              page_count="$(jq 'length' "${release_page_json}")"
+              jq -s '.[0] + .[1]' "${release_list_json}" "${release_page_json}" > "${release_list_json}.next"
+              mv "${release_list_json}.next" "${release_list_json}"
+              if [ "${page_count}" -lt 100 ]; then
+                break
+              fi
+              page=$((page + 1))
+            done
+            if [ "${page}" -gt 10 ] && [ "${page_count}" -eq 100 ]; then
+              echo "GitHub Release list exceeded the bounded recovery scan." >&2
+              exit 1
+            fi
+            matching_release_count="$(jq --arg tag "${RELEASE_TAG}" 'map(select(.tag_name == $tag)) | length' "${release_list_json}")"
+            if [ "${matching_release_count}" -gt 1 ]; then
+              echo "GitHub Release list contains multiple entries for ${RELEASE_TAG}." >&2
+              exit 1
+            fi
+            jq -c --arg tag "${RELEASE_TAG}" \
+              'map(select(.tag_name == $tag)) | if length == 1 then .[0] else empty end' \
+              "${release_list_json}" > "${release_json}"
+            if [ -s "${release_json}" ]; then
+              http_code=200
+            fi
+          fi
+
+          write_upload_files() {
+            {
+              echo "upload_files<<RELEASE_FILES"
+              printf '%s\n' "$1"
+              echo "RELEASE_FILES"
+            } >> "${GITHUB_OUTPUT}"
+          }
+
+          case "${http_code}" in
+            404)
+              echo "release_id=" >> "${GITHUB_OUTPUT}"
+              echo "release_state=missing" >> "${GITHUB_OUTPUT}"
+              echo "target_draft=true" >> "${GITHUB_OUTPUT}"
+              echo "needs_publish=true" >> "${GITHUB_OUTPUT}"
+              write_upload_files "${all_upload_files}"
+              echo "No GitHub Release exists; a draft will be created from the verified artifact." >> "${GITHUB_STEP_SUMMARY}"
+              ;;
+            200)
+              release_id="$(jq -r '.id // empty' "${release_json}")"
+              if ! [[ "${release_id}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Existing GitHub Release has an invalid id." >&2
+                exit 1
+              fi
+              is_draft="$(jq -r '.draft // empty' "${release_json}")"
+              case "${is_draft}" in
+                true) verification_mode=draft; target_draft=true; needs_publish=true ;;
+                false) verification_mode=artifact; target_draft=false; needs_publish=false ;;
+                *) echo "Existing GitHub Release has an invalid draft state." >&2; exit 1 ;;
+              esac
+              verification_json="${RUNNER_TEMP}/release-verification.json"
+              node bin/release/verify-published-release.mjs \
+                --tag "${RELEASE_TAG}" \
+                --assets-dir dist/release \
+                --body-path dist/release/release-notes.md \
+                --release-json "${release_json}" \
+                --prerelease "${EXPECTED_PRERELEASE}" \
+                --mode "${verification_mode}" \
+                --allow-missing-assets true \
+                --result-path "${verification_json}"
+              complete="$(node --input-type=module -e '
+                import { readFileSync } from "node:fs";
+                const result = JSON.parse(readFileSync(process.argv[1], "utf8"));
+                process.stdout.write(String(result.complete));
+              ' "${verification_json}")"
+              echo "release_id=${release_id}" >> "${GITHUB_OUTPUT}"
+              echo "release_state=${verification_mode}" >> "${GITHUB_OUTPUT}"
+              echo "target_draft=${target_draft}" >> "${GITHUB_OUTPUT}"
+              echo "needs_publish=${needs_publish}" >> "${GITHUB_OUTPUT}"
+              if [ "${complete}" = "true" ]; then
+                echo "upload_files=" >> "${GITHUB_OUTPUT}"
+                echo "Existing ${verification_mode} GitHub Release metadata and assets match the checked payload." >> "${GITHUB_STEP_SUMMARY}"
+              else
+                missing_upload_files="$(node --input-type=module -e '
+                  import { readFileSync } from "node:fs";
+                  const result = JSON.parse(readFileSync(process.argv[1], "utf8"));
+                  process.stdout.write(result.missingAssets.map(({ filePath }) => filePath).join("\n"));
+                ' "${verification_json}")"
+                write_upload_files "${missing_upload_files}"
+                echo "Only missing GitHub Release assets will be uploaded; matching assets will be preserved." >> "${GITHUB_STEP_SUMMARY}"
+              fi
+              ;;
+            *)
+              echo "GitHub Release lookup failed with HTTP ${http_code}." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Create or update only the missing Release assets
+        id: release_upload
+        if: steps.release_state.outputs.upload_files != ''
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          files: ${{ steps.release_state.outputs.upload_files }}
+          body_path: dist/release/release-notes.md
+          draft: ${{ steps.release_state.outputs.target_draft == 'true' }}
+          prerelease: ${{ steps.source.outputs.prerelease == 'true' }}
+          generate_release_notes: false
+          overwrite_files: false
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify prepared GitHub Release state
+        id: prepared_release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          EXPECTED_PRERELEASE: ${{ steps.source.outputs.prerelease }}
+          EXISTING_RELEASE_ID: ${{ steps.release_state.outputs.release_id }}
+          UPLOADED_RELEASE_ID: ${{ steps.release_upload.outputs.id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          release_id=""
+          for candidate in "${EXISTING_RELEASE_ID}" "${UPLOADED_RELEASE_ID}"; do
+            if [ -z "${candidate}" ]; then
+              continue
+            fi
+            if ! [[ "${candidate}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "GitHub Release action returned an invalid id: ${candidate}." >&2
+              exit 1
+            fi
+            if [ -n "${release_id}" ] && [ "${release_id}" != "${candidate}" ]; then
+              echo "GitHub Release id changed during recovery preparation: ${release_id} -> ${candidate}." >&2
+              exit 1
+            fi
+            release_id="${candidate}"
+          done
+          if [ -z "${release_id}" ]; then
+            echo "Prepared GitHub Release id is missing." >&2
+            exit 1
+          fi
+
+          release_json="${RUNNER_TEMP}/prepared-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${release_id}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "Prepared GitHub Release lookup failed with HTTP ${http_code}." >&2
+            exit 1
+          fi
+
+          response_release_id="$(jq -r '.id // empty' "${release_json}")"
+          is_draft="$(jq -r '.draft // empty' "${release_json}")"
+          if [ "${response_release_id}" != "${release_id}" ] ||
+            { [ "${is_draft}" != "true" ] && [ "${is_draft}" != "false" ]; }; then
+            echo "Prepared GitHub Release has invalid identity or draft state." >&2
+            exit 1
+          fi
+          verification_mode=artifact
+          needs_publish=false
+          if [ "${is_draft}" = "true" ]; then
+            verification_mode=draft
+            needs_publish=true
+          fi
+          node bin/release/verify-published-release.mjs \
+            --tag "${RELEASE_TAG}" \
+            --assets-dir dist/release \
+            --body-path dist/release/release-notes.md \
+            --release-json "${release_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}" \
+            --mode "${verification_mode}" \
+            --allow-missing-assets false
+
+          {
+            echo "release_id=${release_id}"
+            echo "release_state=${verification_mode}"
+            echo "needs_publish=${needs_publish}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "GitHub Release is prepared safely as ${verification_mode}; no registry has been changed yet." >> "${GITHUB_STEP_SUMMARY}"
+
+  build_and_push_docker:
+    name: Inspect and publish Docker images
+    needs: prepare_release
+    if: needs.prepare_release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      DISPATCH_SHA: ${{ needs.prepare_release.outputs.dispatch_sha }}
+      RELEASE_SHA: ${{ needs.prepare_release.outputs.release_sha }}
+      PRERELEASE: ${{ needs.prepare_release.outputs.prerelease }}
+      RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+      RELEASE_ID: ${{ needs.prepare_release.outputs.release_id }}
+      RELEASE_STATE: ${{ needs.prepare_release.outputs.release_state }}
+      EXPECTED_ASSET_MANIFEST: ${{ needs.prepare_release.outputs.asset_manifest }}
+      DOCKERHUB_IMAGE: docker.io/seakee/cpa-manager-plus
+      DOCKERHUB_REPOSITORY: seakee/cpa-manager-plus
+      GHCR_IMAGE: ghcr.io/seakee/cpa-manager-plus
+
+    steps:
+      - name: Checkout recovery source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify the immutable source remains current
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          current_main_sha="$(git rev-parse --verify origin/main^{commit})"
+          if [ "${current_main_sha}" != "${DISPATCH_SHA}" ]; then
+            echo "main advanced after recovery preparation: expected ${DISPATCH_SHA}, received ${current_main_sha}." >&2
+            exit 1
+          fi
+          if [ "$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")" != "${RELEASE_SHA}" ]; then
+            echo "The release tag no longer points to the checked release source." >&2
+            exit 1
+          fi
+
+      - name: Revalidate prepared GitHub Release before registry mutation
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          release_json="${RUNNER_TEMP}/registry-preflight-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "Prepared GitHub Release lookup failed before registry mutation with HTTP ${http_code}." >&2
+            exit 1
+          fi
+          body_path="${RUNNER_TEMP}/${RELEASE_TAG}-release-notes.md"
+          git show "${RELEASE_SHA}:docs/release-notes/${RELEASE_TAG}-zh.md" > "${body_path}"
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+
+            const [releasePath, bodyPath, manifestJson, expectedState, expectedId, tag, prerelease] = process.argv.slice(1);
+            const release = JSON.parse(readFileSync(releasePath, "utf8"));
+            const expectedAssets = JSON.parse(manifestJson).sort((left, right) => left.name.localeCompare(right.name));
+            const actualAssets = [...release.assets].sort((left, right) => left.name.localeCompare(right.name));
+            const normalize = (value) => String(value ?? "").replace(/\r\n?/g, "\n").trimEnd();
+            const expectedDraft = expectedState === "draft";
+            const validAssets = actualAssets.length === expectedAssets.length && actualAssets.every((asset, index) => {
+              const expected = expectedAssets[index];
+              return asset.name === expected.name && asset.state === "uploaded" && asset.size === expected.size && asset.digest === expected.digest;
+            });
+            if (
+              String(release.id) !== expectedId ||
+              release.tag_name !== tag ||
+              release.draft !== expectedDraft ||
+              release.prerelease !== (prerelease === "true") ||
+              normalize(release.body) !== normalize(readFileSync(bodyPath, "utf8")) ||
+              !validAssets
+            ) {
+              throw new Error("Prepared GitHub Release changed after validation");
+            }
+          ' "${release_json}" "${body_path}" "${EXPECTED_ASSET_MANIFEST}" "${RELEASE_STATE}" "${RELEASE_ID}" "${RELEASE_TAG}" "${PRERELEASE}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Resolve Docker publish targets
+        id: docker_targets
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          images="${GHCR_IMAGE}"
+          dockerhub_enabled=false
+          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            images="${images}"$'\n'"${DOCKERHUB_IMAGE}"
+            dockerhub_enabled=true
+          else
+            echo "::warning::DockerHub credentials are not both configured; DockerHub publication will be skipped."
+          fi
+          {
+            echo "images<<DOCKER_IMAGES"
+            printf '%s\n' "${images}"
+            echo "DOCKER_IMAGES"
+            echo "dockerhub_enabled=${dockerhub_enabled}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ steps.docker_targets.outputs.images }}
+          tags: |
+            type=raw,value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }},enable=${{ env.PRERELEASE == 'false' }}
+            type=raw,value=latest,enable=${{ env.PRERELEASE == 'false' }}
+          labels: |
+            org.opencontainers.image.title=CPA Manager Plus
+            org.opencontainers.image.description=CPA Manager Plus Manager Server container image
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.documentation=${{ github.server_url }}/${{ github.repository }}#readme
+            org.opencontainers.image.revision=${{ env.RELEASE_SHA }}
+            org.opencontainers.image.version=${{ env.RELEASE_VERSION }}
+
+      - name: Reject pre-existing Docker registry tags
+        id: registry_state
+        shell: bash
+        env:
+          RELEASE_REFERENCES: ${{ steps.meta.outputs.tags }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          found_count=0
+          missing_count=0
+          expected_reference_count=0
+          canonical_digest=""
+          ghcr_found_count=0
+          ghcr_digest=""
+          dockerhub_digest=""
+
+          inspect_reference() {
+            local registry="$1"
+            local repository="$2"
+            local tag="$3"
+            local reference="$4"
+            local token="$5"
+            local output_file code digest image_count amd64_count arm64_count revision_count version_count source_count
+            output_file="${RUNNER_TEMP}/image-${registry//[^[:alnum:]]/_}-${tag//[^[:alnum:]]/_}.json"
+            set +e
+            docker buildx imagetools inspect "${reference}" --format '{{json .}}' > "${output_file}" 2> "${output_file}.err"
+            code=$?
+            set -e
+            case "${code}" in
+              0) ;;
+              *)
+                manifest_file="${RUNNER_TEMP}/missing-check-${registry//[^[:alnum:]]/_}-${tag//[^[:alnum:]]/_}.json"
+                http_code="$(curl --silent --show-error \
+                  --output "${manifest_file}" \
+                  --write-out "%{http_code}" \
+                  --header "Authorization: Bearer ${token}" \
+                  --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+                  "https://${registry}/v2/${repository}/manifests/${tag}")"
+                if [ "${http_code}" = "404" ]; then
+                  missing_count=$((missing_count + 1))
+                  echo "Confirmed absent: ${reference}"
+                  return 0
+                fi
+                echo "Registry inspection failed for ${reference}; buildx=${code}, registry HTTP ${http_code}." >&2
+                cat "${output_file}.err" >&2
+                return 1
+                ;;
+            esac
+
+            digest="$(jq -r '.manifest.digest // empty' "${output_file}")"
+            image_count="$(jq '.image | length' "${output_file}")"
+            amd64_count="$(jq '[.manifest.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")] | length' "${output_file}")"
+            arm64_count="$(jq '[.manifest.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")] | length' "${output_file}")"
+            revision_count="$(jq --arg revision "${RELEASE_SHA}" '[.image[] | select(.config.Labels["org.opencontainers.image.revision"] == $revision)] | length' "${output_file}")"
+            version_count="$(jq --arg version "${RELEASE_VERSION}" '[.image[] | select(.config.Labels["org.opencontainers.image.version"] == $version)] | length' "${output_file}")"
+            source_count="$(jq '[.image[] | select(.config.Labels["org.opencontainers.image.source"] == "https://github.com/seakee/CPA-Manager-Plus")] | length' "${output_file}")"
+            if ! [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+              [ "${image_count}" != "2" ] ||
+              [ "${amd64_count}" != "1" ] ||
+              [ "${arm64_count}" != "1" ] ||
+              [ "${revision_count}" != "2" ] ||
+              [ "${version_count}" != "2" ] ||
+              [ "${source_count}" != "2" ]; then
+              echo "Existing registry tag does not match the immutable release source: ${reference}" >&2
+              return 1
+            fi
+            found_count=$((found_count + 1))
+            if [ -z "${canonical_digest}" ]; then
+              canonical_digest="${digest}"
+            elif [ "${canonical_digest}" != "${digest}" ]; then
+              echo "Existing release tags do not share the same manifest digest: ${reference}" >&2
+              return 1
+            fi
+            if [ "${registry}" = "ghcr.io" ]; then
+              ghcr_found_count=$((ghcr_found_count + 1))
+              ghcr_digest="${digest}"
+            else
+              dockerhub_digest="${digest}"
+            fi
+            echo "Verified existing matching image: ${reference} (${digest})"
+          }
+
+          mapfile -t references < <(printf '%s\n' "${RELEASE_REFERENCES}" | sed '/^$/d')
+          if [ "${#references[@]}" -eq 0 ]; then
+            echo "Docker metadata produced no publish references." >&2
+            exit 1
+          fi
+          for reference in "${references[@]}"; do
+            expected_reference_count=$((expected_reference_count + 1))
+            if [[ "${reference}" == ghcr.io/* ]]; then
+              registry=ghcr.io
+              repository="${reference#ghcr.io/}"
+              repository="${repository%:*}"
+              tag="${reference##*:}"
+              token_url="https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull"
+              set +e
+              token_json="$(curl --silent --show-error --fail "${token_url}")"
+              token_status=$?
+              set -e
+              token=""
+              if [ "${token_status}" -eq 0 ]; then
+                token="$(jq -r '.token // .access_token // empty' <<< "${token_json}")"
+              fi
+              if [ -z "${token}" ]; then
+                token_json="$(curl --silent --show-error --fail \
+                  --user "${GITHUB_ACTOR}:${GITHUB_TOKEN}" "${token_url}")"
+                token="$(jq -r '.token // .access_token // empty' <<< "${token_json}")"
+              fi
+            elif [[ "${reference}" == docker.io/* ]]; then
+              registry=registry-1.docker.io
+              repository="${reference#docker.io/}"
+              repository="${repository%:*}"
+              tag="${reference##*:}"
+              docker_auth_args=()
+              if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+                docker_auth_args+=(--user "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}")
+              fi
+              token_json="$(curl --silent --show-error --fail "${docker_auth_args[@]}" \
+                "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull")"
+              token="$(jq -r '.token // .access_token // empty' <<< "${token_json}")"
+            else
+              echo "Unexpected Docker image reference from metadata: ${reference}" >&2
+              exit 1
+            fi
+            if [ -z "${token}" ]; then
+              echo "Could not obtain a read token for ${reference}." >&2
+              exit 1
+            fi
+            inspect_reference "${registry}" "${repository}" "${tag}" "${reference}" "${token}"
+          done
+          if [ "${missing_count}" -eq "${expected_reference_count}" ]; then
+            echo "publish_images=true" >> "${GITHUB_OUTPUT}"
+            echo "All Docker registry tags are absent; publication may proceed." >> "${GITHUB_STEP_SUMMARY}"
+          elif [ "${found_count}" -eq "${expected_reference_count}" ]; then
+            if [ "${ghcr_found_count}" -eq 0 ] || [ -z "${ghcr_digest}" ]; then
+              echo "The mandatory GHCR release image was not verified." >&2
+              exit 1
+            fi
+            if [ -n "${dockerhub_digest}" ] && [ "${dockerhub_digest}" != "${ghcr_digest}" ]; then
+              echo "Existing GHCR and Docker Hub release tags do not share the same manifest digest." >&2
+              exit 1
+            fi
+            echo "publish_images=false" >> "${GITHUB_OUTPUT}"
+            echo "Every Docker registry tag already matches the immutable release source; image publication will be reused." >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Docker registries contain a partial release tag set; automatic recovery is unsafe." >&2
+            exit 1
+          fi
+
+      - name: Reconfirm registry tags immediately before publication
+        if: steps.registry_state.outputs.publish_images == 'true'
+        shell: bash
+        env:
+          RELEASE_REFERENCES: ${{ steps.meta.outputs.tags }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          resolve_token() {
+            local registry="$1"
+            local repository="$2"
+            local token_url token_json token curl_status
+            token=""
+            if [ "${registry}" = "ghcr.io" ]; then
+              token_url="https://ghcr.io/token?service=ghcr.io&scope=repository:${repository}:pull"
+              set +e
+              token_json="$(curl --silent --show-error --fail "${token_url}")"
+              curl_status=$?
+              set -e
+              if [ "${curl_status}" -eq 0 ]; then
+                token="$(jq -r '.token // .access_token // empty' <<< "${token_json}")"
+              fi
+              if [ -z "${token}" ]; then
+                token_json="$(curl --silent --show-error --fail \
+                  --user "${GITHUB_ACTOR}:${GITHUB_TOKEN}" "${token_url}")"
+                token="$(jq -r '.token // .access_token // empty' <<< "${token_json}")"
+              fi
+            else
+              docker_auth_args=()
+              if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+                docker_auth_args+=(--user "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}")
+              fi
+              token_json="$(curl --silent --show-error --fail "${docker_auth_args[@]}" \
+                "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull")"
+              token="$(jq -r '.token // .access_token // empty' <<< "${token_json}")"
+            fi
+            if [ -z "${token}" ]; then
+              echo "Could not obtain a read token for ${registry}/${repository}." >&2
+              return 1
+            fi
+            printf '%s' "${token}"
+          }
+
+          mapfile -t references < <(printf '%s\n' "${RELEASE_REFERENCES}" | sed '/^$/d')
+          for reference in "${references[@]}"; do
+            if [[ "${reference}" == ghcr.io/* ]]; then
+              registry=ghcr.io
+              repository="${reference#ghcr.io/}"
+              repository="${repository%:*}"
+              tag="${reference##*:}"
+            elif [[ "${reference}" == docker.io/* ]]; then
+              registry=registry-1.docker.io
+              repository="${reference#docker.io/}"
+              repository="${repository%:*}"
+              tag="${reference##*:}"
+            else
+              echo "Unexpected Docker image reference from metadata: ${reference}" >&2
+              exit 1
+            fi
+            token="$(resolve_token "${registry}" "${repository}")"
+            manifest_file="${RUNNER_TEMP}/final-prepush-${registry//[^[:alnum:]]/_}-${tag//[^[:alnum:]]/_}.json"
+            code="$(curl --silent --show-error \
+              --output "${manifest_file}" \
+              --write-out "%{http_code}" \
+              --header "Authorization: Bearer ${token}" \
+              --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+              "https://${registry}/v2/${repository}/manifests/${tag}")"
+            case "${code}" in
+              404) ;;
+              200) echo "Registry tag appeared before publication and overwrite is forbidden: ${reference}" >&2; exit 1 ;;
+              *) echo "Final registry tag check failed for ${reference} with HTTP ${code}." >&2; exit 1 ;;
+            esac
+          done
+
+      - name: Login to GitHub Container Registry
+        if: steps.registry_state.outputs.publish_images == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: steps.registry_state.outputs.publish_images == 'true' && steps.docker_targets.outputs.dockerhub_enabled == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and publish Manager Server images
+        if: steps.registry_state.outputs.publish_images == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile.manager-server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.RELEASE_TAG }}
+
+      - name: Verify pushed Docker tags
+        shell: bash
+        env:
+          RELEASE_REFERENCES: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          canonical_digest=""
+          ghcr_digest=""
+          dockerhub_digest=""
+          while IFS= read -r reference; do
+            [ -z "${reference}" ] && continue
+            inspect_json="${RUNNER_TEMP}/published-${reference//[^[:alnum:]]/_}.json"
+            docker buildx imagetools inspect "${reference}" --format '{{json .}}' > "${inspect_json}"
+            digest="$(jq -r '.manifest.digest // empty' "${inspect_json}")"
+            image_count="$(jq '.image | length' "${inspect_json}")"
+            amd64_count="$(jq '[.manifest.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")] | length' "${inspect_json}")"
+            arm64_count="$(jq '[.manifest.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")] | length' "${inspect_json}")"
+            revision_count="$(jq --arg revision "${RELEASE_SHA}" '[.image[] | select(.config.Labels["org.opencontainers.image.revision"] == $revision)] | length' "${inspect_json}")"
+            version_count="$(jq --arg version "${RELEASE_VERSION}" '[.image[] | select(.config.Labels["org.opencontainers.image.version"] == $version)] | length' "${inspect_json}")"
+            source_count="$(jq '[.image[] | select(.config.Labels["org.opencontainers.image.source"] == "https://github.com/seakee/CPA-Manager-Plus")] | length' "${inspect_json}")"
+            if ! [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+              [ "${image_count}" != "2" ] ||
+              [ "${amd64_count}" != "1" ] ||
+              [ "${arm64_count}" != "1" ] ||
+              [ "${revision_count}" != "2" ] ||
+              [ "${version_count}" != "2" ] ||
+              [ "${source_count}" != "2" ]; then
+              echo "Published registry tag failed immutable source verification: ${reference}" >&2
+              exit 1
+            fi
+            if [ -z "${canonical_digest}" ]; then
+              canonical_digest="${digest}"
+            elif [ "${canonical_digest}" != "${digest}" ]; then
+              echo "Published release tags do not share the same manifest digest: ${reference}" >&2
+              exit 1
+            fi
+            if [[ "${reference}" == ghcr.io/* ]]; then
+              ghcr_digest="${digest}"
+            else
+              dockerhub_digest="${digest}"
+            fi
+          done <<< "${RELEASE_REFERENCES}"
+          if [ -z "${ghcr_digest}" ] ||
+            { [ -n "${dockerhub_digest}" ] && [ "${dockerhub_digest}" != "${ghcr_digest}" ]; }; then
+            echo "Published registry digest verification failed." >&2
+            exit 1
+          fi
+          echo "All Docker image tags match the immutable source and share one manifest digest." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Update DockerHub overview
+        if: steps.registry_state.outputs.publish_images == 'true' && steps.docker_targets.outputs.dockerhub_enabled == 'true'
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_REPOSITORY }}
+          short-description: CPA Manager Plus with Dockerized Manager Server
+          readme-filepath: ./README.md
+
+  publish_github_release:
+    name: Publish verified GitHub Release
+    needs:
+      - prepare_release
+      - build_and_push_docker
+    if: needs.prepare_release.result == 'success' && needs.build_and_push_docker.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      DISPATCH_SHA: ${{ needs.prepare_release.outputs.dispatch_sha }}
+      RELEASE_SHA: ${{ needs.prepare_release.outputs.release_sha }}
+      RELEASE_ID: ${{ needs.prepare_release.outputs.release_id }}
+      NEEDS_PUBLISH: ${{ needs.prepare_release.outputs.needs_publish }}
+      EXPECTED_PRERELEASE: ${{ needs.prepare_release.outputs.prerelease }}
+      EXPECTED_ASSET_MANIFEST: ${{ needs.prepare_release.outputs.asset_manifest }}
+
+    steps:
+      - name: Checkout recovery source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Verify the immutable source remains unchanged
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          current_main_sha="$(git rev-parse --verify origin/main^{commit})"
+          if [ "${current_main_sha}" != "${GITHUB_SHA}" ] || [ "${current_main_sha}" != "${DISPATCH_SHA}" ]; then
+            echo "main changed after the recovery workflow was dispatched." >&2
+            exit 1
+          fi
+          if [ "$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")" != "${RELEASE_SHA}" ]; then
+            echo "The immutable release tag no longer points to the checked source." >&2
+            exit 1
+          fi
+
+      - name: Publish the verified draft GitHub Release
+        if: env.NEEDS_PUBLISH == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          release_json="${RUNNER_TEMP}/draft-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "Draft GitHub Release lookup failed with HTTP ${http_code}." >&2
+            exit 1
+          fi
+          if [ "$(jq -r '.draft' "${release_json}")" != "true" ]; then
+            echo "The prepared Release is no longer a draft; refusing to publish an unexpected state." >&2
+            exit 1
+          fi
+          body_path="${RUNNER_TEMP}/${RELEASE_TAG}-release-notes.md"
+          git show "${RELEASE_SHA}:docs/release-notes/${RELEASE_TAG}-zh.md" > "${body_path}"
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+
+            const [releasePath, bodyPath, manifestJson, expectedId, tag, prerelease] = process.argv.slice(1);
+            const release = JSON.parse(readFileSync(releasePath, "utf8"));
+            const expectedAssets = JSON.parse(manifestJson).sort((left, right) => left.name.localeCompare(right.name));
+            const actualAssets = [...release.assets].sort((left, right) => left.name.localeCompare(right.name));
+            const normalize = (value) => String(value ?? "").replace(/\r\n?/g, "\n").trimEnd();
+            const validAssets = actualAssets.length === expectedAssets.length && actualAssets.every((asset, index) => {
+              const expected = expectedAssets[index];
+              return asset.name === expected.name && asset.state === "uploaded" && asset.size === expected.size && asset.digest === expected.digest;
+            });
+            if (
+              String(release.id) !== expectedId ||
+              release.tag_name !== tag ||
+              release.draft !== true ||
+              release.prerelease !== (prerelease === "true") ||
+              normalize(release.body) !== normalize(readFileSync(bodyPath, "utf8")) ||
+              !validAssets
+            ) {
+              throw new Error("Draft GitHub Release changed before publication");
+            }
+          ' "${release_json}" "${body_path}" "${EXPECTED_ASSET_MANIFEST}" "${RELEASE_ID}" "${RELEASE_TAG}" "${EXPECTED_PRERELEASE}"
+          publish_payload="$(jq -cn --argjson prerelease "${EXPECTED_PRERELEASE}" '{draft: false, prerelease: $prerelease}')"
+          published_json="${RUNNER_TEMP}/published-release.json"
+          publish_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${published_json}" \
+            --write-out "%{http_code}" \
+            --request PATCH \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --header "Content-Type: application/json" \
+            --data "${publish_payload}" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${publish_code}" != "200" ]; then
+            echo "Publishing the verified draft GitHub Release failed with HTTP ${publish_code}." >&2
+            exit 1
+          fi
+          echo "Verified draft GitHub Release publication request completed." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Verify final GitHub Release and exact asset digests
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          release_json="${RUNNER_TEMP}/final-release.json"
+          http_code="$(curl \
+            --silent \
+            --show-error \
+            --output "${release_json}" \
+            --write-out "%{http_code}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
+          if [ "${http_code}" != "200" ]; then
+            echo "Final GitHub Release lookup failed with HTTP ${http_code}." >&2
+            exit 1
+          fi
+          body_path="${RUNNER_TEMP}/${RELEASE_TAG}-release-notes.md"
+          git show "${RELEASE_SHA}:docs/release-notes/${RELEASE_TAG}-zh.md" > "${body_path}"
+          node bin/release/verify-published-release.mjs \
+            --mode metadata \
+            --tag "${RELEASE_TAG}" \
+            --body-path "${body_path}" \
+            --release-json "${release_json}" \
+            --prerelease "${EXPECTED_PRERELEASE}"
+          jq -e --argjson expected "${EXPECTED_ASSET_MANIFEST}" '
+            .draft == false and
+            . as $release |
+            ($expected | map({key: .name, value: .}) | from_entries) as $expected_by_name |
+            ($release.assets | length == ($expected | length)) and
+            ($release.assets | all(.[];
+              .state == "uploaded" and
+              .size == $expected_by_name[.name].size and
+              .digest == $expected_by_name[.name].digest
+            ))
+          ' "${release_json}" >/dev/null
+          echo "GitHub Release is published with the exact verified asset manifest." >> "${GITHUB_STEP_SUMMARY}"
+
+  notify_telegram:
+    name: Optionally recover Telegram notification
+    needs:
+      - prepare_release
+      - publish_github_release
+    if: needs.publish_github_release.result == 'success' && github.run_attempt == 1
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+
+    steps:
+      - name: Record explicit Telegram decision
+        if: inputs.confirm_telegram != true
+        run: echo "Telegram recovery was explicitly disabled; no message was sent." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Checkout recovery source for Telegram post
+        if: inputs.confirm_telegram == true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Extract immutable Telegram post
+        if: inputs.confirm_telegram == true
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ needs.prepare_release.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          git show "${RELEASE_SHA}:docs/release-posts/${RELEASE_TAG}-telegram.html" > "${RUNNER_TEMP}/${RELEASE_TAG}-telegram.html"
+
+      - name: Send Telegram release notification
+        if: inputs.confirm_telegram == true
+        shell: bash
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_MESSAGE_THREAD_ID: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}
+          RELEASE_POST_PATH: ${{ runner.temp }}/${{ inputs.release_tag }}-telegram.html
+          TELEGRAM_STRICT: 'true'
+        run: bash bin/release/send-telegram-release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,13 +305,12 @@ jobs:
                 --mode "${verification_mode}" \
                 --allow-missing-assets "${allow_missing}" \
                 --result-path "${verification_json}"
-              complete="$(node --input-type=module - "${verification_json}" <<'NODE'
-              import { readFileSync } from 'node:fs';
+              complete="$(node --input-type=module -e '
+                import { readFileSync } from "node:fs";
 
-              const result = JSON.parse(readFileSync(process.argv[2], 'utf8'));
-              process.stdout.write(String(result.complete));
-              NODE
-              )"
+                const result = JSON.parse(readFileSync(process.argv[1], "utf8"));
+                process.stdout.write(String(result.complete));
+              ' "${verification_json}")"
               echo "state=${verification_mode}" >> "${GITHUB_OUTPUT}"
               if [ "${verification_mode}" = "draft" ]; then
                 echo "finalize=true" >> "${GITHUB_OUTPUT}"
@@ -329,13 +328,12 @@ jobs:
                   echo "Existing GitHub Release matches the checked payload; upload skipped." >> "${GITHUB_STEP_SUMMARY}"
                 fi
               else
-                missing_upload_files="$(node --input-type=module - "${verification_json}" <<'NODE'
-                import { readFileSync } from 'node:fs';
+                missing_upload_files="$(node --input-type=module -e '
+                  import { readFileSync } from "node:fs";
 
-                const result = JSON.parse(readFileSync(process.argv[2], 'utf8'));
-                process.stdout.write(result.missingAssets.map(({ filePath }) => filePath).join('\n'));
-                NODE
-                )"
+                  const result = JSON.parse(readFileSync(process.argv[1], "utf8"));
+                  process.stdout.write(result.missingAssets.map(({ filePath }) => filePath).join("\n"));
+                ' "${verification_json}")"
                 echo "publish=true" >> "${GITHUB_OUTPUT}"
                 write_upload_files "${missing_upload_files}"
                 if [ "${verification_mode}" = "draft" ]; then


### PR DESCRIPTION
## Summary

Promote the exact guarded release-recovery merge from the protected `dev` branch into `main`.

The promotion source is `dev@94e448385b53854aaefaf37120bcf0b321b24f76` and the recorded base is `main@340474092963344d8f2ecf68e30941be711dc5aa`. This makes the reviewed recovery workflow available for a separately authorized `v1.12.0-rc.1` recovery dispatch without moving or recreating the immutable tag.

> Community and maintenance PRs must target `dev`. `main` accepts only a
> promotion PR whose source is this repository’s `dev` branch.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Promote the main-only manual publication recovery workflow that binds a recovery to the exact failed run, artifact, tagged source SHA, and existing tag.
- Promote fail-closed GitHub Release, multi-architecture registry, and optional Telegram recovery checks.
- Promote the standard release workflow fix that replaces two broken nested heredocs with stable Node command substitutions.

## User Impact

No application UI or runtime behavior changes. After this promotion, maintainers can separately dispatch the guarded recovery workflow to publish the already-built `v1.12.0-rc.1` payload while preserving its existing tag and source commit.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; no panel behavior changes.
- Manager Server mode: N/A; no server behavior changes.
- Full Docker / native packages: the recovery workflow verifies and reuses the immutable tagged source and exact existing artifact. It rejects partial or mismatched release and registry state.

## Data / Security Notes

No application data, credentials, admin keys, CPA Management Keys, or secret values are changed. Publication credentials remain step-scoped, GitHub Actions are pinned to full commit SHAs, and the recovery requires explicit operator confirmation plus exact provenance checks.

## Risk / Rollback

Risk level: Medium

Rollback notes: Before any recovery dispatch, revert this promotion to remove the manual workflow from `main`. Merging this PR alone does not move the tag, create a GitHub Release, publish container images, or send Telegram. If a later dispatch performs publication, preserve the immutable tag and published evidence rather than attempting a destructive rollback.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Recovery implementation PR: #531
PR #531 Required checks: SUCCESS
PR #531 merge commit: 94e448385b53854aaefaf37120bcf0b321b24f76
Recorded main base: 340474092963344d8f2ecf68e30941be711dc5aa

/Users/seakee/WorkSpace/Node/CPA-Manager-Plus/node_modules/.bin/vitest run tests/ciWorkflowIntegrity.test.mjs
Result: 1 test file passed; 16 tests passed.

npm run release:validate -- --tag v1.12.0-rc.1 --content-only
Result: ok=true; prerelease=true.

The promotion diff contains only:
- .github/workflows/release-publish-recovery.yml
- .github/workflows/release.yml

The existing tag remains:
refs/tags/v1.12.0-rc.1 -> 340474092963344d8f2ecf68e30941be711dc5aa
```

This promotion must additionally pass `Verify dev promotion source` and all protected required checks. Before merge, both recorded branch SHAs must remain unchanged; after merge, the resulting `main` tree must equal the recorded `dev` tree and its second parent must be `94e448385b53854aaefaf37120bcf0b321b24f76`.

## Screenshots / Recordings

N/A — this PR promotes GitHub Actions release infrastructure only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

The workflow inputs, explicit confirmations, provenance constraints, and fail-closed behavior are documented directly in the Actions workflow and its job summaries. Existing `v1.12.0-rc.1` release notes and Telegram content are unchanged.

## Related

Refs #531 and #530.

Failed tagged run: https://github.com/seakee/CPA-Manager-Plus/actions/runs/31652853376

Immutable tag: `v1.12.0-rc.1`