### PR TITLE
fix(release): preserve false API booleans in recovery

### DIFF
--- a/.github/workflows/release-publish-recovery.yml
+++ b/.github/workflows/release-publish-recovery.yml
@@ -278,7 +278,7 @@ jobs:
             exit 1
           fi
           artifact_name="$(jq -r '.name // empty' "${artifact_json}")"
-          artifact_expired="$(jq -r '.expired // empty' "${artifact_json}")"
+          artifact_expired="$(jq -r '.expired | if type == "boolean" then tostring else empty end' "${artifact_json}")"
           artifact_size="$(jq -r '.size_in_bytes // empty' "${artifact_json}")"
           artifact_head_sha="$(jq -r '.workflow_run.head_sha // empty' "${artifact_json}")"
           artifact_run_id="$(jq -r '.workflow_run.id // empty | tostring' "${artifact_json}")"
@@ -503,7 +503,7 @@ jobs:
                 echo "Existing GitHub Release has an invalid id." >&2
                 exit 1
               fi
-              is_draft="$(jq -r '.draft // empty' "${release_json}")"
+              is_draft="$(jq -r '.draft | if type == "boolean" then tostring else empty end' "${release_json}")"
               case "${is_draft}" in
                 true) verification_mode=draft; target_draft=true; needs_publish=true ;;
                 false) verification_mode=artifact; target_draft=false; needs_publish=false ;;
@@ -611,7 +611,7 @@ jobs:
           fi
 
           response_release_id="$(jq -r '.id // empty' "${release_json}")"
-          is_draft="$(jq -r '.draft // empty' "${release_json}")"
+          is_draft="$(jq -r '.draft | if type == "boolean" then tostring else empty end' "${release_json}")"
           if [ "${response_release_id}" != "${release_id}" ] ||
             { [ "${is_draft}" != "true" ] && [ "${is_draft}" != "false" ]; }; then
             echo "Prepared GitHub Release has invalid identity or draft state." >&2

--- a/tests/ciWorkflowIntegrity.test.mjs
+++ b/tests/ciWorkflowIntegrity.test.mjs
@@ -221,6 +221,15 @@ describe('GitHub Actions workflow integrity', () => {
     expect(telegramScript).not.toContain('--retry-all-errors');
   });
 
+  it('preserves false-valued GitHub API booleans during release recovery', () => {
+    const workflow = readWorkflow('release-publish-recovery.yml');
+    const booleanFilter = 'if type == "boolean" then tostring else empty end';
+
+    expect(workflow).toContain(`.expired | ${booleanFilter}`);
+    expect(workflow.match(new RegExp(`\\.draft \\| ${booleanFilter}`, 'g'))).toHaveLength(2);
+    expect(workflow).not.toMatch(/\.(?:expired|draft)\s*\/\/\s*empty/);
+  });
+
   it('provides a validated explicit Telegram recovery workflow', () => {
     const workflow = readWorkflow('release-telegram-recovery.yml');
     const notifyJob = jobBlock(workflow, 'notify');


### PR DESCRIPTION
## Summary

Fix release publication recovery so valid `false` values returned by GitHub APIs are preserved instead of being discarded by jq fallback semantics. This unblocks validation of the existing unexpired rc.1 artifact while retaining fail-closed checks for missing or invalid field types.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Parse artifact `expired` and Release `draft` values with type-aware jq filters that preserve both boolean values.
- Add workflow-integrity coverage for all three affected reads and reject regressions to boolean-dropping `// empty` expressions.

## User Impact

No application UI or runtime behavior change. Maintainers can safely recover release publication when GitHub returns valid `false` values for artifact expiry or Release draft state.

## Compatibility / Runtime Notes

- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: Publication recovery logic only; package contents and runtime behavior are unchanged.

## Data / Security Notes

N/A. The change does not access new secrets or alter stored data. Invalid, missing, or non-boolean API values continue to fail closed.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `5db0788f` to restore the previous parsing behavior. Do not rerun release recovery after rollback because the previous logic rejects valid `false` values.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Focused workflow integrity: 1 file, 17 tests passed
npm run test: 185 files, 2219 tests passed
All GitHub Actions YAML files parsed successfully
All 66 workflow Bash run blocks passed bash -n
Prettier check passed for both changed files
git diff --check passed
v1.12.0-rc.1 release content and historical topology validation passed
```

## Screenshots / Recordings

N/A — CI-only behavior with no visible UI change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation update is needed because this corrects internal release-recovery validation without changing user-facing release behavior or commands.

## Related

Refs: failed recovery run https://github.com/seakee/CPA-Manager-Plus/actions/runs/31663920735
