### PR TITLE
chore(release): promote rc.1 recovery boolean fix to main

### DIFF
--- a/.github/workflows/release-publish-recovery.yml
+++ b/.github/workflows/release-publish-recovery.yml
@@ -278,7 +278,7 @@ jobs:
             exit 1
           fi
           artifact_name="$(jq -r '.name // empty' "${artifact_json}")"
-          artifact_expired="$(jq -r '.expired // empty' "${artifact_json}")"
+          artifact_expired="$(jq -r '.expired | if type == "boolean" then tostring else empty end' "${artifact_json}")"
           artifact_size="$(jq -r '.size_in_bytes // empty' "${artifact_json}")"
           artifact_head_sha="$(jq -r '.workflow_run.head_sha // empty' "${artifact_json}")"
           artifact_run_id="$(jq -r '.workflow_run.id // empty | tostring' "${artifact_json}")"
@@ -503,7 +503,7 @@ jobs:
                 echo "Existing GitHub Release has an invalid id." >&2
                 exit 1
               fi
-              is_draft="$(jq -r '.draft // empty' "${release_json}")"
+              is_draft="$(jq -r '.draft | if type == "boolean" then tostring else empty end' "${release_json}")"
               case "${is_draft}" in
                 true) verification_mode=draft; target_draft=true; needs_publish=true ;;
                 false) verification_mode=artifact; target_draft=false; needs_publish=false ;;
@@ -611,7 +611,7 @@ jobs:
           fi
 
           response_release_id="$(jq -r '.id // empty' "${release_json}")"
-          is_draft="$(jq -r '.draft // empty' "${release_json}")"
+          is_draft="$(jq -r '.draft | if type == "boolean" then tostring else empty end' "${release_json}")"
           if [ "${response_release_id}" != "${release_id}" ] ||
             { [ "${is_draft}" != "true" ] && [ "${is_draft}" != "false" ]; }; then
             echo "Prepared GitHub Release has invalid identity or draft state." >&2

--- a/tests/ciWorkflowIntegrity.test.mjs
+++ b/tests/ciWorkflowIntegrity.test.mjs
@@ -221,6 +221,15 @@ describe('GitHub Actions workflow integrity', () => {
     expect(telegramScript).not.toContain('--retry-all-errors');
   });
 
+  it('preserves false-valued GitHub API booleans during release recovery', () => {
+    const workflow = readWorkflow('release-publish-recovery.yml');
+    const booleanFilter = 'if type == "boolean" then tostring else empty end';
+
+    expect(workflow).toContain(`.expired | ${booleanFilter}`);
+    expect(workflow.match(new RegExp(`\\.draft \\| ${booleanFilter}`, 'g'))).toHaveLength(2);
+    expect(workflow).not.toMatch(/\.(?:expired|draft)\s*\/\/\s*empty/);
+  });
+
   it('provides a validated explicit Telegram recovery workflow', () => {
     const workflow = readWorkflow('release-telegram-recovery.yml');
     const notifyJob = jobBlock(workflow, 'notify');


### PR DESCRIPTION
## Summary

Promote the reviewed release-recovery boolean parsing fix from `dev` to `main`. This is required before retrying publication recovery for the existing immutable `v1.12.0-rc.1` tag and artifact.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Preserve valid `false` values for GitHub Artifact expiry and Release draft state during guarded publication recovery.
- Add regression coverage that rejects boolean-dropping jq fallback expressions.

## User Impact

No application UI or runtime behavior change. After this promotion, maintainers can safely retry publication recovery for the existing rc.1 artifact without moving or recreating its tag.

## Compatibility / Runtime Notes

- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: Publication recovery workflow only; package contents and runtime behavior are unchanged.

## Data / Security Notes

N/A. No stored data, credentials, tag target, artifact, or release payload is changed. Missing or invalid API field types remain fail-closed.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the promotion merge if necessary. Do not dispatch rc.1 recovery until a correct recovery workflow is present on `main`.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
PR #533 merged to dev as 9d49c6543fb3331384a75903a4dc950f98635a95
PR #533 required checks passed
Local focused workflow integrity: 17 tests passed
Local full suite: 185 files, 2219 tests passed
All GitHub Actions YAML files parsed successfully
All 66 workflow Bash run blocks passed bash -n
Prettier and git diff --check passed
v1.12.0-rc.1 historical content and topology validation passed
Current main...dev file scope: exactly the recovery workflow and its integrity test
```

## Screenshots / Recordings

N/A — CI-only release recovery behavior with no visible UI change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation update is needed because this is an internal correction to guarded publication recovery.

## Related

Refs #533
Refs: failed recovery run https://github.com/seakee/CPA-Manager-Plus/actions/runs/31663920735
