### PR TITLE
fix(release): allow recovery to read prepared draft

### DIFF
--- a/.github/workflows/release-publish-recovery.yml
+++ b/.github/workflows/release-publish-recovery.yml
@@ -645,7 +645,7 @@ jobs:
     if: needs.prepare_release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}

--- a/tests/ciWorkflowIntegrity.test.mjs
+++ b/tests/ciWorkflowIntegrity.test.mjs
@@ -230,6 +230,22 @@ describe('GitHub Actions workflow integrity', () => {
     expect(workflow).not.toMatch(/\.(?:expired|draft)\s*\/\/\s*empty/);
   });
 
+  it('allows release recovery to revalidate its prepared draft before publishing images', () => {
+    const workflow = readWorkflow('release-publish-recovery.yml');
+    const dockerJob = jobBlock(workflow, 'build_and_push_docker');
+    const stepsOffset = dockerJob.indexOf('\n    steps:');
+    const jobConfiguration = dockerJob.slice(0, stepsOffset);
+
+    expect(jobConfiguration).toContain('contents: write');
+    expect(jobConfiguration).toContain('packages: write');
+    expect(dockerJob).toContain(
+      'name: Revalidate prepared GitHub Release before registry mutation'
+    );
+    expect(dockerJob).toContain(
+      '"${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"'
+    );
+  });
+
   it('provides a validated explicit Telegram recovery workflow', () => {
     const workflow = readWorkflow('release-telegram-recovery.yml');
     const notifyJob = jobBlock(workflow, 'notify');


### PR DESCRIPTION
## Summary

Fix the release publication recovery workflow after run 31667325191 failed with HTTP 403 while revalidating its prepared draft Release.
The recovery image job now receives the minimum token scope required to read that draft before any registry mutation.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Grant the recovery image publication job `contents: write` alongside its existing `packages: write` permission.
- Add a workflow integrity regression test for the draft Release revalidation permission boundary.

## User Impact

No application behavior change. Release recovery can proceed past draft Release revalidation while continuing to fail closed before registry publication.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: Release automation only; package and image contents are unchanged.

## Data / Security Notes

The additional permission is scoped to the explicit recovery image job. External Actions remain pinned to full commit SHAs, and the workflow still revalidates the exact draft Release before any registry mutation.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `7b585ce6130dcf9014fef0e2243268449dea8f24`. This would restore the previous read-only contents token and the known HTTP 403 failure.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
node_modules/.bin/vitest run tests/ciWorkflowIntegrity.test.mjs --root .
  1 file passed, 18 tests passed

npm run test
  185 files passed, 2219 tests passed

All 8 GitHub Actions YAML files parsed successfully.
All 66 Bash run blocks passed bash -n.
Prettier check passed.
git diff --check passed.
```

## Screenshots / Recordings

N/A — release automation only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: Internal release workflow permission fix with no user-facing documentation change.

## Related

Refs failed recovery run https://github.com/seakee/CPA-Manager-Plus/actions/runs/31667325191