### PR TITLE
chore(release): promote rc.1 draft access fix to main

### DIFF
--- a/.github/workflows/release-publish-recovery.yml
+++ b/.github/workflows/release-publish-recovery.yml
@@ -645,7 +645,7 @@ jobs:
     if: needs.prepare_release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}

--- a/tests/ciWorkflowIntegrity.test.mjs
+++ b/tests/ciWorkflowIntegrity.test.mjs
@@ -230,6 +230,22 @@ describe('GitHub Actions workflow integrity', () => {
     expect(workflow).not.toMatch(/\.(?:expired|draft)\s*\/\/\s*empty/);
   });
 
+  it('allows release recovery to revalidate its prepared draft before publishing images', () => {
+    const workflow = readWorkflow('release-publish-recovery.yml');
+    const dockerJob = jobBlock(workflow, 'build_and_push_docker');
+    const stepsOffset = dockerJob.indexOf('\n    steps:');
+    const jobConfiguration = dockerJob.slice(0, stepsOffset);
+
+    expect(jobConfiguration).toContain('contents: write');
+    expect(jobConfiguration).toContain('packages: write');
+    expect(dockerJob).toContain(
+      'name: Revalidate prepared GitHub Release before registry mutation'
+    );
+    expect(dockerJob).toContain(
+      '"${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"'
+    );
+  });
+
   it('provides a validated explicit Telegram recovery workflow', () => {
     const workflow = readWorkflow('release-telegram-recovery.yml');
     const notifyJob = jobBlock(workflow, 'notify');


### PR DESCRIPTION
## Summary

Promote the validated release recovery draft-permission fix from `dev` to `main`.
This restores the approved v1.12.0-rc.1 publication recovery path after the image job received HTTP 403 while reading its prepared draft Release.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Promote merge commit `290f6153dc5d8889b633c52d65414969ad658dd2` from the protected `dev` branch.
- Preserve the tested recovery workflow permission and regression assertion exactly as merged in PR #536.

## User Impact

No application behavior change. The protected `main` recovery workflow can safely continue rc.1 publication.

## Compatibility / Runtime Notes

- CPA panel mode: N/A.
- Manager Server mode: N/A.
- Full Docker / native packages: Release automation only; package and image contents are unchanged.

## Data / Security Notes

The recovery image job receives `contents: write` only because GitHub requires write-scoped contents permission to read a draft Release. Its existing `packages: write` permission remains unchanged.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the promotion merge if needed. The release recovery would return to the known pre-registry HTTP 403 failure.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
PR #536: all checks passed.
Focused workflow tests: 18/18.
Full suite: 185 files, 2219 tests.
All workflow YAML parsed.
66 workflow Bash blocks passed bash -n.
Prettier and git diff checks passed.
```

## Screenshots / Recordings

N/A — release automation only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: Promotion of an internal release workflow permission fix.

## Related

Refs #536
Refs failed recovery run https://github.com/seakee/CPA-Manager-Plus/actions/runs/31667325191