### PR TITLE
fix(xai): prefer unified billing quota evidence

### DIFF
--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -29,6 +29,40 @@ import (
 
 const xaiCompletedInferenceAPICallResponse = `{"status_code":200,"body":{"object":"response","status":"completed","error":null,"output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}]}}`
 
+type synchronizedStringList struct {
+	mu     sync.Mutex
+	values []string
+}
+
+func (s *synchronizedStringList) append(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values = append(s.values, value)
+}
+
+func (s *synchronizedStringList) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.values...)
+}
+
+type synchronizedCounter struct {
+	mu    sync.Mutex
+	value int
+}
+
+func (c *synchronizedCounter) increment() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value++
+}
+
+func (c *synchronizedCounter) load() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.value
+}
+
 type failAfterInsertCodexInspectionRepository struct {
 	codexinspectionrepo.Repository
 	failAfter         int
@@ -761,7 +795,7 @@ func TestRunCompletionLogWarnsWhenAutomaticActionFails(t *testing.T) {
 }
 
 func TestRunXAISkipsInferenceWhenDisabled(t *testing.T) {
-	requestedURLs := make([]string, 0, 2)
+	var requestedURLs synchronizedStringList
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -774,7 +808,7 @@ func TestRunXAISkipsInferenceWhenDisabled(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode api-call payload: %v", err)
 			}
-			requestedURLs = append(requestedURLs, payload.URL)
+			requestedURLs.append(payload.URL)
 			if strings.HasSuffix(payload.URL, "/responses") {
 				t.Fatalf("disabled xAI inference requested %s", payload.URL)
 			}
@@ -802,8 +836,9 @@ func TestRunXAISkipsInferenceWhenDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run xAI inspection: %v", err)
 	}
-	if len(requestedURLs) != 2 {
-		t.Fatalf("requested URLs = %#v, want weekly and monthly billing only", requestedURLs)
+	urls := requestedURLs.snapshot()
+	if len(urls) != 2 {
+		t.Fatalf("requested URLs = %#v, want weekly and monthly billing only", urls)
 	}
 	if len(result.Results) != 1 || result.Results[0].Action != "keep" || result.Results[0].ErrorKind != "billing_healthy" {
 		t.Fatalf("xAI billing-only result = %#v", result.Results)
@@ -877,8 +912,8 @@ func TestRunXAILogsMissingAuthIndexAsSkippedWarning(t *testing.T) {
 	}
 }
 
-func TestRunXAIBillingOnlyPrioritizesBlockingFailureOverPartialSummary(t *testing.T) {
-	requestedURLs := make([]string, 0, 2)
+func TestRunXAIBillingOnlyIgnoresDeprecatedMonthlyBlockingFailure(t *testing.T) {
+	var requestedURLs synchronizedStringList
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -890,7 +925,7 @@ func TestRunXAIBillingOnlyPrioritizesBlockingFailureOverPartialSummary(t *testin
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode api-call payload: %v", err)
 			}
-			requestedURLs = append(requestedURLs, payload.URL)
+			requestedURLs.append(payload.URL)
 			if strings.Contains(payload.URL, "format=credits") {
 				_, _ = w.Write([]byte(`{"status_code":200,"body":{"config":{"credit_usage_percent":3,"current_period":{"end":"2026-07-29T00:00:00Z"}}}}`))
 				return
@@ -915,29 +950,78 @@ func TestRunXAIBillingOnlyPrioritizesBlockingFailureOverPartialSummary(t *testin
 	if err != nil {
 		t.Fatalf("run xAI inspection: %v", err)
 	}
-	if len(requestedURLs) != 2 {
-		t.Fatalf("requested URLs = %#v, want weekly and monthly billing only", requestedURLs)
+	urls := requestedURLs.snapshot()
+	if len(urls) != 2 {
+		t.Fatalf("requested URLs = %#v, want weekly and monthly billing only", urls)
 	}
 	if len(result.Results) != 1 {
 		t.Fatalf("xAI result = %#v", result.Results)
 	}
 	item := result.Results[0]
-	if item.Action != "disable" || item.ErrorKind != "spending_limit" || item.StatusCode == nil || *item.StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("xAI partial blocking result = %#v", item)
+	if item.Action != "keep" || item.ErrorKind != "billing_healthy" || item.StatusCode == nil || *item.StatusCode != http.StatusOK {
+		t.Fatalf("xAI unified weekly result = %#v", item)
 	}
 	if len(item.QuotaWindows) != 1 || item.QuotaWindows[0].ID != "xai-weekly" {
 		t.Fatalf("xAI partial blocking quota windows = %#v", item.QuotaWindows)
 	}
 	logEntry := requireInspectionLog(t, result.Logs, "monitoring.xai_inspection_log_server_complete")
-	if logEntry.Level != "warning" {
-		t.Fatalf("xAI blocking billing log level = %q, want warning", logEntry.Level)
+	if logEntry.Level != "info" {
+		t.Fatalf("xAI unified weekly log level = %q, want info", logEntry.Level)
 	}
 	detail := requireInspectionLogDetail(t, logEntry)
-	if detail["inspectionMode"] != "billing" || detail["healthEvidence"] != "spending_limit" {
-		t.Fatalf("xAI blocking billing log detail = %#v", detail)
+	if detail["inspectionMode"] != "billing" || detail["healthEvidence"] != "billing_healthy" || detail["billingPartial"] != false {
+		t.Fatalf("xAI unified weekly log detail = %#v", detail)
 	}
 	if _, ok := detail["inferenceHealthy"]; ok {
 		t.Fatalf("xAI blocking billing log reported inference health: %#v", detail)
+	}
+}
+
+func TestRunXAIAutoDisableDoesNotActOnDeprecatedMonthlyFailure(t *testing.T) {
+	patchCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"files":[{"id":"xai-auth.json","name":"xai-auth.json","auth_index":"xai-1","provider":"xai","account":"xai@example.com"}]}`))
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
+			var payload struct {
+				URL string `json:"url"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode api-call payload: %v", err)
+			}
+			if strings.Contains(payload.URL, "format=credits") {
+				_, _ = w.Write([]byte(`{"status_code":200,"body":{"config":{"credit_usage_percent":3,"current_period":{"type":"weekly","start":"2026-08-13T00:00:00Z","end":"2026-08-20T00:00:00Z"}}}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"status_code":402,"body":{"code":"personal-team-blocked:spending-limit"}}`))
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
+			patchCalled = true
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	db := newCodexInspectionTestStore(t)
+	managerCfg := newCodexInspectionManagerConfig(upstream.URL)
+	managerCfg.CodexInspection.TargetType = "xai"
+	managerCfg.CodexInspection.XAIInferenceEnabled = false
+	managerCfg.CodexInspection.AutoActionMode = model.CodexInspectionAutoActionDisable
+	if err := db.SaveManagerConfig(context.Background(), managerCfg); err != nil {
+		t.Fatalf("save manager config: %v", err)
+	}
+
+	result, err := newCodexInspectionTestService(t, db).Run(context.Background(), RunRequest{TriggerType: "manual"})
+	if err != nil {
+		t.Fatalf("run xAI inspection: %v", err)
+	}
+	if patchCalled {
+		t.Fatal("automatic disable acted on a deprecated monthly failure")
+	}
+	if len(result.Results) != 1 || result.Results[0].Action != "keep" || result.Results[0].ErrorKind != "billing_healthy" {
+		t.Fatalf("xAI automatic-action result = %#v", result.Results)
 	}
 }
 
@@ -960,11 +1044,32 @@ func TestResolveXAIBasicInspectionResultClassifiesNonBlockingPartialBilling(t *t
 	}
 }
 
+func TestResolveXAIBasicInspectionResultKeepsWeeklyBlockingFailureWithLegacySummary(t *testing.T) {
+	monthlyLimit := float64(20000)
+	monthlyUsed := float64(25)
+	result := resolveXAIBasicInspectionResult(
+		model.CodexInspectionResult{},
+		xaiBillingProbe{
+			Summary: &xaiBillingSummary{
+				MonthlyLimitCents: &monthlyLimit,
+				UsedPercent:       &monthlyUsed,
+				HasMonthlyData:    true,
+			},
+			Failures: []xaiProbeDecision{*xaiDecision(http.StatusPaymentRequired, "spending_limit", "weekly quota exhausted")},
+			Partial:  true,
+			Healthy:  true,
+		},
+	)
+	if result.Action != "disable" || result.ErrorKind != "spending_limit" || result.StatusCode == nil || *result.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("xAI weekly blocking failure with legacy summary = %#v", result)
+	}
+}
+
 func TestRunXAIUsesBillingAndInferenceEndpoints(t *testing.T) {
 	const customModel = "grok-custom"
 	const customPrompt = "Return a short health response."
 	const customUserAgent = "xai-custom-agent"
-	requestedURLs := make([]string, 0, 3)
+	var requestedURLs synchronizedStringList
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -979,7 +1084,7 @@ func TestRunXAIUsesBillingAndInferenceEndpoints(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode api-call payload: %v", err)
 			}
-			requestedURLs = append(requestedURLs, payload.URL)
+			requestedURLs.append(payload.URL)
 			if strings.Contains(payload.URL, "chatgpt.com") {
 				t.Fatalf("xAI inspection called Codex endpoint: %s", payload.URL)
 			}
@@ -1041,8 +1146,9 @@ func TestRunXAIUsesBillingAndInferenceEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run xAI inspection: %v", err)
 	}
-	if len(requestedURLs) != 3 || !strings.HasSuffix(requestedURLs[2], "/responses") {
-		t.Fatalf("requested URLs = %#v, want weekly/monthly billing and inference", requestedURLs)
+	urls := requestedURLs.snapshot()
+	if len(urls) != 3 || !strings.HasSuffix(urls[2], "/responses") {
+		t.Fatalf("requested URLs = %#v, want weekly/monthly billing and inference", urls)
 	}
 	if len(result.Results) != 1 || result.Results[0].Provider != "xai" || result.Results[0].Action != "keep" {
 		t.Fatalf("xAI result = %#v", result.Results)
@@ -1129,7 +1235,7 @@ func TestResolveXAIInferenceURLMatchesRuntimeUsingAPISemantics(t *testing.T) {
 }
 
 func TestRunCombinedTargetsSamplesEachCredentialProvider(t *testing.T) {
-	requestedInference := 0
+	var requestedInference synchronizedCounter
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -1145,7 +1251,7 @@ func TestRunCombinedTargetsSamplesEachCredentialProvider(t *testing.T) {
 			case strings.Contains(payload.URL, "chatgpt.com"):
 				_, _ = w.Write([]byte(`{"status_code":200,"body":{"rate_limit":{"primary_window":{"used_percent":10,"limit_window_seconds":18000}}}}`))
 			case strings.HasSuffix(payload.URL, "/responses"):
-				requestedInference++
+				requestedInference.increment()
 				_, _ = w.Write([]byte(xaiCompletedInferenceAPICallResponse))
 			case strings.Contains(payload.URL, "/billing"):
 				_, _ = w.Write([]byte(`{"status_code":200,"body":{"config":{"credit_usage_percent":20,"current_period":{"end":"2026-07-22T00:00:00Z"}}}}`))
@@ -1179,13 +1285,14 @@ func TestRunCombinedTargetsSamplesEachCredentialProvider(t *testing.T) {
 	for _, result := range detail.Results {
 		providers[result.Provider] = true
 	}
-	if !providers["codex"] || !providers["xai"] || requestedInference != 1 {
-		t.Fatalf("providers=%#v inference=%d", providers, requestedInference)
+	inferenceCount := requestedInference.load()
+	if !providers["codex"] || !providers["xai"] || inferenceCount != 1 {
+		t.Fatalf("providers=%#v inference=%d", providers, inferenceCount)
 	}
 }
 
 func TestRunXAIFallsBackToOfficialAPIIdentityHealth(t *testing.T) {
-	requestedURLs := make([]string, 0, 3)
+	var requestedURLs synchronizedStringList
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -1199,7 +1306,7 @@ func TestRunXAIFallsBackToOfficialAPIIdentityHealth(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode api-call payload: %v", err)
 			}
-			requestedURLs = append(requestedURLs, payload.URL)
+			requestedURLs.append(payload.URL)
 			if strings.HasSuffix(payload.URL, "/responses") {
 				if payload.Method != http.MethodPost {
 					t.Fatalf("xAI inference method = %q, want POST", payload.Method)
@@ -1242,8 +1349,9 @@ func TestRunXAIFallsBackToOfficialAPIIdentityHealth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run xAI inspection: %v", err)
 	}
-	if len(requestedURLs) != 4 || requestedURLs[2] != xaiOfficialAPIMeURL || requestedURLs[3] != xaiOfficialAPIBaseURL+"/responses" {
-		t.Fatalf("requested URLs = %#v, want billing, identity fallback, and inference", requestedURLs)
+	urls := requestedURLs.snapshot()
+	if len(urls) != 4 || urls[2] != xaiOfficialAPIMeURL || urls[3] != xaiOfficialAPIBaseURL+"/responses" {
+		t.Fatalf("requested URLs = %#v, want billing, identity fallback, and inference", urls)
 	}
 	if len(result.Results) != 1 {
 		t.Fatalf("xAI result = %#v", result.Results)
@@ -1313,6 +1421,338 @@ func TestParseXAIBillingSummaryDoesNotCreateMonthlyWindowFromWeeklyZeroOnDemandD
 	}
 }
 
+func TestParseXAIBillingSummaryTreatsOmittedWeeklyPercentAsResetZeroOnlyForValidPeriod(t *testing.T) {
+	valid := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "USAGE_PERIOD_TYPE_WEEKLY",
+			"start": "2026-08-13T00:00:00Z",
+			"end":   "2026-08-20T00:00:00Z",
+		},
+	})
+	if valid == nil || valid.UsagePercent == nil || *valid.UsagePercent != 0 {
+		t.Fatalf("valid weekly reset summary = %#v, want zero usage", valid)
+	}
+
+	incomplete := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type": "USAGE_PERIOD_TYPE_WEEKLY",
+			"end":  "2026-08-20T00:00:00Z",
+		},
+	})
+	if incomplete == nil || incomplete.UsagePercent != nil {
+		t.Fatalf("incomplete weekly period summary = %#v, want unknown usage", incomplete)
+	}
+}
+
+func TestParseXAIBillingSummaryTreatsNestedEmptyCentValuesAsPlaceholders(t *testing.T) {
+	summary := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "USAGE_PERIOD_TYPE_WEEKLY",
+			"start": "2026-08-13T00:00:00Z",
+			"end":   "2026-08-20T00:00:00Z",
+		},
+		"onDemandCap": map[string]any{},
+		"usage": map[string]any{
+			"includedUsed": map[string]any{},
+			"onDemandUsed": map[string]any{},
+			"totalUsed":    map[string]any{},
+		},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+	if summary == nil || summary.UsagePercent == nil || *summary.UsagePercent != 0 {
+		t.Fatalf("nested weekly summary = %#v", summary)
+	}
+	for name, value := range map[string]*float64{
+		"used": summary.UsedCents, "included": summary.IncludedUsedCents,
+		"on-demand cap": summary.OnDemandCapCents, "on-demand used": summary.OnDemandUsedCents,
+	} {
+		if value != nil {
+			t.Fatalf("%s cents = %#v, want absent", name, value)
+		}
+	}
+	if summary.MonthlyLimitCents != nil {
+		t.Fatalf("nested usage invented monthly limit: %#v", summary.MonthlyLimitCents)
+	}
+	if windows := xaiSummaryWindows(summary); len(windows) != 1 || windows[0].ID != "xai-weekly" {
+		t.Fatalf("nested zero-value windows = %#v, want weekly only", windows)
+	}
+}
+
+func TestParseXAIBillingSummaryKeepsEmptyLimitAbsentWithRealMonthlyUsage(t *testing.T) {
+	summary := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit":     map[string]any{},
+		"used":             map[string]any{"val": 500},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+	if summary == nil || summary.UsedCents == nil || *summary.UsedCents != 500 || summary.IncludedUsedCents == nil || *summary.IncludedUsedCents != 500 {
+		t.Fatalf("mixed monthly summary = %#v", summary)
+	}
+	if summary.MonthlyLimitCents != nil || summary.UsedPercent != nil || summary.HasMonthlyLimit {
+		t.Fatalf("empty monthly limit became evidence: %#v", summary)
+	}
+	if windows := xaiSummaryWindows(summary); len(windows) != 0 {
+		t.Fatalf("limitless monthly usage produced quota window: %#v", windows)
+	}
+}
+
+func TestParseXAIBillingSummaryFallsThroughAliasPlaceholders(t *testing.T) {
+	summary := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit":  map[string]any{},
+		"monthly_limit": map[string]any{"val": 10000},
+		"onDemandCap":   map[string]any{"val": "invalid"},
+		"on_demand_cap": map[string]any{"val": 5000},
+		"used":          map[string]any{"val": 2500},
+	})
+	for name, value := range map[string]struct {
+		actual *float64
+		want   float64
+	}{
+		"monthly limit": {summary.MonthlyLimitCents, 10000},
+		"used":          {summary.UsedCents, 2500},
+		"included":      {summary.IncludedUsedCents, 2500},
+		"monthly pct":   {summary.UsedPercent, 25},
+		"payg cap":      {summary.OnDemandCapCents, 5000},
+	} {
+		if value.actual == nil || *value.actual != value.want {
+			t.Fatalf("%s = %#v, want %.0f", name, value.actual, value.want)
+		}
+	}
+}
+
+func TestParseXAIBillingSummaryDerivesIncludedUsagePastEmptyPlaceholder(t *testing.T) {
+	summary := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit": map[string]any{"val": 10000},
+		"used":         map[string]any{"val": 12500},
+		"onDemandCap":  map[string]any{"val": 5000},
+		"usage": map[string]any{
+			"includedUsed": map[string]any{},
+		},
+	})
+	for name, value := range map[string]struct {
+		actual *float64
+		want   float64
+	}{
+		"used":           {summary.UsedCents, 12500},
+		"included":       {summary.IncludedUsedCents, 10000},
+		"monthly pct":    {summary.UsedPercent, 100},
+		"on-demand used": {summary.OnDemandUsedCents, 2500},
+		"on-demand pct":  {summary.OnDemandUsedPercent, 50},
+	} {
+		if value.actual == nil || *value.actual != value.want {
+			t.Fatalf("%s = %#v, want %.0f", name, value.actual, value.want)
+		}
+	}
+	if summary.HasIncludedUsed {
+		t.Fatalf("empty included usage became evidence: %#v", summary)
+	}
+}
+
+func TestMergeXAIBillingSummaryUsesLegacyBillingGroupsOverWeeklyPlaceholders(t *testing.T) {
+	weekly := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "USAGE_PERIOD_TYPE_WEEKLY",
+			"start": "2026-08-13T00:00:00Z",
+			"end":   "2026-08-20T00:00:00Z",
+		},
+		"onDemandCap": map[string]any{},
+		"usage": map[string]any{
+			"includedUsed": map[string]any{},
+			"onDemandUsed": map[string]any{},
+			"totalUsed":    map[string]any{},
+		},
+	})
+	legacy := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit":     map[string]any{"val": 10000},
+		"used":             map[string]any{"val": 12500},
+		"onDemandCap":      map[string]any{"val": 5000},
+		"onDemandUsed":     map[string]any{"val": 2500},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+
+	merged := mergeXAIBillingSummary(weekly, legacy)
+	if merged == nil || merged.UsagePercent == nil || *merged.UsagePercent != 0 {
+		t.Fatalf("merged weekly summary = %#v", merged)
+	}
+	for name, value := range map[string]struct {
+		actual *float64
+		want   float64
+	}{
+		"monthly limit": {merged.MonthlyLimitCents, 10000},
+		"used":          {merged.UsedCents, 12500},
+		"included":      {merged.IncludedUsedCents, 10000},
+		"monthly pct":   {merged.UsedPercent, 100},
+		"payg cap":      {merged.OnDemandCapCents, 5000},
+		"payg used":     {merged.OnDemandUsedCents, 2500},
+		"payg pct":      {merged.OnDemandUsedPercent, 50},
+	} {
+		if value.actual == nil || *value.actual != value.want {
+			t.Fatalf("%s = %#v, want %.0f", name, value.actual, value.want)
+		}
+	}
+	if merged.BillingPeriodEnd != "2026-09-01T00:00:00Z" {
+		t.Fatalf("billing period end = %q", merged.BillingPeriodEnd)
+	}
+}
+
+func TestMergeXAIBillingSummaryRecomputesUsedCentsAcrossMixedSources(t *testing.T) {
+	weekly := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "USAGE_PERIOD_TYPE_WEEKLY",
+			"start": "2026-08-13T00:00:00Z",
+			"end":   "2026-08-20T00:00:00Z",
+		},
+		"onDemandCap":      map[string]any{"val": 5000},
+		"onDemandUsed":     map[string]any{"val": 2500},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+	legacy := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit": map[string]any{"val": 10000},
+		"usage": map[string]any{
+			"includedUsed": map[string]any{"val": 8000},
+		},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+
+	merged := mergeXAIBillingSummary(weekly, legacy)
+	for name, value := range map[string]struct {
+		actual *float64
+		want   float64
+	}{
+		"used":        {merged.UsedCents, 10500},
+		"included":    {merged.IncludedUsedCents, 8000},
+		"monthly pct": {merged.UsedPercent, 80},
+		"payg used":   {merged.OnDemandUsedCents, 2500},
+		"payg pct":    {merged.OnDemandUsedPercent, 50},
+	} {
+		if value.actual == nil || *value.actual != value.want {
+			t.Fatalf("%s = %#v, want %.0f", name, value.actual, value.want)
+		}
+	}
+}
+
+func TestMergeXAIBillingSummaryKeepsConflictingUnifiedFields(t *testing.T) {
+	unified := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "weekly",
+			"start": "2026-08-13T00:00:00Z",
+			"end":   "2026-08-20T00:00:00Z",
+		},
+		"monthlyLimit":     map[string]any{"val": 20000},
+		"used":             map[string]any{"val": 5000},
+		"onDemandCap":      map[string]any{"val": 6000},
+		"onDemandUsed":     map[string]any{"val": 1000},
+		"billingPeriodEnd": "2026-09-02T00:00:00Z",
+	})
+	legacy := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit":     map[string]any{"val": 10000},
+		"used":             map[string]any{"val": 9000},
+		"onDemandCap":      map[string]any{"val": 2000},
+		"onDemandUsed":     map[string]any{"val": 1500},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+
+	merged := mergeXAIBillingSummary(unified, legacy)
+	for name, value := range map[string]struct {
+		actual *float64
+		want   float64
+	}{
+		"monthly limit": {merged.MonthlyLimitCents, 20000},
+		"used":          {merged.UsedCents, 5000},
+		"included":      {merged.IncludedUsedCents, 5000},
+		"monthly pct":   {merged.UsedPercent, 25},
+		"payg cap":      {merged.OnDemandCapCents, 6000},
+		"payg used":     {merged.OnDemandUsedCents, 1000},
+	} {
+		if value.actual == nil || *value.actual != value.want {
+			t.Fatalf("%s = %#v, want %.0f", name, value.actual, value.want)
+		}
+	}
+	if merged.BillingPeriodEnd != "2026-09-02T00:00:00Z" {
+		t.Fatalf("billing period end = %q", merged.BillingPeriodEnd)
+	}
+}
+
+func TestMergeXAIBillingSummaryUsesPartialLegacyOnlyForMissingFields(t *testing.T) {
+	unified := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "weekly",
+			"start": "2026-08-13T00:00:00Z",
+			"end":   "2026-08-20T00:00:00Z",
+		},
+		"usage": map[string]any{
+			"includedUsed": map[string]any{"val": 5000},
+		},
+		"onDemandCap":  map[string]any{"val": 6000},
+		"onDemandUsed": map[string]any{"val": 1000},
+	})
+	legacy := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit":     map[string]any{"val": 20000},
+		"billingPeriodEnd": "2026-09-01T00:00:00Z",
+	})
+
+	merged := mergeXAIBillingSummary(unified, legacy)
+	for name, value := range map[string]struct {
+		actual *float64
+		want   float64
+	}{
+		"monthly limit": {merged.MonthlyLimitCents, 20000},
+		"used":          {merged.UsedCents, 6000},
+		"included":      {merged.IncludedUsedCents, 5000},
+		"monthly pct":   {merged.UsedPercent, 25},
+		"payg cap":      {merged.OnDemandCapCents, 6000},
+		"payg used":     {merged.OnDemandUsedCents, 1000},
+	} {
+		if value.actual == nil || *value.actual != value.want {
+			t.Fatalf("%s = %#v, want %.0f", name, value.actual, value.want)
+		}
+	}
+	if merged.BillingPeriodEnd != "2026-09-01T00:00:00Z" {
+		t.Fatalf("billing period end = %q", merged.BillingPeriodEnd)
+	}
+}
+
+func TestRequestXAIBillingBoundsLegacyEnrichmentLatency(t *testing.T) {
+	legacyStarted := make(chan struct{})
+	weeklyReleased := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			URL string `json:"url"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode api-call payload: %v", err)
+		}
+		if strings.Contains(payload.URL, "format=credits") {
+			<-legacyStarted
+			close(weeklyReleased)
+			_, _ = w.Write([]byte(`{"status_code":200,"body":{"config":{"credit_usage_percent":3,"current_period":{"type":"weekly","start":"2026-08-13T00:00:00Z","end":"2026-08-20T00:00:00Z"}}}}`))
+			return
+		}
+		close(legacyStarted)
+		<-weeklyReleased
+		<-r.Context().Done()
+	}))
+	t.Cleanup(upstream.Close)
+
+	settings := model.DefaultCodexInspectionConfig()
+	settings.Timeout = 100
+	startedAt := time.Now()
+	probe, err := New(nil, nil, upstream.Client()).requestXAIBilling(
+		context.Background(),
+		store.Setup{CPAUpstreamURL: upstream.URL, ManagementKey: "management-key"},
+		settings,
+		account{AuthIndex: "xai-1", File: authFile{}},
+	)
+	if err != nil {
+		t.Fatalf("request xAI billing: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 500*time.Millisecond {
+		t.Fatalf("legacy enrichment delayed weekly billing for %s", elapsed)
+	}
+	if probe.Summary == nil || probe.Summary.UsagePercent == nil || *probe.Summary.UsagePercent != 3 || !probe.Healthy {
+		t.Fatalf("weekly billing probe = %#v", probe)
+	}
+}
+
 func TestHasCompletedXAIInferenceOutput(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1358,7 +1798,7 @@ func TestRunXAIDoesNotFallbackToOfficialAPIForExplicitBillingDenials(t *testing.
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			requestedURLs := make([]string, 0, 2)
+			var requestedURLs synchronizedStringList
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -1370,7 +1810,7 @@ func TestRunXAIDoesNotFallbackToOfficialAPIForExplicitBillingDenials(t *testing.
 					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 						t.Fatalf("decode api-call payload: %v", err)
 					}
-					requestedURLs = append(requestedURLs, payload.URL)
+					requestedURLs.append(payload.URL)
 					_, _ = w.Write([]byte(tc.apiCallBody))
 				default:
 					http.NotFound(w, r)
@@ -1390,12 +1830,13 @@ func TestRunXAIDoesNotFallbackToOfficialAPIForExplicitBillingDenials(t *testing.
 			if err != nil {
 				t.Fatalf("run xAI inspection: %v", err)
 			}
-			if len(requestedURLs) != 3 || !strings.HasSuffix(requestedURLs[2], "/responses") {
-				t.Fatalf("requested URLs = %#v, want billing requests followed by inference", requestedURLs)
+			urls := requestedURLs.snapshot()
+			if len(urls) != 3 || !strings.HasSuffix(urls[2], "/responses") {
+				t.Fatalf("requested URLs = %#v, want billing requests followed by inference", urls)
 			}
-			for _, requestedURL := range requestedURLs {
+			for _, requestedURL := range urls {
 				if requestedURL == xaiOfficialAPIMeURL {
-					t.Fatalf("explicit billing denial called official API fallback: %#v", requestedURLs)
+					t.Fatalf("explicit billing denial called official API fallback: %#v", urls)
 				}
 			}
 			if len(result.Results) != 1 || result.Results[0].ErrorKind != tc.classification || result.Results[0].ActionReason != tc.reason {
@@ -1417,7 +1858,7 @@ func TestRunXAIRejectsInvalidOfficialAPIIdentityPayload(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			requestedURLs := make([]string, 0, 3)
+			var requestedURLs synchronizedStringList
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -1429,7 +1870,7 @@ func TestRunXAIRejectsInvalidOfficialAPIIdentityPayload(t *testing.T) {
 					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 						t.Fatalf("decode api-call payload: %v", err)
 					}
-					requestedURLs = append(requestedURLs, payload.URL)
+					requestedURLs.append(payload.URL)
 					if payload.URL == xaiOfficialAPIMeURL {
 						_, _ = w.Write([]byte(tc.apiCallBody))
 						return
@@ -1453,8 +1894,9 @@ func TestRunXAIRejectsInvalidOfficialAPIIdentityPayload(t *testing.T) {
 			if err != nil {
 				t.Fatalf("run xAI inspection: %v", err)
 			}
-			if len(requestedURLs) != 4 || requestedURLs[2] != xaiOfficialAPIMeURL || requestedURLs[3] != xaiCLIChatProxyBaseURL+"/responses" {
-				t.Fatalf("requested URLs = %#v, want billing, rejected identity fallback, and CLI inference", requestedURLs)
+			urls := requestedURLs.snapshot()
+			if len(urls) != 4 || urls[2] != xaiOfficialAPIMeURL || urls[3] != xaiCLIChatProxyBaseURL+"/responses" {
+				t.Fatalf("requested URLs = %#v, want billing, rejected identity fallback, and CLI inference", urls)
 			}
 			if len(result.Results) != 1 || result.Results[0].ErrorKind == "official_api_healthy" {
 				t.Fatalf("invalid official API payload reported healthy: %#v", result.Results)
@@ -1477,13 +1919,13 @@ func TestRunXAIFailedBillingNeverReportsHealthyAndRetriesTransientFailures(t *te
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			requestCount := 0
+			var requestCount synchronizedCounter
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
 				case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 					_, _ = w.Write([]byte(`{"files":[{"name":"xai-auth.json","auth_index":"xai-1","provider":"xai","account":"xai@example.com"}]}`))
 				case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
-					requestCount++
+					requestCount.increment()
 					_, _ = w.Write([]byte(tc.apiCallBody))
 				default:
 					http.NotFound(w, r)
@@ -1504,8 +1946,9 @@ func TestRunXAIFailedBillingNeverReportsHealthyAndRetriesTransientFailures(t *te
 				t.Fatalf("run xAI inspection: %v", err)
 			}
 			wantRequestCount := 6
-			if requestCount != wantRequestCount {
-				t.Fatalf("billing and inference requests = %d, want %d", requestCount, wantRequestCount)
+			gotRequestCount := requestCount.load()
+			if gotRequestCount != wantRequestCount {
+				t.Fatalf("billing and inference requests = %d, want %d", gotRequestCount, wantRequestCount)
 			}
 			if len(detail.Results) != 1 {
 				t.Fatalf("results = %#v", detail.Results)

--- a/apps/manager-server/internal/service/codexinspection/xai_probe.go
+++ b/apps/manager-server/internal/service/codexinspection/xai_probe.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
@@ -16,14 +17,15 @@ import (
 )
 
 const (
-	xaiBillingWeeklyURL    = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
-	xaiBillingMonthlyURL   = "https://cli-chat-proxy.grok.com/v1/billing"
-	xaiOfficialAPIMeURL    = "https://api.x.ai/v1/me"
-	xaiOfficialAPIBaseURL  = "https://api.x.ai/v1"
-	xaiCLIChatProxyBaseURL = "https://cli-chat-proxy.grok.com/v1"
-	xaiGrokVersion         = "0.2.101"
-	xaiGrokUserAgent       = "grok-pager/0.2.101 grok-shell/0.2.101 (macos; aarch64)"
-	xaiInferenceUserAgent  = model.DefaultXAIInferenceUserAgent
+	xaiBillingWeeklyURL     = "https://cli-chat-proxy.grok.com/v1/billing?format=credits"
+	xaiBillingMonthlyURL    = "https://cli-chat-proxy.grok.com/v1/billing"
+	xaiOfficialAPIMeURL     = "https://api.x.ai/v1/me"
+	xaiOfficialAPIBaseURL   = "https://api.x.ai/v1"
+	xaiCLIChatProxyBaseURL  = "https://cli-chat-proxy.grok.com/v1"
+	xaiGrokVersion          = "0.2.101"
+	xaiGrokUserAgent        = "grok-pager/0.2.101 grok-shell/0.2.101 (macos; aarch64)"
+	xaiInferenceUserAgent   = model.DefaultXAIInferenceUserAgent
+	xaiLegacyBillingTimeout = 3 * time.Second
 )
 
 type xaiProbeDecision struct {
@@ -41,9 +43,17 @@ type xaiBillingSummary struct {
 	UsedPercent         *float64
 	OnDemandUsedPercent *float64
 	MonthlyLimitCents   *float64
+	UsedCents           *float64
+	IncludedUsedCents   *float64
 	OnDemandCapCents    *float64
+	OnDemandUsedCents   *float64
 	HasWeeklyData       bool
 	HasMonthlyData      bool
+	HasMonthlyLimit     bool
+	HasUsed             bool
+	HasIncludedUsed     bool
+	HasOnDemandCap      bool
+	HasOnDemandUsed     bool
 	PeriodEnd           string
 	BillingPeriodEnd    string
 	ProductUsage        []xaiProductUsage
@@ -484,32 +494,60 @@ func (s *Service) requestXAIBilling(
 		header["x-userid"] = userID
 	}
 
-	weekly, err := s.requestProviderBilling(ctx, setup, settings, item, xaiBillingWeeklyURL, header)
-	if err != nil {
-		weekly = xaiBillingResult{Failure: xaiDecision(0, "upstream_error", err.Error())}
-	}
-	monthly, err := s.requestProviderBilling(ctx, setup, settings, item, xaiBillingMonthlyURL, header)
-	if err != nil {
-		monthly = xaiBillingResult{Failure: xaiDecision(0, "upstream_error", err.Error())}
-	}
+	var weekly xaiBillingResult
+	var monthly xaiBillingResult
+	var wait sync.WaitGroup
+	wait.Add(2)
+	go func() {
+		defer wait.Done()
+		result, err := s.requestProviderBilling(ctx, setup, settings, item, xaiBillingWeeklyURL, header)
+		if err != nil {
+			result = xaiBillingResult{Failure: xaiDecision(0, "upstream_error", err.Error())}
+		}
+		weekly = result
+	}()
+	go func() {
+		defer wait.Done()
+		legacyTimeout := xaiLegacyBillingTimeout
+		if settings.Timeout > 0 {
+			configuredTimeout := time.Duration(settings.Timeout) * time.Millisecond
+			if configuredTimeout < legacyTimeout {
+				legacyTimeout = configuredTimeout
+			}
+		}
+		legacyCtx, cancel := context.WithTimeout(ctx, legacyTimeout)
+		defer cancel()
+		result, err := s.requestProviderBilling(legacyCtx, setup, settings, item, xaiBillingMonthlyURL, header)
+		if err != nil {
+			result = xaiBillingResult{Failure: xaiDecision(0, "upstream_error", err.Error())}
+		}
+		monthly = result
+	}()
+	wait.Wait()
 
 	probe := xaiBillingProbe{}
-	for _, result := range []xaiBillingResult{weekly, monthly} {
-		if result.Summary != nil {
-			if probe.Summary == nil {
-				probe.Summary = result.Summary
-			} else {
-				probe.Summary = mergeXAIBillingSummary(probe.Summary, result.Summary)
-			}
-			if probe.StatusCode <= 0 {
-				probe.StatusCode = result.StatusCode
-			}
-			probe.Partial = probe.Partial || result.Partial
-			probe.Healthy = true
+	if weekly.Summary != nil {
+		probe.Summary = mergeXAIBillingSummary(weekly.Summary, monthly.Summary)
+		probe.StatusCode = weekly.StatusCode
+		probe.Healthy = true
+		// The deprecated monthly endpoint is optional once unified weekly billing is healthy.
+		// Its absence or denial must not downgrade health or drive an automatic action.
+		return probe, nil
+	}
+	if monthly.Summary != nil {
+		probe.Summary = monthly.Summary
+		probe.StatusCode = monthly.StatusCode
+		probe.Partial = true
+		probe.Healthy = true
+		if weekly.Failure != nil {
+			probe.Failures = append(probe.Failures, *weekly.Failure)
 		}
-		if result.Failure != nil {
-			probe.Failures = append(probe.Failures, *result.Failure)
-		}
+		return probe, nil
+	}
+	if weekly.Failure != nil {
+		probe.Failures = append(probe.Failures, *weekly.Failure)
+	} else if monthly.Failure != nil {
+		probe.Failures = append(probe.Failures, *monthly.Failure)
 	}
 	if probe.Summary == nil {
 		if xaiOfficialAPIFallbackEligible(probe.Failures) {
@@ -529,7 +567,6 @@ func (s *Service) requestXAIBilling(
 		}
 		return probe, fmt.Errorf("xAI billing returned no usable data")
 	}
-	probe.Partial = probe.Partial || len(probe.Failures) > 0
 	return probe, nil
 }
 
@@ -641,33 +678,105 @@ func mergeXAIBillingSummary(primary, fallback *xaiBillingSummary) *xaiBillingSum
 		return primary
 	}
 	merged := *primary
-	if merged.UsagePercent == nil {
+	primaryHasWeeklyData := primary.HasWeeklyData || primary.UsagePercent != nil || len(primary.ProductUsage) > 0
+	if !primaryHasWeeklyData {
 		merged.UsagePercent = fallback.UsagePercent
-	}
-	if merged.UsedPercent == nil {
-		merged.UsedPercent = fallback.UsedPercent
-	}
-	if merged.OnDemandUsedPercent == nil {
-		merged.OnDemandUsedPercent = fallback.OnDemandUsedPercent
-	}
-	if merged.MonthlyLimitCents == nil {
-		merged.MonthlyLimitCents = fallback.MonthlyLimitCents
-	}
-	if merged.OnDemandCapCents == nil {
-		merged.OnDemandCapCents = fallback.OnDemandCapCents
-	}
-	merged.HasWeeklyData = merged.HasWeeklyData || fallback.HasWeeklyData
-	merged.HasMonthlyData = merged.HasMonthlyData || fallback.HasMonthlyData
-	if merged.PeriodEnd == "" {
 		merged.PeriodEnd = fallback.PeriodEnd
-	}
-	if merged.BillingPeriodEnd == "" {
-		merged.BillingPeriodEnd = fallback.BillingPeriodEnd
-	}
-	if len(merged.ProductUsage) == 0 {
 		merged.ProductUsage = fallback.ProductUsage
 	}
+	primaryMonthlyLimit := xaiEvidenceFloat(primary.HasMonthlyLimit, primary.MonthlyLimitCents)
+	fallbackMonthlyLimit := xaiEvidenceFloat(fallback.HasMonthlyLimit, fallback.MonthlyLimitCents)
+	merged.MonthlyLimitCents = firstXAIFloat(primaryMonthlyLimit, fallbackMonthlyLimit)
+	primaryRawUsed := xaiEvidenceFloat(primary.HasUsed, primary.UsedCents)
+	fallbackRawUsed := xaiEvidenceFloat(fallback.HasUsed, fallback.UsedCents)
+	merged.HasIncludedUsed = primary.HasIncludedUsed
+	merged.IncludedUsedCents = xaiEvidenceFloat(primary.HasIncludedUsed, primary.IncludedUsedCents)
+	if merged.IncludedUsedCents == nil && primaryRawUsed != nil {
+		merged.IncludedUsedCents = primaryRawUsed
+	}
+	if merged.IncludedUsedCents == nil && fallback.HasIncludedUsed {
+		merged.IncludedUsedCents = fallback.IncludedUsedCents
+		merged.HasIncludedUsed = merged.IncludedUsedCents != nil
+	}
+	if merged.IncludedUsedCents == nil && fallbackRawUsed != nil {
+		merged.IncludedUsedCents = fallbackRawUsed
+	}
+	if merged.IncludedUsedCents != nil && merged.MonthlyLimitCents != nil && *merged.MonthlyLimitCents > 0 {
+		includedUsed := math.Min(*merged.IncludedUsedCents, *merged.MonthlyLimitCents)
+		merged.IncludedUsedCents = &includedUsed
+	}
+
+	primaryOnDemandCap := xaiEvidenceFloat(primary.HasOnDemandCap, primary.OnDemandCapCents)
+	fallbackOnDemandCap := xaiEvidenceFloat(fallback.HasOnDemandCap, fallback.OnDemandCapCents)
+	merged.OnDemandCapCents = firstXAIFloat(primaryOnDemandCap, fallbackOnDemandCap)
+	merged.HasOnDemandUsed = primary.HasOnDemandUsed
+	merged.OnDemandUsedCents = xaiEvidenceFloat(primary.HasOnDemandUsed, primary.OnDemandUsedCents)
+	if merged.OnDemandUsedCents == nil && primaryRawUsed != nil && merged.MonthlyLimitCents != nil {
+		onDemandUsed := math.Max(0, *primaryRawUsed-*merged.MonthlyLimitCents)
+		merged.OnDemandUsedCents = &onDemandUsed
+	}
+	if merged.OnDemandUsedCents == nil && fallback.HasOnDemandUsed {
+		merged.OnDemandUsedCents = fallback.OnDemandUsedCents
+		merged.HasOnDemandUsed = merged.OnDemandUsedCents != nil
+	}
+	if merged.OnDemandUsedCents == nil && fallbackRawUsed != nil && merged.MonthlyLimitCents != nil {
+		onDemandUsed := math.Max(0, *fallbackRawUsed-*merged.MonthlyLimitCents)
+		merged.OnDemandUsedCents = &onDemandUsed
+	}
+	hasPrimaryComponentEvidence := primary.HasIncludedUsed || primary.HasOnDemandUsed
+	if primaryRawUsed != nil {
+		merged.UsedCents = primaryRawUsed
+	} else if hasPrimaryComponentEvidence && merged.IncludedUsedCents != nil && merged.OnDemandUsedCents != nil {
+		used := *merged.IncludedUsedCents + *merged.OnDemandUsedCents
+		merged.UsedCents = &used
+	} else if hasPrimaryComponentEvidence {
+		merged.UsedCents = firstXAIFloat(merged.IncludedUsedCents, merged.OnDemandUsedCents)
+	} else if fallbackRawUsed != nil {
+		merged.UsedCents = fallbackRawUsed
+	} else if merged.IncludedUsedCents != nil && merged.OnDemandUsedCents != nil {
+		used := *merged.IncludedUsedCents + *merged.OnDemandUsedCents
+		merged.UsedCents = &used
+	} else {
+		merged.UsedCents = firstXAIFloat(merged.IncludedUsedCents, merged.OnDemandUsedCents)
+	}
+	merged.UsedPercent = firstXAIFloat(primary.UsedPercent, fallback.UsedPercent)
+	if merged.MonthlyLimitCents != nil && *merged.MonthlyLimitCents > 0 && merged.IncludedUsedCents != nil {
+		usedPercent := (*merged.IncludedUsedCents / *merged.MonthlyLimitCents) * 100
+		merged.UsedPercent = &usedPercent
+	}
+	merged.OnDemandUsedPercent = firstXAIFloat(primary.OnDemandUsedPercent, fallback.OnDemandUsedPercent)
+	if merged.OnDemandCapCents != nil && *merged.OnDemandCapCents > 0 && merged.OnDemandUsedCents != nil {
+		onDemandUsedPercent := (*merged.OnDemandUsedCents / *merged.OnDemandCapCents) * 100
+		merged.OnDemandUsedPercent = &onDemandUsedPercent
+	}
+	merged.HasMonthlyData = primary.HasMonthlyData || fallback.HasMonthlyData ||
+		merged.MonthlyLimitCents != nil || merged.IncludedUsedCents != nil || merged.UsedPercent != nil
+	merged.HasMonthlyLimit = primary.HasMonthlyLimit || fallback.HasMonthlyLimit
+	merged.HasUsed = primary.HasUsed || (!hasPrimaryComponentEvidence && fallback.HasUsed)
+	merged.HasOnDemandCap = primary.HasOnDemandCap || fallback.HasOnDemandCap
+	merged.BillingPeriodEnd = firstNonEmpty(primary.BillingPeriodEnd, fallback.BillingPeriodEnd)
+	merged.HasWeeklyData = primaryHasWeeklyData || fallback.HasWeeklyData
 	return &merged
+}
+
+func firstXAIFloat(values ...*float64) *float64 {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func xaiEvidenceFloat(hasEvidence bool, value *float64) *float64 {
+	if !hasEvidence {
+		return nil
+	}
+	return value
+}
+
+func positiveXAIFloat(value *float64) bool {
+	return value != nil && *value > 0
 }
 
 type xaiBillingResult struct {
@@ -694,7 +803,11 @@ func (s *Service) requestProviderBilling(
 		if payload == nil {
 			payload = parseRecord(response.BodyText)
 		}
-		summary := parseXAIBillingSummary(readMap(payload, "config"))
+		config := readMap(payload, "config")
+		if config == nil {
+			config = payload
+		}
+		summary := parseXAIBillingSummary(config)
 		if summary == nil {
 			return xaiBillingResult{Failure: xaiDecision(response.StatusCode, "protocol_changed", "xAI billing response schema changed")}, nil
 		}
@@ -815,15 +928,49 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 	if config == nil {
 		return nil
 	}
+	period := readMap(config, "current_period", "currentPeriod")
+	periodType := strings.ToLower(readString(period, "type"))
+	periodStart := readString(period, "start")
+	periodEnd := readString(period, "end")
 	usage := readNullableFloat(config, "credit_usage_percent", "creditUsagePercent")
-	monthlyLimit := readXAICentFloat(config, "monthly_limit", "monthlyLimit")
-	used := readXAICentFloat(config, "used")
-	onDemandCap := readXAICentFloat(config, "on_demand_cap", "onDemandCap")
-	onDemandUsed := readXAICentFloat(config, "on_demand_used", "onDemandUsed")
-	includedUsed := used
-	if includedUsed != nil && monthlyLimit != nil && *monthlyLimit > 0 {
-		value := math.Min(*includedUsed, *monthlyLimit)
-		includedUsed = &value
+	if usage == nil && strings.Contains(periodType, "weekly") && validXAIPeriodWindow(periodStart, periodEnd) {
+		zero := float64(0)
+		usage = &zero
+	}
+	monthlyLimit, hasMonthlyLimitEvidence := readXAICentFloatWithEvidence(config, "monthly_limit", "monthlyLimit")
+	nestedUsage := readMap(config, "usage")
+	nestedIncludedUsed, hasNestedIncludedEvidence := readXAICentFloatWithEvidence(nestedUsage, "included_used", "includedUsed")
+	explicitOnDemandUsed, hasOnDemandUsedEvidence := readXAICentFloatWithEvidence(config, "on_demand_used", "onDemandUsed")
+	if !hasOnDemandUsedEvidence {
+		explicitOnDemandUsed, hasOnDemandUsedEvidence = readXAICentFloatWithEvidence(nestedUsage, "on_demand_used", "onDemandUsed")
+	}
+	used, hasUsedEvidence := readXAICentFloatWithEvidence(config, "used")
+	if !hasUsedEvidence {
+		used, hasUsedEvidence = readXAICentFloatWithEvidence(nestedUsage, "total_used", "totalUsed")
+	}
+	if used == nil && (nestedIncludedUsed != nil || explicitOnDemandUsed != nil) {
+		value := float64(0)
+		if nestedIncludedUsed != nil {
+			value += *nestedIncludedUsed
+		}
+		if explicitOnDemandUsed != nil {
+			value += *explicitOnDemandUsed
+		}
+		used = &value
+	}
+	onDemandCap, hasOnDemandCapEvidence := readXAICentFloatWithEvidence(config, "on_demand_cap", "onDemandCap")
+	onDemandUsed := explicitOnDemandUsed
+	hasMonthlyData := hasMonthlyLimitEvidence || hasUsedEvidence || hasNestedIncludedEvidence
+	includedUsed := (*float64)(nil)
+	if hasMonthlyData {
+		includedUsed = nestedIncludedUsed
+		if includedUsed == nil {
+			includedUsed = used
+		}
+		if includedUsed != nil && monthlyLimit != nil && *monthlyLimit > 0 {
+			value := math.Min(*includedUsed, *monthlyLimit)
+			includedUsed = &value
+		}
 	}
 	if onDemandUsed == nil && used != nil && monthlyLimit != nil {
 		value := math.Max(0, *used-*monthlyLimit)
@@ -839,7 +986,19 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 		value := (*onDemandUsed / *onDemandCap) * 100
 		onDemandUsedPercent = &value
 	}
-	period := readMap(config, "current_period", "currentPeriod")
+	hasOnDemandData := hasOnDemandCapEvidence || hasOnDemandUsedEvidence || positiveXAIFloat(onDemandUsed)
+	if !hasMonthlyData {
+		monthlyLimit = nil
+		includedUsed = nil
+	}
+	if !hasMonthlyData && !hasOnDemandData {
+		used = nil
+	}
+	if !hasOnDemandData {
+		onDemandCap = nil
+		onDemandUsed = nil
+		onDemandUsedPercent = nil
+	}
 	productUsage := make([]xaiProductUsage, 0)
 	if items := readXAIArray(config, "product_usage", "productUsage"); len(items) > 0 {
 		for _, raw := range items {
@@ -853,11 +1012,13 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 			})
 		}
 	}
-	periodType := strings.ToLower(readString(period, "type"))
-	billingPeriodEnd := readString(config, "billing_period_end", "billingPeriodEnd")
+	billingCycle := readMap(config, "billing_cycle", "billingCycle")
+	billingPeriodEnd := firstNonEmpty(
+		readString(config, "billing_period_end", "billingPeriodEnd"),
+		readString(billingCycle, "billing_period_end", "billingPeriodEnd"),
+	)
 	hasWeeklyData := usage != nil || len(productUsage) > 0 || strings.Contains(periodType, "weekly")
-	hasMonthlyData := monthlyLimit != nil || used != nil || (!hasWeeklyData && (onDemandCap != nil || billingPeriodEnd != ""))
-	if !hasWeeklyData && !hasMonthlyData {
+	if !hasWeeklyData && !hasMonthlyData && !hasOnDemandData {
 		return nil
 	}
 	return &xaiBillingSummary{
@@ -865,13 +1026,27 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 		UsedPercent:         monthlyUsed,
 		OnDemandUsedPercent: onDemandUsedPercent,
 		MonthlyLimitCents:   monthlyLimit,
+		UsedCents:           used,
+		IncludedUsedCents:   includedUsed,
 		OnDemandCapCents:    onDemandCap,
+		OnDemandUsedCents:   onDemandUsed,
 		HasWeeklyData:       hasWeeklyData,
 		HasMonthlyData:      hasMonthlyData,
-		PeriodEnd:           readString(period, "end"),
+		HasMonthlyLimit:     hasMonthlyLimitEvidence,
+		HasUsed:             hasUsedEvidence,
+		HasIncludedUsed:     hasNestedIncludedEvidence,
+		HasOnDemandCap:      hasOnDemandCapEvidence,
+		HasOnDemandUsed:     hasOnDemandUsedEvidence,
+		PeriodEnd:           periodEnd,
 		BillingPeriodEnd:    billingPeriodEnd,
 		ProductUsage:        productUsage,
 	}
+}
+
+func validXAIPeriodWindow(start, end string) bool {
+	startAt, startErr := time.Parse(time.RFC3339, start)
+	endAt, endErr := time.Parse(time.RFC3339, end)
+	return startErr == nil && endErr == nil && endAt.After(startAt)
 }
 
 func xaiSummaryUsedPercent(summary *xaiBillingSummary) *float64 {
@@ -1174,9 +1349,9 @@ func readNullableFloat(record map[string]any, keys ...string) *float64 {
 	return nil
 }
 
-func readXAICentFloat(record map[string]any, keys ...string) *float64 {
+func readXAICentFloatWithEvidence(record map[string]any, keys ...string) (*float64, bool) {
 	if record == nil {
-		return nil
+		return nil, false
 	}
 	for _, key := range keys {
 		raw, ok := record[key]
@@ -1184,14 +1359,31 @@ func readXAICentFloat(record map[string]any, keys ...string) *float64 {
 			continue
 		}
 		if object := toMap(raw); object != nil {
-			raw, _ = firstValue(object, "val", "value")
+			if len(object) == 0 {
+				continue
+			}
+			normalized := math.NaN()
+			for _, nestedKey := range []string{"val", "value"} {
+				nestedRaw, ok := object[nestedKey]
+				if !ok {
+					continue
+				}
+				normalized = readFloat(nestedRaw, math.NaN())
+				if !math.IsNaN(normalized) {
+					break
+				}
+			}
+			if math.IsNaN(normalized) {
+				continue
+			}
+			return &normalized, true
 		}
 		value := readFloat(raw, math.NaN())
 		if !math.IsNaN(value) {
-			return &value
+			return &value, true
 		}
 	}
-	return nil
+	return nil, false
 }
 
 func readXAIArray(record map[string]any, keys ...string) []any {

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
@@ -456,6 +456,109 @@ describe('accountQuotaDisplayWindows', () => {
     });
   });
 
+  it('does not create a monthly window from an on-demand billing reset alone', () => {
+    const stores = {
+      ...emptyStores(),
+      xaiQuota: {
+        'xai.json': {
+          status: 'success',
+          billing: {
+            periodType: 'weekly',
+            usagePercent: 0,
+            periodStart: '2026-08-13T00:00:00Z',
+            periodEnd: '2026-08-20T00:00:00Z',
+            productUsage: [],
+            monthlyLimitCents: null,
+            usedCents: null,
+            includedUsedCents: null,
+            onDemandCapCents: 5_000,
+            onDemandUsedCents: 0,
+            onDemandUsedPercent: 0,
+            billingPeriodEnd: '2026-09-01T00:00:00Z',
+            usedPercent: null,
+          },
+        },
+      },
+    } satisfies AccountQuotaStores;
+    const row = buildRow({ name: 'xai.json', type: 'xai' }, stores);
+
+    const windows = buildAccountQuotaDisplayWindows(row, {
+      stores,
+      translateQuotaWindowLabel,
+      t,
+    });
+
+    expect(windows.map((window) => window.key)).toEqual(['credits-period', 'pay-as-you-go']);
+  });
+
+  it('does not create a monthly window from weekly protobuf zero placeholders', () => {
+    const stores = {
+      ...emptyStores(),
+      xaiQuota: {
+        'xai.json': {
+          status: 'success',
+          billing: {
+            periodType: 'weekly',
+            usagePercent: 0,
+            periodStart: '2026-08-13T00:00:00Z',
+            periodEnd: '2026-08-20T00:00:00Z',
+            productUsage: [],
+            monthlyLimitCents: null,
+            usedCents: 0,
+            includedUsedCents: 0,
+            onDemandCapCents: 0,
+            onDemandUsedCents: 0,
+            onDemandUsedPercent: null,
+            billingPeriodEnd: '2026-09-01T00:00:00Z',
+            usedPercent: null,
+          },
+        },
+      },
+    } satisfies AccountQuotaStores;
+    const row = buildRow({ name: 'xai.json', type: 'xai' }, stores);
+
+    const windows = buildAccountQuotaDisplayWindows(row, {
+      stores,
+      translateQuotaWindowLabel,
+      t,
+    });
+
+    expect(windows.map((window) => window.key)).toEqual(['credits-period']);
+  });
+
+  it('does not create a monthly window when usage exists without limit evidence', () => {
+    const stores = {
+      ...emptyStores(),
+      xaiQuota: {
+        'xai.json': {
+          status: 'success',
+          billing: {
+            periodType: 'monthly',
+            usagePercent: null,
+            productUsage: [],
+            monthlyLimitCents: null,
+            usedCents: 500,
+            includedUsedCents: 500,
+            onDemandCapCents: null,
+            onDemandUsedCents: null,
+            onDemandUsedPercent: null,
+            billingPeriodEnd: '2026-09-01T00:00:00Z',
+            usedPercent: null,
+          },
+        },
+      },
+    } satisfies AccountQuotaStores;
+    const row = buildRow({ name: 'xai.json', type: 'xai' }, stores);
+
+    expect(
+      buildAccountQuotaDisplayWindows(row, {
+        stores,
+        translateQuotaWindowLabel,
+        t,
+      })
+    ).toEqual([]);
+  });
+
   it('does not render billing windows for official API identity health', () => {
     const stores = {
       ...emptyStores(),

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
@@ -592,9 +592,7 @@ const buildXaiQuotaDisplayWindows = (
 
   if (
     monthlyUsedPercent !== null ||
-    billing.monthlyLimitCents !== null ||
-    billing.includedUsedCents !== null ||
-    billing.billingPeriodEnd
+    billing.monthlyLimitCents !== null
   ) {
     windows.push(
       buildAccountQuotaDisplayWindow({

--- a/apps/web/src/features/demo/DemoPage.test.tsx
+++ b/apps/web/src/features/demo/DemoPage.test.tsx
@@ -474,7 +474,8 @@ describe('DemoPage', () => {
     expect(kimiQuotaByFileName.get('kimi-exhausted.json')?.rows[1]?.used).toBe(200);
     expect(xaiQuotaByFileName.get('xai-ops.json')?.billing?.periodType).toBe('weekly');
     expect(xaiQuotaByFileName.get('xai-ops.json')?.billing?.usagePercent).toBe(42);
-    expect(xaiQuotaByFileName.get('xai-ops.json')?.billing?.usedPercent).toBe(86);
+    expect(xaiQuotaByFileName.get('xai-ops.json')?.billing?.monthlyLimitCents).toBeNull();
+    expect(xaiQuotaByFileName.get('xai-ops.json')?.billing?.usedPercent).toBeNull();
     expect(xaiQuotaByFileName.get('xai-payg-buffer.json')?.billing?.usedPercent).toBe(100);
     expect(xaiQuotaByFileName.get('xai-payg-buffer.json')?.billing?.onDemandUsedPercent).toBe(26);
     expect(xaiQuotaByFileName.get('xai-payg-cap.json')?.billing?.onDemandUsedPercent).toBe(100);

--- a/apps/web/src/features/demo/demoFixtures.inspection.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.inspection.test.ts
@@ -77,12 +77,11 @@ describe('credential health inspection demo fixtures', () => {
       action: 'keep',
       errorKind: 'inference_healthy',
       disabled: true,
-      usedPercent: 22,
+      usedPercent: 3,
       planType: null,
     });
     expect(healthy?.quotaWindows?.map((window) => window.id)).toEqual([
       'xai-weekly',
-      'xai-monthly',
       'xai-product-0',
     ]);
     expect(limited).toMatchObject({
@@ -99,7 +98,6 @@ describe('credential health inspection demo fixtures', () => {
     });
     expect(expired?.quotaWindows?.map((window) => window.id)).toEqual([
       'xai-weekly',
-      'xai-monthly',
       'xai-product-0',
     ]);
   });
@@ -296,6 +294,11 @@ describe('credential health inspection demo fixtures', () => {
         },
       },
     });
+    const deprecatedMonthly = getDemoApiCallResult({
+      authIndex: 'xai-ops-01',
+      url: 'https://cli-chat-proxy.grok.com/v1/billing',
+    });
+    expect(deprecatedMonthly).toMatchObject({ status_code: 200, body: { config: {} } });
     expect(inference).toMatchObject({
       status_code: 200,
       body: {

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -4737,7 +4737,7 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
     actionReason: 'monitoring.xai_inspection_reason_inference_manual_disable',
     actionStatus: 'none',
     statusCode: 200,
-    usedPercent: 22,
+    usedPercent: 3,
     isQuota: false,
     planType: null,
     quotaWindows: [
@@ -4746,13 +4746,6 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
         labelKey: 'xai_quota.weekly_limit',
         usedPercent: 3,
         resetLabel: new Date(baseNow + 6 * day).toISOString(),
-        limitWindowSeconds: null,
-      },
-      {
-        id: 'xai-monthly',
-        labelKey: 'xai_quota.monthly_limit',
-        usedPercent: 22,
-        resetLabel: new Date(baseNow + 19 * day).toISOString(),
         limitWindowSeconds: null,
       },
       {
@@ -4791,13 +4784,6 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
         labelKey: 'xai_quota.weekly_limit',
         usedPercent: 100,
         resetLabel: new Date(baseNow + 6 * day).toISOString(),
-        limitWindowSeconds: null,
-      },
-      {
-        id: 'xai-monthly',
-        labelKey: 'xai_quota.monthly_limit',
-        usedPercent: 100,
-        resetLabel: new Date(baseNow + 19 * day).toISOString(),
         limitWindowSeconds: null,
       },
       {
@@ -4841,13 +4827,6 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
         limitWindowSeconds: null,
       },
       {
-        id: 'xai-monthly',
-        labelKey: 'xai_quota.monthly_limit',
-        usedPercent: 12,
-        resetLabel: new Date(baseNow + 19 * day).toISOString(),
-        limitWindowSeconds: null,
-      },
-      {
         id: 'xai-product-0',
         labelKey: 'xai_quota.product_usage',
         labelParams: { product: 'Grok Build' },
@@ -4875,7 +4854,7 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
     actionReason: 'monitoring.xai_inspection_reason_inference_healthy',
     actionStatus: 'none',
     statusCode: 200,
-    usedPercent: 22,
+    usedPercent: 100,
     isQuota: false,
     planType: null,
     quotaWindows: [
@@ -4889,7 +4868,14 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
       {
         id: 'xai-monthly',
         labelKey: 'xai_quota.monthly_limit',
-        usedPercent: 22,
+        usedPercent: 100,
+        resetLabel: new Date(baseNow + 19 * day).toISOString(),
+        limitWindowSeconds: null,
+      },
+      {
+        id: 'xai-on-demand',
+        labelKey: 'xai_quota.on_demand_cap',
+        usedPercent: 26,
         resetLabel: new Date(baseNow + 19 * day).toISOString(),
         limitWindowSeconds: null,
       },
@@ -4920,7 +4906,7 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
     actionReason: 'monitoring.xai_inspection_reason_inference_healthy',
     actionStatus: 'none',
     statusCode: 200,
-    usedPercent: 22,
+    usedPercent: 100,
     isQuota: false,
     planType: null,
     quotaWindows: [
@@ -4934,7 +4920,14 @@ const buildDemoInspectionResults = (baseNow: number): CodexInspectionResult[] =>
       {
         id: 'xai-monthly',
         labelKey: 'xai_quota.monthly_limit',
-        usedPercent: 22,
+        usedPercent: 100,
+        resetLabel: new Date(baseNow + 19 * day).toISOString(),
+        limitWindowSeconds: null,
+      },
+      {
+        id: 'xai-on-demand',
+        labelKey: 'xai_quota.on_demand_cap',
+        usedPercent: 100,
         resetLabel: new Date(baseNow + 19 * day).toISOString(),
         limitWindowSeconds: null,
       },
@@ -6217,15 +6210,13 @@ const getDemoQuotaStoreStateByFileName = (): DemoQuotaStoreState => ({
           { product: 'Grok Code Fast', usagePercent: 37 },
           { product: 'Grok Code Thinking', usagePercent: 52 },
         ],
-        monthlyLimitCents: 100_000,
-        usedCents: 86_000,
-        includedUsedCents: 86_000,
-        onDemandCapCents: 50_000,
-        onDemandUsedCents: 12_000,
-        onDemandUsedPercent: 24,
-        billingPeriodStart: demoResetIso(-15 * day),
-        billingPeriodEnd: demoResetIso(15 * day),
-        usedPercent: 86,
+        monthlyLimitCents: null,
+        usedCents: null,
+        includedUsedCents: null,
+        onDemandCapCents: null,
+        onDemandUsedCents: null,
+        onDemandUsedPercent: null,
+        usedPercent: null,
       },
     },
     'xai-payg-buffer.json': {
@@ -7123,21 +7114,24 @@ export const getDemoApiCallResult = (payload: DemoApiCallPayload = {}) => {
       },
     };
   } else if (requestUrl.includes('/billing') && requestUrl.includes('grok.com')) {
-    body = {
-      config: {
-        currentPeriod: {
-          type: 'USAGE_PERIOD_TYPE_MONTHLY',
-          start: new Date(now() - 11 * day).toISOString(),
-          end: new Date(now() + 19 * day).toISOString(),
-        },
-        monthlyLimit: { val: 10000 },
-        used: { val: isXaiSpendingLimited ? 10000 : isXaiExpired ? 1200 : 2200 },
-        onDemandCap: { val: 0 },
-        onDemandUsed: { val: 0 },
-        billingPeriodStart: new Date(now() - 11 * day).toISOString(),
-        billingPeriodEnd: new Date(now() + 19 * day).toISOString(),
-      },
-    };
+    const usesLegacyBilling = ['xai-payg-buffer-02', 'xai-payg-cap-03'].includes(authIndex);
+    body = usesLegacyBilling
+      ? {
+          config: {
+            currentPeriod: {
+              type: 'USAGE_PERIOD_TYPE_MONTHLY',
+              start: new Date(now() - 11 * day).toISOString(),
+              end: new Date(now() + 19 * day).toISOString(),
+            },
+            monthlyLimit: { val: 10000 },
+            used: { val: authIndex === 'xai-payg-cap-03' ? 15000 : 12600 },
+            onDemandCap: { val: authIndex === 'xai-payg-cap-03' ? 5000 : 10000 },
+            onDemandUsed: { val: authIndex === 'xai-payg-cap-03' ? 5000 : 2600 },
+            billingPeriodStart: new Date(now() - 11 * day).toISOString(),
+            billingPeriodEnd: new Date(now() + 19 * day).toISOString(),
+          },
+        }
+      : { config: {} };
   } else if (requestUrl.includes('api.x.ai/v1/me')) {
     if (isXaiExpired) {
       statusCode = 401;

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -1098,6 +1098,79 @@ describe('monitoringCenterPageModel account quota', () => {
     });
   });
 
+  it('does not synthesize monthly credits from an on-demand reset timestamp', async () => {
+    vi.mocked(fetchXaiQuota).mockResolvedValue({
+      periodType: 'weekly',
+      usagePercent: 0,
+      periodStart: '2026-08-13T00:00:00Z',
+      periodEnd: '2026-08-20T00:00:00Z',
+      productUsage: [],
+      monthlyLimitCents: null,
+      usedCents: null,
+      includedUsedCents: null,
+      onDemandCapCents: 5_000,
+      onDemandUsedCents: 0,
+      onDemandUsedPercent: 0,
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+      usedPercent: null,
+    });
+
+    const entry = await requestAccountQuota(
+      createTarget({ provider: 'xai', authIndex: '3', fileName: 'xai.json' }),
+      t
+    );
+
+    expect(entry.windows?.map((window) => window.id)).toEqual(['weekly-limit', 'pay-as-you-go']);
+  });
+
+  it('does not synthesize monthly credits from weekly protobuf zero placeholders', async () => {
+    vi.mocked(fetchXaiQuota).mockResolvedValue({
+      periodType: 'weekly',
+      usagePercent: 0,
+      periodStart: '2026-08-13T00:00:00Z',
+      periodEnd: '2026-08-20T00:00:00Z',
+      productUsage: [],
+      monthlyLimitCents: null,
+      usedCents: 0,
+      includedUsedCents: 0,
+      onDemandCapCents: 0,
+      onDemandUsedCents: 0,
+      onDemandUsedPercent: null,
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+      usedPercent: null,
+    });
+
+    const entry = await requestAccountQuota(
+      createTarget({ provider: 'xai', authIndex: '3', fileName: 'xai.json' }),
+      t
+    );
+
+    expect(entry.windows?.map((window) => window.id)).toEqual(['weekly-limit']);
+  });
+
+  it('does not synthesize monthly credits from usage without limit evidence', async () => {
+    vi.mocked(fetchXaiQuota).mockResolvedValue({
+      periodType: 'monthly',
+      usagePercent: null,
+      productUsage: [],
+      monthlyLimitCents: null,
+      usedCents: 500,
+      includedUsedCents: 500,
+      onDemandCapCents: null,
+      onDemandUsedCents: null,
+      onDemandUsedPercent: null,
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+      usedPercent: null,
+    });
+
+    const entry = await requestAccountQuota(
+      createTarget({ provider: 'xai', authIndex: '3', fileName: 'xai.json' }),
+      t
+    );
+
+    expect(entry.windows).toEqual([]);
+  });
+
   it('maps official API health without synthesizing quota windows', async () => {
     vi.mocked(fetchXaiQuota).mockResolvedValue({
       periodType: 'unknown',

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -1088,9 +1088,7 @@ const buildXaiAccountQuotaWindows = (
       Boolean(billing.periodEnd) ||
       billing.productUsage.length > 0);
   const hasMonthlyData =
-    billing.monthlyLimitCents !== null ||
-    billing.usedCents !== null ||
-    Boolean(billing.billingPeriodEnd);
+    billing.usedPercent !== null || billing.monthlyLimitCents !== null;
 
   if (hasWeeklyData) {
     windows.push({

--- a/apps/web/src/features/monitoring/model/xaiInspectionProbe.test.ts
+++ b/apps/web/src/features/monitoring/model/xaiInspectionProbe.test.ts
@@ -314,15 +314,73 @@ describe('inspectSingleXaiAccount', () => {
     });
   });
 
-  it('prioritizes a blocking partial billing failure while retaining quota windows', async () => {
+  it('keeps a healthy weekly result when the deprecated monthly endpoint reports a limit', async () => {
     const blockingFailure = billingError(402, {
       code: 'personal-team-blocked:spending-limit',
     });
     mockProbeXaiQuota.mockResolvedValue({
       summary: healthySummary,
+      failures: [],
+      partial: false,
+      source: 'billing',
+      statusCode: 200,
+    });
+
+    const result = await inspectSingleXaiAccount(baseAccount, {
+      ...settings,
+      xaiInferenceEnabled: false,
+    });
+
+    expect(result).toMatchObject({
+      action: 'keep',
+      statusCode: 200,
+      errorKind: 'billing_healthy',
+      usedPercent: 40,
+    });
+    expect(result.quotaWindows).not.toHaveLength(0);
+    expect(blockingFailure.decision.suggestedAction).toBe('disable');
+  });
+
+  it('does not create a local monthly inspection window from protobuf zero placeholders', async () => {
+    mockProbeXaiQuota.mockResolvedValue({
+      summary: {
+        periodType: 'weekly',
+        usagePercent: 0,
+        periodEnd: '2026-08-20T00:00:00Z',
+        productUsage: [],
+        monthlyLimitCents: null,
+        usedCents: 0,
+        includedUsedCents: 0,
+        onDemandCapCents: 0,
+        onDemandUsedCents: 0,
+        onDemandUsedPercent: null,
+        billingPeriodEnd: '2026-09-01T00:00:00Z',
+        usedPercent: null,
+      },
+      failures: [],
+      partial: false,
+      source: 'billing',
+      statusCode: 200,
+    });
+
+    const result = await inspectSingleXaiAccount(baseAccount, {
+      ...settings,
+      xaiInferenceEnabled: false,
+    });
+
+    expect(result.quotaWindows?.map((window) => window.id)).toEqual(['xai-weekly']);
+  });
+
+  it('keeps an authoritative weekly blocking failure when only legacy quota data is available', async () => {
+    const blockingFailure = billingError(402, {
+      code: 'personal-team-blocked:spending-limit',
+    });
+    mockProbeXaiQuota.mockResolvedValue({
+      summary: { ...healthySummary, periodType: 'monthly', usagePercent: null },
       failures: [blockingFailure],
       partial: true,
       source: 'billing',
+      statusCode: 200,
       blockingFailure,
     });
 
@@ -335,7 +393,6 @@ describe('inspectSingleXaiAccount', () => {
       action: 'disable',
       statusCode: 402,
       errorKind: 'spending_limit',
-      usedPercent: 40,
     });
     expect(result.quotaWindows).not.toHaveLength(0);
   });

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -476,8 +476,9 @@ export interface KimiQuotaState extends CredentialScopedQuotaState {
 }
 
 // xAI/Grok API payload types
-export interface XaiBillingCent {
+export interface XaiBillingCent extends Record<string, unknown> {
   val?: number | string;
+  value?: number | string;
 }
 
 export type XaiBillingPeriodType = 'weekly' | 'monthly' | 'unknown';

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -1932,6 +1932,132 @@ describe('buildXaiBillingSummary', () => {
     });
   });
 
+  it('treats an omitted weekly percentage as zero only for a complete valid period', () => {
+    expect(
+      buildXaiBillingSummary({
+        currentPeriod: {
+          type: 'USAGE_PERIOD_TYPE_WEEKLY',
+          start: '2026-08-13T00:00:00Z',
+          end: '2026-08-20T00:00:00Z',
+        },
+      })
+    ).toMatchObject({ periodType: 'weekly', usagePercent: 0 });
+
+    expect(
+      buildXaiBillingSummary({
+        currentPeriod: {
+          type: 'USAGE_PERIOD_TYPE_WEEKLY',
+          end: '2026-08-20T00:00:00Z',
+        },
+      })
+    ).toMatchObject({ periodType: 'weekly', usagePercent: null });
+  });
+
+  it('treats nested protobuf zero placeholders as absent billing evidence', () => {
+    const summary = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'weekly',
+        start: '2026-08-13T00:00:00Z',
+        end: '2026-08-20T00:00:00Z',
+      },
+      onDemandCap: {},
+      usage: {
+        includedUsed: {},
+        onDemandUsed: {},
+        totalUsed: {},
+      },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+
+    expect(summary).toMatchObject({
+      usagePercent: 0,
+      usedCents: null,
+      includedUsedCents: null,
+      onDemandCapCents: null,
+      onDemandUsedCents: null,
+    });
+    expect(summary?.monthlyLimitCents).toBeNull();
+    expect(summary?.billingPeriodEnd).toBeUndefined();
+  });
+
+  it('keeps empty cents placeholders absent when sibling monthly fields have evidence', () => {
+    const summary = buildXaiBillingSummary({
+      monthlyLimit: {},
+      used: { val: 500 },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+
+    expect(summary).toMatchObject({
+      monthlyLimitCents: null,
+      usedCents: 500,
+      includedUsedCents: 500,
+      usedPercent: null,
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+  });
+
+  it('falls through camel-case placeholders to snake-case cents evidence', () => {
+    const summary = buildXaiBillingSummary({
+      monthlyLimit: {},
+      monthly_limit: { val: 10_000 },
+      onDemandCap: { val: 'invalid' },
+      on_demand_cap: { val: 5_000 },
+      used: { val: 2_500 },
+    });
+
+    expect(summary).toMatchObject({
+      monthlyLimitCents: 10_000,
+      usedCents: 2_500,
+      includedUsedCents: 2_500,
+      usedPercent: 25,
+      onDemandCapCents: 5_000,
+    });
+  });
+
+  it('derives included usage when its placeholder is mixed with real monthly values', () => {
+    const summary = buildXaiBillingSummary({
+      monthlyLimit: { val: 10_000 },
+      used: { val: 12_500 },
+      onDemandCap: { val: 5_000 },
+      usage: {
+        includedUsed: {},
+      },
+    });
+
+    expect(summary).toMatchObject({
+      monthlyLimitCents: 10_000,
+      usedCents: 12_500,
+      includedUsedCents: 10_000,
+      usedPercent: 100,
+      onDemandUsedCents: 2_500,
+      onDemandUsedPercent: 50,
+    });
+  });
+
+  it('falls through top-level protobuf placeholders to nested billing values', () => {
+    const summary = buildXaiBillingSummary({
+      monthlyLimit: { val: 10_000 },
+      used: {},
+      onDemandCap: { val: 5_000 },
+      onDemandUsed: {},
+      usage: {
+        includedUsed: { val: 10_000 },
+        onDemandUsed: { val: 2_500 },
+        totalUsed: { val: 12_500 },
+      },
+    });
+
+    expect(summary).toMatchObject({
+      monthlyLimitCents: 10_000,
+      usedCents: 12_500,
+      includedUsedCents: 10_000,
+      usedPercent: 100,
+      onDemandCapCents: 5_000,
+      onDemandUsedCents: 2_500,
+      onDemandUsedPercent: 50,
+    });
+  });
+
   it('preserves the billing reset for weekly plans with positive on-demand credits', () => {
     const summary = buildXaiBillingSummary({
       currentPeriod: {
@@ -1980,6 +2106,138 @@ describe('mergeXaiBillingSummaries', () => {
       usedCents: 2500,
       billingPeriodEnd: '2026-08-01T00:00:00Z',
     });
+  });
+
+  it('does not let weekly protobuf zero placeholders override legacy billing groups', () => {
+    const weekly = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'weekly',
+        start: '2026-08-13T00:00:00Z',
+        end: '2026-08-20T00:00:00Z',
+      },
+      usage: {
+        includedUsed: {},
+        onDemandUsed: {},
+        totalUsed: {},
+      },
+      onDemandCap: {},
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+    const legacy = buildXaiBillingSummary({
+      monthlyLimit: { val: 10_000 },
+      used: { val: 12_500 },
+      onDemandCap: { val: 5_000 },
+      onDemandUsed: { val: 2_500 },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+
+    expect(mergeXaiBillingSummaries(weekly, legacy)).toMatchObject({
+      periodType: 'weekly',
+      usagePercent: 0,
+      monthlyLimitCents: 10_000,
+      usedCents: 12_500,
+      includedUsedCents: 10_000,
+      usedPercent: 100,
+      onDemandCapCents: 5_000,
+      onDemandUsedCents: 2_500,
+      onDemandUsedPercent: 50,
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+  });
+
+  it('recomputes total usage when monthly and pay-as-you-go data come from different sources', () => {
+    const weekly = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'weekly',
+        start: '2026-08-13T00:00:00Z',
+        end: '2026-08-20T00:00:00Z',
+      },
+      onDemandCap: { val: 5_000 },
+      onDemandUsed: { val: 2_500 },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+    const legacy = buildXaiBillingSummary({
+      monthlyLimit: { val: 10_000 },
+      usage: {
+        includedUsed: { val: 8_000 },
+      },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+
+    expect(mergeXaiBillingSummaries(weekly, legacy)).toMatchObject({
+      monthlyLimitCents: 10_000,
+      usedCents: 10_500,
+      includedUsedCents: 8_000,
+      usedPercent: 80,
+      onDemandCapCents: 5_000,
+      onDemandUsedCents: 2_500,
+      onDemandUsedPercent: 50,
+    });
+  });
+
+  it('keeps conflicting unified billing fields over deprecated legacy values', () => {
+    const unified = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'weekly',
+        start: '2026-08-13T00:00:00Z',
+        end: '2026-08-20T00:00:00Z',
+      },
+      monthlyLimit: { val: 20_000 },
+      used: { val: 5_000 },
+      onDemandCap: { val: 6_000 },
+      onDemandUsed: { val: 1_000 },
+      billingPeriodEnd: '2026-09-02T00:00:00Z',
+    });
+    const legacy = buildXaiBillingSummary({
+      monthlyLimit: { val: 10_000 },
+      used: { val: 9_000 },
+      onDemandCap: { val: 2_000 },
+      onDemandUsed: { val: 1_500 },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+
+    const merged = mergeXaiBillingSummaries(unified, legacy);
+    expect(merged).toMatchObject({
+      monthlyLimitCents: 20_000,
+      usedCents: 5_000,
+      includedUsedCents: 5_000,
+      usedPercent: 25,
+      onDemandCapCents: 6_000,
+      onDemandUsedCents: 1_000,
+      billingPeriodEnd: '2026-09-02T00:00:00Z',
+    });
+    expect(merged?.onDemandUsedPercent).toBeCloseTo(100 / 6);
+  });
+
+  it('uses partial legacy billing only to fill missing unified fields', () => {
+    const unified = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'weekly',
+        start: '2026-08-13T00:00:00Z',
+        end: '2026-08-20T00:00:00Z',
+      },
+      usage: {
+        includedUsed: { val: 5_000 },
+      },
+      onDemandCap: { val: 6_000 },
+      onDemandUsed: { val: 1_000 },
+    });
+    const legacy = buildXaiBillingSummary({
+      monthlyLimit: { val: 20_000 },
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+
+    const merged = mergeXaiBillingSummaries(unified, legacy);
+    expect(merged).toMatchObject({
+      monthlyLimitCents: 20_000,
+      usedCents: 6_000,
+      includedUsedCents: 5_000,
+      usedPercent: 25,
+      onDemandCapCents: 6_000,
+      onDemandUsedCents: 1_000,
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+    expect(merged?.onDemandUsedPercent).toBeCloseTo(100 / 6);
   });
 });
 
@@ -2051,6 +2309,7 @@ describe('fetchXaiQuota', () => {
         'x-userid': 'user-123',
       }),
     });
+    expect(mocks.request.mock.calls[1][1]).toMatchObject({ timeout: 3000 });
     expect(result).toMatchObject({
       periodType: 'weekly',
       usagePercent: 40,
@@ -2100,6 +2359,71 @@ describe('fetchXaiQuota', () => {
       partial: true,
       diagnostics: [expect.objectContaining({ classification: 'upstream_error', statusCode: 500 })],
     });
+  });
+
+  it('keeps an authoritative weekly blocking failure when legacy monthly data is usable', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 402,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '{"code":"personal-team-blocked:spending-limit"}',
+        body: { code: 'personal-team-blocked:spending-limit' },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: { config: { monthly_limit: 20000, used: 5000 } },
+      });
+
+    const result = await probeXaiQuota({ name: 'xai.json', type: 'xai', authIndex: 'xai-1' }, t);
+
+    expect(result).toMatchObject({
+      partial: true,
+      summary: { periodType: 'monthly', usedPercent: 25 },
+      blockingFailure: {
+        decision: { classification: 'spending_limit', suggestedAction: 'disable' },
+      },
+    });
+  });
+
+  it('keeps unified weekly billing healthy when the optional monthly endpoint fails', async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '',
+        body: {
+          config: {
+            current_period: {
+              type: 'weekly',
+              start: '2026-08-13T00:00:00Z',
+              end: '2026-08-20T00:00:00Z',
+            },
+            credit_usage_percent: 3,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 402,
+        hasStatusCode: true,
+        header: {},
+        bodyText: '{"code":"personal-team-blocked:spending-limit"}',
+        body: { code: 'personal-team-blocked:spending-limit' },
+      });
+
+    const result = await probeXaiQuota({ name: 'xai.json', type: 'xai', authIndex: 'xai-1' }, t);
+
+    expect(result).toMatchObject({
+      partial: false,
+      failures: [],
+      summary: { periodType: 'weekly', usagePercent: 3 },
+      statusCode: 200,
+    });
+    expect(result.blockingFailure).toBeUndefined();
   });
 
   it('falls back to official API identity health when both CLI billing endpoints deny access', async () => {
@@ -2323,7 +2647,7 @@ describe('fetchXaiQuota', () => {
     expect(result.failures).toHaveLength(1);
   });
 
-  it('preserves usable billing data while exposing a one-sided spending limit as blocking', async () => {
+  it('ignores a deprecated monthly spending-limit response when weekly billing is usable', async () => {
     mocks.request
       .mockResolvedValueOnce({
         statusCode: 200,
@@ -2343,16 +2667,15 @@ describe('fetchXaiQuota', () => {
     const result = await probeXaiQuota({ name: 'xai.json', type: 'xai', authIndex: 'xai-1' }, t);
 
     expect(result).toMatchObject({
-      partial: true,
+      partial: false,
+      failures: [],
       summary: { usagePercent: 3 },
       statusCode: 200,
-      blockingFailure: {
-        decision: { classification: 'spending_limit', suggestedAction: 'disable' },
-      },
     });
+    expect(result.blockingFailure).toBeUndefined();
   });
 
-  it('prefers a verified xAI quota signal when both billing requests fail differently', async () => {
+  it('keeps the unified weekly failure authoritative when both billing requests fail', async () => {
     mocks.request
       .mockResolvedValueOnce({
         statusCode: 500,
@@ -2372,11 +2695,11 @@ describe('fetchXaiQuota', () => {
     await expect(
       probeXaiBilling({ name: 'xai.json', type: 'xai', authIndex: 'xai-1' }, t)
     ).rejects.toMatchObject({
-      decision: { classification: 'free_quota_exhausted' },
+      decision: { classification: 'upstream_error', suggestedAction: 'keep' },
     });
   });
 
-  it('prefers auth invalid over a generic forbidden billing failure', async () => {
+  it('does not let legacy monthly auth errors override the weekly failure', async () => {
     mocks.request
       .mockResolvedValueOnce({
         statusCode: 403,
@@ -2396,11 +2719,11 @@ describe('fetchXaiQuota', () => {
     await expect(
       probeXaiBilling({ name: 'xai.json', type: 'xai', authIndex: 'xai-1' }, t)
     ).rejects.toMatchObject({
-      decision: { classification: 'auth_invalid', suggestedAction: 'reauth' },
+      decision: { classification: 'permission_unknown', suggestedAction: 'keep' },
     });
   });
 
-  it('prefers an explicit entitlement denial over an earlier generic forbidden failure', async () => {
+  it('does not let legacy monthly entitlement denial override the weekly failure', async () => {
     mocks.request
       .mockResolvedValueOnce({
         statusCode: 403,
@@ -2415,14 +2738,22 @@ describe('fetchXaiQuota', () => {
         header: {},
         bodyText: 'Need a Grok subscription',
         body: { error: 'Need a Grok subscription' },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 503,
+        hasStatusCode: true,
+        header: {},
+        bodyText: 'identity unavailable',
+        body: { error: 'identity unavailable' },
       });
 
     await expect(
       fetchXaiQuota({ name: 'xai.json', type: 'xai', authIndex: 'xai-1' }, t)
     ).rejects.toMatchObject({
-      decision: { classification: 'entitlement_denied', suggestedAction: 'disable' },
+      decision: { classification: 'permission_unknown', suggestedAction: 'keep' },
     });
-    expect(mocks.request).toHaveBeenCalledTimes(2);
+    expect(mocks.request).toHaveBeenCalledTimes(3);
+    expect(mocks.request.mock.calls[2][0]).toMatchObject({ url: XAI_OFFICIAL_API_ME_URL });
   });
 
   it('throws the upstream error when weekly and monthly billing both fail', async () => {

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -85,6 +85,7 @@ import { classifyXaiProbe, parseXaiErrorEnvelope, XaiProbeError } from './xaiErr
 
 const DEFAULT_ANTIGRAVITY_PROJECT_ID = 'bamboo-precept-lgxtn';
 const CODEX_RESET_CREDITS_REQUEST_TIMEOUT_MS = 8000;
+const XAI_LEGACY_BILLING_REQUEST_TIMEOUT_MS = 3000;
 
 export type CodexQuotaData = {
   planType: string | null;
@@ -1088,9 +1089,31 @@ export const fetchKimiQuota = async (
 const normalizeXaiCentValue = (value: unknown): number | null => {
   if (value === undefined || value === null) return null;
   if (typeof value === 'object' && !Array.isArray(value)) {
-    return normalizeNumberValue((value as { val?: unknown }).val);
+    const record = value as { val?: unknown; value?: unknown };
+    if (Object.keys(record).length === 0) return null;
+    return normalizeNumberValue(record.val) ?? normalizeNumberValue(record.value);
   }
   return normalizeNumberValue(value);
+};
+
+const resolveXaiCentCandidate = (...values: unknown[]) => {
+  for (const value of values) {
+    const normalized = normalizeXaiCentValue(value);
+    if (normalized !== null) {
+      return { value: normalized, hasEvidence: true };
+    }
+  }
+  return { value: null, hasEvidence: false };
+};
+
+const normalizeXaiPeriodTimestamp = (value: unknown): string | undefined =>
+  normalizeStringValue(value) ?? undefined;
+
+const hasValidXaiPeriodWindow = (start?: string, end?: string): boolean => {
+  if (!start || !end) return false;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  return Number.isFinite(startMs) && Number.isFinite(endMs) && endMs > startMs;
 };
 
 const resolveXaiBillingConfig = (payload: XaiBillingPayload | null): XaiBillingConfig | null => {
@@ -1134,6 +1157,25 @@ const emptyXaiBillingSummary = (): XaiBillingSummary => ({
   usedPercent: null,
 });
 
+type XaiBillingFieldEvidence = {
+  monthlyLimit: boolean;
+  used: boolean;
+  includedUsed: boolean;
+  onDemandCap: boolean;
+  onDemandUsed: boolean;
+};
+
+const xaiBillingFieldEvidence = new WeakMap<XaiBillingSummary, XaiBillingFieldEvidence>();
+
+const getXaiBillingFieldEvidence = (summary: XaiBillingSummary): XaiBillingFieldEvidence =>
+  xaiBillingFieldEvidence.get(summary) ?? {
+    monthlyLimit: summary.monthlyLimitCents !== null,
+    used: summary.usedCents !== null,
+    includedUsed: summary.includedUsedCents !== null,
+    onDemandCap: summary.onDemandCapCents !== null,
+    onDemandUsed: summary.onDemandUsedCents !== null,
+  };
+
 export const buildXaiBillingSummary = (
   config: XaiBillingConfig | null | undefined
 ): XaiBillingSummary | null => {
@@ -1142,42 +1184,47 @@ export const buildXaiBillingSummary = (
   const summary = emptyXaiBillingSummary();
   const currentPeriod = config.currentPeriod ?? config.current_period ?? null;
   const periodType = resolveXaiPeriodType(currentPeriod);
-  const creditUsagePercent = normalizeNumberValue(
+  const rawCreditUsagePercent = normalizeNumberValue(
     config.creditUsagePercent ?? config.credit_usage_percent
   );
-  const periodStart =
-    normalizeStringValue(currentPeriod?.start) ??
-    normalizeStringValue(config.billingPeriodStart ?? config.billing_period_start) ??
-    undefined;
-  const periodEnd =
-    normalizeStringValue(currentPeriod?.end) ??
-    normalizeStringValue(config.billingPeriodEnd ?? config.billing_period_end) ??
-    undefined;
+  const periodStart = normalizeXaiPeriodTimestamp(currentPeriod?.start);
+  const periodEnd = normalizeXaiPeriodTimestamp(currentPeriod?.end);
+  const creditUsagePercent =
+    rawCreditUsagePercent ??
+    (periodType === 'weekly' && hasValidXaiPeriodWindow(periodStart, periodEnd) ? 0 : null);
   const billingCycle = config.billingCycle ?? config.billing_cycle ?? null;
   const nestedUsage = config.usage ?? null;
   const productUsage = normalizeXaiProductUsage(
     config.productUsage ?? config.product_usage,
     'Product'
   );
-  const monthlyLimitCents = normalizeXaiCentValue(config.monthlyLimit ?? config.monthly_limit);
-  const nestedIncludedUsedCents = normalizeXaiCentValue(
-    nestedUsage?.includedUsed ?? nestedUsage?.included_used
+  const monthlyLimit = resolveXaiCentCandidate(config.monthlyLimit, config.monthly_limit);
+  const nestedIncludedUsed = resolveXaiCentCandidate(
+    nestedUsage?.includedUsed,
+    nestedUsage?.included_used
   );
-  const explicitOnDemandUsedCents = normalizeXaiCentValue(
-    config.onDemandUsed ??
-      config.on_demand_used ??
-      nestedUsage?.onDemandUsed ??
-      nestedUsage?.on_demand_used
+  const explicitOnDemandUsed = resolveXaiCentCandidate(
+    config.onDemandUsed,
+    config.on_demand_used,
+    nestedUsage?.onDemandUsed,
+    nestedUsage?.on_demand_used
   );
-  const rawUsedCents = normalizeXaiCentValue(
-    config.used ?? nestedUsage?.totalUsed ?? nestedUsage?.total_used
+  const rawUsed = resolveXaiCentCandidate(
+    config.used,
+    nestedUsage?.totalUsed,
+    nestedUsage?.total_used
   );
+  const onDemandCap = resolveXaiCentCandidate(config.onDemandCap, config.on_demand_cap);
+  const monthlyLimitCents = monthlyLimit.value;
+  const nestedIncludedUsedCents = nestedIncludedUsed.value;
+  const explicitOnDemandUsedCents = explicitOnDemandUsed.value;
+  const rawUsedCents = rawUsed.value;
   const usedCents =
     rawUsedCents ??
     (nestedIncludedUsedCents !== null || explicitOnDemandUsedCents !== null
       ? (nestedIncludedUsedCents ?? 0) + (explicitOnDemandUsedCents ?? 0)
       : null);
-  const onDemandCapCents = normalizeXaiCentValue(config.onDemandCap ?? config.on_demand_cap);
+  const onDemandCapCents = onDemandCap.value;
   const billingPeriodStart =
     normalizeStringValue(
       config.billingPeriodStart ??
@@ -1193,13 +1240,16 @@ export const buildXaiBillingSummary = (
         billingCycle?.billing_period_end
     ) ?? undefined;
 
-  const includedUsedCents =
-    nestedIncludedUsedCents ??
-    (usedCents === null
-      ? null
-      : monthlyLimitCents !== null && monthlyLimitCents > 0
-        ? Math.min(usedCents, monthlyLimitCents)
-        : usedCents);
+  const hasMonthlyData =
+    monthlyLimit.hasEvidence || rawUsed.hasEvidence || nestedIncludedUsed.hasEvidence;
+  const includedUsedCents = hasMonthlyData
+    ? (nestedIncludedUsedCents ??
+      (usedCents === null
+        ? null
+        : monthlyLimitCents !== null && monthlyLimitCents > 0
+          ? Math.min(usedCents, monthlyLimitCents)
+          : usedCents))
+    : null;
   const derivedOnDemandUsedCents =
     usedCents !== null && monthlyLimitCents !== null
       ? Math.max(0, usedCents - monthlyLimitCents)
@@ -1216,33 +1266,41 @@ export const buildXaiBillingSummary = (
 
   const hasWeeklyData =
     creditUsagePercent !== null || periodType === 'weekly' || productUsage.length > 0;
-  const hasMonthlyData =
-    monthlyLimitCents !== null ||
-    usedCents !== null ||
-    (!hasWeeklyData && (onDemandCapCents !== null || !!billingPeriodEnd));
-  const hasBillingPeriodData =
-    hasMonthlyData || onDemandCapCents !== null || onDemandUsedCents !== null;
+  const hasOnDemandData =
+    onDemandCap.hasEvidence ||
+    explicitOnDemandUsed.hasEvidence ||
+    (derivedOnDemandUsedCents !== null && derivedOnDemandUsedCents > 0);
+  const hasBillingPeriodData = hasMonthlyData || hasOnDemandData;
 
-  if (!hasWeeklyData && !hasMonthlyData) return null;
+  if (!hasWeeklyData && !hasMonthlyData && !hasOnDemandData) return null;
 
   summary.periodType = hasWeeklyData
     ? periodType === 'unknown'
       ? 'weekly'
       : periodType
-    : 'monthly';
+    : hasMonthlyData
+      ? 'monthly'
+      : 'unknown';
   summary.usagePercent = hasWeeklyData ? creditUsagePercent : usedPercent;
   summary.periodStart = hasWeeklyData ? periodStart : billingPeriodStart;
   summary.periodEnd = hasWeeklyData ? periodEnd : billingPeriodEnd;
   summary.productUsage = productUsage;
-  summary.monthlyLimitCents = monthlyLimitCents;
-  summary.usedCents = usedCents;
+  summary.monthlyLimitCents = hasMonthlyData ? monthlyLimitCents : null;
+  summary.usedCents = hasBillingPeriodData ? usedCents : null;
   summary.includedUsedCents = includedUsedCents;
-  summary.onDemandCapCents = onDemandCapCents;
-  summary.onDemandUsedCents = onDemandUsedCents;
-  summary.onDemandUsedPercent = onDemandUsedPercent;
+  summary.onDemandCapCents = hasOnDemandData ? onDemandCapCents : null;
+  summary.onDemandUsedCents = hasOnDemandData ? onDemandUsedCents : null;
+  summary.onDemandUsedPercent = hasOnDemandData ? onDemandUsedPercent : null;
   summary.billingPeriodStart = hasBillingPeriodData ? billingPeriodStart : undefined;
   summary.billingPeriodEnd = hasBillingPeriodData ? billingPeriodEnd : undefined;
   summary.usedPercent = usedPercent;
+  xaiBillingFieldEvidence.set(summary, {
+    monthlyLimit: monthlyLimit.hasEvidence,
+    used: rawUsed.hasEvidence,
+    includedUsed: nestedIncludedUsed.hasEvidence,
+    onDemandCap: onDemandCap.hasEvidence,
+    onDemandUsed: explicitOnDemandUsed.hasEvidence,
+  });
 
   return summary;
 };
@@ -1254,22 +1312,93 @@ export const mergeXaiBillingSummaries = (
   if (!primary) return fallback;
   if (!fallback) return primary;
 
-  return {
-    periodType: primary.periodType !== 'unknown' ? primary.periodType : fallback.periodType,
-    usagePercent: primary.usagePercent ?? fallback.usagePercent,
-    periodStart: primary.periodStart ?? fallback.periodStart,
-    periodEnd: primary.periodEnd ?? fallback.periodEnd,
-    productUsage: primary.productUsage.length > 0 ? primary.productUsage : fallback.productUsage,
-    monthlyLimitCents: primary.monthlyLimitCents ?? fallback.monthlyLimitCents,
-    usedCents: primary.usedCents ?? fallback.usedCents,
-    includedUsedCents: primary.includedUsedCents ?? fallback.includedUsedCents,
-    onDemandCapCents: primary.onDemandCapCents ?? fallback.onDemandCapCents,
-    onDemandUsedCents: primary.onDemandUsedCents ?? fallback.onDemandUsedCents,
-    onDemandUsedPercent: primary.onDemandUsedPercent ?? fallback.onDemandUsedPercent,
+  const primaryHasWeeklyData =
+    primary.periodType === 'weekly' ||
+    primary.usagePercent !== null ||
+    primary.productUsage.length > 0;
+  const weeklySource = primaryHasWeeklyData ? primary : fallback;
+  const primaryEvidence = getXaiBillingFieldEvidence(primary);
+  const fallbackEvidence = getXaiBillingFieldEvidence(fallback);
+  const primaryMonthlyLimit = primaryEvidence.monthlyLimit ? primary.monthlyLimitCents : null;
+  const fallbackMonthlyLimit = fallbackEvidence.monthlyLimit ? fallback.monthlyLimitCents : null;
+  const monthlyLimitCents = primaryMonthlyLimit ?? fallbackMonthlyLimit;
+  const primaryRawUsed = primaryEvidence.used ? primary.usedCents : null;
+  const fallbackRawUsed = fallbackEvidence.used ? fallback.usedCents : null;
+  let includedUsedHasEvidence = primaryEvidence.includedUsed;
+  let includedUsedCents = includedUsedHasEvidence ? primary.includedUsedCents : null;
+  if (includedUsedCents === null && primaryRawUsed !== null) {
+    includedUsedCents = primaryRawUsed;
+  }
+  if (includedUsedCents === null && fallbackEvidence.includedUsed) {
+    includedUsedCents = fallback.includedUsedCents;
+    includedUsedHasEvidence = includedUsedCents !== null;
+  }
+  if (includedUsedCents === null && fallbackRawUsed !== null) {
+    includedUsedCents = fallbackRawUsed;
+  }
+  if (includedUsedCents !== null && monthlyLimitCents !== null && monthlyLimitCents > 0) {
+    includedUsedCents = Math.min(includedUsedCents, monthlyLimitCents);
+  }
+
+  const primaryOnDemandCap = primaryEvidence.onDemandCap ? primary.onDemandCapCents : null;
+  const fallbackOnDemandCap = fallbackEvidence.onDemandCap ? fallback.onDemandCapCents : null;
+  const onDemandCapCents = primaryOnDemandCap ?? fallbackOnDemandCap;
+  let onDemandUsedHasEvidence = primaryEvidence.onDemandUsed;
+  let onDemandUsedCents = onDemandUsedHasEvidence ? primary.onDemandUsedCents : null;
+  if (onDemandUsedCents === null && primaryRawUsed !== null && monthlyLimitCents !== null) {
+    onDemandUsedCents = Math.max(0, primaryRawUsed - monthlyLimitCents);
+  }
+  if (onDemandUsedCents === null && fallbackEvidence.onDemandUsed) {
+    onDemandUsedCents = fallback.onDemandUsedCents;
+    onDemandUsedHasEvidence = onDemandUsedCents !== null;
+  }
+  if (onDemandUsedCents === null && fallbackRawUsed !== null && monthlyLimitCents !== null) {
+    onDemandUsedCents = Math.max(0, fallbackRawUsed - monthlyLimitCents);
+  }
+  const hasPrimaryComponentEvidence = primaryEvidence.includedUsed || primaryEvidence.onDemandUsed;
+  const usedCents =
+    primaryRawUsed ??
+    (hasPrimaryComponentEvidence
+      ? includedUsedCents !== null && onDemandUsedCents !== null
+        ? includedUsedCents + onDemandUsedCents
+        : (includedUsedCents ?? onDemandUsedCents)
+      : (fallbackRawUsed ??
+        (includedUsedCents !== null && onDemandUsedCents !== null
+          ? includedUsedCents + onDemandUsedCents
+          : (includedUsedCents ?? onDemandUsedCents))));
+  const usedPercent =
+    monthlyLimitCents !== null && monthlyLimitCents > 0 && includedUsedCents !== null
+      ? (includedUsedCents / monthlyLimitCents) * 100
+      : (primary.usedPercent ?? fallback.usedPercent);
+  const onDemandUsedPercent =
+    onDemandCapCents !== null && onDemandCapCents > 0 && onDemandUsedCents !== null
+      ? (onDemandUsedCents / onDemandCapCents) * 100
+      : (primary.onDemandUsedPercent ?? fallback.onDemandUsedPercent);
+
+  const merged: XaiBillingSummary = {
+    periodType: weeklySource.periodType,
+    usagePercent: weeklySource.usagePercent,
+    periodStart: weeklySource.periodStart,
+    periodEnd: weeklySource.periodEnd,
+    productUsage: weeklySource.productUsage,
+    monthlyLimitCents,
+    usedCents,
+    includedUsedCents,
+    onDemandCapCents,
+    onDemandUsedCents,
+    onDemandUsedPercent,
     billingPeriodStart: primary.billingPeriodStart ?? fallback.billingPeriodStart,
     billingPeriodEnd: primary.billingPeriodEnd ?? fallback.billingPeriodEnd,
-    usedPercent: primary.usedPercent ?? fallback.usedPercent,
+    usedPercent,
   };
+  xaiBillingFieldEvidence.set(merged, {
+    monthlyLimit: primaryEvidence.monthlyLimit || fallbackEvidence.monthlyLimit,
+    used: primaryEvidence.used || (!hasPrimaryComponentEvidence && fallbackEvidence.used),
+    includedUsed: includedUsedHasEvidence,
+    onDemandCap: primaryEvidence.onDemandCap || fallbackEvidence.onDemandCap,
+    onDemandUsed: onDemandUsedHasEvidence,
+  });
+  return merged;
 };
 
 const toXaiRecord = (value: unknown): Record<string, unknown> | null =>
@@ -1692,17 +1821,26 @@ const requestXaiBillingProbe = async (
 ) => {
   const authIndex = resolveXaiProbeAuthIndex(file, t);
   const requestHeader = buildXaiRequestHeaders(file);
+  const configuredTimeout = requestConfig?.timeout;
+  const legacyRequestConfig: AxiosRequestConfig = {
+    ...requestConfig,
+    timeout:
+      typeof configuredTimeout === 'number' && configuredTimeout > 0
+        ? Math.min(configuredTimeout, XAI_LEGACY_BILLING_REQUEST_TIMEOUT_MS)
+        : XAI_LEGACY_BILLING_REQUEST_TIMEOUT_MS,
+  };
   const [weeklyResult, monthlyResult] = await Promise.allSettled([
     requestXaiBilling(authIndex, XAI_BILLING_WEEKLY_URL, requestHeader, requestConfig),
-    requestXaiBilling(authIndex, XAI_BILLING_MONTHLY_URL, requestHeader, requestConfig),
+    requestXaiBilling(authIndex, XAI_BILLING_MONTHLY_URL, requestHeader, legacyRequestConfig),
   ]);
   const weeklyProbe = weeklyResult.status === 'fulfilled' ? weeklyResult.value : null;
   const monthlyProbe = monthlyResult.status === 'fulfilled' ? monthlyResult.value : null;
   const weeklySummary = weeklyProbe?.summary ?? null;
   const monthlySummary = monthlyProbe?.summary ?? null;
-  const failures = [weeklyResult, monthlyResult].flatMap((result) =>
-    result.status === 'rejected' ? [result.reason] : []
-  );
+  const weeklyFailures = weeklyResult.status === 'rejected' ? [weeklyResult.reason] : [];
+  const monthlyFailures = monthlyResult.status === 'rejected' ? [monthlyResult.reason] : [];
+  const weeklyFailure = weeklyFailures[0];
+  const failures = weeklySummary ? [] : weeklyFailure ? [weeklyFailure] : monthlyFailures;
 
   return {
     authIndex,
@@ -1719,8 +1857,11 @@ export const probeXaiBilling = async (
   t: TFunction,
   requestConfig?: AxiosRequestConfig
 ): Promise<XaiBillingProbeResult> => {
-  const { failures, monthlySummary, statusCode, summary, weeklySummary } =
-    await requestXaiBillingProbe(file, t, requestConfig);
+  const { failures, statusCode, summary, weeklySummary } = await requestXaiBillingProbe(
+    file,
+    t,
+    requestConfig
+  );
   if (!summary) {
     if (failures.length > 0) throw selectXaiBillingFailure(failures);
     throw new Error(t('xai_quota.empty_data'));
@@ -1729,7 +1870,7 @@ export const probeXaiBilling = async (
   return {
     summary,
     failures,
-    partial: failures.length > 0 || weeklySummary === null || monthlySummary === null,
+    partial: weeklySummary === null,
     statusCode,
   };
 };
@@ -1739,22 +1880,27 @@ export const probeXaiQuota = async (
   t: TFunction,
   requestConfig?: AxiosRequestConfig
 ): Promise<XaiQuotaProbeResult> => {
-  const { authIndex, failures, monthlySummary, statusCode, summary, weeklySummary } =
-    await requestXaiBillingProbe(file, t, requestConfig);
+  const { authIndex, failures, statusCode, summary, weeklySummary } = await requestXaiBillingProbe(
+    file,
+    t,
+    requestConfig
+  );
   if (summary) {
     return {
       summary,
       failures,
-      partial: failures.length > 0 || weeklySummary === null || monthlySummary === null,
+      partial: weeklySummary === null,
       source: 'billing',
       statusCode,
-      blockingFailure: selectXaiBlockingBillingFailure(failures),
+      blockingFailure:
+        weeklySummary === null ? selectXaiBlockingBillingFailure(failures) : undefined,
     };
   }
   if (failures.length === 0) {
     throw new Error(t('xai_quota.empty_data'));
   }
-  if (!failures.every(isXaiOfficialApiFallbackFailure)) {
+  const canFallbackToOfficialApi = failures.every(isXaiOfficialApiFallbackFailure);
+  if (!canFallbackToOfficialApi) {
     throw selectXaiBillingFailure(failures);
   }
 


### PR DESCRIPTION
## Summary

Fix xAI/SuperGrok quota parsing after the billing response contract changed by treating `/v1/billing?format=credits` as the authoritative unified source and using deprecated billing data only to enrich missing fields.

Preserve field-level absence so placeholder objects do not become false zero-dollar monthly quotas, keeping local and Manager Server inspection aligned.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Track direct evidence independently for xAI billing limits, usage, periods, and pay-as-you-go fields across the Web and Manager Server parsers.
- Preserve authoritative unified values while filling only missing fields from the deprecated billing response, then recompute derived usage and percentages.
- Suppress unsupported monthly quota windows in Accounts and Monitoring, and update regression coverage and demo fixtures for mixed, placeholder, alias, and conflicting payloads.

## User Impact

SuperGrok accounts no longer show a false zero-dollar monthly quota when the unified billing response omits that field. Valid unified quota values also remain stable when legacy billing returns conflicting data.

Both browser-local inspection and scheduled/manual Manager Server inspection now follow the same evidence rules.

## Compatibility / Runtime Notes

- CPA panel mode: Browser-local xAI inspection uses the corrected precedence and field-evidence handling; no configuration change is required.
- Manager Server mode: Manual and scheduled xAI inspection use the same corrected parsing behavior while retaining legacy fallback compatibility.
- Full Docker / native packages: No migration or configuration change is required; the behavior takes effect with the updated panel and Manager Server binaries.

## Data / Security Notes

N/A. The change only interprets existing read-only xAI billing responses. It does not change credential handling, persistence, logging, SQLite schemas, or exposed raw data.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert the two commits in this PR. There is no database migration or configuration rollback.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
# 0 errors; one pre-existing Fast Refresh warning in AccountHealthBadge.tsx

npm run test
# 187 test files passed; 2266 tests passed

npm run manager-server:test
go -C apps/manager-server test -race ./internal/service/codexinspection

npm --workspace apps/web run build:bundle
npm run check:demo-isolation
npm --workspace apps/web run build:demo:bundle
npm run docs:build

git diff --check dev...HEAD
```

## Screenshots / Recordings

N/A. This changes quota evidence interpretation without changing layout or styling; Accounts, Monitoring, and demo behavior are covered by regression tests and fixtures.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

Existing documentation already describes xAI CLI billing and local/server inspection. This fix restores that documented behavior without adding configuration or a new capability.

## Related

N/A