### PR TITLE
✨ feat(dashboard): link displayed versions to releases

### DIFF
--- a/apps/web/src/features/dashboard/components/VersionCard.module.scss
+++ b/apps/web/src/features/dashboard/components/VersionCard.module.scss
@@ -171,6 +171,37 @@
     text-overflow: ellipsis;
   }
 
+  .versionLink {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    max-width: 100%;
+    color: var(--text-primary);
+    text-decoration: none;
+    border-radius: 4px;
+
+    .value {
+      min-width: 0;
+      color: inherit;
+    }
+
+    svg {
+      flex: 0 0 auto;
+    }
+
+    &:hover {
+      color: var(--focus-text);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-border);
+      outline-offset: 2px;
+    }
+  }
+
   .valueWrap {
     display: flex;
     align-items: center;

--- a/apps/web/src/features/dashboard/components/VersionCard.tsx
+++ b/apps/web/src/features/dashboard/components/VersionCard.tsx
@@ -19,6 +19,7 @@ import type { UsageServiceStatus } from '@/services/api/usageService';
 import type { ConnectionStatus } from '@/types';
 import { compareVersions, type VersionComparison } from '@/utils/version';
 import { readApiLatestVersion, readManagerLatestTag } from '@/features/system/versionChecks';
+import { buildDashboardVersionReleaseURL } from '@/features/dashboard/versionReleaseLinks';
 import styles from './VersionCard.module.scss';
 
 interface VersionCardProps {
@@ -70,6 +71,19 @@ const renderBadge = (
     return { label: t('dashboard.version_is_latest'), className: styles.badgeLatest };
   }
   return null;
+};
+
+const renderVersionValue = (value: string, releaseUrl: string): ReactNode => {
+  if (!releaseUrl) {
+    return <span className={styles.value}>{value}</span>;
+  }
+
+  return (
+    <a className={styles.versionLink} href={releaseUrl} target="_blank" rel="noopener noreferrer">
+      <span className={styles.value}>{value}</span>
+      <IconExternalLink size={12} />
+    </a>
+  );
 };
 
 export function VersionCard({
@@ -205,6 +219,14 @@ export function VersionCard({
     () => renderBadge(compareVersions(latest.latestApi, apiVersion), latest.latestApi, t),
     [apiVersion, latest.latestApi, t]
   );
+  const appReleaseUrl = useMemo(
+    () => buildDashboardVersionReleaseURL('manager', appVersion),
+    [appVersion]
+  );
+  const apiReleaseUrl = useMemo(
+    () => buildDashboardVersionReleaseURL('core', apiVersion),
+    [apiVersion]
+  );
 
   const buildTimeDisplay = serverBuildDate
     ? new Date(serverBuildDate).toLocaleString(i18n.language)
@@ -321,8 +343,13 @@ export function VersionCard({
                 </Button>
               </div>
               <div className={styles.valueWrap}>
-                <span className={styles.value}>{appVersion || t('dashboard.version_unknown')}</span>
-                {appBadge && <span className={`${styles.badge} ${appBadge.className}`}>{appBadge.label}</span>}
+                {renderVersionValue(
+                  appVersion || t('dashboard.version_unknown'),
+                  appReleaseUrl
+                )}
+                {appBadge && (
+                  <span className={`${styles.badge} ${appBadge.className}`}>{appBadge.label}</span>
+                )}
               </div>
             </div>
           </div>
@@ -347,8 +374,13 @@ export function VersionCard({
                 </Button>
               </div>
               <div className={styles.valueWrap}>
-                <span className={styles.value}>{apiVersion || t('dashboard.version_unknown')}</span>
-                {apiBadge && <span className={`${styles.badge} ${apiBadge.className}`}>{apiBadge.label}</span>}
+                {renderVersionValue(
+                  apiVersion || t('dashboard.version_unknown'),
+                  apiReleaseUrl
+                )}
+                {apiBadge && (
+                  <span className={`${styles.badge} ${apiBadge.className}`}>{apiBadge.label}</span>
+                )}
               </div>
             </div>
           </div>

--- a/apps/web/src/features/dashboard/versionReleaseLinks.test.ts
+++ b/apps/web/src/features/dashboard/versionReleaseLinks.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDashboardVersionReleaseURL,
+  normalizeDashboardReleaseTag,
+} from './versionReleaseLinks';
+
+describe('dashboard version release links', () => {
+  it('builds the Manager release URL from a tagged version', () => {
+    expect(buildDashboardVersionReleaseURL('manager', 'v1.12.0')).toBe(
+      'https://github.com/seakee/CPA-Manager-Plus/releases/tag/v1.12.0'
+    );
+  });
+
+  it('builds the CLIProxyAPI release URL and adds a missing v prefix', () => {
+    expect(buildDashboardVersionReleaseURL('core', '7.2.130')).toBe(
+      'https://github.com/router-for-me/CLIProxyAPI/releases/tag/v7.2.130'
+    );
+  });
+
+  it('preserves valid prerelease identifiers while normalizing the v prefix', () => {
+    expect(normalizeDashboardReleaseTag(' V1.12.0-rc.1 ')).toBe('v1.12.0-rc.1');
+    expect(normalizeDashboardReleaseTag('1.12.0-beta3')).toBe('v1.12.0-beta3');
+  });
+
+  it.each([
+    '',
+    'dev',
+    'unknown',
+    'v1.12',
+    'v01.2.3',
+    'v1.2.3+build.1',
+    'v1.2.3-5-gabcdef',
+    'release/v1.2.3',
+  ])('does not link non-release version %j', (version) => {
+    expect(normalizeDashboardReleaseTag(version)).toBe('');
+    expect(buildDashboardVersionReleaseURL('manager', version)).toBe('');
+  });
+});

--- a/apps/web/src/features/dashboard/versionReleaseLinks.ts
+++ b/apps/web/src/features/dashboard/versionReleaseLinks.ts
@@ -1,0 +1,27 @@
+export type DashboardVersionReleaseTarget = 'manager' | 'core';
+
+const RELEASE_REPOSITORIES: Record<DashboardVersionReleaseTarget, string> = {
+  manager: 'seakee/CPA-Manager-Plus',
+  core: 'router-for-me/CLIProxyAPI',
+};
+
+const prereleaseIdentifier = String.raw`(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const releaseVersionPattern = new RegExp(
+  String.raw`^[vV]?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-${prereleaseIdentifier}(?:\.${prereleaseIdentifier})*)?$`
+);
+const gitDescribeVersionPattern = /-\d+-g[0-9a-f]+(?:-dirty)?$/i;
+
+export const normalizeDashboardReleaseTag = (version?: string | null): string => {
+  const trimmed = version?.trim() || '';
+  if (gitDescribeVersionPattern.test(trimmed) || !releaseVersionPattern.test(trimmed)) return '';
+  return `v${trimmed.replace(/^[vV]/, '')}`;
+};
+
+export const buildDashboardVersionReleaseURL = (
+  target: DashboardVersionReleaseTarget,
+  version?: string | null
+): string => {
+  const tag = normalizeDashboardReleaseTag(version);
+  if (!tag) return '';
+  return `https://github.com/${RELEASE_REPOSITORIES[target]}/releases/tag/${encodeURIComponent(tag)}`;
+};


### PR DESCRIPTION
## Summary

Make the dashboard's displayed manager and core version values link directly to their corresponding GitHub release pages when the version is a valid release tag.

Development, unknown, and git-describe versions remain plain text so non-release builds do not link to unavailable release pages.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add release-tag normalization and repository-specific GitHub release URL construction for Manager and CLIProxyAPI versions.
- Render valid dashboard version values as accessible external links with new-tab and noopener noreferrer behavior.
- Preserve existing update checks and badges, with focused coverage for release, prerelease, and non-release versions.

## User Impact

Users can click the manager version or core version shown on the dashboard to open the matching GitHub release page.

## Compatibility / Runtime Notes

- CPA panel mode: Frontend-only behavior; no runtime or API contract changes.
- Manager Server mode: The embedded dashboard uses the same frontend behavior after the normal panel build; no backend changes.
- Full Docker / native packages: No packaging or runtime configuration changes.

## Data / Security Notes

N/A. No credentials, persistence, or usage data are involved.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit 9787a046 to restore the previous plain-text version display.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test
npm run build
git diff --check
Focused version release-link tests: 11 passed
Full test suite: 186 files / 2230 tests passed
Lint completed with one pre-existing warning in unmodified AccountHealthBadge.tsx
```

## Screenshots / Recordings

N/A — no browser automation was run in this environment.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

This is a small dashboard interaction enhancement with no documentation or release-note impact.

## Related

N/A