### PR TITLE
feat(model-prices): configure GPT-5.6 Fast billing mode

### DIFF
--- a/apps/docs/manual/model-prices.md
+++ b/apps/docs/manual/model-prices.md
@@ -56,8 +56,16 @@ description: 配置 CPA Manager Plus 模型价格、service tier、长上下文�
 
 - `experimental.modes.fast.cost` 同时匹配使用数据中的 `fast` 和 API `priority`。
 - 短上下文优先使用显式 Fast/Priority 价格；缺失字段继承基础价格，显式零值保持为零。
-- 命中上下文阶梯或旧版 GPT 长上下文规则时，使用对应的标准上下文价格，不再叠加 Fast/Priority。
+- Fast/Priority 倍率应用于选中的完整标准价格，包括已命中的上下文阶梯；不会只对短上下文部分生效。
 - 非 models.dev、旧数据或没有显式模式价格的模型继续使用现有倍率作为兼容回退。
+
+模型价格页为 GPT-5.6 系列提供 **Fast/Priority 计费模式**：
+
+- **API Priority（2×）**：按 API Priority Processing 的显式价格或兼容倍率估算。
+- **Codex Fast 额度（2.5×）**：按基础价格（包括已命中的长上下文阶梯）整体乘以 2.5，用于估算 Codex 订阅额度消耗。
+- **按提供商自动判断**：`codex` 提供商使用 2.5×，其他提供商使用 2×。管理 API 还支持通过 `providerOverrides` 为特定 CPA provider 覆盖模式。
+
+该设置只影响 CPAMP 的本地成本估算，不改变 CPA 转发的 Token，也不修改上游实际扣费。普通（非 `fast`/`priority`）请求始终按 1×计算。
 
 模型价格页只读展示已同步的上下文阶梯和服务层级价格。当前手动编辑器只维护基础价格；保存手动价格会明确清除该模型已有的同步高级规则，界面会在保存前提示。
 

--- a/apps/manager-server/internal/app/context.go
+++ b/apps/manager-server/internal/app/context.go
@@ -22,6 +22,7 @@ import (
 	modelpricesvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/modelprice"
 	monitoringsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/monitoring"
 	panelsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/panel"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
 	proxysvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/proxy"
 	quotasnapshotsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/quotasnapshot"
 	setupsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/setup"
@@ -148,6 +149,9 @@ func fromExisting(
 		TTL:            cfg.UsageImportSessionTTL,
 	}))
 	authFileMutationCoordinator := cpaauthfiles.NewMutationCoordinator()
+	if fastBilling, err := st.LoadFastBillingSettings(context.Background()); err == nil {
+		pricing.SetFastBillingSettings(fastBilling)
+	}
 	return &Context{
 		Config:               cfg,
 		Store:                st,

--- a/apps/manager-server/internal/http/controller/modelprice/handler.go
+++ b/apps/manager-server/internal/http/controller/modelprice/handler.go
@@ -24,6 +24,25 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	path := strings.TrimRight(r.URL.Path, "/")
 	switch {
+	case path == "/v0/management/model-prices/fast-billing-settings" && r.Method == http.MethodGet:
+		settings, err := h.App.ModelPriceService.FastBillingSettings(r.Context())
+		if err != nil {
+			response.Error(w, http.StatusInternalServerError, err)
+			return
+		}
+		response.JSON(w, http.StatusOK, modelpricesvc.FastBillingSettingsResponse{Settings: settings})
+	case path == "/v0/management/model-prices/fast-billing-settings" && r.Method == http.MethodPut:
+		var req modelpricesvc.FastBillingSettingsResponse
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			response.Error(w, http.StatusBadRequest, err)
+			return
+		}
+		settings, err := h.App.ModelPriceService.UpdateFastBillingSettings(r.Context(), req.Settings)
+		if err != nil {
+			response.Error(w, http.StatusBadRequest, err)
+			return
+		}
+		response.JSON(w, http.StatusOK, modelpricesvc.FastBillingSettingsResponse{Settings: settings})
 	case path == "/v0/management/model-prices/usage-summary" && r.Method == http.MethodGet:
 		summary, err := h.App.ModelPriceService.UsageSummary(r.Context(), h.App.Config.QueryLimit)
 		if err != nil {

--- a/apps/manager-server/internal/http/controller/modelprice/handler_test.go
+++ b/apps/manager-server/internal/http/controller/modelprice/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/app"
@@ -55,5 +56,53 @@ func TestHandleUsageSummaryUsesQueryLimitAndPanelAuthorization(t *testing.T) {
 	}
 	if len(summary.Models) != 1 || summary.Models[0].Model != "gpt-new" || summary.Models[0].Calls != 1 || summary.Models[0].RequestedCalls != 1 {
 		t.Fatalf("models = %#v", summary.Models)
+	}
+}
+
+func TestFastBillingSettingsRoundTrip(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	st := testutil.NewStore(t, cfg)
+	handler := &Handler{App: &app.Context{
+		AdminAuthService:  adminauthsvc.New(cfg, st),
+		ModelPriceService: modelpricesvc.New(st, nil),
+	}}
+
+	put := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v0/management/model-prices/fast-billing-settings", strings.NewReader(`{"settings":{"mode":"automatic","providerOverrides":[{"provider":"openai","mode":"api_priority"}]}}`))
+	req.Header.Set("Authorization", "Bearer "+testutil.AdminKey)
+	handler.Handle(put, req)
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, body = %s", put.Code, put.Body.String())
+	}
+
+	get := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v0/management/model-prices/fast-billing-settings", nil)
+	req.Header.Set("Authorization", "Bearer "+testutil.AdminKey)
+	handler.Handle(get, req)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body = %s", get.Code, get.Body.String())
+	}
+	if !strings.Contains(get.Body.String(), `"mode":"automatic"`) || !strings.Contains(get.Body.String(), `"provider":"openai"`) {
+		t.Fatalf("unexpected GET body: %s", get.Body.String())
+	}
+}
+
+func TestFastBillingSettingsDefaultsToAPIPriority(t *testing.T) {
+	cfg := testutil.NewConfig(t)
+	st := testutil.NewStore(t, cfg)
+	handler := &Handler{App: &app.Context{
+		AdminAuthService:  adminauthsvc.New(cfg, st),
+		ModelPriceService: modelpricesvc.New(st, nil),
+	}}
+
+	get := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/model-prices/fast-billing-settings", nil)
+	req.Header.Set("Authorization", "Bearer "+testutil.AdminKey)
+	handler.Handle(get, req)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body = %s", get.Code, get.Body.String())
+	}
+	if !strings.Contains(get.Body.String(), `"mode":"api_priority"`) {
+		t.Fatalf("unexpected default body: %s", get.Body.String())
 	}
 }

--- a/apps/manager-server/internal/model/fast_billing.go
+++ b/apps/manager-server/internal/model/fast_billing.go
@@ -1,0 +1,87 @@
+package model
+
+import "strings"
+
+// FastBillingMode selects how Fast/Priority usage is represented in local cost estimates.
+type FastBillingMode string
+
+const (
+	FastBillingModeAPIPriority  FastBillingMode = "api_priority"
+	FastBillingModeCodexCredits FastBillingMode = "codex_credits"
+	FastBillingModeAutomatic    FastBillingMode = "automatic"
+)
+
+// FastBillingProviderOverride applies a billing mode to one CPA provider/channel.
+type FastBillingProviderOverride struct {
+	Provider string          `json:"provider"`
+	Mode     FastBillingMode `json:"mode"`
+}
+
+// FastBillingSettings controls the local estimated-cost multiplier for requests
+// whose effective service tier is fast or priority.
+type FastBillingSettings struct {
+	Mode              FastBillingMode               `json:"mode"`
+	ProviderOverrides []FastBillingProviderOverride `json:"providerOverrides,omitempty"`
+	UpdatedAtMS       int64                         `json:"updatedAtMs,omitempty"`
+}
+
+func DefaultFastBillingSettings() FastBillingSettings {
+	return FastBillingSettings{Mode: FastBillingModeAPIPriority}
+}
+
+func NormalizeFastBillingMode(mode FastBillingMode) FastBillingMode {
+	switch FastBillingMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	case FastBillingModeAPIPriority:
+		return FastBillingModeAPIPriority
+	case FastBillingModeCodexCredits:
+		return FastBillingModeCodexCredits
+	case FastBillingModeAutomatic:
+		return FastBillingModeAutomatic
+	default:
+		return ""
+	}
+}
+
+func NormalizeFastBillingSettings(settings FastBillingSettings) FastBillingSettings {
+	mode := NormalizeFastBillingMode(settings.Mode)
+	if mode == "" {
+		mode = FastBillingModeAPIPriority
+	}
+	result := FastBillingSettings{Mode: mode, UpdatedAtMS: settings.UpdatedAtMS}
+	seen := map[string]bool{}
+	for _, override := range settings.ProviderOverrides {
+		provider := strings.ToLower(strings.TrimSpace(override.Provider))
+		overrideMode := NormalizeFastBillingMode(override.Mode)
+		if provider == "" || (overrideMode != FastBillingModeAPIPriority && overrideMode != FastBillingModeCodexCredits) || seen[provider] {
+			continue
+		}
+		seen[provider] = true
+		result.ProviderOverrides = append(result.ProviderOverrides, FastBillingProviderOverride{
+			Provider: provider,
+			Mode:     overrideMode,
+		})
+	}
+	return result
+}
+
+func (settings FastBillingSettings) ProviderAware() bool {
+	normalized := NormalizeFastBillingSettings(settings)
+	return normalized.Mode == FastBillingModeAutomatic || len(normalized.ProviderOverrides) > 0
+}
+
+func (settings FastBillingSettings) ResolveMode(provider string) FastBillingMode {
+	normalized := NormalizeFastBillingSettings(settings)
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	for _, override := range normalized.ProviderOverrides {
+		if override.Provider == provider {
+			return override.Mode
+		}
+	}
+	if normalized.Mode == FastBillingModeAutomatic {
+		if provider == "codex" {
+			return FastBillingModeCodexCredits
+		}
+		return FastBillingModeAPIPriority
+	}
+	return normalized.Mode
+}

--- a/apps/manager-server/internal/model/fast_billing_test.go
+++ b/apps/manager-server/internal/model/fast_billing_test.go
@@ -1,0 +1,25 @@
+package model
+
+import "testing"
+
+func TestFastBillingSettingsResolveMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings FastBillingSettings
+		provider string
+		want     FastBillingMode
+	}{
+		{name: "default", settings: FastBillingSettings{}, provider: "codex", want: FastBillingModeAPIPriority},
+		{name: "codex credits", settings: FastBillingSettings{Mode: FastBillingModeCodexCredits}, provider: "openai", want: FastBillingModeCodexCredits},
+		{name: "automatic codex", settings: FastBillingSettings{Mode: FastBillingModeAutomatic}, provider: "codex", want: FastBillingModeCodexCredits},
+		{name: "automatic api", settings: FastBillingSettings{Mode: FastBillingModeAutomatic}, provider: "openai", want: FastBillingModeAPIPriority},
+		{name: "provider override", settings: FastBillingSettings{Mode: FastBillingModeAPIPriority, ProviderOverrides: []FastBillingProviderOverride{{Provider: " CODEX ", Mode: FastBillingModeCodexCredits}}}, provider: "codex", want: FastBillingModeCodexCredits},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.settings.ResolveMode(tt.provider); got != tt.want {
+				t.Fatalf("ResolveMode(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/manager-server/internal/repository/setting/repository.go
+++ b/apps/manager-server/internal/repository/setting/repository.go
@@ -15,6 +15,7 @@ const managerConfigKey = "manager_config_v1"
 const automationSettingsKey = "automation_settings_v1"
 const adminCredentialKey = "admin_credential_v1"
 const bootstrapStateKey = "bootstrap_state_v1"
+const fastBillingSettingsKey = "fast_billing_settings_v1"
 
 type Repository interface {
 	SaveManagerConfig(ctx context.Context, cfg model.ManagerConfig) error
@@ -27,7 +28,42 @@ type Repository interface {
 	LoadAdminCredential(ctx context.Context) (model.AdminCredential, bool, error)
 	SaveBootstrapState(ctx context.Context, state model.BootstrapState) error
 	LoadBootstrapState(ctx context.Context) (model.BootstrapState, bool, error)
+	SaveFastBillingSettings(ctx context.Context, settings model.FastBillingSettings) (model.FastBillingSettings, error)
+	LoadFastBillingSettings(ctx context.Context) (model.FastBillingSettings, bool, error)
 	HasHistoricalData(ctx context.Context) (bool, error)
+}
+
+func (r *repository) SaveFastBillingSettings(ctx context.Context, settings model.FastBillingSettings) (model.FastBillingSettings, error) {
+	settings = model.NormalizeFastBillingSettings(settings)
+	settings.UpdatedAtMS = time.Now().UnixMilli()
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return model.FastBillingSettings{}, err
+	}
+	_, err = r.db.ExecContext(ctx, `insert into settings(key, value, updated_at_ms)
+		 values(?, ?, ?)
+		 on conflict(key) do update set value = excluded.value, updated_at_ms = excluded.updated_at_ms`,
+		fastBillingSettingsKey, string(data), settings.UpdatedAtMS)
+	if err != nil {
+		return model.FastBillingSettings{}, err
+	}
+	return settings, nil
+}
+
+func (r *repository) LoadFastBillingSettings(ctx context.Context) (model.FastBillingSettings, bool, error) {
+	var raw string
+	err := r.db.QueryRowContext(ctx, `select value from settings where key = ?`, fastBillingSettingsKey).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return model.DefaultFastBillingSettings(), false, nil
+	}
+	if err != nil {
+		return model.FastBillingSettings{}, false, err
+	}
+	var settings model.FastBillingSettings
+	if err := json.Unmarshal([]byte(raw), &settings); err != nil {
+		return model.FastBillingSettings{}, false, err
+	}
+	return model.NormalizeFastBillingSettings(settings), true, nil
 }
 
 type repository struct {

--- a/apps/manager-server/internal/repository/usageevent/aggregate.go
+++ b/apps/manager-server/internal/repository/usageevent/aggregate.go
@@ -80,6 +80,7 @@ type ModelStat struct {
 	usage.PricingBand
 	Model               string
 	BillingModel        string
+	Provider            string
 	ServiceTier         string
 	Calls               int64
 	SuccessCalls        int64
@@ -186,6 +187,7 @@ select
 	e.pricing_model_value,
 	e.context_threshold_tokens_value,
 	coalesce(e.service_tier, '') as service_tier,
+	coalesce(e.provider, '') as provider,
 	count(*) as calls,
 	sum(case when e.failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(coalesce(e.normalized_total_input_tokens, e.input_tokens)), 0),
@@ -202,7 +204,7 @@ select
 	coalesce(sum(e.total_tokens), 0)
 from banded_usage_events e
 join top_models t on t.model = e.analytics_model_value
-group by e.analytics_model_value, billing_model, e.pricing_model_value, e.context_threshold_tokens_value, coalesce(e.service_tier, '')
+group by e.analytics_model_value, billing_model, e.pricing_model_value, e.context_threshold_tokens_value, coalesce(e.service_tier, ''), coalesce(e.provider, '')
 order by max(t.model_calls) desc, e.analytics_model_value, calls desc`, usage.LongContextInputTokenThreshold)
 
 // TopModelsBetween returns the most active models ordered by call count.
@@ -225,6 +227,7 @@ func (r *repository) TopModelsBetween(ctx context.Context, fromMs, toMs int64, l
 			&stat.PricingModel,
 			&stat.ContextThresholdTokens,
 			&stat.ServiceTier,
+			&stat.Provider,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,
@@ -254,6 +257,7 @@ select
 	pricing_model_value,
 	context_threshold_tokens_value,
 	coalesce(service_tier, '') as service_tier,
+	coalesce(provider, '') as provider,
 	count(*) as calls,
 	sum(case when failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(coalesce(normalized_total_input_tokens, input_tokens)), 0),
@@ -270,7 +274,7 @@ select
 	coalesce(sum(total_tokens), 0)
 from banded_usage_events
 where timestamp_ms >= ? and timestamp_ms < ?
-group by analytics_model_value, billing_model, pricing_model_value, context_threshold_tokens_value, coalesce(service_tier, '')
+group by analytics_model_value, billing_model, pricing_model_value, context_threshold_tokens_value, coalesce(service_tier, ''), coalesce(provider, '')
 order by calls desc`, usage.LongContextInputTokenThreshold)
 
 // ModelStatsBetween returns per-model totals for all models in a window.
@@ -290,6 +294,7 @@ func (r *repository) ModelStatsBetween(ctx context.Context, fromMs, toMs int64) 
 			&stat.PricingModel,
 			&stat.ContextThresholdTokens,
 			&stat.ServiceTier,
+			&stat.Provider,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -115,6 +115,7 @@ type TimelinePoint struct {
 	usage.PricingBand
 	BucketMS            int64
 	Model               string
+	Provider            string
 	BillingModel        string
 	ServiceTier         string
 	Calls               int64
@@ -243,6 +244,7 @@ type AccountWindowModelStat struct {
 	usage.PricingBand
 	RequestIndex        int
 	Model               string
+	Provider            string
 	BillingModel        string
 	ServiceTier         string
 	Calls               int64
@@ -322,6 +324,7 @@ type APIKeyTimelinePoint struct {
 	APIKeyHash          string
 	BucketMS            int64
 	Model               string
+	Provider            string
 	BillingModel        string
 	ServiceTier         string
 	Calls               int64
@@ -513,6 +516,7 @@ select
 	pricing_model_value,
 	context_threshold_tokens_value,
 	coalesce(service_tier, '') as service_tier,
+	coalesce(provider, '') as provider,
 	count(*) as calls,
 	sum(case when failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(` + normalizedInputExpr + `), 0),
@@ -528,7 +532,7 @@ select
 	coalesce(sum(` + longCacheCreationExpr + `), 0),
 	coalesce(sum(total_tokens), 0)
 from banded_usage_events ` + where + `
-group by analytics_model_value, billing_model, pricing_model_value, context_threshold_tokens_value, coalesce(service_tier, '')
+group by analytics_model_value, billing_model, pricing_model_value, context_threshold_tokens_value, coalesce(service_tier, ''), coalesce(provider, '')
 order by calls desc`
 	if limit > 0 {
 		query = pricingBandedUsageEventsCTE + `, filtered as (
@@ -547,6 +551,7 @@ select
 	f.pricing_model_value,
 	f.context_threshold_tokens_value,
 	coalesce(f.service_tier, '') as service_tier,
+	coalesce(f.provider, '') as provider,
 	count(*) as calls,
 	sum(case when f.failed = 0 then 1 else 0 end) as success,
 	coalesce(sum(f.input_tokens), 0),
@@ -563,7 +568,7 @@ select
 	coalesce(sum(f.total_tokens), 0)
 from filtered f
 join top_models t on t.model = f.analytics_model_value
-group by f.analytics_model_value, billing_model, f.pricing_model_value, f.context_threshold_tokens_value, coalesce(f.service_tier, '')
+group by f.analytics_model_value, billing_model, f.pricing_model_value, f.context_threshold_tokens_value, coalesce(f.service_tier, ''), coalesce(f.provider, '')
 order by max(t.model_calls) desc, f.analytics_model_value, calls desc`
 		args = append(args, limit)
 	}
@@ -582,6 +587,7 @@ order by max(t.model_calls) desc, f.analytics_model_value, calls desc`
 			&stat.PricingModel,
 			&stat.ContextThresholdTokens,
 			&stat.ServiceTier,
+			&stat.Provider,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,
@@ -614,6 +620,7 @@ select
 	pricing_model_value,
 	context_threshold_tokens_value,
 	coalesce(service_tier, '') as service_tier,
+	coalesce(provider, '') as provider,
 		failed,
 		`+normalizedInputExpr+`,
 	output_tokens,
@@ -637,6 +644,7 @@ order by timestamp_ms, analytics_model_value`, where)
 		billingModel           string
 		pricingModel           string
 		serviceTier            string
+		provider               string
 		contextThresholdTokens int64
 	}
 	grouped := map[key]*TimelinePoint{}
@@ -647,6 +655,7 @@ order by timestamp_ms, analytics_model_value`, where)
 		var billingModel string
 		var pricingModel string
 		var serviceTier string
+		var provider string
 		var contextThresholdTokens int64
 		var failed int
 		var latency sql.NullFloat64
@@ -664,6 +673,7 @@ order by timestamp_ms, analytics_model_value`, where)
 			&pricingModel,
 			&contextThresholdTokens,
 			&serviceTier,
+			&provider,
 			&failed,
 			&inputTokens,
 			&outputTokens,
@@ -682,6 +692,7 @@ order by timestamp_ms, analytics_model_value`, where)
 			billingModel:           billingModel,
 			pricingModel:           pricingModel,
 			serviceTier:            serviceTier,
+			provider:               provider,
 			contextThresholdTokens: contextThresholdTokens,
 		}
 		point := grouped[mapKey]
@@ -695,6 +706,7 @@ order by timestamp_ms, analytics_model_value`, where)
 				Model:        model,
 				BillingModel: billingModel,
 				ServiceTier:  serviceTier,
+				Provider:     provider,
 			}
 			grouped[mapKey] = point
 			order = append(order, mapKey)
@@ -747,6 +759,7 @@ select
 	pricing_model_value,
 	context_threshold_tokens_value,
 	coalesce(service_tier, '') as service_tier,
+	coalesce(provider, '') as provider,
 	failed,
 	`+normalizedInputExpr+`,
 	output_tokens,
@@ -771,6 +784,7 @@ order by timestamp_ms, api_key_hash, analytics_model_value`, where)
 		billingModel           string
 		pricingModel           string
 		serviceTier            string
+		provider               string
 		contextThresholdTokens int64
 	}
 	grouped := map[key]*APIKeyTimelinePoint{}
@@ -789,6 +803,7 @@ order by timestamp_ms, api_key_hash, analytics_model_value`, where)
 			&point.PricingModel,
 			&point.ContextThresholdTokens,
 			&point.ServiceTier,
+			&point.Provider,
 			&failed,
 			&point.InputTokens,
 			&point.OutputTokens,
@@ -808,6 +823,7 @@ order by timestamp_ms, api_key_hash, analytics_model_value`, where)
 			billingModel:           point.BillingModel,
 			pricingModel:           point.PricingModel,
 			serviceTier:            point.ServiceTier,
+			provider:               point.Provider,
 			contextThresholdTokens: point.ContextThresholdTokens,
 		}
 		entry := grouped[mapKey]
@@ -819,6 +835,7 @@ order by timestamp_ms, api_key_hash, analytics_model_value`, where)
 				Model:        point.Model,
 				BillingModel: point.BillingModel,
 				ServiceTier:  point.ServiceTier,
+				Provider:     point.Provider,
 			}
 			grouped[mapKey] = entry
 			order = append(order, mapKey)
@@ -1606,6 +1623,7 @@ select
 	e.pricing_model_value,
 	e.context_threshold_tokens_value,
 	coalesce(e.service_tier, '') as service_tier,
+	coalesce(max(e.auth_provider_snapshot), max(e.provider), '') as provider,
 	count(*),
 	sum(case when e.failed = 0 then 1 else 0 end),
 	sum(case when e.failed = 1 then 1 else 0 end),
@@ -1643,6 +1661,7 @@ order by w.request_index, max(e.timestamp_ms) desc`, args...)
 			&stat.PricingModel,
 			&stat.ContextThresholdTokens,
 			&stat.ServiceTier,
+			&stat.Provider,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.FailureCalls,

--- a/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
@@ -63,6 +63,7 @@ type accountWindowStatKey struct {
 	pricingModel     string
 	contextThreshold int64
 	serviceTier      string
+	provider         string
 }
 
 func mergeProjectedAccountWindowStats(
@@ -90,6 +91,7 @@ func mergeProjectedAccountWindowStats(
 		pricing_model_value,
 		context_threshold_tokens_value,
 		coalesce(service_tier, ''),
+		coalesce(provider, ''),
 		count(*),
 		coalesce(sum(case when failed = 0 then 1 else 0 end), 0),
 		coalesce(sum(case when failed = 1 then 1 else 0 end), 0),
@@ -107,7 +109,7 @@ func mergeProjectedAccountWindowStats(
 		max(timestamp_ms)
 	from banded_events
 		group by request_index, analytics_model, billing_model_value, pricing_model_value,
-		context_threshold_tokens_value, coalesce(service_tier, '')`, monitoringBandedProjectedEventsCTE(source))
+		context_threshold_tokens_value, coalesce(service_tier, ''), coalesce(provider, '')`, monitoringBandedProjectedEventsCTE(source))
 	args = appendLongContextThresholdArgs(args)
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -158,6 +160,7 @@ func mergeStoredAccountWindowStats(
 		d.pricing_model,
 		d.context_threshold_tokens,
 		coalesce(d.service_tier, ''),
+		coalesce(nullif(d.auth_provider_snapshot, ''), d.provider, ''),
 		coalesce(sum(d.calls), 0),
 		coalesce(sum(case when d.failed = 0 then d.calls else 0 end), 0),
 		coalesce(sum(case when d.failed = 1 then d.calls else 0 end), 0),
@@ -189,7 +192,7 @@ func mergeStoredAccountWindowStats(
 			)
 		)
 	group by w.request_index, d.model, d.billing_model, d.pricing_model,
-		d.context_threshold_tokens, coalesce(d.service_tier, '')`, args...)
+		d.context_threshold_tokens, coalesce(d.service_tier, ''), coalesce(nullif(d.auth_provider_snapshot, ''), d.provider, '')`, args...)
 	if err != nil {
 		return err
 	}
@@ -207,6 +210,7 @@ func mergeAccountWindowStatRows(rows *sql.Rows, grouped map[accountWindowStatKey
 			&stat.PricingModel,
 			&stat.ContextThresholdTokens,
 			&stat.ServiceTier,
+			&stat.Provider,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.FailureCalls,
@@ -232,6 +236,7 @@ func mergeAccountWindowStatRows(rows *sql.Rows, grouped map[accountWindowStatKey
 			pricingModel:     stat.PricingModel,
 			contextThreshold: stat.ContextThresholdTokens,
 			serviceTier:      stat.ServiceTier,
+			provider:         stat.Provider,
 		}
 		current := grouped[key]
 		if current == nil {
@@ -316,7 +321,7 @@ func accountWindowEventSourceSQL(
 		values ` + strings.Join(values, ",") + `
 	)
 	select
-		w.request_index, p.requested_model as model, p.analytics_model, p.resolved_model, p.service_tier, p.failed,
+		w.request_index, p.requested_model as model, p.analytics_model, p.resolved_model, p.service_tier, coalesce(nullif(p.auth_provider_snapshot, ''), p.provider, '') as provider, p.failed,
 		p.normalized_total_input_tokens, p.output_tokens, p.cached_tokens,
 		p.cache_tokens, p.cache_read_tokens, p.cache_creation_tokens,
 		p.total_tokens, p.timestamp_ms
@@ -345,7 +350,7 @@ func accountWindowEventSourceSQL(
 	union all
 	select
 		w.request_index, ` + usageidentity.SQLEffectiveRequestedModelExpression("e.model", "e.requested_model") + `, ` + usageidentity.SQLRequestAnalyticsModelExpression("e.model", "e.requested_model") + `, coalesce(e.resolved_model, ''),
-		coalesce(e.service_tier, ''), coalesce(e.failed, 0),
+		coalesce(e.service_tier, ''), coalesce(nullif(e.auth_provider_snapshot, ''), e.provider, ''), coalesce(e.failed, 0),
 		coalesce(e.normalized_total_input_tokens, e.input_tokens, 0),
 		coalesce(e.output_tokens, 0), coalesce(e.cached_tokens, 0),
 		coalesce(e.cache_tokens, 0), coalesce(e.cache_read_tokens, 0),

--- a/apps/manager-server/internal/repository/usagemonitoring/core_stats_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/core_stats_read.go
@@ -22,6 +22,7 @@ type dailyModelStatKey struct {
 	pricingModel     string
 	contextThreshold int64
 	serviceTier      string
+	provider         string
 }
 
 func loadDailyAggregate(
@@ -294,7 +295,7 @@ func mergeStoredModelStats(
 	conditions, args := storedStatsConditions(filter, revision, fromMS, toMS)
 	rows, err := tx.QueryContext(ctx, `select
 		model, billing_model, pricing_model, context_threshold_tokens,
-		service_tier, sum(calls),
+		service_tier, coalesce(nullif(auth_provider_snapshot, ''), provider, '') as effective_provider, sum(calls),
 		sum(case when failed = 0 then calls else 0 end),
 		sum(input_tokens), sum(output_tokens), sum(reasoning_tokens),
 		sum(cached_tokens), sum(cache_read_tokens), sum(cache_creation_tokens),
@@ -304,7 +305,7 @@ func mergeStoredModelStats(
 	from usage_monitoring_account_daily_rollups_v1
 	where `+strings.Join(conditions, " and ")+`
 	group by model, billing_model, pricing_model, context_threshold_tokens,
-		service_tier`, args...)
+		service_tier, coalesce(nullif(auth_provider_snapshot, ''), provider, '')`, args...)
 	if err != nil {
 		return err
 	}
@@ -328,12 +329,12 @@ func mergeProjectedModelStats(
 	source, args := filteredEventSourceSQL(
 		filter,
 		projectionCoverageEventID,
-		`p.requested_model as model, p.analytics_model, p.resolved_model, p.service_tier, p.failed,
+		`p.requested_model as model, p.analytics_model, p.resolved_model, p.service_tier, coalesce(nullif(p.auth_provider_snapshot, ''), p.provider, '') as provider, p.failed,
 		p.normalized_total_input_tokens, p.output_tokens, p.reasoning_tokens,
 		p.cached_tokens, p.cache_tokens, p.cache_read_tokens,
 		p.cache_creation_tokens, p.total_tokens`,
 		usageidentity.SQLEffectiveRequestedModelExpression("e.model", "e.requested_model")+`, `+usageidentity.SQLRequestAnalyticsModelExpression("e.model", "e.requested_model")+`, coalesce(e.resolved_model, ''),
-		coalesce(e.service_tier, ''), coalesce(e.failed, 0),
+		coalesce(e.service_tier, ''), coalesce(nullif(e.auth_provider_snapshot, ''), e.provider, ''), coalesce(e.failed, 0),
 		coalesce(e.normalized_total_input_tokens, e.input_tokens, 0),
 		coalesce(e.output_tokens, 0), coalesce(e.reasoning_tokens, 0),
 		coalesce(e.cached_tokens, 0), coalesce(e.cache_tokens, 0),
@@ -348,7 +349,7 @@ func mergeProjectedModelStats(
 	query := fmt.Sprintf(`%s
 	select
 		analytics_model, billing_model_value, pricing_model_value,
-		context_threshold_tokens_value, service_tier,
+		context_threshold_tokens_value, service_tier, provider,
 		count(*), coalesce(sum(case when failed = 0 then 1 else 0 end), 0),
 		coalesce(sum(normalized_total_input_tokens), 0),
 		coalesce(sum(output_tokens), 0), coalesce(sum(reasoning_tokens), 0),
@@ -362,7 +363,7 @@ func mergeProjectedModelStats(
 		coalesce(sum(total_tokens), 0)
 	from banded_events
 	group by analytics_model, billing_model_value, pricing_model_value,
-		context_threshold_tokens_value, service_tier`, monitoringBandedProjectedEventsCTE(source))
+		context_threshold_tokens_value, service_tier, provider`, monitoringBandedProjectedEventsCTE(source))
 	args = appendLongContextThresholdArgs(args)
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -381,6 +382,7 @@ func scanDailyModelStats(rows *sql.Rows, grouped map[dailyModelStatKey]*ModelSta
 			&row.PricingModel,
 			&row.ContextThresholdTokens,
 			&row.ServiceTier,
+			&row.Provider,
 			&row.Calls,
 			&row.SuccessCalls,
 			&row.InputTokens,
@@ -404,6 +406,7 @@ func scanDailyModelStats(rows *sql.Rows, grouped map[dailyModelStatKey]*ModelSta
 			pricingModel:     row.PricingModel,
 			contextThreshold: row.ContextThresholdTokens,
 			serviceTier:      row.ServiceTier,
+			provider:         row.Provider,
 		}
 		entry := grouped[key]
 		if entry == nil {
@@ -438,19 +441,21 @@ func sortedDailyModelStats(grouped map[dailyModelStatKey]*ModelStat) []ModelStat
 		if result[i].Calls != result[j].Calls {
 			return result[i].Calls > result[j].Calls
 		}
-		left := fmt.Sprintf("%s\x00%s\x00%s\x00%020d\x00%s",
+		left := fmt.Sprintf("%s\x00%s\x00%s\x00%020d\x00%s\x00%s",
 			result[i].Model,
 			result[i].BillingModel,
 			result[i].PricingModel,
 			result[i].ContextThresholdTokens,
 			result[i].ServiceTier,
+			result[i].Provider,
 		)
-		right := fmt.Sprintf("%s\x00%s\x00%s\x00%020d\x00%s",
+		right := fmt.Sprintf("%s\x00%s\x00%s\x00%020d\x00%s\x00%s",
 			result[j].Model,
 			result[j].BillingModel,
 			result[j].PricingModel,
 			result[j].ContextThresholdTokens,
 			result[j].ServiceTier,
+			result[j].Provider,
 		)
 		return left < right
 	})

--- a/apps/manager-server/internal/repository/usagemonitoring/event_stats_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/event_stats_read.go
@@ -137,12 +137,12 @@ func (r *repository) LoadModelStats(ctx context.Context, filter AnalyticsFilter)
 	source, args := filteredEventSourceSQL(
 		filter,
 		state.CoverageEventID,
-		`p.requested_model as model, p.analytics_model, p.resolved_model, p.service_tier, p.failed,
+		`p.requested_model as model, p.analytics_model, p.resolved_model, p.service_tier, coalesce(nullif(p.auth_provider_snapshot, ''), p.provider, '') as provider, p.failed,
 		p.normalized_total_input_tokens, p.output_tokens, p.reasoning_tokens,
 		p.cached_tokens, p.cache_tokens, p.cache_read_tokens,
 		p.cache_creation_tokens, p.total_tokens`,
 		usageidentity.SQLEffectiveRequestedModelExpression("e.model", "e.requested_model")+`, `+usageidentity.SQLRequestAnalyticsModelExpression("e.model", "e.requested_model")+`, coalesce(e.resolved_model, ''),
-		coalesce(e.service_tier, ''), coalesce(e.failed, 0),
+		coalesce(e.service_tier, ''), coalesce(nullif(e.auth_provider_snapshot, ''), e.provider, ''), coalesce(e.failed, 0),
 		coalesce(e.normalized_total_input_tokens, e.input_tokens, 0),
 		coalesce(e.output_tokens, 0), coalesce(e.reasoning_tokens, 0),
 		coalesce(e.cached_tokens, 0), coalesce(e.cache_tokens, 0),
@@ -181,6 +181,7 @@ func (r *repository) LoadModelStats(ctx context.Context, filter AnalyticsFilter)
 		pricing_model_value,
 		context_threshold_tokens_value,
 		service_tier,
+		provider,
 		count(*),
 		coalesce(sum(case when failed = 0 then 1 else 0 end), 0),
 		coalesce(sum(normalized_total_input_tokens), 0),
@@ -197,7 +198,7 @@ func (r *repository) LoadModelStats(ctx context.Context, filter AnalyticsFilter)
 		coalesce(sum(total_tokens), 0)
 	from banded_events
 		group by analytics_model, billing_model_value, pricing_model_value,
-		context_threshold_tokens_value, service_tier
+		context_threshold_tokens_value, service_tier, provider
 	order by count(*) desc`, source, model.ModelPriceBaseContextThreshold, usage.LongContextInputTokenThreshold)
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -213,6 +214,7 @@ func (r *repository) LoadModelStats(ctx context.Context, filter AnalyticsFilter)
 			&stat.PricingModel,
 			&stat.ContextThresholdTokens,
 			&stat.ServiceTier,
+			&stat.Provider,
 			&stat.Calls,
 			&stat.SuccessCalls,
 			&stat.InputTokens,

--- a/apps/manager-server/internal/service/dashboard/service.go
+++ b/apps/manager-server/internal/service/dashboard/service.go
@@ -824,6 +824,7 @@ func aggregateModelStats(stats []store.ModelStat, prices map[string]store.ModelP
 func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		PricingModel:            stat.PricingModel,
+		Provider:                stat.Provider,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,
 		OutputTokens:            stat.OutputTokens,
@@ -840,6 +841,7 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
+		Provider:                stat.AuthProviderSnapshot,
 		PricingModel:            stat.PricingModel,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,

--- a/apps/manager-server/internal/service/modelprice/service.go
+++ b/apps/manager-server/internal/service/modelprice/service.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
 
@@ -39,6 +40,10 @@ const defaultSyncProxyResolutionTimeout = 5 * time.Second
 
 type UpdateRequest struct {
 	Prices map[string]store.ModelPrice `json:"prices"`
+}
+
+type FastBillingSettingsResponse struct {
+	Settings store.FastBillingSettings `json:"settings"`
 }
 
 type SyncRequest struct {
@@ -268,6 +273,22 @@ func newMultiSource(
 
 func (s *Service) List(ctx context.Context) (map[string]store.ModelPrice, error) {
 	return s.store.LoadModelPrices(ctx)
+}
+
+func (s *Service) FastBillingSettings(ctx context.Context) (store.FastBillingSettings, error) {
+	settings, err := s.store.LoadFastBillingSettings(ctx)
+	if err == nil {
+		pricing.SetFastBillingSettings(settings)
+	}
+	return settings, err
+}
+
+func (s *Service) UpdateFastBillingSettings(ctx context.Context, settings store.FastBillingSettings) (store.FastBillingSettings, error) {
+	saved, err := s.store.SaveFastBillingSettings(ctx, settings)
+	if err == nil {
+		pricing.SetFastBillingSettings(saved)
+	}
+	return saved, err
 }
 
 func (s *Service) UsageSummary(ctx context.Context, limit int) (store.ModelUsageSummary, error) {

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -3513,6 +3513,7 @@ func buildAccountHistoryTotals(rows []store.AccountHistoryRollupRow, prices map[
 			[]string{row.BillingModel, row.Model},
 			row.ServiceTier,
 			pricing.ModelTokens{
+				Provider:                row.AuthProviderSnapshot,
 				InputTokens:             row.InputTokens,
 				OutputTokens:            row.OutputTokens,
 				CachedTokens:            row.CachedTokens,
@@ -3552,6 +3553,7 @@ func buildPricingAccountHistoryTotals(rows []store.UsagePricingAccountRow, price
 			[]string{row.BillingModel, row.Model},
 			row.ServiceTier,
 			pricing.ModelTokens{
+				Provider:                row.AuthProviderSnapshot,
 				PricingModel:            row.PricingModel,
 				ContextThresholdTokens:  row.ContextThresholdTokens,
 				InputTokens:             row.InputTokens,
@@ -3810,6 +3812,7 @@ func buildAccountWindowUsageTotals(rows []store.AccountWindowModelStat, prices m
 			[]string{row.BillingModel, row.Model},
 			row.ServiceTier,
 			pricing.ModelTokens{
+				Provider:                row.Provider,
 				PricingModel:            row.PricingModel,
 				ContextThresholdTokens:  row.ContextThresholdTokens,
 				InputTokens:             row.InputTokens,
@@ -3860,6 +3863,7 @@ func sumCost(stats []store.ModelStat, prices map[string]store.ModelPrice) float6
 func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
 		PricingModel:            stat.PricingModel,
+		Provider:                stat.Provider,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,
 		OutputTokens:            stat.OutputTokens,
@@ -3876,6 +3880,7 @@ func costForStat(stat store.ModelStat, prices map[string]store.ModelPrice) float
 
 func costForTimelinePoint(point store.TimelinePoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
+		Provider:                point.Provider,
 		PricingModel:            point.PricingModel,
 		ContextThresholdTokens:  point.ContextThresholdTokens,
 		InputTokens:             point.InputTokens,
@@ -3893,6 +3898,7 @@ func costForTimelinePoint(point store.TimelinePoint, prices map[string]store.Mod
 
 func costForHeatmapPoint(point store.HeatmapPoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
+		Provider:                point.Provider,
 		PricingModel:            point.PricingModel,
 		ContextThresholdTokens:  point.ContextThresholdTokens,
 		InputTokens:             point.InputTokens,
@@ -3910,6 +3916,7 @@ func costForHeatmapPoint(point store.HeatmapPoint, prices map[string]store.Model
 
 func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
+		Provider:                stat.AuthProviderSnapshot,
 		PricingModel:            stat.PricingModel,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,
@@ -3927,6 +3934,7 @@ func costForChannelStat(stat store.ChannelModelStat, prices map[string]store.Mod
 
 func costForAccountModelStat(stat store.AccountModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
+		Provider:                stat.Provider,
 		PricingModel:            stat.PricingModel,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,
@@ -3944,6 +3952,7 @@ func costForAccountModelStat(stat store.AccountModelStat, prices map[string]stor
 
 func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
+		Provider:                stat.AuthProviderSnapshot,
 		PricingModel:            stat.PricingModel,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,
@@ -3961,6 +3970,7 @@ func costForAPIKeyModelStat(stat store.APIKeyModelStat, prices map[string]store.
 
 func costForCredentialModelStat(stat store.CredentialModelStat, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{stat.BillingModel, stat.Model}, stat.ServiceTier, pricing.ModelTokens{
+		Provider:                stat.AuthProviderSnapshot,
 		PricingModel:            stat.PricingModel,
 		ContextThresholdTokens:  stat.ContextThresholdTokens,
 		InputTokens:             stat.InputTokens,
@@ -3978,6 +3988,7 @@ func costForCredentialModelStat(stat store.CredentialModelStat, prices map[strin
 
 func costForCredentialTimelinePoint(point store.CredentialTimelinePoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
+		Provider:                point.AuthProviderSnapshot,
 		PricingModel:            point.PricingModel,
 		ContextThresholdTokens:  point.ContextThresholdTokens,
 		InputTokens:             point.InputTokens,
@@ -3995,6 +4006,7 @@ func costForCredentialTimelinePoint(point store.CredentialTimelinePoint, prices 
 
 func costForAPIKeyTimelinePoint(point store.APIKeyTimelinePoint, prices map[string]store.ModelPrice) float64 {
 	return pricing.CostForModelCandidatesWithServiceTier([]string{point.BillingModel, point.Model}, point.ServiceTier, pricing.ModelTokens{
+		Provider:                point.Provider,
 		PricingModel:            point.PricingModel,
 		ContextThresholdTokens:  point.ContextThresholdTokens,
 		InputTokens:             point.InputTokens,

--- a/apps/manager-server/internal/service/pricing/cost.go
+++ b/apps/manager-server/internal/service/pricing/cost.go
@@ -3,6 +3,7 @@ package pricing
 
 import (
 	"strings"
+	"sync/atomic"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 )
@@ -15,6 +16,8 @@ const PerMillion = 1_000_000.0
 // fine-grained cache_read/cache_creation values have already been removed.
 type ModelTokens struct {
 	PricingModel            string
+	Provider                string
+	FastBillingSettings     *model.FastBillingSettings
 	ContextThresholdTokens  int64
 	InputTokens             int64
 	OutputTokens            int64
@@ -26,6 +29,20 @@ type ModelTokens struct {
 	LongCachedTokens        int64
 	LongCacheReadTokens     int64
 	LongCacheCreationTokens int64
+}
+
+var fastBillingSettings atomic.Value
+
+func init() {
+	fastBillingSettings.Store(model.DefaultFastBillingSettings())
+}
+
+func SetFastBillingSettings(settings model.FastBillingSettings) {
+	fastBillingSettings.Store(model.NormalizeFastBillingSettings(settings))
+}
+
+func FastBillingSettings() model.FastBillingSettings {
+	return fastBillingSettings.Load().(model.FastBillingSettings)
 }
 
 // CostForModel computes the dollar cost for a single (model, tokens) pair.
@@ -274,6 +291,18 @@ func supportsLongContextPremium(modelName string) bool {
 }
 
 func costForPriceWithServiceTier(modelName, serviceTier string, tokens ModelTokens, price model.ModelPrice) float64 {
+	settings := FastBillingSettings()
+	if tokens.FastBillingSettings != nil {
+		settings = model.NormalizeFastBillingSettings(*tokens.FastBillingSettings)
+	}
+	if isFastServiceTier(serviceTier) && isGPT56Model(modelName) {
+		switch settings.ResolveMode(tokens.Provider) {
+		case model.FastBillingModeCodexCredits:
+			return costForPrice(modelName, tokens, price) * 2.5
+		case model.FastBillingModeAPIPriority:
+			return costForPrice(modelName, tokens, price) * 2
+		}
+	}
 	if activeContextTier(tokens, price) {
 		return costForPrice(modelName, tokens, price)
 	}
@@ -297,6 +326,11 @@ func costForPriceWithServiceTier(modelName, serviceTier string, tokens ModelToke
 		return costForPriceWithLegacyLongContext(modelName, tokens, effectivePrice, len(price.ContextTiers) == 0)
 	}
 	return costForPrice(modelName, tokens, price) * ServiceTierMultiplier(modelName, serviceTier)
+}
+
+func isFastServiceTier(serviceTier string) bool {
+	tier := strings.ToLower(strings.TrimSpace(serviceTier))
+	return tier == "priority" || tier == "fast"
 }
 
 func splitLegacyLongContextTokens(tokens ModelTokens) (ModelTokens, ModelTokens) {

--- a/apps/manager-server/internal/service/pricing/cost_test.go
+++ b/apps/manager-server/internal/service/pricing/cost_test.go
@@ -132,7 +132,7 @@ func TestContextTierOverridesLegacyLongContextPricing(t *testing.T) {
 	}
 }
 
-func TestContextTierDoesNotStackPriorityMultiplier(t *testing.T) {
+func TestGPT56ContextTierStacksAPIPriorityMultiplier(t *testing.T) {
 	prices := map[string]model.ModelPrice{
 		"gpt-5.6-sol": {
 			Prompt: 5, Completion: 30,
@@ -151,8 +151,8 @@ func TestContextTierDoesNotStackPriorityMultiplier(t *testing.T) {
 	}
 	standard := CostForModelWithServiceTier("gpt-5.6-sol", "default", tokens, prices)
 	priority := CostForModelWithServiceTier("gpt-5.6-sol", "priority", tokens, prices)
-	if math.Abs(priority-standard) > 0.000001 {
-		t.Fatalf("priority context-tier cost = %v, want standard context-tier cost %v", priority, standard)
+	if math.Abs(priority-standard*2) > 0.000001 {
+		t.Fatalf("priority context-tier cost = %v, want %v", priority, standard*2)
 	}
 }
 
@@ -588,12 +588,13 @@ func TestLongContextPremiumCoversGPT54AndGPT55(t *testing.T) {
 	}
 }
 
-func TestLongContextDoesNotStackPriorityMultiplier(t *testing.T) {
-	tokens := ModelTokens{InputTokens: 300_000, OutputTokens: 100_000, LongInputTokens: 300_000, LongOutputTokens: 100_000}
+func TestGPT56APIPriorityStacksOnLongContext(t *testing.T) {
+	settings := model.FastBillingSettings{Mode: model.FastBillingModeAPIPriority}
+	tokens := ModelTokens{InputTokens: 300_000, OutputTokens: 100_000, LongInputTokens: 300_000, LongOutputTokens: 100_000, FastBillingSettings: &settings}
 	standard := CostForModelWithServiceTier("gpt-5.6-luna", "default", tokens, nil)
 	priority := CostForModelWithServiceTier("gpt-5.6-luna", "priority", tokens, nil)
-	if math.Abs(priority-standard) > 0.000001 {
-		t.Fatalf("priority long cost = %v, want standard long cost %v", priority, standard)
+	if math.Abs(priority-standard*2) > 0.000001 {
+		t.Fatalf("priority long cost = %v, want %v", priority, standard*2)
 	}
 }
 
@@ -629,5 +630,53 @@ func BenchmarkCostForModelWithExplicitServiceTier(b *testing.B) {
 	}
 	if cost == 0 {
 		b.Fatal("cost = 0")
+	}
+}
+
+func TestCodexCreditsFastBillingUsesTwoPointFiveMultiplier(t *testing.T) {
+	prices := map[string]model.ModelPrice{
+		"gpt-5.6-sol": {
+			Prompt: 5, Completion: 30, Cache: 0.5,
+			ContextTiers: []model.ModelPriceContextTier{{
+				ThresholdTokens: 272_000, Prompt: 10, Completion: 45,
+				PromptConfigured: true, CompletionConfigured: true,
+			}},
+			ServiceTiers: []model.ModelPriceServiceTier{{
+				Mode: "fast", ServiceTier: "priority", Prompt: 10, Completion: 60,
+				PromptConfigured: true, CompletionConfigured: true,
+			}},
+		},
+	}
+	settings := model.FastBillingSettings{Mode: model.FastBillingModeCodexCredits}
+	short := ModelTokens{InputTokens: 100_000, OutputTokens: 10_000, FastBillingSettings: &settings}
+	standardShort := CostForModelWithServiceTier("gpt-5.6-sol", "auto", short, prices)
+	fastShort := CostForModelWithServiceTier("gpt-5.6-sol", "priority", short, prices)
+	if math.Abs(fastShort-standardShort*2.5) > 0.000001 {
+		t.Fatalf("short fast cost = %v, want %v", fastShort, standardShort*2.5)
+	}
+
+	long := ModelTokens{
+		InputTokens: 300_000, OutputTokens: 10_000,
+		LongInputTokens: 300_000, LongOutputTokens: 10_000,
+		ContextThresholdTokens: 272_000,
+		FastBillingSettings:    &settings,
+	}
+	standardLong := CostForModelWithServiceTier("gpt-5.6-sol", "auto", long, prices)
+	fastLong := CostForModelWithServiceTier("gpt-5.6-sol", "priority", long, prices)
+	if math.Abs(fastLong-standardLong*2.5) > 0.000001 {
+		t.Fatalf("long fast cost = %v, want %v", fastLong, standardLong*2.5)
+	}
+}
+
+func TestAutomaticFastBillingUsesProvider(t *testing.T) {
+	prices := map[string]model.ModelPrice{"gpt-5.6-sol": {Prompt: 5, Completion: 30, Cache: 0.5}}
+	settings := model.FastBillingSettings{Mode: model.FastBillingModeAutomatic}
+	codexTokens := ModelTokens{InputTokens: 1_000_000, Provider: "codex", FastBillingSettings: &settings}
+	apiTokens := ModelTokens{InputTokens: 1_000_000, Provider: "openai", FastBillingSettings: &settings}
+	if got := CostForModelWithServiceTier("gpt-5.6-sol", "priority", codexTokens, prices); math.Abs(got-12.5) > 0.000001 {
+		t.Fatalf("codex automatic cost = %v, want 12.5", got)
+	}
+	if got := CostForModelWithServiceTier("gpt-5.6-sol", "priority", apiTokens, prices); math.Abs(got-10) > 0.000001 {
+		t.Fatalf("api automatic cost = %v, want 10", got)
 	}
 }

--- a/apps/manager-server/internal/service/usagehourly/reader.go
+++ b/apps/manager-server/internal/service/usagehourly/reader.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -118,7 +119,7 @@ func SupportsAnalyticsFilter(filter store.AnalyticsFilter) bool {
 }
 
 func (r *Reader) loadRows(ctx context.Context, filter store.AnalyticsFilter, dashboardTimelineReady bool, analyticsTimelineReady bool) (Snapshot, bool) {
-	if !r.enabled {
+	if !r.enabled || pricing.FastBillingSettings().ProviderAware() {
 		return Snapshot{}, false
 	}
 	if filter.FromMS >= filter.ToMS {

--- a/apps/manager-server/internal/service/usagemonitoring/reader.go
+++ b/apps/manager-server/internal/service/usagemonitoring/reader.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	monitoringrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usagemonitoring"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
 
@@ -35,7 +36,7 @@ func PrefersEventProjection(filter store.AnalyticsFilter) bool {
 }
 
 func (r *Reader) AccountStats(ctx context.Context, filter store.AnalyticsFilter) ([]store.AccountModelStat, bool) {
-	if r == nil || r.store == nil {
+	if r == nil || r.store == nil || pricing.FastBillingSettings().ProviderAware() {
 		return nil, false
 	}
 	if !monitoringrepo.SupportsEventProjectionFilter(filter) {
@@ -54,7 +55,7 @@ func (r *Reader) AccountStats(ctx context.Context, filter store.AnalyticsFilter)
 }
 
 func (r *Reader) AccountWindowStats(ctx context.Context, windows []store.AccountWindowUsageQuery) ([]store.AccountWindowModelStat, bool) {
-	if r == nil || r.store == nil {
+	if r == nil || r.store == nil || pricing.FastBillingSettings().ProviderAware() {
 		return nil, false
 	}
 	rows, state, available, err := r.store.UsageMonitoringAccountWindowStats(ctx, windows)
@@ -70,7 +71,7 @@ func (r *Reader) AccountWindowStats(ctx context.Context, windows []store.Account
 }
 
 func (r *Reader) APIKeyStats(ctx context.Context, filter store.AnalyticsFilter) ([]store.APIKeyModelStat, bool) {
-	if r == nil || r.store == nil {
+	if r == nil || r.store == nil || pricing.FastBillingSettings().ProviderAware() {
 		return nil, false
 	}
 	if !monitoringrepo.SupportsEventProjectionFilter(filter) {
@@ -146,7 +147,7 @@ func (r *Reader) Aggregate(ctx context.Context, filter store.AnalyticsFilter) (s
 }
 
 func (r *Reader) ModelStats(ctx context.Context, filter store.AnalyticsFilter) ([]store.ModelStat, bool) {
-	if r == nil || r.store == nil {
+	if r == nil || r.store == nil || pricing.FastBillingSettings().ProviderAware() {
 		return nil, false
 	}
 	if !monitoringrepo.SupportsEventProjectionFilter(filter) {

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -47,6 +47,7 @@ type ModelPrice = model.ModelPrice
 type ModelPriceContextTier = model.ModelPriceContextTier
 type ModelPriceServiceTier = model.ModelPriceServiceTier
 type ModelPriceSyncResult = model.ModelPriceSyncResult
+type FastBillingSettings = model.FastBillingSettings
 type ModelUsageStat = model.ModelUsageStat
 type ModelUsageSummary = model.ModelUsageSummary
 type APIKeyAlias = model.APIKeyAlias
@@ -215,6 +216,15 @@ func (s *Store) SaveBootstrapState(ctx context.Context, state BootstrapState) er
 
 func (s *Store) LoadBootstrapState(ctx context.Context) (BootstrapState, bool, error) {
 	return s.Settings.LoadBootstrapState(ctx)
+}
+
+func (s *Store) SaveFastBillingSettings(ctx context.Context, settings model.FastBillingSettings) (model.FastBillingSettings, error) {
+	return s.Settings.SaveFastBillingSettings(ctx, settings)
+}
+
+func (s *Store) LoadFastBillingSettings(ctx context.Context) (model.FastBillingSettings, error) {
+	settings, _, err := s.Settings.LoadFastBillingSettings(ctx)
+	return settings, err
 }
 
 func (s *Store) HasHistoricalData(ctx context.Context) (bool, error) {

--- a/apps/web/src/features/monitoring/ModelPricesPage.module.scss
+++ b/apps/web/src/features/monitoring/ModelPricesPage.module.scss
@@ -476,3 +476,64 @@
     grid-template-columns: 1fr;
   }
 }
+
+.fastBillingPanel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 360px);
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--pricing-line);
+  border-radius: 14px;
+  background: var(--pricing-surface);
+  box-shadow: var(--shadow);
+}
+
+.fastBillingPanel p,
+.fastBillingControl small {
+  margin: 4px 0 0;
+  color: var(--pricing-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.fastBillingControl {
+  display: grid;
+  gap: 4px;
+}
+
+@media (max-width: 720px) {
+  .fastBillingPanel {
+    grid-template-columns: 1fr;
+  }
+}
+
+.fastBillingOverrides {
+  display: grid;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.fastBillingOverrideRow {
+  display: grid;
+  grid-template-columns: minmax(110px, 1fr) minmax(150px, 1fr) 32px;
+  align-items: center;
+  gap: 6px;
+}
+
+.fastBillingOverrideRow :global(.form-group) {
+  margin: 0;
+}
+
+.fastBillingActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+@media (max-width: 520px) {
+  .fastBillingOverrideRow {
+    grid-template-columns: 1fr 1fr 32px;
+  }
+}

--- a/apps/web/src/features/monitoring/ModelPricesPage.tsx
+++ b/apps/web/src/features/monitoring/ModelPricesPage.tsx
@@ -3,10 +3,13 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
 import { IconPencil, IconSearch, IconTrash2, IconX } from '@/components/ui/icons';
 import { usePanelFeatureAvailability } from '@/hooks/usePanelFeatureAvailability';
 import {
   usageServiceApi,
+  type FastBillingMode,
+  type FastBillingSettings,
   type ModelPriceSyncCandidate,
   type ModelPriceSyncResponse,
   type ModelPriceUsageSummaryResponse,
@@ -61,6 +64,10 @@ export function ModelPricesPage() {
   const [selectedCandidates, setSelectedCandidates] = useState<Record<string, string>>({});
   const [draft, setDraft] = useState<PriceDraft>(() => createEmptyPriceDraft());
   const [manualEditorOpen, setManualEditorOpen] = useState(false);
+  const [fastBillingSettings, setFastBillingSettings] = useState<FastBillingSettings>({
+    mode: 'api_priority',
+  });
+  const [fastBillingSaving, setFastBillingSaving] = useState(false);
   const modelPriceServiceBase = featureAvailability.modelPricesAvailable
     ? featureAvailability.managerServiceBase
     : '';
@@ -126,6 +133,64 @@ export function ModelPricesPage() {
 
     return () => controller.abort();
   }, [managementKey, modelPriceServiceBase]);
+
+  useEffect(() => {
+    if (!modelPriceServiceBase) return;
+    void usageServiceApi
+      .getFastBillingSettings(modelPriceServiceBase, managementKey)
+      .then((response) => setFastBillingSettings(response.settings))
+      .catch(() => undefined);
+  }, [managementKey, modelPriceServiceBase]);
+
+  const handleSaveFastBillingSettings = async () => {
+    setFastBillingSaving(true);
+    try {
+      const response = await usageServiceApi.saveFastBillingSettings(
+        modelPriceServiceBase,
+        fastBillingSettings,
+        managementKey
+      );
+      setFastBillingSettings(response.settings);
+      showNotification(t('model_prices.fast_billing_saved'), 'success');
+    } catch (error: unknown) {
+      showNotification(`${t('model_prices.fast_billing_save_failed')}: ${String(error)}`, 'error');
+    } finally {
+      setFastBillingSaving(false);
+    }
+  };
+
+  const updateFastBillingOverride = (index: number, field: 'provider' | 'mode', value: string) => {
+    setFastBillingSettings((previous) => ({
+      ...previous,
+      providerOverrides: (previous.providerOverrides ?? []).map((override, itemIndex) =>
+        itemIndex === index
+          ? {
+              ...override,
+              [field]: field === 'mode' ? (value as FastBillingMode) : value,
+            }
+          : override
+      ),
+    }));
+  };
+
+  const addFastBillingOverride = () => {
+    setFastBillingSettings((previous) => ({
+      ...previous,
+      providerOverrides: [
+        ...(previous.providerOverrides ?? []),
+        { provider: '', mode: 'api_priority' },
+      ],
+    }));
+  };
+
+  const removeFastBillingOverride = (index: number) => {
+    setFastBillingSettings((previous) => ({
+      ...previous,
+      providerOverrides: (previous.providerOverrides ?? []).filter(
+        (_, itemIndex) => itemIndex !== index
+      ),
+    }));
+  };
 
   const handleSync = async () => {
     if (syncModels.length === 0) {
@@ -246,6 +311,76 @@ export function ModelPricesPage() {
           <Button size="xs" onClick={() => void handleSync()} loading={syncing}>
             {t('usage_stats.model_price_sync')}
           </Button>
+        </div>
+      </section>
+
+      <section className={styles.fastBillingPanel}>
+        <div>
+          <strong>{t('model_prices.fast_billing_title')}</strong>
+          <p>{t('model_prices.fast_billing_hint')}</p>
+        </div>
+        <div className={styles.fastBillingControl}>
+          <Select
+            value={fastBillingSettings.mode}
+            disabled={!modelPriceServiceBase || fastBillingSaving}
+            ariaLabel={t('model_prices.fast_billing_title')}
+            options={[
+              { value: 'api_priority', label: t('model_prices.fast_billing_api') },
+              { value: 'codex_credits', label: t('model_prices.fast_billing_codex') },
+              { value: 'automatic', label: t('model_prices.fast_billing_auto') },
+            ]}
+            onChange={(value) =>
+              setFastBillingSettings((previous) => ({
+                ...previous,
+                mode: value as FastBillingMode,
+              }))
+            }
+          />
+          <small>{t('model_prices.fast_billing_auto_hint')}</small>
+          <div className={styles.fastBillingOverrides}>
+            {(fastBillingSettings.providerOverrides ?? []).map((override, index) => (
+              <div className={styles.fastBillingOverrideRow} key={`${index}-${override.provider}`}>
+                <Input
+                  value={override.provider}
+                  placeholder={t('model_prices.fast_billing_provider_placeholder')}
+                  onChange={(event) =>
+                    updateFastBillingOverride(index, 'provider', event.target.value)
+                  }
+                />
+                <Select
+                  value={override.mode}
+                  ariaLabel={t('model_prices.fast_billing_override_mode')}
+                  options={[
+                    { value: 'api_priority', label: t('model_prices.fast_billing_api') },
+                    { value: 'codex_credits', label: t('model_prices.fast_billing_codex') },
+                  ]}
+                  onChange={(value) => updateFastBillingOverride(index, 'mode', value)}
+                />
+                <button
+                  type="button"
+                  className={styles.iconAction}
+                  title={t('common.delete')}
+                  aria-label={t('common.delete')}
+                  onClick={() => removeFastBillingOverride(index)}
+                >
+                  <IconTrash2 size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+          <div className={styles.fastBillingActions}>
+            <Button size="xs" variant="secondary" onClick={addFastBillingOverride}>
+              {t('model_prices.fast_billing_add_override')}
+            </Button>
+            <Button
+              size="xs"
+              loading={fastBillingSaving}
+              disabled={!modelPriceServiceBase}
+              onClick={() => void handleSaveFastBillingSettings()}
+            >
+              {t('common.save')}
+            </Button>
+          </div>
         </div>
       </section>
 
@@ -413,8 +548,7 @@ export function ModelPricesPage() {
                     candidates.find(
                       (candidate) =>
                         getModelPriceCandidateIdentity(candidate) === requestedCandidateIdentity
-                    ) ??
-                    candidates[0];
+                    ) ?? candidates[0];
                   const selectedCandidateIdentity = selectedCandidate
                     ? getModelPriceCandidateIdentity(selectedCandidate)
                     : '';

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2135,7 +2135,18 @@
     "add_manual": "Add manually",
     "unmatched_title": "Unmatched models",
     "optional_price_placeholder": "Auto when blank",
-    "empty": "No matching model prices"
+    "empty": "No matching model prices",
+    "fast_billing_title": "GPT-5.6 Fast/Priority billing mode",
+    "fast_billing_hint": "Choose how CPAMP estimates GPT-5.6 requests marked fast or priority. Standard requests always remain 1×.",
+    "fast_billing_api": "API Priority · 2×",
+    "fast_billing_codex": "Codex Fast credits · 2.5×",
+    "fast_billing_auto": "Automatic by provider",
+    "fast_billing_auto_hint": "Automatic uses 2.5× for the codex provider and 2× for other providers. Provider overrides are supported by the API.",
+    "fast_billing_saved": "Fast billing mode saved",
+    "fast_billing_save_failed": "Failed to save Fast billing mode",
+    "fast_billing_provider_placeholder": "Provider/channel, e.g. codex",
+    "fast_billing_override_mode": "Provider billing mode",
+    "fast_billing_add_override": "Add provider override"
   },
   "usage_stats": {
     "title": "Usage Statistics",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -2135,7 +2135,18 @@
     "add_manual": "Добавить вручную",
     "unmatched_title": "Модели без совпадений",
     "optional_price_placeholder": "Автоматически, если пусто",
-    "empty": "Подходящих цен моделей нет"
+    "empty": "Подходящих цен моделей нет",
+    "fast_billing_title": "Режим тарификации GPT-5.6 Fast/Priority",
+    "fast_billing_hint": "Выберите, как CPAMP оценивает запросы GPT-5.6 fast или priority. Обычные запросы всегда остаются 1×.",
+    "fast_billing_api": "API Priority · 2×",
+    "fast_billing_codex": "Codex Fast credits · 2.5×",
+    "fast_billing_auto": "Автоматически по провайдеру",
+    "fast_billing_auto_hint": "Автоматический режим использует 2.5× для провайдера codex и 2× для остальных; API поддерживает переопределения.",
+    "fast_billing_saved": "Режим Fast сохранён",
+    "fast_billing_save_failed": "Не удалось сохранить режим Fast",
+    "fast_billing_provider_placeholder": "Провайдер/канал, например codex",
+    "fast_billing_override_mode": "Режим канала",
+    "fast_billing_add_override": "Добавить правило канала"
   },
   "usage_stats": {
     "title": "Статистика использования",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -2135,7 +2135,18 @@
     "add_manual": "手动添加",
     "unmatched_title": "未匹配模型",
     "optional_price_placeholder": "留空时自动计算",
-    "empty": "没有符合条件的模型价格"
+    "empty": "没有符合条件的模型价格",
+    "fast_billing_title": "GPT-5.6 Fast/Priority 计费模式",
+    "fast_billing_hint": "选择 CPAMP 如何估算标记为 fast 或 priority 的 GPT-5.6 请求；普通请求始终保持 1×。",
+    "fast_billing_api": "API Priority · 2×",
+    "fast_billing_codex": "Codex Fast 额度 · 2.5×",
+    "fast_billing_auto": "按提供商自动判断",
+    "fast_billing_auto_hint": "自动模式对 codex 提供商使用 2.5×，其他提供商使用 2×；API 支持提供商覆盖配置。",
+    "fast_billing_saved": "Fast 计费模式已保存",
+    "fast_billing_save_failed": "Fast 计费模式保存失败",
+    "fast_billing_provider_placeholder": "提供商/渠道，例如 codex",
+    "fast_billing_override_mode": "渠道计费模式",
+    "fast_billing_add_override": "添加渠道覆盖"
   },
   "usage_stats": {
     "title": "使用统计",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -2135,7 +2135,18 @@
     "add_manual": "手動新增",
     "unmatched_title": "未匹配模型",
     "optional_price_placeholder": "留空時自動計算",
-    "empty": "沒有符合條件的模型價格"
+    "empty": "沒有符合條件的模型價格",
+    "fast_billing_title": "GPT-5.6 Fast/Priority 計費模式",
+    "fast_billing_hint": "選擇 CPAMP 如何估算標記為 fast 或 priority 的 GPT-5.6 請求；一般請求始終維持 1×。",
+    "fast_billing_api": "API Priority · 2×",
+    "fast_billing_codex": "Codex Fast 額度 · 2.5×",
+    "fast_billing_auto": "依提供者自動判斷",
+    "fast_billing_auto_hint": "自動模式對 codex 提供者使用 2.5×，其他提供者使用 2×；API 支援提供者覆寫設定。",
+    "fast_billing_saved": "Fast 計費模式已儲存",
+    "fast_billing_save_failed": "Fast 計費模式儲存失敗",
+    "fast_billing_provider_placeholder": "提供者/渠道，例如 codex",
+    "fast_billing_override_mode": "渠道計費模式",
+    "fast_billing_add_override": "新增渠道覆寫"
   },
   "usage_stats": {
     "title": "使用統計",

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -364,6 +364,23 @@ export interface ModelPricesResponse {
   prices: Record<string, ModelPrice>;
 }
 
+export type FastBillingMode = 'api_priority' | 'codex_credits' | 'automatic';
+
+export interface FastBillingProviderOverride {
+  provider: string;
+  mode: FastBillingMode;
+}
+
+export interface FastBillingSettings {
+  mode: FastBillingMode;
+  providerOverrides?: FastBillingProviderOverride[];
+  updatedAtMs?: number;
+}
+
+export interface FastBillingSettingsResponse {
+  settings: FastBillingSettings;
+}
+
 export interface ModelPriceUsageStat {
   model: string;
   calls: number;
@@ -466,12 +483,7 @@ export interface UsageImportResponse {
 }
 
 export type UsageImportSessionStatus =
-  | 'uploading'
-  | 'ready'
-  | 'processing'
-  | 'completed'
-  | 'failed'
-  | 'cancelled';
+  'uploading' | 'ready' | 'processing' | 'completed' | 'failed' | 'cancelled';
 
 export interface UsageImportSession {
   id: string;
@@ -929,16 +941,9 @@ export interface MonitoringAccountWindowUsageResponse {
 }
 
 export type AccountQuotaSnapshotWindowMode =
-  | 'fixed'
-  | 'calendar'
-  | 'rolling'
-  | 'non_window'
-  | 'unknown';
+  'fixed' | 'calendar' | 'rolling' | 'non_window' | 'unknown';
 export type AccountQuotaSnapshotSource =
-  | 'api_query'
-  | 'response_header'
-  | 'response_body'
-  | 'inspection';
+  'api_query' | 'response_header' | 'response_body' | 'inspection';
 export type AccountQuotaSnapshotBoundaryAccuracy = 'exact' | 'derived' | 'estimated' | 'unknown';
 export type AccountQuotaSnapshotInventoryMode = 'complete' | 'partial' | 'delta';
 
@@ -2853,6 +2858,48 @@ export const usageServiceApi = {
     return withUsageServiceError(async () => {
       const response = await axios.get<ModelPricesResponse>(
         buildUrl(base, '/v0/management/model-prices'),
+        {
+          timeout: USAGE_SERVICE_TIMEOUT_MS,
+          headers: authHeaders(managementKey),
+        }
+      );
+      return response.data;
+    });
+  },
+
+  getFastBillingSettings: async (
+    base: string,
+    managementKey?: string
+  ): Promise<FastBillingSettingsResponse> => {
+    if (__DEMO_SITE__ && isDemoMode()) {
+      return { settings: { mode: 'api_priority' } };
+    }
+
+    return withUsageServiceError(async () => {
+      const response = await axios.get<FastBillingSettingsResponse>(
+        buildUrl(base, '/v0/management/model-prices/fast-billing-settings'),
+        {
+          timeout: USAGE_SERVICE_TIMEOUT_MS,
+          headers: authHeaders(managementKey),
+        }
+      );
+      return response.data;
+    });
+  },
+
+  saveFastBillingSettings: async (
+    base: string,
+    settings: FastBillingSettings,
+    managementKey?: string
+  ): Promise<FastBillingSettingsResponse> => {
+    if (__DEMO_SITE__ && isDemoMode()) {
+      return { settings };
+    }
+
+    return withUsageServiceError(async () => {
+      const response = await axios.put<FastBillingSettingsResponse>(
+        buildUrl(base, '/v0/management/model-prices/fast-billing-settings'),
+        { settings },
         {
           timeout: USAGE_SERVICE_TIMEOUT_MS,
           headers: authHeaders(managementKey),


### PR DESCRIPTION
## Summary

Add a configurable GPT-5.6 Fast/Priority billing mode so CPAMP can estimate either API Priority pricing (2×) or Codex Fast subscription credit usage (2.5×). The setting can be global, automatically resolved by CPA provider, or overridden per provider/channel.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add persisted `api_priority`, `codex_credits`, and `automatic` Fast billing modes plus provider overrides.
- Add Manager Server GET/PUT APIs and a model-pricing UI control for selecting the mode and editing channel overrides.
- Preserve provider identity through raw and preaggregated usage paths so automatic/per-provider estimates remain consistent.
- Apply the selected multiplier after GPT-5.6 context pricing, including long-context tiers; standard requests remain 1×.

## User Impact

Users can switch GPT-5.6 Fast cost estimates between API Priority 2× and Codex Fast credits 2.5× without modifying model prices. Mixed deployments can select automatic mode or override individual CPA providers/channels.

## Compatibility / Runtime Notes

- CPA panel mode: no CPA request mutation; this only changes CPAMP local cost estimates.
- Manager Server mode: defaults to the existing API Priority 2× behavior when no setting is saved.
- Full Docker / native packages: setting is stored in the existing SQLite `settings` table; no schema migration is required.

## Data / Security Notes

The setting contains only billing mode names and provider identifiers. No keys, credentials, raw requests, or account data are stored.

## Risk / Rollback

Risk level: Medium

Rollback notes: revert this commit. Existing databases remain compatible because the new setting is an optional row in the current `settings` table.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run type-check
npm --workspace apps/web run lint
npm --workspace apps/web run build
npm --workspace apps/web run test -- src/features/monitoring/modelPricesPageUiState.test.ts
cd apps/manager-server && go test ./internal/repository/usageevent ./internal/repository/usagemonitoring ./internal/service/pricing ./internal/service/modelprice ./internal/http/controller/modelprice ./internal/service/dashboard ./internal/service/monitoring ./internal/service/usagehourly ./internal/service/usagemonitoring ./internal/httpapi -count=1
```

Lint completes with one pre-existing `react-refresh/only-export-components` warning in `AccountHealthBadge.tsx` and no errors.

## Screenshots / Recordings

Manual responsive rendering was checked in Chrome against the demo build. Screenshot can be attached during review if requested.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [x] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: updated `apps/docs/manual/model-prices.md`; the feature is scoped to model pricing and does not require a README-level capability entry.

## Related

Refs #98, #415, #458
