### PR TITLE
docs(release): prepare v1.12.0-rc.2

### DIFF
--- a/docs/release-notes/v1.12.0-rc.2-en.md
+++ b/docs/release-notes/v1.12.0-rc.2-en.md
@@ -1,0 +1,41 @@
+# CPA Manager Plus v1.12.0-rc.2
+
+> 17 commits · 108 files changed · +7776 / -767
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-rc.2/docs/release-notes/v1.12.0-rc.2-zh.md)
+
+## Overview
+
+This is the second release candidate for v1.12.0. It fixes reasoning-suffix model normalization across monitoring and usage analytics, proxy-aware provider model discovery, and unified xAI / SuperGrok billing quota evidence. It also improves disabled-credential maintenance, quota-window boundaries, and dashboard version links, while tightening release recovery around exact source, artifact, and remote-state validation.
+
+## Highlights
+
+### Features
+
+- Accounts can refresh quota, edit writable configuration, and open configuration directly for disabled credentials without returning them to request routing.
+- Quota history preserves scheduled window boundaries and attributes the first request after a confirmed early reset to the new window; regular cost estimates use two decimal places while realtime request estimates retain three.
+- Valid Manager and CLIProxyAPI versions on the Dashboard link directly to their matching GitHub Releases, while development and unknown versions remain plain text.
+
+### Fixes
+
+- CPA-supported reasoning suffixes map to a canonical analytics model while preserving the original requested, upstream, billing, and pricing identities; unknown parenthesized aliases remain unchanged.
+- Monitoring, Usage Analytics, Dashboard, filters, and model prices use the appropriate model identity, while realtime requests continue to show the requested and actual upstream models.
+- Provider model discovery and health checks forward the configured request-level proxy, so OpenAI-compatible requests no longer bypass it and unexpectedly use a blocked direct connection.
+- xAI / SuperGrok treats the unified billing response as authoritative and uses legacy responses only to fill missing fields, preventing absent monthly limits from appearing as zero-dollar quota or being overwritten by conflicting legacy values.
+
+### CI / Build
+
+- Add a guarded release-recovery workflow that binds an existing tag, failed run, source SHA, and build artifact before validating the Release, assets, and multi-architecture image state.
+- Preserve valid `false` booleans returned by GitHub APIs and grant the minimum permission needed to read a prepared Draft Release before image publication.
+
+## Upgrade Notes
+
+- This is a prerelease. Stable Docker tags and `latest` are not updated; use the explicit `v1.12.0-rc.2` release assets or image.
+- Manager Server startup migration adds model-identity fields and transactionally rebuilds related aggregates, rollups, and search data. Back up the SQLite database, WAL, SHM, and `data.key` together before upgrading.
+- Request-level provider proxying requires CPA v7.2.130+. Older versions ignore the unsupported field and retain their existing credential proxy, global proxy, or direct-connection behavior.
+- Disabled credentials remain excluded from request routing; quota refresh and configuration maintenance do not re-enable them automatically.
+- The xAI / SuperGrok quota fix requires no configuration or database migration. Browser-local and Manager Server inspection now use the same evidence precedence.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-rc.1...v1.12.0-rc.2

--- a/docs/release-notes/v1.12.0-rc.2-zh.md
+++ b/docs/release-notes/v1.12.0-rc.2-zh.md
@@ -1,0 +1,41 @@
+# CPA Manager Plus v1.12.0-rc.2
+
+> 17 commits · 108 files changed · +7776 / -767
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-rc.2/docs/release-notes/v1.12.0-rc.2-en.md)
+
+## Overview
+
+这是 v1.12.0 的第二个 release candidate，重点修复推理后缀模型在监控与用量分析中的归一化、Provider 模型发现代理和 xAI / SuperGrok 统一计费额度，并完善禁用凭证的维护操作、额度窗口边界与 Dashboard 版本入口。发布恢复流程同时增加严格的来源、产物和远端状态校验。
+
+## Highlights
+
+### Features
+
+- Accounts 支持在不恢复请求路由的前提下为禁用凭证刷新额度、编辑可写配置，并从凭证列表直接打开配置。
+- 额度历史会保留计划窗口边界并正确归属提前重置后的首个请求；普通成本估算保留两位小数，实时请求估算保留三位。
+- Dashboard 中有效的 Manager 和 CLIProxyAPI 版本可直接打开对应的 GitHub Release，开发版和未知版本继续显示为普通文本。
+
+### Fixes
+
+- CPA 支持的推理后缀会归入规范分析模型，同时保留原始请求模型、上游模型、计费模型和定价模型；未知括号别名保持不变。
+- Monitoring、Usage Analytics、Dashboard、筛选和模型价格使用各自正确的模型身份，实时请求继续展示请求模型与实际上游模型。
+- Provider 模型发现和健康检查会转发已配置的请求级代理，OpenAI-compatible 请求不再绕过代理后直接访问受限网络。
+- xAI / SuperGrok 以统一计费响应为权威来源，仅用旧版响应补齐缺失字段，避免缺失月额度被显示为零美元或被冲突旧值覆盖。
+
+### CI / Build
+
+- 增加受保护的发布恢复流程，在发布前绑定既有 tag、失败运行、来源 SHA 和构建产物，并校验 Release、资产和多架构镜像状态。
+- 发布恢复会保留 GitHub API 返回的有效 `false` 布尔值，并以最小权限读取已准备的 Draft Release 后再执行镜像发布。
+
+## Upgrade Notes
+
+- 这是预发布版本；稳定 Docker 标签和 `latest` 不会更新，请显式使用 `v1.12.0-rc.2` 对应的发布资产或镜像。
+- Manager Server 启动迁移会新增模型身份字段并事务性重建相关聚合、rollup 和搜索数据。升级前请同时备份 SQLite 数据库、WAL、SHM 与 `data.key`。
+- Provider 请求级代理需要 CPA v7.2.130+；旧版本会忽略不支持的字段，并保留现有凭证代理、全局代理或直连行为。
+- 禁用凭证仍不会参与请求路由；额度刷新和配置维护不会自动重新启用凭证。
+- xAI / SuperGrok 额度修复不需要配置或数据库迁移，浏览器本地巡检与 Manager Server 巡检会采用相同的证据优先级。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-rc.1...v1.12.0-rc.2

--- a/docs/release-posts/v1.12.0-rc.2-telegram.html
+++ b/docs/release-posts/v1.12.0-rc.2-telegram.html
@@ -1,0 +1,16 @@
+🚀 <b>8 月 14 日 · v1.12.0-rc.2</b>
+
+✨ <b>更新内容</b>
+
+• Monitoring 与 Usage Analytics 会将 CPA 支持的推理后缀归入规范模型，同时保留请求模型和上游模型。
+• Provider 模型发现和健康检查可通过已配置代理访问，避免意外直连受限网络。
+• 禁用凭证无需重新参与请求路由，也可刷新额度并维护可写配置。
+• 额度历史可正确保留计划窗口和提前重置边界，成本精度在各页面保持一致。
+• xAI 与 SuperGrok 优先采用统一计费证据，不再显示缺失字段造成的零美元月额度。
+• Dashboard 中的 Manager 与 CLIProxyAPI 版本可直接打开对应 GitHub Release。
+
+⚠️ <b>注意事项</b>
+
+• 这是预发布版本；稳定 Docker 标签和 <code>latest</code> 不会更新，请显式使用 <code>v1.12.0-rc.2</code> 资产或镜像。
+• Provider 请求级代理需要 CPA v7.2.130+；旧版本会保留现有凭证代理、全局代理或直连行为。
+• Manager Server 启动时会新增模型身份字段并重建相关派生用量数据，升级前请同时备份 SQLite、WAL、SHM 与 <code>data.key</code>。


### PR DESCRIPTION
## Summary

Prepare the reviewed release notes and Telegram announcement for CPA Manager Plus v1.12.0-rc.2.

This release candidate documents canonical reasoning-suffix analytics, proxy-aware provider model discovery, disabled-credential quota controls, quota lifecycle fixes, unified xAI / SuperGrok billing evidence, dashboard release links, and guarded release recovery.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.0-rc.2 release notes with reciprocal tag-pinned links.
- Add the reviewed Telegram HTML announcement used by the release workflow.
- Document the prerelease channel, SQLite backup guidance, CPA v7.2.130+ proxy compatibility, and disabled-credential routing behavior.

## User Impact

Users receive a complete technical and community-facing description of the v1.12.0-rc.2 changes and upgrade considerations. This PR does not change runtime behavior by itself.

## Compatibility / Runtime Notes

- CPA panel mode: No runtime change in this PR; the notes describe browser-local inspection and optional request-level proxy compatibility.
- Manager Server mode: No runtime change in this PR; the notes document the model-identity migration and derived-data rebuild.
- Full Docker / native packages: The RC remains a prerelease and does not update stable or `latest` tags.

## Data / Security Notes

This documentation-only PR introduces no credential, key, database, or runtime configuration changes. The notes require a coordinated SQLite, WAL, SHM, and `data.key` backup before the model-identity migration.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the release documentation commit before promotion or tagging if the frozen release scope changes.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
npm run release:validate -- --tag v1.12.0-rc.2 --content-only
Result: ok=true, prerelease=true; reciprocal note links and Telegram HTML validated.

git diff --check
Result: passed.

SHA-256:
3946f6c2b782db1881b33be85684f3d65fc524e341db793165ac538c9b11392c  docs/release-notes/v1.12.0-rc.2-zh.md
b4558faeec5ea73dc9859973ab4b67a38a827ad72bc95e00e725cacebe2f58a6  docs/release-notes/v1.12.0-rc.2-en.md
83709206cbf1ef497b25943995aecac8c318f2890d9c724a077f17dc7ef928bf  docs/release-posts/v1.12.0-rc.2-telegram.html
```

## Screenshots / Recordings

N/A — documentation-only release preparation.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: This PR adds the versioned bilingual release notes and Telegram announcement required by the release workflow. Product documentation changes are already part of the frozen release scope.

## Related

Refs #362, #516
