### PR TITLE
docs(release): prepare v1.12.0-rc.3

### DIFF
--- a/docs/release-notes/v1.12.0-rc.3-en.md
+++ b/docs/release-notes/v1.12.0-rc.3-en.md
@@ -1,0 +1,36 @@
+# CPA Manager Plus v1.12.0-rc.3
+
+> 17 commits · 53 files changed · +8477 / -1126
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-rc.3/docs/release-notes/v1.12.0-rc.3-zh.md)
+
+## Overview
+
+This is the third release candidate for v1.12.0, focused on Manager Server startup availability, resumable online migration, and read correctness while derived data is incomplete. Large-table scans, derived cleanup, and rebuilds no longer block the HTTP listener; migrations run in bounded background batches with committed checkpoints, while reads fall back to `usage_events` when derived data is incomplete. The release also adds a guarded offline finalization command and SQLite process ownership, while preserving legacy quota-snapshot lifecycle and model identity.
+
+## Highlights
+
+### Features
+
+- Manager Server adds the `cleanup-derived` offline maintenance command for deferred indexes, obsolete derived indexes, old FTS / projection generations, and oversized legacy quota observation groups.
+- `GET /status` now exposes `changedRows` and `appliedRows` under `dataMigration`, alongside migration phase, progress, retryable failure, and completion reporting.
+
+### Fixes
+
+- Startup now performs only bounded schema / metadata work and safe empty-table index preparation; indexes on non-empty tables, derived cleanup, and rebuilds are deferred until after the HTTP listener is available or explicit offline maintenance is requested.
+- Cache-accounting correction, legacy quota-snapshot backfill, and derived cleanup run in bounded transactions with committed checkpoints, resuming the active phase after interruption or restart without repeating committed batches.
+- Monitoring, Usage Analytics, and Dashboard reads use a complete revision or fall back to raw `usage_events` while rollups are rebuilding, revisions are changing, or stale derived rows are being cleared.
+- Legacy quota-snapshot backfill preserves scheduled and early-reset lifecycle boundaries and historical model identity.
+- Manager Server, admin reset, and offline maintenance use a cross-platform SQLite process lock to serialize access to the same database and prevent conflicting maintenance.
+
+## Upgrade Notes
+
+- This is a prerelease. Stable Docker tags and `latest` are not updated; use the explicit `v1.12.0-rc.3` release assets or image.
+- When upgrading an existing database, background migration continues after the HTTP service is available. Back up the SQLite database, WAL, SHM, and `data.key` together before upgrading.
+- If logs report deferred index preparation, `cleanup requires offline finalization`, or `offline cleanup required`, stop every Manager Server process using the database and run `cpa-manager-plus cleanup-derived --db-path /data/usage.sqlite` with the same-version binary; native installations using the default path may omit `--db-path`.
+- `cleanup-derived` refuses to run while the database lock is held; the persistent lock file does not need manual deletion. Do not start a second Manager Server against the same SQLite database or CPA queue to accelerate migration.
+- `usage_events` remains the authoritative input and is never modified or deleted by derived-data rebuilds; raw-event fallback continues to provide correct reads while migration is incomplete.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-rc.2...v1.12.0-rc.3

--- a/docs/release-notes/v1.12.0-rc.3-zh.md
+++ b/docs/release-notes/v1.12.0-rc.3-zh.md
@@ -1,0 +1,36 @@
+# CPA Manager Plus v1.12.0-rc.3
+
+> 17 commits · 53 files changed · +8477 / -1126
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0-rc.3/docs/release-notes/v1.12.0-rc.3-en.md)
+
+## Overview
+
+这是 v1.12.0 的第三个 release candidate，聚焦 Manager Server 派生数据维护的启动可用性、在线迁移的可恢复性以及升级期间的读一致性。大表扫描、派生清理和重建不再阻塞 HTTP 服务监听；迁移按有界批次在后台推进并记录 checkpoint，未完成时读取路径回退到 `usage_events`。同时增加安全的离线收尾命令和 SQLite 进程锁，完善旧 quota snapshot 与 rollup 的生命周期和身份保留。
+
+## Highlights
+
+### Features
+
+- Manager Server 新增 `cleanup-derived` 离线维护命令，可完成延后索引、过期派生索引、旧 FTS / projection generation 以及超大 legacy quota observation group 的收尾。
+- `GET /status` 的 `dataMigration` 增加 `changedRows` 和 `appliedRows`，并持续报告迁移阶段、进度、可重试失败和完成状态。
+
+### Fixes
+
+- 启动阶段仅执行有界的 schema / metadata 工作和安全的空表索引准备；非空表索引、派生数据清理和重建会延后到 HTTP 监听后或显式离线维护。
+- cache accounting、legacy quota snapshot backfill 和派生清理按有界事务与已提交 checkpoint 分阶段执行，中断或重启后从当前阶段继续，不重复处理已提交批次。
+- Monitoring、Usage Analytics 和 Dashboard 在 rollup 重建、revision 切换或过期派生行清理期间使用完整 revision 或回退到 raw `usage_events`，保持读取正确性。
+- legacy quota snapshot backfill 保留计划与提前重置后的生命周期边界，以及历史记录的 model identity。
+- Manager Server、admin reset 和离线维护命令通过跨平台 SQLite 进程锁串行访问同一数据库，避免并发维护破坏数据状态。
+
+## Upgrade Notes
+
+- 这是预发布版本；稳定 Docker 标签和 `latest` 不会更新，请显式使用 `v1.12.0-rc.3` 对应的发布资产或镜像。
+- 升级旧数据库时，后台迁移会在 HTTP 服务可用后继续执行；升级前请同时备份 SQLite 数据库、WAL、SHM 与 `data.key`。
+- 如果日志出现 deferred index preparation、`cleanup requires offline finalization` 或 `offline cleanup required`，请停止所有使用该数据库的 Manager Server 进程，再使用同版本二进制运行 `cpa-manager-plus cleanup-derived --db-path /data/usage.sqlite`；默认原生路径可省略 `--db-path`。
+- `cleanup-derived` 会在数据库锁仍被持有时拒绝执行；锁文件会持久保留，无需手工删除。不要启动第二个 Manager Server 连接同一 SQLite 或 CPA queue 来加速迁移。
+- `usage_events` 仍是权威输入，派生数据重建不会修改或删除它；迁移未完成期间的 raw-event fallback 会继续提供正确读取。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.0-rc.2...v1.12.0-rc.3

--- a/docs/release-posts/v1.12.0-rc.3-telegram.html
+++ b/docs/release-posts/v1.12.0-rc.3-telegram.html
@@ -1,0 +1,17 @@
+🚀 <b>8 月 15 日 · v1.12.0-rc.3</b>
+
+✨ <b>更新内容</b>
+
+• Manager Server 会在大规模派生数据维护完成前先开放 HTTP 监听和健康检查。
+• 派生数据迁移按有界、可恢复的阶段推进，并在状态接口和日志中报告进度。
+• Monitoring、Usage Analytics 和 Dashboard 会在 rollup 重建期间安全回退到 raw <code>usage_events</code>。
+• 新增 <code>cleanup-derived</code> 命令，用于离线完成延后索引、过期派生数据和超大 legacy quota 清理。
+• legacy quota snapshot 回填会保留生命周期边界和历史 model identity。
+• SQLite 进程锁会阻止多个 Manager Server 或维护命令同时操作同一数据库。
+
+⚠️ <b>注意事项</b>
+
+• 这是预发布版本；稳定 Docker 标签和 <code>latest</code> 不会更新，请使用 <code>v1.12.0-rc.3</code> 对应的资产或镜像。
+• 升级前请备份 SQLite、WAL、SHM 与 <code>data.key</code>；后台迁移会在 HTTP 服务可用后继续执行。
+• 如果日志提示需要 offline cleanup，请停止所有使用该数据库的 Manager Server，再用同版本二进制运行 <code>cpa-manager-plus cleanup-derived --db-path /data/usage.sqlite</code>。
+• 不要启动第二个 Manager Server 连接同一 SQLite 或 CPA queue 来加速迁移；<code>usage_events</code> 不会被修改或删除。


### PR DESCRIPTION
## Summary

Prepare the v1.12.0-rc.3 release content on the release branch. The release notes document startup-safe derived-data maintenance, resumable migrations, raw-event fallbacks, and offline cleanup guidance.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the formal Chinese and English release notes for v1.12.0-rc.3.
- Add the reviewed Telegram release post used by the tag-triggered workflow.
- Document bounded startup work, resumable derived-data maintenance, raw-event fallback behavior, SQLite ownership, and offline cleanup requirements.

## User Impact

Users receive the v1.12.0-rc.3 release documentation and upgrade guidance for Manager Server derived-data maintenance without any additional application behavior change in this docs-only PR.

## Compatibility / Runtime Notes

- CPA panel mode: No frontend contract change; the release notes describe Manager Server and shared runtime behavior.
- Manager Server mode: The release notes document background bounded migration, status progress fields, raw-event fallback, and the same-version offline cleanup command.
- Full Docker / native packages: The release notes document the backup and stopped-process requirements for offline cleanup.

## Data / Security Notes

The release notes preserve the requirement to back up SQLite, WAL, SHM, and `data.key` before upgrading. They do not contain secrets, database files, admin keys, or CPA Management Keys.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this documentation PR before release publication, or omit the tag until the release content is corrected. No runtime or database state is changed by this PR.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Release tag: v1.12.0-rc.3
Source dev SHA: 9fea230db8c3abd48fbdecf436bfe448836da281
Release branch commit: 2ea3d055bd6c432af15411e4389fd20b20c88326
Changed files: exactly the three required release files
Language links: reciprocal tag-pinned GitHub blob URLs
Telegram post: 816 Unicode characters, supported HTML tags only, no secrets
Content digests recorded in the release manifest
```

## Screenshots / Recordings

N/A — release notes and a Telegram post only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: This PR adds the required versioned release notes and Telegram post. The Manager Server operation manuals were updated in the preceding source PR.

## Related

N/A