### PR TITLE
docs(release): prepare v1.12.0

### DIFF
--- a/docs/release-notes/v1.12.0-en.md
+++ b/docs/release-notes/v1.12.0-en.md
@@ -1,0 +1,67 @@
+# CPA Manager Plus v1.12.0
+
+> 196 commits · 552 files changed · +119770 / -24846
+>
+> v1.12.0-rc.3 → v1.12.0: 0 product commits · 0 product files changed
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0/docs/release-notes/v1.12.0-zh.md)
+
+## Overview
+
+`v1.12.0` is the stable 1.x release promoted after the complete RC validation cycle. Its product source is identical to `v1.12.0-rc.3`; this release adds only the stable release material and rebuilds with `VERSION=v1.12.0`, so it introduces no post-RC.3 runtime behavior change. The stable channel now includes the unified Accounts credential workspace, quota lifecycle and diagnostics, model-identity and proxy fixes, and startup-safe resumable derived-data migration.
+
+## Highlights
+
+### Features
+
+- Make `/accounts` the unified credential-management entry for quota, configuration, models, activity, inspection, and reauthorization workflows across desktop and mobile layouts.
+- Show current and previous quota cycles, model scopes, reset records, recent requests, usage forecasts, and account-level diagnostics in credential details.
+- Keep provider quota refresh explicitly user-triggered while Manager Server persists allowlisted quota observations, windows, lifecycles, and account-usage evidence.
+- Support weighted round-robin credential routing and show effective and default weights in compatible provider credential details.
+- Let Monitoring full display mode show normalized and bounded client IP, unverified X-Forwarded-For, and User-Agent request metadata.
+- Allow disabled credentials to refresh quota, edit writable configuration, and open configuration from the list without returning to request routing.
+- Link valid Manager and CLIProxyAPI versions on the Dashboard to their matching GitHub Releases.
+- Add the `cleanup-derived` offline maintenance command, while `dataMigration` under `GET /status` reports migration phase, progress, failures, and completion.
+
+### Fixes
+
+- Scope credential state by file name, `auth_index`, provider, connection, and session so stale requests, HTTP 499, and client cancellation cannot overwrite current evidence.
+- Synchronize passive Header evidence, server inspection, manual quota refresh, and completed Codex OAuth reauthorization into Accounts to reduce stale limited or re-login states.
+- Preserve current and previous cycle usage across scheduled and early quota resets, asynchronous deep-link resolution, and credential-drawer reopen.
+- Map CPA-supported reasoning suffixes to canonical analytics models while preserving requested, upstream, billing, pricing, and unknown-alias identities.
+- Forward configured request-level proxies during provider model discovery and health checks so OpenAI-compatible requests do not unexpectedly use blocked direct connections.
+- Prefer unified xAI and SuperGrok billing evidence and use legacy responses only to fill missing fields, avoiding incorrect zero-dollar monthly quota.
+- Limit startup to bounded schema and metadata work; defer large-table indexes, derived cleanup, and rebuilds until after the HTTP listener is available or explicit offline maintenance runs.
+- Run cache-accounting correction, legacy quota-snapshot backfill, and derived cleanup in bounded transactions with committed checkpoints that resume after interruption or restart.
+- Keep Monitoring, Usage Analytics, and Dashboard correct during incomplete rollups by using a complete revision or falling back to raw `usage_events`.
+- Serialize Manager Server, admin reset, and offline maintenance access to the same database with a cross-platform SQLite process lock.
+
+### Performance
+
+- Prefer fully covered derived readers for account-window usage and use identity and time indexes to reduce account-history, quota-window, and latest-status scans.
+- Release SQLite readers before loading compatible-usage details in batches so slow downloads no longer hold WAL checkpoints open.
+
+### Docs
+
+- Align Chinese and English documentation, navigation, and deployment guidance around Accounts credential management, quota behavior, migration, and offline maintenance.
+
+### CI / Build
+
+- Verify a complete Draft Release before explicit publication, and bind guarded recovery to the exact tag, source SHA, artifacts, assets, and multi-architecture image state.
+- Exclude nested `node_modules` directories from Docker build contexts so workspace dependencies cannot contaminate image builds.
+
+## Upgrade Notes
+
+- `v1.12.0` updates the stable release assets, Docker `1.12`, and `latest`; its product source is identical to `v1.12.0-rc.3`.
+- Use Accounts for credential management, quota, inspection, and reauthorization. The standalone Auth Files and Quota pages and routes are removed, while compatibility APIs remain available to Accounts.
+- Back up the SQLite database, WAL, SHM, and `data.key` together before upgrading. Background migration continues after the HTTP service becomes available.
+- If logs report deferred index preparation, `cleanup requires offline finalization`, or `offline cleanup required`, stop every Manager Server using the database and run `cpa-manager-plus cleanup-derived --db-path /data/usage.sqlite` with the same-version binary; native installations using the default path may omit `--db-path`.
+- `cleanup-derived` refuses to run while the database lock is held, and the persistent lock file does not need manual deletion. Do not start a second Manager Server against the same SQLite database or CPA queue; derived rebuilds never modify or delete `usage_events`.
+- Request-level provider proxying requires CPA v7.2.130+. Weighted round robin requires a CPA runtime that supports the routing strategy and credential weight fields.
+- Provider quotas remain explicitly user-triggered. Persisted quota history, account-window usage, and server inspection require Manager Server; pure CPA Panel deployments hide unavailable features.
+- Request metadata may contain sensitive client information. It is available only in full display mode and is excluded from compatible usage and JSONL exports.
+- When the configured `/v0/management/usage` limit exceeds 50,000 records, the endpoint returns the latest 50,000; `/v0/management/usage/export` continues to honor the configured limit.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.12...v1.12.0

--- a/docs/release-notes/v1.12.0-zh.md
+++ b/docs/release-notes/v1.12.0-zh.md
@@ -1,0 +1,67 @@
+# CPA Manager Plus v1.12.0
+
+> 196 commits · 552 files changed · +119770 / -24846
+>
+> v1.12.0-rc.3 → v1.12.0: 0 product commits · 0 product files changed
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.0/docs/release-notes/v1.12.0-en.md)
+
+## Overview
+
+`v1.12.0` 是经过完整 RC 验证的 1.x 稳定版。产品源码与 `v1.12.0-rc.3` 完全一致，本次仅增加正式版发布材料并以 `VERSION=v1.12.0` 重新构建，因此不会引入 RC.3 之后的运行行为变化。此版本将统一的 Accounts 凭证工作区、额度生命周期与诊断、模型身份与代理修复，以及启动安全、可恢复的派生数据迁移带入稳定渠道。
+
+## Highlights
+
+### Features
+
+- `/accounts` 成为统一凭证管理入口，集中提供额度、配置、模型、活动、巡检与重新登录工作流，并适配桌面和移动端。
+- 凭证详情支持当前与历史额度周期、模型范围、重置记录、最近请求、用量预测和账号级诊断。
+- Provider 额度刷新保持显式手动操作，Manager Server 可持久化额度观察、窗口、生命周期和账号用量证据。
+- 支持 weighted round-robin 凭证路由，并在兼容 Provider 的凭证详情中展示有效权重与默认权重。
+- Monitoring 完整显示模式可展示规范化且限制长度的客户端 IP、未验证 X-Forwarded-For 和 User-Agent 请求元数据。
+- 禁用凭证无需恢复请求路由，也可刷新额度、编辑可写配置并从列表直接打开配置。
+- Dashboard 中有效的 Manager 与 CLIProxyAPI 版本可直接打开对应的 GitHub Release。
+- Manager Server 新增 `cleanup-derived` 离线维护命令；`GET /status` 的 `dataMigration` 会报告迁移阶段、进度、失败与完成状态。
+
+### Fixes
+
+- 凭证状态按文件名、`auth_index`、Provider、连接和会话隔离，过期请求、HTTP 499 与客户端取消不再覆盖当前证据。
+- Accounts 会同步被动 Header、服务端巡检、手动额度刷新和 Codex OAuth 重新登录结果，减少陈旧限额或重新登录状态。
+- Accounts 会正确处理计划与提前额度重置、深链凭证解析和详情抽屉重开后的当前与上一周期用量。
+- CPA 支持的推理后缀会归入规范分析模型，同时保留请求、上游、计费、定价与未知别名身份。
+- Provider 模型发现和健康检查会转发已配置的请求级代理，避免 OpenAI-compatible 请求意外直连受限网络。
+- xAI 与 SuperGrok 优先采用统一计费证据，并仅用旧响应补齐缺失字段，避免错误的零美元月额度。
+- Manager Server 启动阶段只执行有界 schema 与 metadata 工作，大表索引、派生清理和重建会延后到 HTTP 监听后或显式离线维护。
+- cache accounting、legacy quota snapshot backfill 和派生清理按有界事务与已提交 checkpoint 推进，中断或重启后可继续当前阶段。
+- Monitoring、Usage Analytics 和 Dashboard 在 rollup 未完整时使用完整 revision 或回退到 raw `usage_events`，保持读取正确性。
+- Manager Server、admin reset 和离线维护通过跨平台 SQLite 进程锁串行访问同一数据库。
+
+### Performance
+
+- 账号窗口用量优先使用覆盖完整的派生读取，并通过身份与时间索引减少账号历史、额度窗口和最近状态查询扫描。
+- 兼容用量接口在释放 SQLite 读取器后分批加载详情，慢速下载不再长期阻塞 WAL checkpoint。
+
+### Docs
+
+- 中英文文档、导航和部署说明统一指向 Accounts 凭证管理流程，并更新额度、迁移与离线维护指导。
+
+### CI / Build
+
+- 发布流程会先验证完整 Draft Release，再显式发布，并为受控恢复校验 tag、来源 SHA、产物、资产和多架构镜像状态。
+- Docker 构建上下文排除所有层级的 `node_modules`，避免工作区依赖污染镜像构建。
+
+## Upgrade Notes
+
+- `v1.12.0` 会更新稳定发布资产、Docker `1.12` 与 `latest`；产品源码与 `v1.12.0-rc.3` 完全一致。
+- 凭证管理、额度、巡检和重新登录请使用 Accounts；旧 Auth Files 与独立 Quota 页面和路由已移除，内部兼容 API 继续供 Accounts 使用。
+- 升级前请同时备份 SQLite 数据库、WAL、SHM 与 `data.key`。后台迁移会在 HTTP 服务可用后继续执行。
+- 如果日志出现 deferred index preparation、`cleanup requires offline finalization` 或 `offline cleanup required`，请停止所有使用该数据库的 Manager Server，再用同版本二进制运行 `cpa-manager-plus cleanup-derived --db-path /data/usage.sqlite`；默认原生路径可省略 `--db-path`。
+- `cleanup-derived` 会在数据库锁仍被持有时拒绝执行；锁文件无需手工删除。不要启动第二个 Manager Server 连接同一 SQLite 或 CPA queue，`usage_events` 不会被派生重建修改或删除。
+- Provider 请求级代理需要 CPA v7.2.130+；weighted round robin 需要支持对应路由策略和凭证权重字段的 CPA 运行时。
+- Provider 额度仍只在用户主动刷新时请求；持久化额度历史、账号窗口用量和服务端巡检依赖 Manager Server，纯 CPA Panel 模式会隐藏不可用功能。
+- 请求元数据可能包含敏感客户端信息，仅在完整显示模式提供，并且不会进入兼容用量导出或 JSONL 导出。
+- 当 `/v0/management/usage` 的配置上限超过 50,000 条时，将返回最新 50,000 条；`/v0/management/usage/export` 仍遵循原配置上限。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.11.12...v1.12.0

--- a/docs/release-posts/v1.12.0-telegram.html
+++ b/docs/release-posts/v1.12.0-telegram.html
@@ -1,0 +1,39 @@
+🚀 <b>8 月 17 日 · v1.12.0</b>
+
+✨ <b>更新内容</b>
+
+• Accounts 工作区统一凭证、额度、配置、模型、巡检和重新登录入口，并完成桌面与移动端适配。
+• 凭证详情可查看当前与历史额度周期、模型范围、重置记录、最近请求和用量预测。
+• Provider 额度刷新保持手动触发，Manager Server 可持久化额度窗口与账号用量证据。
+• Accounts 会同步被动 Header、服务端巡检、手动刷新和 OAuth 结果，减少陈旧限额或重新登录状态。
+• 凭证身份、连接与会话均被隔离，过期请求和客户端取消不会覆盖当前状态。
+• OAuth 排除模型与模型别名可在统一工作区安全预览、管理并在失败时回滚。
+• weighted round robin 可按凭证权重路由，并在凭证详情显示有效权重。
+• Monitoring 完整显示模式可查看受限的客户端 IP、X-Forwarded-For 和 User-Agent 请求元数据。
+• 实时监控可显示精确推理 Token，USD 费用在监控、分析和 Accounts 中统一为三位小数。
+• Accounts 会正确处理计划与提前额度重置、深链加载和详情抽屉重开后的周期用量。
+• 慢速兼容用量下载不再长期占用 SQLite 读取器，WAL 检查点可及时推进。
+• 管理面板的日志入口、插件导航和系统信息更直观。
+• Dashboard 中的 Manager 与 CLIProxyAPI 版本可直达对应 GitHub Release。
+• 推理后缀模型会归入规范分析模型，同时保留请求、上游、计费和定价身份。
+• Provider 模型发现与健康检查可使用已配置代理，避免意外直连受限网络。
+• 禁用凭证无需恢复请求路由，也可刷新额度和维护可写配置。
+• xAI 与 SuperGrok 优先使用统一计费证据，避免缺失字段显示为零美元月额度。
+• Manager Server 会先开放 HTTP 监听和健康检查，再执行大规模派生数据维护。
+• 派生数据迁移按有界、可恢复阶段推进，并在状态接口和日志中报告进度。
+• Monitoring、Usage Analytics 和 Dashboard 会在 rollup 未完整时回退到 raw <code>usage_events</code>。
+• 新增 <code>cleanup-derived</code> 离线收尾命令，用于处理延后索引、过期派生数据和超大 legacy quota。
+• SQLite 进程锁会阻止多个 Manager Server 或维护命令同时操作同一数据库。
+• 稳定发布资产、Docker <code>1.12</code> 与 <code>latest</code> 将随 v1.12.0 正式更新。
+
+⚠️ <b>注意事项</b>
+
+• <code>v1.12.0</code> 的产品源码与 <code>v1.12.0-rc.3</code> 完全一致；本次只新增正式版发布材料并重新构建稳定资产。
+• 凭证管理、额度、巡检和重新登录请使用 Accounts；旧 Auth Files 与独立 Quota 页面已移除。
+• 升级前请同时备份 SQLite、WAL、SHM 与 <code>data.key</code>；后台迁移会在 HTTP 服务可用后继续执行。
+• 如果日志提示需要 offline cleanup，请停止所有使用该数据库的 Manager Server，再用同版本二进制运行 <code>cpa-manager-plus cleanup-derived --db-path /data/usage.sqlite</code>。
+• 不要启动第二个 Manager Server 连接同一 SQLite 或 CPA queue；锁文件无需手工删除，<code>usage_events</code> 不会被修改或删除。
+• Provider 请求级代理需要 CPA v7.2.130+，weighted round robin 需要兼容的 CPA 运行时。
+• Provider 额度仍需手动刷新；持久化额度历史、账号窗口用量和服务端巡检依赖 Manager Server。
+• 请求元数据可能包含敏感信息，仅在完整显示模式提供，并且不会进入用量导出。
+• 当 <code>/v0/management/usage</code> 的配置上限超过 50,000 条时返回最新 50,000 条，导出接口仍遵循原配置上限。


### PR DESCRIPTION
## Summary

Prepare the v1.12.0 stable release content from the fully validated v1.12.0-rc.3 source. The product source has zero commits and zero product-file changes after rc.3; this PR adds only the stable release notes and Telegram post.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the formal Chinese release notes for v1.12.0.
- Add the matching English release notes with the reciprocal tag-pinned GitHub blob link.
- Add the reviewed Telegram HTML post used by the tag-triggered workflow.
- Record the stable-channel upgrade guidance and the zero-drift relationship to v1.12.0-rc.3.

## User Impact

This PR adds the stable v1.12.0 release documentation and notification content. It introduces no runtime or database behavior beyond the already validated v1.12.0-rc.3 source.

## Compatibility / Runtime Notes

- CPA panel mode: The release content preserves the existing panel capability boundaries; persisted quota history and server inspection remain Manager Server features.
- Manager Server mode: The release notes document startup-safe, resumable derived-data migration, raw-event fallback, process ownership, and offline cleanup.
- Full Docker / native packages: The stable release rebuild will use VERSION=v1.12.0 and publish the stable Docker channels after the protected promotion and dry-run.

## Data / Security Notes

The release content contains no secrets, database files, admin keys, or CPA Management Keys. It preserves the requirement to back up SQLite, WAL, SHM, and data.key before upgrades and documents that usage_events remains authoritative.

## Risk / Rollback

Risk level: Low

Rollback notes: Before promotion or tagging, correct the release PR and repeat the protected release flow. Never retarget the stable tag. After tagging, use the separately approved release-recovery process if required.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Release tag: v1.12.0
Previous release tag: v1.12.0-rc.3
Source dev SHA: cdc97ce3ccd78e16cfedb510ff477adecb9fcba0
Release branch commit: a37cf80b1966f1012b022732e6f367663e0873d4
Release content validator: npm run release:validate -- --tag v1.12.0 --content-only (passed)
Changed files: exactly the three required release files
Chinese note SHA-256: 02466ce01a9a457f0330206b8f4f2eee79e1a877c5ad1b643cbad071025614dc
English note SHA-256: 77a46eeda83fa1139e4ed72b7dd6d87765ba8ae999e025413d34d87c18c24983
Telegram post SHA-256: 1789d4d206664fc504c739a1deb809dbb13a2d8588e820c21dccd1840c7e3c55
Telegram post: 1,913 Unicode characters, supported HTML tags only, no secrets
```

## Screenshots / Recordings

N/A — release notes and a Telegram post only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: This PR adds the required versioned release notes and Telegram post. The corresponding product and operational documentation was already included in the validated v1.12.0 source.

## Related

N/A