### PR TITLE
🐛 fix(web): relax plugin host stylesheet overrides

### DIFF
--- a/apps/web/src/features/plugins/pluginHostStyle.test.ts
+++ b/apps/web/src/features/plugins/pluginHostStyle.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { buildPluginHostStyle, placePluginHostStyle } from './pluginHostStyle';
+
+type FakeHead = {
+  children: FakeElement[];
+  mutations: number;
+  insertBefore: (node: FakeElement, reference: FakeElement | null) => FakeElement;
+  appendChild: (node: FakeElement) => FakeElement;
+};
+
+type FakeElement = {
+  tagName: string;
+  parentElement: FakeHead | null;
+  attributes: Map<string, string>;
+  getAttribute: (name: string) => string | null;
+};
+
+const createElement = (tagName: string, attributes: Record<string, string> = {}): FakeElement => {
+  const element: FakeElement = {
+    tagName: tagName.toUpperCase(),
+    parentElement: null,
+    attributes: new Map(Object.entries(attributes)),
+    getAttribute: (name) => element.attributes.get(name) ?? null,
+  };
+  return element;
+};
+
+const createHead = (...initialChildren: FakeElement[]): FakeHead => {
+  const head: FakeHead = {
+    children: [],
+    mutations: 0,
+    insertBefore: (node, reference) => {
+      head.mutations += 1;
+      if (node.parentElement === head) {
+        const currentIndex = head.children.indexOf(node);
+        if (currentIndex >= 0) head.children.splice(currentIndex, 1);
+      }
+      node.parentElement = head;
+
+      const referenceIndex = reference ? head.children.indexOf(reference) : -1;
+      if (referenceIndex < 0) {
+        head.children.push(node);
+      } else {
+        head.children.splice(referenceIndex, 0, node);
+      }
+      return node;
+    },
+    appendChild: (node) => {
+      head.mutations += 1;
+      if (node.parentElement === head) {
+        const currentIndex = head.children.indexOf(node);
+        if (currentIndex >= 0) head.children.splice(currentIndex, 1);
+      }
+      node.parentElement = head;
+      head.children.push(node);
+      return node;
+    },
+  };
+
+  initialChildren.forEach((child) => head.appendChild(child));
+  head.mutations = 0;
+  return head;
+};
+
+const asHead = (head: FakeHead) => head as unknown as HTMLHeadElement;
+const asStyle = (style: FakeElement) => style as unknown as HTMLStyleElement;
+
+describe('plugin host style bridge', () => {
+  it('generates scoped, overridable light and dark theme baselines', () => {
+    const lightStyle = buildPluginHostStyle('light');
+    const darkStyle = buildPluginHostStyle('dark');
+
+    expect(lightStyle).not.toContain('!important');
+    expect(lightStyle).toContain(":where(html[data-cpamp-plugin-host='true'])");
+    expect(lightStyle).toContain(':where(p, span, label, small, li, dt, dd)');
+    expect(lightStyle).toContain('color-scheme: light;');
+    expect(darkStyle).toContain('color-scheme: dark;');
+    expect(lightStyle).toContain('--app-bg: #eff2f7;');
+  });
+
+  it('places the host style before the first plugin stylesheet', () => {
+    const metadata = createElement('meta');
+    const pluginStyle = createElement('style');
+    const hostStyle = createElement('style');
+    const head = createHead(metadata, pluginStyle, hostStyle);
+
+    placePluginHostStyle(asHead(head), asStyle(hostStyle));
+
+    expect(head.children).toEqual([metadata, hostStyle, pluginStyle]);
+  });
+
+  it('recognizes stylesheet links and preserves an existing earlier position', () => {
+    const metadata = createElement('meta');
+    const hostStyle = createElement('style');
+    const pluginLink = createElement('link', { rel: 'preload stylesheet' });
+    const head = createHead(metadata, pluginLink, hostStyle);
+
+    placePluginHostStyle(asHead(head), asStyle(hostStyle));
+    expect(head.children).toEqual([metadata, hostStyle, pluginLink]);
+
+    head.mutations = 0;
+    placePluginHostStyle(asHead(head), asStyle(hostStyle));
+    expect(head.mutations).toBe(0);
+  });
+});

--- a/apps/web/src/features/plugins/pluginHostStyle.ts
+++ b/apps/web/src/features/plugins/pluginHostStyle.ts
@@ -11,6 +11,7 @@ export interface PluginHostStyleBridge {
 
 const PLUGIN_HOST_STYLE_ID = 'cpamp-plugin-host-style';
 const PLUGIN_HOST_ATTR = 'data-cpamp-plugin-host';
+const PLUGIN_HOST_SCOPE = `:where(html[${PLUGIN_HOST_ATTR}='true'])`;
 const CUSTOM_PROPERTY_NAME_RE = /^--[a-zA-Z0-9_-]+$/;
 
 const HOST_STYLE_FALLBACKS: Record<string, string> = {
@@ -90,120 +91,105 @@ const buildVariableBlock = () =>
     .map(([name, value]) => `  ${name}: ${value};`)
     .join('\n');
 
-const buildPluginHostStyle = (theme: PluginHostTheme) => `
-:root {
+export const buildPluginHostStyle = (theme: PluginHostTheme) =>
+  `
+${PLUGIN_HOST_SCOPE} {
 ${buildVariableBlock()}
   --cpamp-plugin-font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color-scheme: ${theme === 'dark' ? 'dark' : 'light'};
-}
-
-html {
   min-height: 100%;
-  background: var(--bg-primary) !important;
-  color: var(--text-primary) !important;
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
-body {
+${PLUGIN_HOST_SCOPE} :where(body) {
   min-height: 100vh;
   margin: 0;
-  background: var(--bg-primary) !important;
-  color: var(--text-primary) !important;
-  font-family: var(--cpamp-plugin-font-family) !important;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--cpamp-plugin-font-family);
   font-size: 14px;
   line-height: 1.5;
   letter-spacing: 0;
 }
 
-*,
-*::before,
-*::after {
+${PLUGIN_HOST_SCOPE} *,
+${PLUGIN_HOST_SCOPE} *::before,
+${PLUGIN_HOST_SCOPE} *::after {
   box-sizing: border-box;
 }
 
-body,
-button,
-input,
-select,
-textarea {
-  font-family: var(--cpamp-plugin-font-family) !important;
+${PLUGIN_HOST_SCOPE} :where(body, button, input, select, textarea) {
+  font-family: var(--cpamp-plugin-font-family);
 }
 
-a {
-  color: var(--primary-color) !important;
-  text-decoration-color: color-mix(in srgb, var(--primary-color) 38%, transparent) !important;
+${PLUGIN_HOST_SCOPE} :where(a) {
+  color: var(--primary-color);
+  text-decoration-color: color-mix(in srgb, var(--primary-color) 38%, transparent);
 }
 
-a:hover {
-  color: var(--primary-active) !important;
+${PLUGIN_HOST_SCOPE} :where(a:hover) {
+  color: var(--primary-active);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: var(--text-primary) !important;
-  letter-spacing: 0 !important;
+${PLUGIN_HOST_SCOPE} :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--text-primary);
+  letter-spacing: 0;
 }
 
-p,
-span,
-label,
-small,
-li,
-dt,
-dd {
-  color: inherit !important;
+${PLUGIN_HOST_SCOPE} :where(p, span, label, small, li, dt, dd) {
+  color: inherit;
 }
 
-hr {
-  border: 0 !important;
-  border-top: 1px solid var(--border-color) !important;
+${PLUGIN_HOST_SCOPE} :where(hr) {
+  border: 0;
+  border-top: 1px solid var(--border-color);
 }
 
-button,
-input,
-select,
-textarea {
-  color: var(--text-primary) !important;
+${PLUGIN_HOST_SCOPE} :where(button, input, select, textarea) {
+  color: var(--text-primary);
 }
 
-input:not([type='checkbox']):not([type='radio']):not([type='range']),
-select,
-textarea {
+${PLUGIN_HOST_SCOPE} :where(
+  input:not([type='checkbox']):not([type='radio']):not([type='range']),
+  select,
+  textarea
+) {
   min-height: 34px;
-  border: 1px solid var(--border-color) !important;
-  border-radius: var(--app-radius-sm, 8px) !important;
-  background: var(--app-input-bg, var(--bg-primary)) !important;
-  color: var(--text-primary) !important;
-  outline: none !important;
-  box-shadow: none !important;
+  border: 1px solid var(--border-color);
+  border-radius: var(--app-radius-sm, 8px);
+  background: var(--app-input-bg, var(--bg-primary));
+  color: var(--text-primary);
+  outline: none;
+  box-shadow: none;
 }
 
-input:not([type='checkbox']):not([type='radio']):not([type='range']):focus,
-select:focus,
-textarea:focus {
-  border-color: var(--primary-color) !important;
-  background: var(--app-input-bg-focus, var(--bg-primary)) !important;
-  box-shadow: inset 0 0 0 1px var(--focus-inset) !important;
+${PLUGIN_HOST_SCOPE} :where(
+  input:not([type='checkbox']):not([type='radio']):not([type='range']):focus,
+  select:focus,
+  textarea:focus
+) {
+  border-color: var(--primary-color);
+  background: var(--app-input-bg-focus, var(--bg-primary));
+  box-shadow: inset 0 0 0 1px var(--focus-inset);
 }
 
-input::placeholder,
-textarea::placeholder {
-  color: var(--text-tertiary) !important;
+${PLUGIN_HOST_SCOPE} :where(input, textarea)::placeholder {
+  color: var(--text-tertiary);
 }
 
-button,
-input[type='button'],
-input[type='reset'],
-input[type='submit'],
-[role='button'] {
+${PLUGIN_HOST_SCOPE} :where(
+  button,
+  input[type='button'],
+  input[type='reset'],
+  input[type='submit'],
+  [role='button']
+) {
   min-height: 34px;
-  border: 1px solid var(--border-color) !important;
-  border-radius: var(--app-radius-md, 12px) !important;
-  background: var(--app-surface-muted, var(--bg-tertiary)) !important;
-  color: var(--text-primary) !important;
+  border: 1px solid var(--border-color);
+  border-radius: var(--app-radius-md, 12px);
+  background: var(--app-surface-muted, var(--bg-tertiary));
+  color: var(--text-primary);
   font-weight: 600;
   line-height: 1.2;
   transition:
@@ -213,117 +199,161 @@ input[type='submit'],
     box-shadow 0.15s ease;
 }
 
-button:not(:disabled),
-input[type='button']:not(:disabled),
-input[type='reset']:not(:disabled),
-input[type='submit']:not(:disabled),
-[role='button']:not([aria-disabled='true']) {
+${PLUGIN_HOST_SCOPE} :where(
+  button:not(:disabled),
+  input[type='button']:not(:disabled),
+  input[type='reset']:not(:disabled),
+  input[type='submit']:not(:disabled),
+  [role='button']:not([aria-disabled='true'])
+) {
   cursor: pointer;
 }
 
-button:hover:not(:disabled),
-input[type='button']:hover:not(:disabled),
-input[type='reset']:hover:not(:disabled),
-[role='button']:hover:not([aria-disabled='true']) {
-  border-color: var(--border-hover) !important;
-  background: var(--bg-hover, var(--app-surface-muted)) !important;
-  color: var(--primary-color) !important;
+${PLUGIN_HOST_SCOPE} :where(
+  button:hover:not(:disabled),
+  input[type='button']:hover:not(:disabled),
+  input[type='reset']:hover:not(:disabled),
+  [role='button']:hover:not([aria-disabled='true'])
+) {
+  border-color: var(--border-hover);
+  background: var(--bg-hover, var(--app-surface-muted));
+  color: var(--primary-color);
 }
 
-button[type='submit'],
-input[type='submit'],
-.btn-primary,
-.button-primary,
-button.primary,
-input.primary,
-[role='button'].primary {
-  border-color: var(--primary-color) !important;
-  background: var(--primary-color) !important;
-  color: var(--primary-contrast, #fff) !important;
+${PLUGIN_HOST_SCOPE} :where(
+  button[type='submit'],
+  input[type='submit'],
+  .btn-primary,
+  .button-primary,
+  button.primary,
+  input.primary,
+  [role='button'].primary
+) {
+  border-color: var(--primary-color);
+  background: var(--primary-color);
+  color: var(--primary-contrast, #fff);
 }
 
-button[type='submit']:hover:not(:disabled),
-input[type='submit']:hover:not(:disabled),
-.btn-primary:hover,
-.button-primary:hover,
-button.primary:hover:not(:disabled),
-input.primary:hover:not(:disabled),
-[role='button'].primary:hover:not([aria-disabled='true']) {
-  border-color: var(--primary-hover) !important;
-  background: var(--primary-hover) !important;
-  color: var(--primary-contrast, #fff) !important;
+${PLUGIN_HOST_SCOPE} :where(
+  button[type='submit']:hover:not(:disabled),
+  input[type='submit']:hover:not(:disabled),
+  .btn-primary:hover,
+  .button-primary:hover,
+  button.primary:hover:not(:disabled),
+  input.primary:hover:not(:disabled),
+  [role='button'].primary:hover:not([aria-disabled='true'])
+) {
+  border-color: var(--primary-hover);
+  background: var(--primary-hover);
+  color: var(--primary-contrast, #fff);
 }
 
-button:disabled,
-input:disabled,
-select:disabled,
-textarea:disabled {
+${PLUGIN_HOST_SCOPE} :where(button:disabled, input:disabled, select:disabled, textarea:disabled) {
   cursor: not-allowed;
   opacity: 0.62;
 }
 
-table {
-  color: var(--text-primary) !important;
-  border-color: var(--border-color) !important;
+${PLUGIN_HOST_SCOPE} :where(table) {
+  color: var(--text-primary);
+  border-color: var(--border-color);
   border-collapse: collapse;
 }
 
-thead,
-th {
-  background: color-mix(in srgb, var(--bg-tertiary) 72%, var(--bg-primary)) !important;
-  color: var(--text-secondary) !important;
+${PLUGIN_HOST_SCOPE} :where(thead, th) {
+  background: color-mix(in srgb, var(--bg-tertiary) 72%, var(--bg-primary));
+  color: var(--text-secondary);
 }
 
-td,
-th {
-  border-color: var(--border-color) !important;
+${PLUGIN_HOST_SCOPE} :where(td, th) {
+  border-color: var(--border-color);
 }
 
-pre,
-code,
-kbd,
-samp {
-  border-color: var(--border-color) !important;
-  background: color-mix(in srgb, var(--bg-tertiary) 76%, var(--bg-primary)) !important;
-  color: var(--text-primary) !important;
+${PLUGIN_HOST_SCOPE} :where(pre, code, kbd, samp) {
+  border-color: var(--border-color);
+  background: color-mix(in srgb, var(--bg-tertiary) 76%, var(--bg-primary));
+  color: var(--text-primary);
 }
 
-:where(.card, .panel, .box, .tile, .widget, .surface, [class*='card'], [class*='panel']) {
-  border-color: var(--border-color) !important;
-  background: var(--bg-primary) !important;
-  color: var(--text-primary) !important;
+${PLUGIN_HOST_SCOPE} :where(
+  .card,
+  .panel,
+  .box,
+  .tile,
+  .widget,
+  .surface,
+  [class*='card'],
+  [class*='panel']
+) {
+  border-color: var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
-:focus-visible {
-  outline: 2px solid var(--focus-border) !important;
+${PLUGIN_HOST_SCOPE} :where(:focus-visible) {
+  outline: 2px solid var(--focus-border);
   outline-offset: 2px;
 }
 
-::selection {
+${PLUGIN_HOST_SCOPE}::selection,
+${PLUGIN_HOST_SCOPE} ::selection {
   background: color-mix(in srgb, var(--primary-color) 24%, transparent);
   color: var(--text-primary);
 }
 
-* {
+${PLUGIN_HOST_SCOPE},
+${PLUGIN_HOST_SCOPE} * {
   scrollbar-color: color-mix(in srgb, var(--primary-color) 32%, var(--border-color)) transparent;
 }
 
-::-webkit-scrollbar {
+${PLUGIN_HOST_SCOPE}::-webkit-scrollbar,
+${PLUGIN_HOST_SCOPE} *::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
-::-webkit-scrollbar-thumb {
+${PLUGIN_HOST_SCOPE}::-webkit-scrollbar-thumb,
+${PLUGIN_HOST_SCOPE} *::-webkit-scrollbar-thumb {
   border: 2px solid transparent;
   border-radius: 999px;
   background: color-mix(in srgb, var(--primary-color) 32%, var(--border-color));
   background-clip: padding-box;
 }
 
-::-webkit-scrollbar-track {
+${PLUGIN_HOST_SCOPE}::-webkit-scrollbar-track,
+${PLUGIN_HOST_SCOPE} *::-webkit-scrollbar-track {
   background: transparent;
 }
 `.trim();
+
+const isPluginStylesheetElement = (element: Element) => {
+  const tagName = element.tagName.toLowerCase();
+  if (tagName === 'style') return true;
+  if (tagName !== 'link') return false;
+
+  return (element.getAttribute('rel') ?? '')
+    .split(/\s+/)
+    .some((token) => token.toLowerCase() === 'stylesheet');
+};
+
+export const placePluginHostStyle = (head: HTMLHeadElement, style: HTMLStyleElement) => {
+  const children = Array.from(head.children);
+  const styleIndex = children.indexOf(style);
+  const firstPluginStylesheetIndex = children.findIndex(
+    (element) => element !== style && isPluginStylesheetElement(element)
+  );
+
+  if (
+    firstPluginStylesheetIndex >= 0 &&
+    (styleIndex < 0 || styleIndex > firstPluginStylesheetIndex)
+  ) {
+    head.insertBefore(style, children[firstPluginStylesheetIndex]);
+    return;
+  }
+
+  if (styleIndex < 0) {
+    head.appendChild(style);
+  }
+};
 
 export const createPluginHostStyleBridge = (
   iframe: HTMLIFrameElement,
@@ -377,7 +407,10 @@ export const createPluginHostStyleBridge = (
     observeDocument(doc, head);
 
     doc.documentElement.setAttribute(PLUGIN_HOST_ATTR, 'true');
-    doc.documentElement.setAttribute('data-theme', currentOptions.theme === 'dark' ? 'dark' : 'white');
+    doc.documentElement.setAttribute(
+      'data-theme',
+      currentOptions.theme === 'dark' ? 'dark' : 'white'
+    );
     doc.documentElement.classList.add('cpamp-plugin-host');
     doc.documentElement.classList.toggle('theme-dark', currentOptions.theme === 'dark');
     doc.documentElement.classList.toggle('theme-light', currentOptions.theme !== 'dark');
@@ -386,17 +419,15 @@ export const createPluginHostStyleBridge = (
     if (!style) {
       style = doc.createElement('style');
       style.id = PLUGIN_HOST_STYLE_ID;
-      style.setAttribute(PLUGIN_HOST_ATTR, 'true');
     }
+    style.setAttribute(PLUGIN_HOST_ATTR, 'true');
 
     const nextStyle = buildPluginHostStyle(currentOptions.theme);
     if (style.textContent !== nextStyle) {
       style.textContent = nextStyle;
     }
 
-    if (style.parentElement !== head || head.lastElementChild !== style) {
-      head.appendChild(style);
-    }
+    placePluginHostStyle(head, style);
 
     return true;
   };


### PR DESCRIPTION
## Summary

Relax injected plugin host stylesheet overrides so plugin-owned styles can take precedence while CPAMP still supplies a theme baseline.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Scope host baseline rules to the plugin host and remove `!important` declarations.
- Keep the host stylesheet before plugin `<style>` and stylesheet `<link>` nodes so plugin CSS can override colors, controls, typography, and surfaces.
- Preserve theme variable synchronization, iframe bridge behavior, and MutationObserver updates; add focused ordering and CSS-generation tests.

## User Impact

Plugins can use their own visual styles without fighting host-level `!important` rules. CPAMP theme defaults remain available as a fallback.

## Compatibility / Runtime Notes

- CPA panel mode: Plugin host styling remains scoped to `html[data-cpamp-plugin-host='true']`; theme refresh and iframe bridge behavior are unchanged.
- Manager Server mode: N/A; no backend changes.
- Full Docker / native packages: No serving or packaging code changed.

## Data / Security Notes

N/A. No data, credentials, SQLite, auth files, or security boundaries changed.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the single commit `f580db83`; no migration or persistent state changes are involved.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Focused plugin host tests: 3 passed
npm run test: 189 files, 2280 tests passed
npm run type-check: passed
npm run lint: passed (one pre-existing warning in apps/web/src/features/accounts/components/AccountHealthBadge.tsx:73)
npm run build: passed
git diff --check: passed
Synthetic same-origin iframe browser check: one host style, host-before-plugin ordering, no !important, plugin style precedence, and dark-theme refresh all passed
```

## Screenshots / Recordings

N/A — no layout or asset change; browser assertion check covered stylesheet cascade and theme refresh.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No new configuration, API, or operational behavior needs documentation.

## Related

Fixes #548