### PR TITLE
fix(manager-server): limit account-history recent request scans

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/latest_account_request.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request.go
@@ -7,6 +7,29 @@ import (
 	"strings"
 )
 
+const (
+	latestRequestAuthFileIndex = "idx_usage_events_latest_request_auth_file"
+	latestRequestSourceIndex   = "idx_usage_events_latest_request_source"
+)
+
+// snapshotLatestRequestByFileAndIndexSQL is the indexed Top-N path for a
+// credential with a non-empty auth_index. EXPLAIN tests pin this to the
+// composite latest-request auth-file index, including auth_index.
+const snapshotLatestRequestByFileAndIndexSQL = `select
+	e.id,
+	e.timestamp_ms,
+	e.failed,
+	e.fail_status_code,
+	coalesce(e.fail_summary, ''),
+	coalesce(e.header_error_kind, ''),
+	coalesce(e.header_error_code, ''),
+	coalesce(e.header_trace_id, '')
+from usage_events e
+where e.auth_file_snapshot collate nocase = ?
+	and e.auth_index collate nocase = ?
+order by e.timestamp_ms desc, e.id desc
+limit ?`
+
 // LatestAccountRequestQuery identifies one credential using the immutable
 // snapshot captured with a request. AuthFileSnapshot is the primary identity;
 // Source is used only for records created before auth-file snapshots existed.
@@ -35,6 +58,11 @@ type rankedAccountRequest struct {
 	id int64
 }
 
+type latestRequestPredicate struct {
+	sql  string
+	args []any
+}
+
 func (r *repository) RecentAccountRequests(
 	ctx context.Context,
 	targets []LatestAccountRequestQuery,
@@ -43,7 +71,36 @@ func (r *repository) RecentAccountRequests(
 	if len(targets) == 0 || limit <= 0 {
 		return []LatestAccountRequest{}, nil
 	}
+	ready, err := r.latestRequestIndexesReady(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if ready {
+		return r.recentAccountRequestsIndexed(ctx, targets, limit)
+	}
+	return r.recentAccountRequestsBatched(ctx, targets, limit)
+}
 
+func (r *repository) latestRequestIndexesReady(ctx context.Context) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx, `select count(*) from sqlite_master
+		where type = 'index'
+			and tbl_name = 'usage_events'
+			and name in (?, ?)`,
+		latestRequestAuthFileIndex,
+		latestRequestSourceIndex,
+	).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count == 2, nil
+}
+
+func (r *repository) recentAccountRequestsIndexed(
+	ctx context.Context,
+	targets []LatestAccountRequestQuery,
+	limit int,
+) ([]LatestAccountRequest, error) {
 	requests := make([]LatestAccountRequest, 0, len(targets)*limit)
 	for _, target := range targets {
 		if err := ctx.Err(); err != nil {
@@ -54,27 +111,20 @@ func (r *repository) RecentAccountRequests(
 			continue
 		}
 		authIndex := strings.TrimSpace(target.AuthIndex)
-		snapshot, err := r.recentAccountRequestsByPredicate(
+		snapshot, err := r.recentAccountRequestsByPredicates(
 			ctx,
 			target.RequestIndex,
 			limit,
-			`e.auth_file_snapshot collate nocase = ?
-				and coalesce(e.auth_index, '') collate nocase = ?`,
-			authFileSnapshot,
-			authIndex,
+			snapshotLatestRequestPredicates(authFileSnapshot, authIndex),
 		)
 		if err != nil {
 			return nil, err
 		}
-		legacy, err := r.recentAccountRequestsByPredicate(
+		legacy, err := r.recentAccountRequestsByPredicates(
 			ctx,
 			target.RequestIndex,
 			limit,
-			`coalesce(e.auth_file_snapshot, '') = ''
-				and e.source collate nocase = ?
-				and coalesce(e.auth_index, '') collate nocase = ?`,
-			authFileSnapshot,
-			authIndex,
+			legacyLatestRequestPredicates(authFileSnapshot, authIndex),
 		)
 		if err != nil {
 			return nil, err
@@ -84,15 +134,67 @@ func (r *repository) RecentAccountRequests(
 	return requests, nil
 }
 
+func snapshotLatestRequestPredicates(authFileSnapshot, authIndex string) []latestRequestPredicate {
+	return latestRequestPredicates(
+		`e.auth_file_snapshot collate nocase = ?`,
+		[]any{authFileSnapshot},
+		authIndex,
+	)
+}
+
+func legacyLatestRequestPredicates(authFileSnapshot, authIndex string) []latestRequestPredicate {
+	filePredicates := []latestRequestPredicate{
+		{sql: `e.auth_file_snapshot is null and e.source collate nocase = ?`, args: []any{authFileSnapshot}},
+		{sql: `e.auth_file_snapshot = '' and e.source collate nocase = ?`, args: []any{authFileSnapshot}},
+	}
+	predicates := make([]latestRequestPredicate, 0, 4)
+	for _, filePredicate := range filePredicates {
+		predicates = append(predicates, latestRequestPredicates(filePredicate.sql, filePredicate.args, authIndex)...)
+	}
+	return predicates
+}
+
+func latestRequestPredicates(baseSQL string, baseArgs []any, authIndex string) []latestRequestPredicate {
+	if authIndex != "" {
+		return []latestRequestPredicate{{
+			sql:  baseSQL + ` and e.auth_index collate nocase = ?`,
+			args: append(append([]any{}, baseArgs...), authIndex),
+		}}
+	}
+	return []latestRequestPredicate{
+		{sql: baseSQL + ` and e.auth_index is null`, args: append([]any{}, baseArgs...)},
+		{sql: baseSQL + ` and e.auth_index = ''`, args: append([]any{}, baseArgs...)},
+	}
+}
+
+func (r *repository) recentAccountRequestsByPredicates(
+	ctx context.Context,
+	requestIndex int,
+	limit int,
+	predicates []latestRequestPredicate,
+) ([]rankedAccountRequest, error) {
+	parts := make([][]rankedAccountRequest, 0, len(predicates))
+	for _, predicate := range predicates {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		rows, err := r.recentAccountRequestsByPredicate(ctx, requestIndex, limit, predicate)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, rows)
+	}
+	merged := mergeRankedAccountRequests(limit, parts...)
+	return merged, nil
+}
+
 func (r *repository) recentAccountRequestsByPredicate(
 	ctx context.Context,
 	requestIndex int,
 	limit int,
-	predicate string,
-	args ...any,
+	predicate latestRequestPredicate,
 ) ([]rankedAccountRequest, error) {
-	queryArgs := append([]any{}, args...)
-	queryArgs = append(queryArgs, limit)
+	args := append(append([]any{}, predicate.args...), limit)
 	rows, err := r.db.QueryContext(ctx, `select
 	e.id,
 	e.timestamp_ms,
@@ -103,9 +205,9 @@ func (r *repository) recentAccountRequestsByPredicate(
 	coalesce(e.header_error_code, ''),
 	coalesce(e.header_trace_id, '')
 from usage_events e
-where `+predicate+`
+where `+predicate.sql+`
 order by e.timestamp_ms desc, e.id desc
-limit ?`, queryArgs...)
+limit ?`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +236,138 @@ limit ?`, queryArgs...)
 	return requests, rows.Err()
 }
 
+func (r *repository) recentAccountRequestsBatched(
+	ctx context.Context,
+	targets []LatestAccountRequestQuery,
+	limit int,
+) ([]LatestAccountRequest, error) {
+	values := make([]string, 0, len(targets))
+	args := make([]any, 0, len(targets)*3+1)
+	for _, target := range targets {
+		authFileSnapshot := strings.TrimSpace(target.AuthFileSnapshot)
+		if authFileSnapshot == "" {
+			continue
+		}
+		values = append(values, "(?, ?, ?)")
+		args = append(
+			args,
+			target.RequestIndex,
+			authFileSnapshot,
+			strings.TrimSpace(target.AuthIndex),
+		)
+	}
+	if len(values) == 0 {
+		return []LatestAccountRequest{}, nil
+	}
+	args = append(args, limit)
+
+	rows, err := r.db.QueryContext(ctx, `with credential_targets(
+	request_index, auth_file_snapshot, auth_index
+) as (
+	values `+strings.Join(values, ",")+`
+), snapshot_candidates as (
+	select
+		t.request_index,
+		e.id,
+		e.timestamp_ms,
+		e.failed,
+		e.fail_status_code,
+		coalesce(e.fail_summary, '') as fail_summary,
+		coalesce(e.header_error_kind, '') as header_error_kind,
+		coalesce(e.header_error_code, '') as header_error_code,
+		coalesce(e.header_trace_id, '') as header_trace_id
+	from credential_targets t
+	join usage_events e
+		on e.auth_file_snapshot collate nocase = t.auth_file_snapshot
+		and coalesce(e.auth_index, '') collate nocase = t.auth_index
+), legacy_source_candidates as (
+	select
+		t.request_index,
+		e.id,
+		e.timestamp_ms,
+		e.failed,
+		e.fail_status_code,
+		coalesce(e.fail_summary, '') as fail_summary,
+		coalesce(e.header_error_kind, '') as header_error_kind,
+		coalesce(e.header_error_code, '') as header_error_code,
+		coalesce(e.header_trace_id, '') as header_trace_id
+	from credential_targets t
+	join usage_events e
+		on coalesce(e.auth_file_snapshot, '') = ''
+		and e.source collate nocase = t.auth_file_snapshot
+		and coalesce(e.auth_index, '') collate nocase = t.auth_index
+), candidates as (
+	select * from snapshot_candidates
+	union all
+	select * from legacy_source_candidates
+), ranked as (
+	select
+		request_index,
+		timestamp_ms,
+		failed,
+		fail_status_code,
+		fail_summary,
+		header_error_kind,
+		header_error_code,
+		header_trace_id,
+		row_number() over (
+			partition by request_index
+			order by timestamp_ms desc, id desc
+		) as row_number
+	from candidates
+)
+select
+	request_index,
+	timestamp_ms,
+	failed,
+	fail_status_code,
+	fail_summary,
+	header_error_kind,
+	header_error_code,
+	header_trace_id
+from ranked
+where row_number <= ?
+order by request_index, row_number`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	requests := make([]LatestAccountRequest, 0, len(values)*limit)
+	for rows.Next() {
+		var request LatestAccountRequest
+		var failed int
+		if err := rows.Scan(
+			&request.RequestIndex,
+			&request.TimestampMS,
+			&failed,
+			&request.FailStatusCode,
+			&request.FailSummary,
+			&request.HeaderErrorKind,
+			&request.HeaderErrorCode,
+			&request.HeaderTraceID,
+		); err != nil {
+			return nil, err
+		}
+		request.Failed = failed != 0
+		requests = append(requests, request)
+	}
+	return requests, rows.Err()
+}
+
 func mergeRecentAccountRequests(limit int, parts ...[]rankedAccountRequest) []LatestAccountRequest {
+	merged := mergeRankedAccountRequests(limit, parts...)
+	if len(merged) == 0 {
+		return nil
+	}
+	requests := make([]LatestAccountRequest, len(merged))
+	for i, request := range merged {
+		requests[i] = request.LatestAccountRequest
+	}
+	return requests
+}
+
+func mergeRankedAccountRequests(limit int, parts ...[]rankedAccountRequest) []rankedAccountRequest {
 	total := 0
 	for _, part := range parts {
 		total += len(part)
@@ -155,9 +388,5 @@ func mergeRecentAccountRequests(limit int, parts ...[]rankedAccountRequest) []La
 	if len(merged) > limit {
 		merged = merged[:limit]
 	}
-	requests := make([]LatestAccountRequest, len(merged))
-	for i, request := range merged {
-		requests[i] = request.LatestAccountRequest
-	}
-	return requests
+	return merged
 }

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request.go
@@ -3,6 +3,7 @@ package usageevent
 import (
 	"context"
 	"database/sql"
+	"sort"
 	"strings"
 )
 
@@ -29,6 +30,11 @@ type LatestAccountRequest struct {
 	HeaderTraceID   string
 }
 
+type rankedAccountRequest struct {
+	LatestAccountRequest
+	id int64
+}
+
 func (r *repository) RecentAccountRequests(
 	ctx context.Context,
 	targets []LatestAccountRequestQuery,
@@ -38,104 +44,79 @@ func (r *repository) RecentAccountRequests(
 		return []LatestAccountRequest{}, nil
 	}
 
-	values := make([]string, 0, len(targets))
-	args := make([]any, 0, len(targets)*3+1)
+	requests := make([]LatestAccountRequest, 0, len(targets)*limit)
 	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		authFileSnapshot := strings.TrimSpace(target.AuthFileSnapshot)
 		if authFileSnapshot == "" {
 			continue
 		}
-		values = append(values, "(?, ?, ?)")
-		args = append(
-			args,
+		authIndex := strings.TrimSpace(target.AuthIndex)
+		snapshot, err := r.recentAccountRequestsByPredicate(
+			ctx,
 			target.RequestIndex,
+			limit,
+			`e.auth_file_snapshot collate nocase = ?
+				and coalesce(e.auth_index, '') collate nocase = ?`,
 			authFileSnapshot,
-			strings.TrimSpace(target.AuthIndex),
+			authIndex,
 		)
+		if err != nil {
+			return nil, err
+		}
+		legacy, err := r.recentAccountRequestsByPredicate(
+			ctx,
+			target.RequestIndex,
+			limit,
+			`coalesce(e.auth_file_snapshot, '') = ''
+				and e.source collate nocase = ?
+				and coalesce(e.auth_index, '') collate nocase = ?`,
+			authFileSnapshot,
+			authIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+		requests = append(requests, mergeRecentAccountRequests(limit, snapshot, legacy)...)
 	}
-	if len(values) == 0 {
-		return []LatestAccountRequest{}, nil
-	}
-	args = append(args, limit)
+	return requests, nil
+}
 
-	rows, err := r.db.QueryContext(ctx, `with credential_targets(
-	request_index, auth_file_snapshot, auth_index
-) as (
-	values `+strings.Join(values, ",")+`
-), snapshot_candidates as (
-	select
-		t.request_index,
-		e.id,
-		e.timestamp_ms,
-		e.failed,
-		e.fail_status_code,
-		coalesce(e.fail_summary, '') as fail_summary,
-		coalesce(e.header_error_kind, '') as header_error_kind,
-		coalesce(e.header_error_code, '') as header_error_code,
-		coalesce(e.header_trace_id, '') as header_trace_id
-	from credential_targets t
-	join usage_events e
-		on e.auth_file_snapshot collate nocase = t.auth_file_snapshot
-		and coalesce(e.auth_index, '') collate nocase = t.auth_index
-), legacy_source_candidates as (
-	select
-		t.request_index,
-		e.id,
-		e.timestamp_ms,
-		e.failed,
-		e.fail_status_code,
-		coalesce(e.fail_summary, '') as fail_summary,
-		coalesce(e.header_error_kind, '') as header_error_kind,
-		coalesce(e.header_error_code, '') as header_error_code,
-		coalesce(e.header_trace_id, '') as header_trace_id
-	from credential_targets t
-	join usage_events e
-		on coalesce(e.auth_file_snapshot, '') = ''
-		and e.source collate nocase = t.auth_file_snapshot
-		and coalesce(e.auth_index, '') collate nocase = t.auth_index
-), candidates as (
-	select * from snapshot_candidates
-	union all
-	select * from legacy_source_candidates
-), ranked as (
-	select
-		request_index,
-		timestamp_ms,
-		failed,
-		fail_status_code,
-		fail_summary,
-		header_error_kind,
-		header_error_code,
-		header_trace_id,
-		row_number() over (
-			partition by request_index
-			order by timestamp_ms desc, id desc
-		) as row_number
-	from candidates
-)
-select
-	request_index,
-	timestamp_ms,
-	failed,
-	fail_status_code,
-	fail_summary,
-	header_error_kind,
-	header_error_code,
-	header_trace_id
-from ranked
-where row_number <= ?
-order by request_index, row_number`, args...)
+func (r *repository) recentAccountRequestsByPredicate(
+	ctx context.Context,
+	requestIndex int,
+	limit int,
+	predicate string,
+	args ...any,
+) ([]rankedAccountRequest, error) {
+	queryArgs := append([]any{}, args...)
+	queryArgs = append(queryArgs, limit)
+	rows, err := r.db.QueryContext(ctx, `select
+	e.id,
+	e.timestamp_ms,
+	e.failed,
+	e.fail_status_code,
+	coalesce(e.fail_summary, ''),
+	coalesce(e.header_error_kind, ''),
+	coalesce(e.header_error_code, ''),
+	coalesce(e.header_trace_id, '')
+from usage_events e
+where `+predicate+`
+order by e.timestamp_ms desc, e.id desc
+limit ?`, queryArgs...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	requests := make([]LatestAccountRequest, 0, len(values)*limit)
+	requests := make([]rankedAccountRequest, 0, limit)
 	for rows.Next() {
-		var request LatestAccountRequest
+		var request rankedAccountRequest
 		var failed int
 		if err := rows.Scan(
-			&request.RequestIndex,
+			&request.id,
 			&request.TimestampMS,
 			&failed,
 			&request.FailStatusCode,
@@ -146,8 +127,37 @@ order by request_index, row_number`, args...)
 		); err != nil {
 			return nil, err
 		}
+		request.RequestIndex = requestIndex
 		request.Failed = failed != 0
 		requests = append(requests, request)
 	}
 	return requests, rows.Err()
+}
+
+func mergeRecentAccountRequests(limit int, parts ...[]rankedAccountRequest) []LatestAccountRequest {
+	total := 0
+	for _, part := range parts {
+		total += len(part)
+	}
+	if total == 0 {
+		return nil
+	}
+	merged := make([]rankedAccountRequest, 0, total)
+	for _, part := range parts {
+		merged = append(merged, part...)
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		if merged[i].TimestampMS != merged[j].TimestampMS {
+			return merged[i].TimestampMS > merged[j].TimestampMS
+		}
+		return merged[i].id > merged[j].id
+	})
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	requests := make([]LatestAccountRequest, len(merged))
+	for i, request := range merged {
+		requests[i] = request.LatestAccountRequest
+	}
+	return requests
 }

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request.go
@@ -30,6 +30,24 @@ where e.auth_file_snapshot collate nocase = ?
 order by e.timestamp_ms desc, e.id desc
 limit ?`
 
+// snapshotLatestRequestByFileAndEmptyIndexSQL is the indexed Top-N path for a
+// credential whose auth_index is the empty string. EXPLAIN tests pin this to
+// the same composite index, including COLLATE NOCASE on auth_index.
+const snapshotLatestRequestByFileAndEmptyIndexSQL = `select
+	e.id,
+	e.timestamp_ms,
+	e.failed,
+	e.fail_status_code,
+	coalesce(e.fail_summary, ''),
+	coalesce(e.header_error_kind, ''),
+	coalesce(e.header_error_code, ''),
+	coalesce(e.header_trace_id, '')
+from usage_events e
+where e.auth_file_snapshot collate nocase = ?
+	and e.auth_index collate nocase = ''
+order by e.timestamp_ms desc, e.id desc
+limit ?`
+
 // LatestAccountRequestQuery identifies one credential using the immutable
 // snapshot captured with a request. AuthFileSnapshot is the primary identity;
 // Source is used only for records created before auth-file snapshots existed.
@@ -163,7 +181,7 @@ func latestRequestPredicates(baseSQL string, baseArgs []any, authIndex string) [
 	}
 	return []latestRequestPredicate{
 		{sql: baseSQL + ` and e.auth_index is null`, args: append([]any{}, baseArgs...)},
-		{sql: baseSQL + ` and e.auth_index = ''`, args: append([]any{}, baseArgs...)},
+		{sql: baseSQL + ` and e.auth_index collate nocase = ''`, args: append([]any{}, baseArgs...)},
 	}
 }
 

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
@@ -2,6 +2,7 @@ package usageevent
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -103,6 +104,52 @@ func TestRecentAccountRequestsUseSnapshotIdentityLimitAndConservativeLegacyFallb
 	}
 	if _, ok := byIndex[2]; ok {
 		t.Fatalf("missing credential unexpectedly matched: %#v", byIndex[2])
+	}
+}
+
+func TestRecentAccountRequestsStopsAtLimitInsteadOfScanningOlderRows(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+	ctx := context.Background()
+	baseMS := int64(1_700_100_000_000)
+
+	events := make([]usage.Event, 0, 40)
+	for i := 0; i < 40; i++ {
+		events = append(events, latestAccountRequestEvent(
+			fmt.Sprintf("old-%d", i),
+			baseMS+int64(i),
+			"hot.json",
+			"idx-1",
+			"hot.json",
+		))
+	}
+	latest := latestAccountRequestEvent("hot-latest", baseMS+1000, "hot.json", "idx-1", "hot.json")
+	previous := latestAccountRequestEvent("hot-previous", baseMS+900, "hot.json", "idx-1", "hot.json")
+	events = append(events, previous, latest)
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	requests, err := repo.RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+		{RequestIndex: 7, AuthFileSnapshot: "hot.json", AuthIndex: "idx-1"},
+	}, 2)
+	if err != nil {
+		t.Fatalf("recent account requests: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %#v", requests)
+	}
+	if requests[0].TimestampMS != latest.TimestampMS || requests[1].TimestampMS != previous.TimestampMS {
+		t.Fatalf("limit order = %#v", requests)
+	}
+	for _, request := range requests {
+		if request.RequestIndex != 7 {
+			t.Fatalf("request index = %#v", request)
+		}
 	}
 }
 

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
@@ -113,8 +113,18 @@ func TestRecentAccountRequestsStopsAtLimitInsteadOfScanningOlderRows(t *testing.
 		t.Fatalf("open database: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	repo := New(db)
 	ctx := context.Background()
+	if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+		t.Fatalf("prepare latest-request indexes: %v", err)
+	}
+	repo := New(db)
+	ready, err := repo.(*repository).latestRequestIndexesReady(ctx)
+	if err != nil {
+		t.Fatalf("inspect indexes: %v", err)
+	}
+	if !ready {
+		t.Fatal("latest-request indexes were not created for the indexed Top-N path")
+	}
 	baseMS := int64(1_700_100_000_000)
 
 	events := make([]usage.Event, 0, 40)
@@ -268,6 +278,46 @@ func TestSnapshotLatestRequestQueryUsesAuthFileAndAuthIndexIndex(t *testing.T) {
 	}
 }
 
+func TestSnapshotLatestRequestEmptyAuthIndexUsesCompositeIndex(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := sqliterepo.RunDerivedStartupMaintenance(context.Background(), db); err != nil {
+		t.Fatalf("prepare latest-request indexes: %v", err)
+	}
+
+	rows, err := db.Query(`explain query plan `+snapshotLatestRequestByFileAndEmptyIndexSQL, "file-a.json", 10)
+	if err != nil {
+		t.Fatalf("explain empty auth_index query: %v", err)
+	}
+	defer rows.Close()
+
+	details := make([]string, 0, 8)
+	usesCompositeIndex := false
+	fullUsageScan := false
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		details = append(details, detail)
+		usesCompositeIndex = usesCompositeIndex ||
+			strings.Contains(detail, "INDEX "+latestRequestAuthFileIndex) &&
+				strings.Contains(detail, "auth_file_snapshot=?") &&
+				strings.Contains(detail, "auth_index=?")
+		fullUsageScan = fullUsageScan || strings.Contains(detail, "SCAN usage_events")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("query plan rows: %v", err)
+	}
+	if !usesCompositeIndex || fullUsageScan {
+		t.Fatalf("empty auth_index query did not use the composite auth-file index: %v", details)
+	}
+}
+
 func TestRecentAccountRequestsMatchesNullAndEmptyAuthIndex(t *testing.T) {
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {
@@ -281,9 +331,8 @@ func TestRecentAccountRequestsMatchesNullAndEmptyAuthIndex(t *testing.T) {
 	ctx := context.Background()
 	baseMS := int64(1_700_200_000_000)
 
-	emptyIndex := latestAccountRequestEvent("empty-index", baseMS+2, "file-a.json", "", "file-a.json")
 	nonEmpty := latestAccountRequestEvent("non-empty", baseMS+3, "file-a.json", "idx-1", "file-a.json")
-	if _, err := repo.InsertBatch(ctx, []usage.Event{emptyIndex, nonEmpty}); err != nil {
+	if _, err := repo.InsertBatch(ctx, []usage.Event{nonEmpty}); err != nil {
 		t.Fatalf("insert events: %v", err)
 	}
 	if _, err := db.Exec(`insert into usage_events (
@@ -299,6 +348,29 @@ func TestRecentAccountRequestsMatchesNullAndEmptyAuthIndex(t *testing.T) {
 	); err != nil {
 		t.Fatalf("insert null auth_index: %v", err)
 	}
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, model, auth_file_snapshot, auth_index, source, created_at_ms
+	) values (?, ?, ?, ?, ?, '', ?, ?)`,
+		"empty-index",
+		baseMS+2,
+		time.UnixMilli(baseMS+2).UTC().Format(time.RFC3339Nano),
+		"gpt-test",
+		"file-a.json",
+		"file-a.json",
+		baseMS+2,
+	); err != nil {
+		t.Fatalf("insert empty auth_index: %v", err)
+	}
+	var storedNull, storedEmpty int
+	if err := db.QueryRow(`select
+		sum(case when auth_index is null then 1 else 0 end),
+		sum(case when auth_index = '' then 1 else 0 end)
+	from usage_events where auth_file_snapshot = 'file-a.json'`).Scan(&storedNull, &storedEmpty); err != nil {
+		t.Fatalf("inspect stored auth_index values: %v", err)
+	}
+	if storedNull != 1 || storedEmpty != 1 {
+		t.Fatalf("stored auth_index null=%d empty=%d, want 1 and 1", storedNull, storedEmpty)
+	}
 
 	emptyRequests, err := repo.RecentAccountRequests(ctx, []LatestAccountRequestQuery{
 		{RequestIndex: 0, AuthFileSnapshot: "file-a.json", AuthIndex: ""},
@@ -309,7 +381,7 @@ func TestRecentAccountRequestsMatchesNullAndEmptyAuthIndex(t *testing.T) {
 	if len(emptyRequests) != 2 {
 		t.Fatalf("empty auth_index requests = %#v", emptyRequests)
 	}
-	if emptyRequests[0].TimestampMS != emptyIndex.TimestampMS || emptyRequests[1].TimestampMS != baseMS+1 {
+	if emptyRequests[0].TimestampMS != baseMS+2 || emptyRequests[1].TimestampMS != baseMS+1 {
 		t.Fatalf("empty auth_index order = %#v", emptyRequests)
 	}
 

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
@@ -177,3 +177,236 @@ func latestAccountRequestEvent(
 		CreatedAtMS:      timestampMS,
 	}
 }
+
+func TestRecentAccountRequestsIndexedMatchesBatchedFallback(t *testing.T) {
+	ctx := context.Background()
+	seed := func(t *testing.T, withIndexes bool) Repository {
+		t.Helper()
+		db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+		if err != nil {
+			t.Fatalf("open database: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		if withIndexes {
+			if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+				t.Fatalf("prepare latest-request indexes: %v", err)
+			}
+		}
+		repo := New(db)
+		legacy := latestAccountRequestEvent("legacy", 1_700_000_003_000, "", "legacy.json", "legacy.json")
+		latest := latestAccountRequestEvent("latest", 1_700_000_002_000, "credential-a.json", "auth-a", "source-a")
+		current := latestAccountRequestEvent("current", 1_700_000_001_000, "credential-a.json", "auth-a", "source-a")
+		if _, err := repo.InsertBatch(ctx, []usage.Event{legacy, latest, current}); err != nil {
+			t.Fatalf("insert events: %v", err)
+		}
+		ready, err := repo.(*repository).latestRequestIndexesReady(ctx)
+		if err != nil {
+			t.Fatalf("inspect indexes: %v", err)
+		}
+		if ready != withIndexes {
+			t.Fatalf("latestRequestIndexesReady = %t, want %t", ready, withIndexes)
+		}
+		return repo
+	}
+
+	indexed, err := seed(t, true).RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+		{RequestIndex: 0, AuthFileSnapshot: "credential-a.json", AuthIndex: "auth-a"},
+		{RequestIndex: 1, AuthFileSnapshot: "legacy.json", AuthIndex: "legacy.json"},
+	}, 2)
+	if err != nil {
+		t.Fatalf("indexed recent account requests: %v", err)
+	}
+	batched, err := seed(t, false).RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+		{RequestIndex: 0, AuthFileSnapshot: "credential-a.json", AuthIndex: "auth-a"},
+		{RequestIndex: 1, AuthFileSnapshot: "legacy.json", AuthIndex: "legacy.json"},
+	}, 2)
+	if err != nil {
+		t.Fatalf("batched recent account requests: %v", err)
+	}
+	if !sameLatestAccountRequests(indexed, batched) {
+		t.Fatalf("indexed = %#v batched = %#v", indexed, batched)
+	}
+}
+
+func TestSnapshotLatestRequestQueryUsesAuthFileAndAuthIndexIndex(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := sqliterepo.RunDerivedStartupMaintenance(context.Background(), db); err != nil {
+		t.Fatalf("prepare latest-request indexes: %v", err)
+	}
+
+	rows, err := db.Query(`explain query plan `+snapshotLatestRequestByFileAndIndexSQL, "credential-a.json", "auth-a", 10)
+	if err != nil {
+		t.Fatalf("explain snapshot latest-request query: %v", err)
+	}
+	defer rows.Close()
+
+	details := make([]string, 0, 8)
+	usesCompositeIndex := false
+	fullUsageScan := false
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		details = append(details, detail)
+		usesCompositeIndex = usesCompositeIndex ||
+			strings.Contains(detail, "INDEX "+latestRequestAuthFileIndex) &&
+				strings.Contains(detail, "auth_file_snapshot=?") &&
+				strings.Contains(detail, "auth_index=?")
+		fullUsageScan = fullUsageScan || strings.Contains(detail, "SCAN usage_events")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("query plan rows: %v", err)
+	}
+	if !usesCompositeIndex || fullUsageScan {
+		t.Fatalf("snapshot latest-request query did not use the composite auth-file index: %v", details)
+	}
+}
+
+func TestRecentAccountRequestsMatchesNullAndEmptyAuthIndex(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := sqliterepo.RunDerivedStartupMaintenance(context.Background(), db); err != nil {
+		t.Fatalf("prepare latest-request indexes: %v", err)
+	}
+	repo := New(db)
+	ctx := context.Background()
+	baseMS := int64(1_700_200_000_000)
+
+	emptyIndex := latestAccountRequestEvent("empty-index", baseMS+2, "file-a.json", "", "file-a.json")
+	nonEmpty := latestAccountRequestEvent("non-empty", baseMS+3, "file-a.json", "idx-1", "file-a.json")
+	if _, err := repo.InsertBatch(ctx, []usage.Event{emptyIndex, nonEmpty}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, model, auth_file_snapshot, auth_index, source, created_at_ms
+	) values (?, ?, ?, ?, ?, null, ?, ?)`,
+		"null-index",
+		baseMS+1,
+		time.UnixMilli(baseMS+1).UTC().Format(time.RFC3339Nano),
+		"gpt-test",
+		"file-a.json",
+		"file-a.json",
+		baseMS+1,
+	); err != nil {
+		t.Fatalf("insert null auth_index: %v", err)
+	}
+
+	emptyRequests, err := repo.RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+		{RequestIndex: 0, AuthFileSnapshot: "file-a.json", AuthIndex: ""},
+	}, 10)
+	if err != nil {
+		t.Fatalf("empty auth_index query: %v", err)
+	}
+	if len(emptyRequests) != 2 {
+		t.Fatalf("empty auth_index requests = %#v", emptyRequests)
+	}
+	if emptyRequests[0].TimestampMS != emptyIndex.TimestampMS || emptyRequests[1].TimestampMS != baseMS+1 {
+		t.Fatalf("empty auth_index order = %#v", emptyRequests)
+	}
+
+	indexedRequests, err := repo.RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+		{RequestIndex: 1, AuthFileSnapshot: "file-a.json", AuthIndex: "idx-1"},
+	}, 10)
+	if err != nil {
+		t.Fatalf("non-empty auth_index query: %v", err)
+	}
+	if len(indexedRequests) != 1 || indexedRequests[0].TimestampMS != nonEmpty.TimestampMS {
+		t.Fatalf("non-empty auth_index requests = %#v", indexedRequests)
+	}
+}
+
+func TestRecentAccountRequestsMergesNewerLegacyWithoutSnapshot(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := sqliterepo.RunDerivedStartupMaintenance(context.Background(), db); err != nil {
+		t.Fatalf("prepare latest-request indexes: %v", err)
+	}
+	repo := New(db)
+	ctx := context.Background()
+	baseMS := int64(1_700_300_000_000)
+
+	snapshot := latestAccountRequestEvent("snap", baseMS+1_000, "cred.json", "idx-1", "other-source")
+	legacyNewer := latestAccountRequestEvent("legacy-newer", baseMS+2_000, "", "idx-1", "cred.json")
+	if _, err := repo.InsertBatch(ctx, []usage.Event{snapshot, legacyNewer}); err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+
+	requests, err := repo.RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+		{RequestIndex: 4, AuthFileSnapshot: "cred.json", AuthIndex: "idx-1"},
+	}, 1)
+	if err != nil {
+		t.Fatalf("recent account requests: %v", err)
+	}
+	if len(requests) != 1 || requests[0].TimestampMS != legacyNewer.TimestampMS {
+		t.Fatalf("global top-n = %#v", requests)
+	}
+}
+
+func sameLatestAccountRequests(left, right []LatestAccountRequest) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		a, b := left[i], right[i]
+		if a.RequestIndex != b.RequestIndex || a.TimestampMS != b.TimestampMS || a.Failed != b.Failed ||
+			a.FailSummary != b.FailSummary || a.HeaderErrorKind != b.HeaderErrorKind ||
+			a.HeaderErrorCode != b.HeaderErrorCode || a.HeaderTraceID != b.HeaderTraceID {
+			return false
+		}
+		if a.FailStatusCode.Valid != b.FailStatusCode.Valid || a.FailStatusCode.Int64 != b.FailStatusCode.Int64 {
+			return false
+		}
+	}
+	return true
+}
+
+func BenchmarkRecentAccountRequests200Targets(b *testing.B) {
+	db, err := sqliterepo.Open(filepath.Join(b.TempDir(), "usage.sqlite"))
+	if err != nil {
+		b.Fatalf("open database: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+	if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+		b.Fatalf("prepare latest-request indexes: %v", err)
+	}
+	repo := New(db)
+	events := make([]usage.Event, 0, 200*5)
+	targets := make([]LatestAccountRequestQuery, 0, 200)
+	baseMS := int64(1_700_400_000_000)
+	for i := 0; i < 200; i++ {
+		file := fmt.Sprintf("cred-%03d.json", i)
+		index := fmt.Sprintf("idx-%03d", i)
+		for n := 0; n < 5; n++ {
+			events = append(events, latestAccountRequestEvent(
+				fmt.Sprintf("e-%d-%d", i, n),
+				baseMS+int64(i*10+n),
+				file,
+				index,
+				file,
+			))
+		}
+		targets = append(targets, LatestAccountRequestQuery{RequestIndex: i, AuthFileSnapshot: file, AuthIndex: index})
+	}
+	if _, err := repo.InsertBatch(ctx, events); err != nil {
+		b.Fatalf("insert events: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := repo.RecentAccountRequests(ctx, targets, 10); err != nil {
+			b.Fatalf("recent account requests: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`RecentAccountRequests` already had the right indexes, but it ranked every matching `usage_events` row before keeping the latest N. Account-history totals stayed on rollups; the Accounts page still timed out because the same handler loaded latest/recent requests that way.

The snapshot path is now per-credential indexed Top-N. The legacy empty-snapshot `source` lookup stays as a compatibility merge and is not fully bounded yet.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Use per-credential `ORDER BY timestamp_ms DESC, id DESC LIMIT n` only when both latest-request indexes exist.
- Non-empty `auth_index` compares with `COLLATE NOCASE`; empty values match `NULL` and `''` separately, also with `COLLATE NOCASE`, so the composite index order can be used.
- Merge snapshot and legacy hits into a global Top-N. Without those indexes, keep the original batched window query.
- Tests cover EXPLAIN QUERY PLAN for non-empty and empty `auth_index`, indexed-vs-batched parity, literal `NULL` / `''` rows, snapshot/legacy interleaving, indexed limit coverage, and a 200-target benchmark.

## User Impact

The Accounts page lifetime totals were already cheap. Latest-request timestamps and the last 10 request summaries should return in milliseconds per credential on the snapshot path, instead of scanning tens of thousands of historical rows.

## Compatibility / Runtime Notes

- CPA panel mode: no panel or CPA-key change.
- Manager Server mode: same `/v0/management/monitoring/account-history` contract; `latest_request` / `recent_requests` still return up to N rows, newest first.
- Full Docker / native packages: backend-only; rebuild/replace the Manager Server binary. Embedded `management.html` is unchanged.
- Boundary: the snapshot path is indexed Top-N. The legacy `source` compatibility lookup can still grow with that credential's source history; a partial index for empty `auth_file_snapshot` is a follow-up.

## Data / Security Notes

Read-path SQL only. No schema change, no rewrite of `usage_events`, no extra fields in the API. `fail_body` / `raw_json` remain unselected.

## Risk / Rollback

Risk level: Low

Rollback notes: revert this commit. Response shape is unchanged. Worst case is the previous full-history window scan.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
cd apps/manager-server && CGO_ENABLED=0 go test ./internal/repository/usageevent/ -count=1
```

Frontend type/lint/build were skipped: no `apps/web` changes.

## Screenshots / Recordings

N/A — backend query-shape fix. The Accounts card still shows the same latest-request timestamp and 10 recent rows.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

User-visible performance fix for the Accounts page on large `usage_events` databases. Please mention it in the next patch/release notes. No README or docs-manual change in this PR.

## Related

Fixes #574
Refs #563
