### PR TITLE
🐛 fix(web): localize server Codex quota reset times

### DIFF
--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -6556,6 +6556,8 @@ export const getDemoCodexInspectionLocalRun = (baseNow = now()): CodexInspection
         labelParams: window.labelParams,
         usedPercent: window.usedPercent ?? null,
         resetLabel: window.resetLabel ?? '',
+        resetAtMs: window.resetAtMs ?? null,
+        resetAccuracy: window.resetAccuracy,
         limitWindowSeconds: window.limitWindowSeconds ?? null,
       })),
       errorKind: item.errorKind,

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.lifecycle.test.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.lifecycle.test.tsx
@@ -4,6 +4,7 @@ import type { TFunction } from 'i18next';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import type {
+  CodexInspectionResult,
   CodexInspectionRun,
   CodexInspectionRunDetail,
   ManagerConfig,
@@ -14,7 +15,7 @@ import {
   getRunStatusLabel,
   hasActiveRun,
 } from '@/features/monitoring/model/serverCodexInspectionLifecycle';
-import { ServerCodexInspectionPage } from './ServerCodexInspectionPage';
+import { ServerCodexInspectionPage, toServerResultItem } from './ServerCodexInspectionPage';
 
 const mocks = vi.hoisted(() => ({
   authState: {
@@ -192,6 +193,46 @@ const flush = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
   await Promise.resolve();
 };
+
+describe('ServerCodexInspectionPage quota mapping', () => {
+  it('preserves absolute reset metadata from the server result', () => {
+    const resetAtMs = Date.parse('2026-08-20T03:40:00Z');
+    const item: CodexInspectionResult = {
+      id: 7,
+      runId: 1,
+      accountKey: 'codex.json::auth-1',
+      fileName: 'codex.json',
+      displayAccount: 'account@example.com',
+      provider: 'codex',
+      disabled: false,
+      action: 'keep',
+      actionReason: '',
+      isQuota: false,
+      createdAtMs: 0,
+      quotaWindows: [
+        {
+          id: 'five-hour',
+          labelKey: 'codex_quota.primary_window',
+          usedPercent: 42,
+          resetLabel: '08/20 03:40',
+          resetAtMs,
+          resetAccuracy: 'exact',
+          limitWindowSeconds: 18_000,
+        },
+      ],
+    };
+
+    const mapped = toServerResultItem(item, t, undefined, 'en');
+
+    expect(mapped.quotaWindows).toEqual([
+      expect.objectContaining({
+        resetLabel: '08/20 03:40',
+        resetAtMs,
+        resetAccuracy: 'exact',
+      }),
+    ]);
+  });
+});
 
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
@@ -593,7 +593,8 @@ function buildObservedHeaderEvidence(
   return evidence;
 }
 
-function toServerResultItem(
+// eslint-disable-next-line react-refresh/only-export-components -- pure mapper is exported for unit testing
+export function toServerResultItem(
   item: CodexInspectionResult,
   t: ReturnType<typeof useTranslation>['t'],
   snapshot: UsageHeaderSnapshot | undefined,
@@ -631,6 +632,8 @@ function toServerResultItem(
       labelParams: window.labelParams,
       usedPercent: window.usedPercent ?? null,
       resetLabel: window.resetLabel ?? '',
+      resetAtMs: window.resetAtMs ?? null,
+      resetAccuracy: window.resetAccuracy,
       limitWindowSeconds: window.limitWindowSeconds ?? null,
     })),
     quotaInventoryObserved: item.quotaInventoryObserved,

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -4885,6 +4885,8 @@ describe('Codex inspection last-run cache', () => {
               labelKey: 'codex_quota.monthly_window',
               usedPercent: 87,
               resetLabel: '06/18 12:00',
+              resetAtMs: Date.parse('2026-06-18T04:00:00Z'),
+              resetAccuracy: 'exact',
               limitWindowSeconds: 2_592_000,
             },
           ],
@@ -4907,6 +4909,8 @@ describe('Codex inspection last-run cache', () => {
         labelParams: undefined,
         usedPercent: 87,
         resetLabel: '06/18 12:00',
+        resetAtMs: Date.parse('2026-06-18T04:00:00Z'),
+        resetAccuracy: 'exact',
         limitWindowSeconds: 2_592_000,
       },
     ]);

--- a/apps/web/src/features/monitoring/components/CodexInspectionQuotaWindows.test.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionQuotaWindows.test.tsx
@@ -1,10 +1,14 @@
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { describe, expect, it } from 'vitest';
+import { formatQuotaResetTime } from '@/utils/quota/formatters';
 import { CodexInspectionQuotaWindows } from './CodexInspectionQuotaWindows';
 import styles from '../CodexInspectionPage.module.scss';
 
-const t = ((key: string, options?: Record<string, unknown>) =>
-  options?.percent ? `${key}:${options.percent}` : key) as never;
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (options?.percent !== undefined) return `${key}:${options.percent}`;
+  if (options?.time !== undefined) return `${key}:${options.time}`;
+  return key;
+}) as never;
 
 const collectText = (renderer: ReactTestRenderer) =>
   renderer.root
@@ -12,6 +16,87 @@ const collectText = (renderer: ReactTestRenderer) =>
     .flatMap((node) => node.children.filter((child): child is string => typeof child === 'string'));
 
 describe('CodexInspectionQuotaWindows', () => {
+  it('prefers the canonical reset timestamp over a server-formatted reset label', () => {
+    const resetAtMs = Date.parse('2026-08-20T12:37:00Z');
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <CodexInspectionQuotaWindows
+          windows={[
+            {
+              id: 'five-hour',
+              labelKey: 'five-hour',
+              usedPercent: 3,
+              resetLabel: '08/20 03:40',
+              resetAtMs,
+              resetAccuracy: 'exact',
+            },
+          ]}
+          t={t}
+        />
+      );
+    });
+
+    const text = collectText(renderer!);
+    expect(text).toContain(
+      `monitoring.codex_inspection_quota_reset:${formatQuotaResetTime(resetAtMs)}`
+    );
+    expect(text).not.toContain('monitoring.codex_inspection_quota_reset:08/20 03:40');
+  });
+
+  it('falls back to a non-absolute reset label when no timestamp is available', () => {
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <CodexInspectionQuotaWindows
+          windows={[
+            {
+              id: 'five-hour',
+              labelKey: 'five-hour',
+              usedPercent: 3,
+              resetLabel: '2h 18m',
+              resetAtMs: null,
+            },
+          ]}
+          t={t}
+        />
+      );
+    });
+
+    expect(collectText(renderer!)).toContain('monitoring.codex_inspection_quota_reset:2h 18m');
+  });
+
+  it('formats an ISO legacy reset label in the browser timezone', () => {
+    const resetLabel = '2026-08-20T03:40:00Z';
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <CodexInspectionQuotaWindows
+          windows={[{ id: 'weekly', labelKey: 'weekly', usedPercent: 3, resetLabel }]}
+          t={t}
+        />
+      );
+    });
+
+    expect(collectText(renderer!)).toContain(
+      `monitoring.codex_inspection_quota_reset:${formatQuotaResetTime(resetLabel)}`
+    );
+  });
+
+  it('omits the reset message when no reset information is available', () => {
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <CodexInspectionQuotaWindows
+          windows={[{ id: 'monthly', labelKey: 'monthly', usedPercent: 3, resetLabel: '-' }]}
+          t={t}
+        />
+      );
+    });
+
+    expect(collectText(renderer!)).not.toContain('monitoring.codex_inspection_quota_reset');
+  });
+
   it('shows the remaining percentage using the remaining-width progress bar', () => {
     let renderer: ReactTestRenderer;
     act(() => {

--- a/apps/web/src/features/monitoring/components/CodexInspectionQuotaWindows.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionQuotaWindows.tsx
@@ -1,5 +1,7 @@
 import type { TFunction } from 'i18next';
+import type { CodexInspectionQuotaWindow } from '@/features/monitoring/codexInspection';
 import { formatInspectionQuotaResetLabel } from '@/features/monitoring/model/codexInspectionPresentation';
+import { formatQuotaResetTime, isValidQuotaResetAtMs } from '@/utils/quota/formatters';
 import styles from '../CodexInspectionPage.module.scss';
 
 export type CodexInspectionQuotaWindowView = {
@@ -8,6 +10,8 @@ export type CodexInspectionQuotaWindowView = {
   labelParams?: Record<string, string | number>;
   usedPercent?: number | null;
   resetLabel?: string;
+  resetAtMs?: number | null;
+  resetAccuracy?: CodexInspectionQuotaWindow['resetAccuracy'];
 };
 
 type CodexInspectionQuotaWindowsProps = {
@@ -51,6 +55,8 @@ export function CodexInspectionQuotaWindows({
             id: window.id,
             label: formatQuotaLabel(window, t),
             resetLabel: window.resetLabel,
+            resetAtMs: window.resetAtMs,
+            resetAccuracy: window.resetAccuracy,
             usedPercent,
           },
         ];
@@ -65,6 +71,8 @@ export function CodexInspectionQuotaWindows({
               id: 'overall',
               label: t('monitoring.codex_inspection_used_percent'),
               resetLabel: '',
+              resetAtMs: null,
+              resetAccuracy: undefined,
               usedPercent: normalizedFallbackUsedPercent,
             },
           ];
@@ -85,7 +93,9 @@ export function CodexInspectionQuotaWindows({
       {rows.map((row) => {
         const usedPercent = normalizePercent(row.usedPercent);
         const remainingPercent = usedPercent === null ? null : clampPercent(100 - usedPercent);
-        const resetTime = formatInspectionQuotaResetLabel(row.resetLabel);
+        const resetTime = isValidQuotaResetAtMs(row.resetAtMs)
+          ? formatQuotaResetTime(row.resetAtMs)
+          : formatInspectionQuotaResetLabel(row.resetLabel);
         const resetLabel = resetTime
           ? t('monitoring.codex_inspection_quota_reset', { time: resetTime })
           : '';

--- a/apps/web/src/features/monitoring/model/codexInspectionStorage.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionStorage.ts
@@ -126,20 +126,42 @@ const normalizeQuotaWindowLabelParams = (
   return Object.keys(params).length > 0 ? params : undefined;
 };
 
-const serializeQuotaWindow = (window: CodexInspectionQuotaWindow): CodexInspectionQuotaWindow => ({
-  id: readString(window.id),
-  labelKey: readString(window.labelKey),
-  labelParams: normalizeQuotaWindowLabelParams(window.labelParams),
-  usedPercent: readNullableNumber(window.usedPercent),
-  resetLabel: readString(window.resetLabel),
-  limitWindowSeconds: readNullableNumber(window.limitWindowSeconds),
-});
+const normalizeQuotaResetAccuracy = (
+  value: unknown
+): CodexInspectionQuotaWindow['resetAccuracy'] | undefined => {
+  switch (value) {
+    case 'exact':
+    case 'derived':
+    case 'estimated':
+    case 'unknown':
+      return value;
+    default:
+      return undefined;
+  }
+};
+
+const serializeQuotaWindow = (window: CodexInspectionQuotaWindow): CodexInspectionQuotaWindow => {
+  const resetAtMs = readNullableNumber(window.resetAtMs);
+  const resetAccuracy = normalizeQuotaResetAccuracy(window.resetAccuracy);
+  return {
+    id: readString(window.id),
+    labelKey: readString(window.labelKey),
+    labelParams: normalizeQuotaWindowLabelParams(window.labelParams),
+    usedPercent: readNullableNumber(window.usedPercent),
+    resetLabel: readString(window.resetLabel),
+    ...(resetAtMs !== null ? { resetAtMs } : {}),
+    ...(resetAccuracy ? { resetAccuracy } : {}),
+    limitWindowSeconds: readNullableNumber(window.limitWindowSeconds),
+  };
+};
 
 const hydrateQuotaWindow = (value: unknown): CodexInspectionQuotaWindow | null => {
   if (!isRecord(value)) return null;
   const id = readString(value.id);
   const labelKey = readString(value.labelKey);
   if (!id || !labelKey) return null;
+  const resetAtMs = readNullableNumber(value.resetAtMs);
+  const resetAccuracy = normalizeQuotaResetAccuracy(value.resetAccuracy);
 
   return {
     id,
@@ -147,6 +169,8 @@ const hydrateQuotaWindow = (value: unknown): CodexInspectionQuotaWindow | null =
     labelParams: normalizeQuotaWindowLabelParams(value.labelParams),
     usedPercent: readNullableNumber(value.usedPercent),
     resetLabel: readString(value.resetLabel),
+    ...(resetAtMs !== null ? { resetAtMs } : {}),
+    ...(resetAccuracy ? { resetAccuracy } : {}),
     limitWindowSeconds: readNullableNumber(value.limitWindowSeconds),
   };
 };


### PR DESCRIPTION
## Summary

Fix Server Codex inspection quota reset times by rendering the canonical resetAtMs in the browser local timezone. The server-provided resetLabel remains available for compatibility and fallback.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Preserve resetAtMs and resetAccuracy through server result mapping, demo fixtures, and last-run cache serialization/hydration.
- Prefer a valid resetAtMs with the existing browser-local formatter, then fall back to resetLabel for legacy and non-absolute values.
- Add coverage for timestamp precedence, text fallback, legacy ISO labels, missing reset data, result mapping, and cache round trips.

## User Impact

Users see Server Codex inspection reset times in their browser local timezone. UTC containers and host timezone settings no longer shift canonical reset timestamps. Browser/local inspection behavior remains unchanged.

## Compatibility / Runtime Notes

- CPA panel mode: shared frontend behavior preserves local inspection rendering; schedule timezone is not used for quota reset display.
- Manager Server mode: resetAtMs is consumed as the canonical value and legacy resetLabel remains supported.
- Full Docker / native packages: no image, package, or configuration changes; display is independent of Docker and OS timezone.

## Data / Security Notes

No backend API, SQLite, authentication, secret, raw usage-data, or quota-calculation changes. The frontend cache extension is additive and remains compatible with legacy records.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit adb9b685. Legacy resetLabel fallback remains available, and no server scheduling or reset timestamp generation was changed.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run test                                      # 192 suites / 2384 tests passed
npm --workspace apps/web run type-check           # passed
npm --workspace apps/web run lint                 # 0 errors; one pre-existing warning
npm run build                                     # single-file Vite build passed
npm run manager-server:test                       # go test ./... passed
git diff --check                                  # passed
```

## Screenshots / Recordings

N/A — browser visual recording was not run; the visible behavior is covered by automated component tests.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — this is a bug fix with no documentation or navigation change.

Docs decision: No documentation update is required.

## Related

Fixes #577