### PR TITLE
🐛 fix(web): localize credential quota reset times

### DIFF
--- a/apps/web/src/features/accounts/model/accountListPresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.test.ts
@@ -130,6 +130,25 @@ describe('accountListPresentation', () => {
     expect(item.recommendation.actionLabelKey).toBe('accounts.recommend_action_reauth');
   });
 
+  it('uses Codex status reset timestamps when quota windows are unavailable', () => {
+    const resetAtMs = Date.parse('2026-08-20T03:40:00Z');
+    const item = buildAccountListItem(makeRow(), {
+      codexStatus: makeCodexStatus({
+        isFiveHourLimited: true,
+        isQuotaLimited: true,
+        fiveHourResetLabel: '08/20 03:40',
+        fiveHourResetAtMs: resetAtMs,
+        fiveHourResetAccuracy: 'exact',
+      }),
+    });
+
+    expect(item.health).toMatchObject({
+      status: 'five_hour_exhausted',
+      resetAtMs,
+    });
+    expect(item.health.tooltipParams.resetAt).toBe('08/20 03:40');
+  });
+
   it('lets a newer successful request clear stale inspection health and advice', () => {
     const row = makeRow({
       inspection: {

--- a/apps/web/src/features/accounts/model/accountListPresentation.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.ts
@@ -565,16 +565,32 @@ const getResetForLimitKind = (
     };
   }
 
-  const codexResetLabel =
+  const codexReset =
     kind === 'monthly'
-      ? codexStatus?.monthlyResetLabel
+      ? {
+          resetLabel: codexStatus?.monthlyResetLabel,
+          resetAtMs: codexStatus?.monthlyResetAtMs ?? null,
+          resetAccuracy: codexStatus?.monthlyResetAccuracy ?? 'unknown',
+        }
       : kind === 'weekly'
-        ? codexStatus?.weeklyResetLabel
+        ? {
+            resetLabel: codexStatus?.weeklyResetLabel,
+            resetAtMs: codexStatus?.weeklyResetAtMs ?? null,
+            resetAccuracy: codexStatus?.weeklyResetAccuracy ?? 'unknown',
+          }
         : kind === 'five_hour'
-          ? codexStatus?.fiveHourResetLabel
+          ? {
+              resetLabel: codexStatus?.fiveHourResetLabel,
+              resetAtMs: codexStatus?.fiveHourResetAtMs ?? null,
+              resetAccuracy: codexStatus?.fiveHourResetAccuracy ?? 'unknown',
+            }
           : null;
-  if (codexResetLabel) {
-    return { resetLabel: codexResetLabel, resetAtMs: null, resetAccuracy: 'unknown' };
+  if (codexReset && (codexReset.resetLabel || codexReset.resetAtMs !== null)) {
+    return {
+      resetLabel: codexReset.resetLabel ?? fallback.resetLabel,
+      resetAtMs: codexReset.resetAtMs ?? null,
+      resetAccuracy: codexReset.resetAccuracy ?? 'unknown',
+    };
   }
   return fallback;
 };

--- a/apps/web/src/features/authFiles/model/credentialStatus.test.ts
+++ b/apps/web/src/features/authFiles/model/credentialStatus.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AuthFileItem, CodexQuotaState } from '@/types';
 import type { UsageHeaderSnapshot } from '@/services/api/usageService';
+import { formatQuotaResetTime } from '@/utils/quota/formatters';
 import {
   authFileMatchesCodexStatusFilter,
   buildAuthFileCodexInspectionMap,
@@ -211,6 +212,36 @@ describe('auth file Codex status helpers', () => {
     expect(authFileMatchesCodexStatusFilter(status, 'five_hour_limited')).toBe(true);
     expect(authFileMatchesCodexStatusFilter(status, 'weekly_limited')).toBe(false);
     expect(status.badges.map((badge) => badge.kind)).toContain('five_hour_limited');
+  });
+
+  it('uses the absolute reset timestamp for disabled recovery status display', () => {
+    const resetAtMs = Date.parse('2026-08-20T03:40:00Z');
+    const status = getAuthFileCodexStatus(
+      codexFile({ disabled: true }),
+      codexQuota({
+        windows: [
+          {
+            id: 'five-hour',
+            label: '5-hour limit',
+            usedPercent: 100,
+            resetLabel: '08/20 03:40',
+            resetAtMs,
+            resetAccuracy: 'exact',
+            limitWindowSeconds: 18_000,
+          },
+        ],
+      })
+    );
+
+    expect(status.fiveHourResetAtMs).toBe(resetAtMs);
+    expect(status.fiveHourResetAccuracy).toBe('exact');
+    expect(status.fiveHourResetLabel).toBe(formatQuotaResetTime(resetAtMs));
+    expect(status.recoveryResetAtMs).toBe(resetAtMs);
+    expect(status.recoveryResetAccuracy).toBe('exact');
+    expect(status.recoveryResetLabel).toBe(formatQuotaResetTime(resetAtMs));
+    expect(status.badges.find((badge) => badge.kind === 'disabled_with_reset')).toMatchObject({
+      labelParams: { reset: formatQuotaResetTime(resetAtMs) },
+    });
   });
 
   it('detects monthly-limited Codex quota without treating it as weekly-limited', () => {

--- a/apps/web/src/features/authFiles/model/credentialStatus.ts
+++ b/apps/web/src/features/authFiles/model/credentialStatus.ts
@@ -1,6 +1,7 @@
-import type { AuthFileItem, CodexQuotaState } from '@/types';
+import type { AuthFileItem, CodexQuotaState, CodexQuotaWindow, QuotaResetAccuracy } from '@/types';
 import type { UsageHeaderSnapshot } from '@/services/api/usageService';
 import { getXaiProbeIssueKey } from '@/utils/quota/xaiPresentation';
+import { formatQuotaResetTime, isValidQuotaResetAtMs } from '@/utils/quota/formatters';
 import {
   getHeaderSnapshotErrorCode,
   getHeaderSnapshotErrorKind,
@@ -73,9 +74,17 @@ export type AuthFileCodexStatusSummary = {
   isMonthlyLimited: boolean;
   hasDisabledRecoveryReset: boolean;
   fiveHourResetLabel: string | null;
+  fiveHourResetAtMs?: number | null;
+  fiveHourResetAccuracy?: QuotaResetAccuracy;
   weeklyResetLabel: string | null;
+  weeklyResetAtMs?: number | null;
+  weeklyResetAccuracy?: QuotaResetAccuracy;
   monthlyResetLabel: string | null;
+  monthlyResetAtMs?: number | null;
+  monthlyResetAccuracy?: QuotaResetAccuracy;
   recoveryResetLabel: string | null;
+  recoveryResetAtMs?: number | null;
+  recoveryResetAccuracy?: QuotaResetAccuracy;
   fiveHourUsedPercent: number | null;
   weeklyUsedPercent: number | null;
   monthlyUsedPercent: number | null;
@@ -164,6 +173,23 @@ const formatObservedRecoverLabel = (value: number | null) => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
   return date.toLocaleString();
+};
+
+type CodexStatusReset = {
+  label: string | null;
+  resetAtMs: number | null;
+  resetAccuracy: QuotaResetAccuracy;
+};
+
+const resolveCodexStatusReset = (window?: CodexQuotaWindow | null): CodexStatusReset => {
+  const resetAtMs = isValidQuotaResetAtMs(window?.resetAtMs) ? (window?.resetAtMs ?? null) : null;
+  const legacyLabel = isKnownResetLabel(window?.resetLabel) ? window.resetLabel.trim() : null;
+  const canonicalLabel = resetAtMs === null ? null : formatQuotaResetTime(resetAtMs);
+  return {
+    label: canonicalLabel && canonicalLabel !== '-' ? canonicalLabel : legacyLabel,
+    resetAtMs,
+    resetAccuracy: resetAtMs === null ? 'unknown' : (window?.resetAccuracy ?? 'unknown'),
+  };
 };
 
 const OBSERVED_AUTH_ERROR_PATTERNS = [
@@ -1077,9 +1103,17 @@ export const getAuthFileCodexStatus = (
       isMonthlyLimited: false,
       hasDisabledRecoveryReset: false,
       fiveHourResetLabel: null,
+      fiveHourResetAtMs: null,
+      fiveHourResetAccuracy: 'unknown',
       weeklyResetLabel: null,
+      weeklyResetAtMs: null,
+      weeklyResetAccuracy: 'unknown',
       monthlyResetLabel: null,
+      monthlyResetAtMs: null,
+      monthlyResetAccuracy: 'unknown',
       recoveryResetLabel: null,
+      recoveryResetAtMs: null,
+      recoveryResetAccuracy: 'unknown',
       fiveHourUsedPercent: null,
       weeklyUsedPercent: null,
       monthlyUsedPercent: null,
@@ -1152,15 +1186,12 @@ export const getAuthFileCodexStatus = (
   const longWindowUsedPercent = weeklyWindowUsedPercent ?? monthlyUsedPercent;
   const weeklyUsedPercent =
     weeklyWindowUsedPercent ?? (!monthlyWindow ? inspectionUsedPercent : null);
-  const fiveHourResetLabel = isKnownResetLabel(fiveHourWindow?.resetLabel)
-    ? fiveHourWindow.resetLabel.trim()
-    : null;
-  const weeklyResetLabel = isKnownResetLabel(weeklyWindow?.resetLabel)
-    ? weeklyWindow.resetLabel.trim()
-    : null;
-  const monthlyResetLabel = isKnownResetLabel(monthlyWindow?.resetLabel)
-    ? monthlyWindow.resetLabel.trim()
-    : null;
+  const fiveHourReset = resolveCodexStatusReset(fiveHourWindow);
+  const weeklyReset = resolveCodexStatusReset(weeklyWindow);
+  const monthlyReset = resolveCodexStatusReset(monthlyWindow);
+  const fiveHourResetLabel = fiveHourReset.label;
+  const weeklyResetLabel = weeklyReset.label;
+  const monthlyResetLabel = monthlyReset.label;
   const credentialEvidences = [
     options.ignoreRawStatusCode ? null : getAuthFileCredentialEvidence(file),
     getInspectionCredentialEvidence(inspection),
@@ -1198,12 +1229,20 @@ export const getAuthFileCodexStatus = (
     (observedQuotaLimitedStatus && !isFiveHourLimited && !isWeeklyLimited && !isMonthlyLimited);
   const isQuotaLimited =
     isFiveHourLimited || isWeeklyLimited || isMonthlyLimited || isUnknownQuotaLimited;
-  const recoveryResetLabel =
-    (isMonthlyLimited && monthlyResetLabel) ||
-    (isWeeklyLimited && weeklyResetLabel) ||
-    (isFiveHourLimited && fiveHourResetLabel) ||
-    (observedQuotaLimitedStatus && observedRecoverLabel) ||
-    null;
+  const recoveryReset =
+    (isMonthlyLimited && monthlyResetLabel ? monthlyReset : null) ||
+    (isWeeklyLimited && weeklyResetLabel ? weeklyReset : null) ||
+    (isFiveHourLimited && fiveHourResetLabel ? fiveHourReset : null) ||
+    (observedQuotaLimitedStatus && observedRecoverLabel
+      ? {
+          label: observedRecoverLabel,
+          resetAtMs: observedRecoverAtMS,
+          resetAccuracy: 'exact' as const,
+        }
+      : null);
+  const recoveryResetLabel = recoveryReset?.label ?? null;
+  const recoveryResetAtMs = recoveryReset?.resetAtMs ?? null;
+  const recoveryResetAccuracy = recoveryReset?.resetAccuracy ?? 'unknown';
   const hasDisabledRecoveryReset = effectiveDisabled && recoveryResetLabel !== null;
   const badges: AuthFileCodexStatusBadge[] = [];
 
@@ -1350,9 +1389,17 @@ export const getAuthFileCodexStatus = (
     isMonthlyLimited,
     hasDisabledRecoveryReset,
     fiveHourResetLabel,
+    fiveHourResetAtMs: fiveHourReset.resetAtMs,
+    fiveHourResetAccuracy: fiveHourReset.resetAccuracy,
     weeklyResetLabel,
+    weeklyResetAtMs: weeklyReset.resetAtMs,
+    weeklyResetAccuracy: weeklyReset.resetAccuracy,
     monthlyResetLabel,
+    monthlyResetAtMs: monthlyReset.resetAtMs,
+    monthlyResetAccuracy: monthlyReset.resetAccuracy,
     recoveryResetLabel,
+    recoveryResetAtMs,
+    recoveryResetAccuracy,
     fiveHourUsedPercent,
     weeklyUsedPercent,
     monthlyUsedPercent,

--- a/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
@@ -30,6 +30,7 @@ import {
   buildAccountSecondaryText,
   buildAccountSummaryMetrics,
   buildCacheTokenPresentation,
+  formatAccountQuotaResetDisplay,
   formatPercent,
   getAccountStatusDotClassName,
   getAccountStatusLabel,
@@ -221,7 +222,7 @@ function AccountQuotaPanel({
               <span className={styles.quotaProgressBar} style={barStyle} />
             </div>
             <div className={styles.quotaWindowMeta}>
-              <small>{`${t('monitoring.account_quota_reset_at')}: ${window.resetLabel}`}</small>
+              <small>{`${t('monitoring.account_quota_reset_at')}: ${formatAccountQuotaResetDisplay(window.resetAtMs, window.resetLabel)}`}</small>
               {window.usageLabel ? <small>{window.usageLabel}</small> : null}
             </div>
           </div>

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.test.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.test.ts
@@ -6,8 +6,14 @@ describe('accountOverviewPresentation reset display', () => {
   it('prefers the canonical timestamp over a legacy reset label', () => {
     const resetAtMs = Date.parse('2026-08-20T03:40:00Z');
 
-    expect(formatAccountQuotaResetDisplay(resetAtMs, 'legacy server label')).toBe(
-      formatQuotaResetTime(resetAtMs)
+    expect(
+      formatAccountQuotaResetDisplay(resetAtMs, '08/20 03:40', {
+        locale: 'zh-CN',
+        timeZone: 'Asia/Shanghai',
+      })
+    ).toBe('08/20 11:40');
+    expect(formatQuotaResetTime(resetAtMs, { locale: 'zh-CN', timeZone: 'UTC' })).toBe(
+      '08/20 03:40'
     );
   });
 

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.test.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { formatQuotaResetTime } from '@/utils/quota/formatters';
+import { formatAccountQuotaResetDisplay } from './accountOverviewPresentation';
+
+describe('accountOverviewPresentation reset display', () => {
+  it('prefers the canonical timestamp over a legacy reset label', () => {
+    const resetAtMs = Date.parse('2026-08-20T03:40:00Z');
+
+    expect(formatAccountQuotaResetDisplay(resetAtMs, 'legacy server label')).toBe(
+      formatQuotaResetTime(resetAtMs)
+    );
+  });
+
+  it('preserves legacy relative text when no timestamp is available', () => {
+    expect(formatAccountQuotaResetDisplay(null, '2h 18m')).toBe('2h 18m');
+  });
+
+  it('formats an ISO legacy label when no canonical timestamp is available', () => {
+    const resetLabel = '2026-08-20T03:40:00Z';
+
+    expect(formatAccountQuotaResetDisplay(null, resetLabel)).toBe(formatQuotaResetTime(resetLabel));
+  });
+
+  it('returns the empty reset marker when neither source has a value', () => {
+    expect(formatAccountQuotaResetDisplay(null, '-')).toBe('-');
+    expect(formatAccountQuotaResetDisplay(null, null)).toBe('-');
+  });
+});

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -4,7 +4,10 @@ import type { MonitoringAccountQuotaProvider } from '@/features/monitoring/accou
 import type { MonitoringAccountRow } from '@/features/monitoring/hooks/useMonitoringData';
 import type { QuotaResetAccuracy } from '@/types';
 import { normalizePlanType } from '@/utils/quota';
-import { formatQuotaResetTime } from '@/utils/quota/formatters';
+import {
+  formatQuotaResetTime,
+  type QuotaResetTimeFormatOptions,
+} from '@/utils/quota/formatters';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import styles from '../MonitoringCenterPage.module.scss';
 
@@ -64,12 +67,13 @@ export const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
 
 export const formatAccountQuotaResetDisplay = (
   resetAtMs: number | null | undefined,
-  resetLabel: string | null | undefined
+  resetLabel: string | null | undefined,
+  options?: QuotaResetTimeFormatOptions
 ): string => {
-  const canonicalLabel = formatQuotaResetTime(resetAtMs);
+  const canonicalLabel = formatQuotaResetTime(resetAtMs, options);
   if (canonicalLabel !== '-') return canonicalLabel;
   const fallbackLabel = resetLabel?.trim() ?? '';
-  const parsedFallbackLabel = formatQuotaResetTime(fallbackLabel);
+  const parsedFallbackLabel = formatQuotaResetTime(fallbackLabel, options);
   return parsedFallbackLabel !== '-' ? parsedFallbackLabel : fallbackLabel || '-';
 };
 

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -2,7 +2,9 @@ import type { TFunction } from 'i18next';
 import type { MonitoringAccountAuthState } from '@/features/monitoring/accountOverviewState';
 import type { MonitoringAccountQuotaProvider } from '@/features/monitoring/accountOverviewQuotaTargets';
 import type { MonitoringAccountRow } from '@/features/monitoring/hooks/useMonitoringData';
+import type { QuotaResetAccuracy } from '@/types';
 import { normalizePlanType } from '@/utils/quota';
+import { formatQuotaResetTime } from '@/utils/quota/formatters';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import styles from '../MonitoringCenterPage.module.scss';
 
@@ -13,6 +15,8 @@ export type AccountQuotaWindow = {
   label: string;
   remainingPercent: number | null;
   resetLabel: string;
+  resetAtMs?: number | null;
+  resetAccuracy?: QuotaResetAccuracy;
   usageLabel: string | null;
 };
 
@@ -57,6 +61,17 @@ export type CacheTokenPresentation = {
 };
 
 export const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
+
+export const formatAccountQuotaResetDisplay = (
+  resetAtMs: number | null | undefined,
+  resetLabel: string | null | undefined
+): string => {
+  const canonicalLabel = formatQuotaResetTime(resetAtMs);
+  if (canonicalLabel !== '-') return canonicalLabel;
+  const fallbackLabel = resetLabel?.trim() ?? '';
+  const parsedFallbackLabel = formatQuotaResetTime(fallbackLabel);
+  return parsedFallbackLabel !== '-' ? parsedFallbackLabel : fallbackLabel || '-';
+};
 
 const joinShort = (values: string[], limit = 2) => {
   if (values.length <= limit) {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -119,6 +119,30 @@ const createTarget = (
   planType: overrides.planType ?? null,
 });
 
+const createMergeAccountQuotaEntry = (
+  resetLabel: string,
+  resetAtMs: number | null,
+  resetAccuracy: AccountQuotaEntry['windows'][number]['resetAccuracy'] = 'unknown'
+): AccountQuotaEntry => ({
+  key: 'codex::merge::codex.json',
+  provider: 'codex',
+  providerLabel: 'Codex Quota',
+  authLabel: 'Auth',
+  fileName: 'codex.json',
+  planType: 'plus',
+  windows: [
+    {
+      id: 'monthly',
+      label: 'Monthly limit',
+      remainingPercent: 50,
+      resetLabel,
+      resetAtMs,
+      resetAccuracy,
+      usageLabel: 'Used 50%',
+    },
+  ],
+});
+
 const createAccountRow = (
   account: string,
   overrides: Partial<MonitoringAccountRow> = {}
@@ -452,6 +476,43 @@ describe('monitoringCenterPageModel account quota', () => {
           resetAtMs: Date.parse('2026-07-01T01:00:00Z'),
           resetAccuracy: 'exact',
           usageLabel: '1.5h / 5h used',
+        },
+      ],
+    });
+  });
+
+  it('does not retain an active canonical reset when observed data only has a legacy label', () => {
+    const activeEntry = createMergeAccountQuotaEntry(
+      '06/30 12:00',
+      Date.parse('2026-06-30T12:00:00Z'),
+      'exact'
+    );
+    const observedEntry = createMergeAccountQuotaEntry('2h 18m', null, 'unknown');
+
+    expect(mergeObservedAccountQuotaEntry(activeEntry, observedEntry)).toMatchObject({
+      windows: [
+        {
+          id: 'monthly',
+          resetLabel: '2h 18m',
+          resetAtMs: null,
+          resetAccuracy: 'unknown',
+        },
+      ],
+    });
+  });
+
+  it('preserves active reset metadata when observed data has no reset information', () => {
+    const resetAtMs = Date.parse('2026-06-30T12:00:00Z');
+    const activeEntry = createMergeAccountQuotaEntry('06/30 12:00', resetAtMs, 'exact');
+    const observedEntry = createMergeAccountQuotaEntry('-', null, 'unknown');
+
+    expect(mergeObservedAccountQuotaEntry(activeEntry, observedEntry)).toMatchObject({
+      windows: [
+        {
+          id: 'monthly',
+          resetLabel: '06/30 12:00',
+          resetAtMs,
+          resetAccuracy: 'exact',
         },
       ],
     });
@@ -1129,6 +1190,44 @@ describe('monitoringCenterPageModel account quota', () => {
         },
       ],
     });
+  });
+
+  it('does not use the monthly billing period as a product usage reset fallback', async () => {
+    vi.mocked(fetchXaiQuota).mockResolvedValue({
+      periodType: 'weekly',
+      usagePercent: null,
+      productUsage: [{ product: 'Grok 4', usagePercent: 25 }],
+      periodStart: undefined,
+      periodEnd: undefined,
+      monthlyLimitCents: 10000,
+      usedCents: 2500,
+      includedUsedCents: 2500,
+      onDemandCapCents: null,
+      onDemandUsedCents: null,
+      onDemandUsedPercent: null,
+      billingPeriodStart: '2026-08-01T00:00:00Z',
+      billingPeriodEnd: '2026-09-01T00:00:00Z',
+      usedPercent: 25,
+    });
+
+    const entry = await requestAccountQuota(
+      createTarget({
+        provider: 'xai',
+        authIndex: '3',
+        fileName: 'xai.json',
+      }),
+      t
+    );
+
+    expect(entry.windows).toContainEqual(
+      expect.objectContaining({
+        id: 'product-0-Grok 4',
+        remainingPercent: 75,
+        resetLabel: '-',
+        resetAtMs: null,
+        resetAccuracy: 'unknown',
+      })
+    );
   });
 
   it('does not synthesize monthly credits from an on-demand reset timestamp', async () => {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -10,6 +10,7 @@ import {
 import zhCN from '@/i18n/locales/zh-CN.json';
 import zhTW from '@/i18n/locales/zh-TW.json';
 import type { MonitoringAccountQuotaTarget } from '@/features/monitoring/accountOverviewQuotaTargets';
+import type { AccountQuotaEntry } from '@/features/monitoring/components/accountOverviewPresentation';
 import type {
   MonitoringAccountRow,
   MonitoringApiKeyRow,
@@ -285,6 +286,8 @@ describe('monitoringCenterPageModel account quota', () => {
           labelKey: 'claude_quota.five_hour',
           usedPercent: 40,
           resetLabel: '05/20 12:00',
+          resetAtMs: Date.parse('2026-05-20T12:00:00Z'),
+          resetAccuracy: 'exact',
         },
         {
           id: 'weekly-scoped-fable%205%20max',
@@ -314,6 +317,8 @@ describe('monitoringCenterPageModel account quota', () => {
           label: '5-hour limit',
           remainingPercent: 60,
           resetLabel: '05/20 12:00',
+          resetAtMs: Date.parse('2026-05-20T12:00:00Z'),
+          resetAccuracy: 'exact',
         },
         {
           id: 'weekly-scoped-fable%205%20max',
@@ -340,6 +345,8 @@ describe('monitoringCenterPageModel account quota', () => {
           labelKey: 'codex_quota.monthly_window',
           usedPercent: 5,
           resetLabel: '06/30 12:00',
+          resetAtMs: Date.parse('2026-06-30T12:00:00Z'),
+          resetAccuracy: 'exact',
           limitWindowSeconds: 2_592_000,
         },
       ],
@@ -365,6 +372,8 @@ describe('monitoringCenterPageModel account quota', () => {
           label: 'Monthly limit',
           remainingPercent: 95,
           resetLabel: '06/30 12:00',
+          resetAtMs: Date.parse('2026-06-30T12:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '1.5d / 30d used',
         },
       ],
@@ -372,7 +381,7 @@ describe('monitoringCenterPageModel account quota', () => {
   });
 
   it('merges observed Codex account quota without dropping existing API-only windows', () => {
-    const activeEntry = {
+    const activeEntry: AccountQuotaEntry = {
       key: 'codex::2::codex.json',
       provider: 'codex' as const,
       providerLabel: 'Codex Quota',
@@ -386,6 +395,8 @@ describe('monitoringCenterPageModel account quota', () => {
           label: 'Monthly limit',
           remainingPercent: 95,
           resetLabel: '06/30 12:00',
+          resetAtMs: Date.parse('2026-06-30T12:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '1.5d / 30d used',
         },
         {
@@ -393,11 +404,13 @@ describe('monitoringCenterPageModel account quota', () => {
           label: 'spark 5-hour limit',
           remainingPercent: 70,
           resetLabel: '07/01 01:00',
+          resetAtMs: Date.parse('2026-07-01T01:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '1.5h / 5h used',
         },
       ],
     };
-    const observedEntry = {
+    const observedEntry: AccountQuotaEntry = {
       key: 'codex::2::codex.json',
       provider: 'codex' as const,
       providerLabel: 'Codex Quota',
@@ -411,6 +424,8 @@ describe('monitoringCenterPageModel account quota', () => {
           label: 'Monthly limit',
           remainingPercent: 55,
           resetLabel: '07/01 02:00',
+          resetAtMs: Date.parse('2026-07-01T02:00:00Z'),
+          resetAccuracy: 'estimated',
           usageLabel: '13.5d / 30d used',
         },
       ],
@@ -426,12 +441,16 @@ describe('monitoringCenterPageModel account quota', () => {
           id: 'monthly',
           remainingPercent: 55,
           resetLabel: '07/01 02:00',
+          resetAtMs: Date.parse('2026-07-01T02:00:00Z'),
+          resetAccuracy: 'estimated',
           usageLabel: '13.5d / 30d used',
         },
         {
           id: 'spark-five-hour-0',
           remainingPercent: 70,
           resetLabel: '07/01 01:00',
+          resetAtMs: Date.parse('2026-07-01T01:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '1.5h / 5h used',
         },
       ],
@@ -972,6 +991,8 @@ describe('monitoringCenterPageModel account quota', () => {
           used: 25,
           limit: 100,
           resetHint: '2026-07-31T00:00:00Z',
+          resetAtMs: Date.parse('2026-07-31T00:00:00Z'),
+          resetAccuracy: 'exact',
         },
       ],
     });
@@ -993,6 +1014,8 @@ describe('monitoringCenterPageModel account quota', () => {
           id: 'daily',
           label: 'Daily',
           remainingPercent: 75,
+          resetAtMs: Date.parse('2026-07-31T00:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: null,
         },
       ],
@@ -1033,12 +1056,16 @@ describe('monitoringCenterPageModel account quota', () => {
           id: 'monthly-limit',
           label: 'Monthly credits',
           remainingPercent: 0,
+          resetAtMs: Date.parse('2026-06-01T00:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '$0.00 / $100.00 remaining',
         },
         {
           id: 'pay-as-you-go',
           label: 'Pay-as-you-go',
           remainingPercent: 50,
+          resetAtMs: Date.parse('2026-06-01T00:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '$25.00 / $50.00 remaining',
         },
       ],
@@ -1080,18 +1107,24 @@ describe('monitoringCenterPageModel account quota', () => {
           id: 'weekly-limit',
           label: 'Weekly limit',
           remainingPercent: 60,
+          resetAtMs: Date.parse('2026-07-08T00:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: 'Used 40%',
         },
         {
           id: 'product-0-Grok 4',
           label: 'Grok 4 usage',
           remainingPercent: 75,
+          resetAtMs: Date.parse('2026-07-08T00:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: 'Used 25%',
         },
         {
           id: 'monthly-limit',
           label: 'Monthly credits',
           remainingPercent: 75,
+          resetAtMs: Date.parse('2026-08-01T00:00:00Z'),
+          resetAccuracy: 'exact',
           usageLabel: '$75.00 / $100.00 remaining',
         },
       ],

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -1115,7 +1115,9 @@ const buildXaiAccountQuotaWindows = (
   const windows: AccountQuotaWindow[] = [];
   const weeklyReset = resolveAbsoluteQuotaReset(billing.periodEnd);
   const monthlyReset = resolveAbsoluteQuotaReset(billing.billingPeriodEnd);
-  const productReset = weeklyReset.resetAtMs !== null ? weeklyReset : monthlyReset;
+  // Product usage belongs to the current period window. A billing-period end
+  // is a separate monthly boundary and must not be inferred as its reset.
+  const productReset = weeklyReset;
   const hasWeeklyData =
     billing.periodType === 'weekly' &&
     (billing.usagePercent !== null ||

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -45,6 +45,7 @@ import {
   filterFreshCodexQuotaWindows,
   formatKimiResetHint,
   formatQuotaResetTime,
+  resolveAbsoluteQuotaReset,
 } from '@/utils/quota';
 import {
   buildObservedCodexQuotaFromHeaderSnapshot,
@@ -799,6 +800,8 @@ const buildCodexAccountQuotaWindows = (
         : window.label,
       remainingPercent,
       resetLabel: window.resetLabel,
+      resetAtMs: window.resetAtMs ?? null,
+      resetAccuracy: window.resetAccuracy ?? 'unknown',
       usageLabel,
     };
   });
@@ -815,21 +818,40 @@ const readFiniteTimestamp = (value: unknown): number | null =>
 const mergeAccountQuotaWindow = (
   activeWindow: AccountQuotaWindow,
   observedWindow: AccountQuotaWindow
-): AccountQuotaWindow => ({
-  ...activeWindow,
-  ...(observedWindow.label.trim() ? { label: observedWindow.label } : {}),
-  ...(observedWindow.remainingPercent !== null &&
-  observedWindow.remainingPercent !== undefined &&
-  Number.isFinite(observedWindow.remainingPercent)
-    ? { remainingPercent: observedWindow.remainingPercent }
-    : {}),
-  ...(hasKnownAccountQuotaResetLabel(observedWindow.resetLabel)
-    ? { resetLabel: observedWindow.resetLabel }
-    : {}),
-  ...(observedWindow.usageLabel && observedWindow.usageLabel.trim()
-    ? { usageLabel: observedWindow.usageLabel }
-    : {}),
-});
+): AccountQuotaWindow => {
+  const hasObservedResetAt =
+    typeof observedWindow.resetAtMs === 'number' &&
+    Number.isFinite(observedWindow.resetAtMs) &&
+    observedWindow.resetAtMs > 0;
+  const hasObservedResetLabel = hasKnownAccountQuotaResetLabel(observedWindow.resetLabel);
+  const resetMetadata = hasObservedResetAt
+    ? {
+        resetLabel: hasObservedResetLabel ? observedWindow.resetLabel : activeWindow.resetLabel,
+        resetAtMs: observedWindow.resetAtMs,
+        resetAccuracy: observedWindow.resetAccuracy,
+      }
+    : hasObservedResetLabel
+      ? {
+          resetLabel: observedWindow.resetLabel,
+          resetAtMs: null,
+          resetAccuracy: 'unknown' as const,
+        }
+      : {};
+
+  return {
+    ...activeWindow,
+    ...(observedWindow.label.trim() ? { label: observedWindow.label } : {}),
+    ...(observedWindow.remainingPercent !== null &&
+    observedWindow.remainingPercent !== undefined &&
+    Number.isFinite(observedWindow.remainingPercent)
+      ? { remainingPercent: observedWindow.remainingPercent }
+      : {}),
+    ...resetMetadata,
+    ...(observedWindow.usageLabel && observedWindow.usageLabel.trim()
+      ? { usageLabel: observedWindow.usageLabel }
+      : {}),
+  };
+};
 
 const mergeAccountQuotaWindows = (
   activeWindows: AccountQuotaWindow[],
@@ -1028,6 +1050,8 @@ const buildClaudeAccountQuotaWindows = (
     label: window.labelKey ? t(window.labelKey) : window.label,
     remainingPercent: buildRemainingFromUsedPercent(window.usedPercent),
     resetLabel: window.resetLabel,
+    resetAtMs: window.resetAtMs ?? null,
+    resetAccuracy: window.resetAccuracy ?? 'unknown',
     usageLabel: null,
   }));
 
@@ -1035,13 +1059,18 @@ const buildAntigravityAccountQuotaWindows = (
   groups: AntigravityQuotaGroup[]
 ): AccountQuotaWindow[] =>
   groups.flatMap((group) =>
-    group.buckets.map((bucket) => ({
-      id: `${group.id}:${bucket.id}`,
-      label: `${group.label} · ${bucket.label}`,
-      remainingPercent: clampRemainingPercent(bucket.remainingFraction * 100),
-      resetLabel: formatQuotaResetTime(bucket.resetTime),
-      usageLabel: bucket.description ?? group.description ?? null,
-    }))
+    group.buckets.map((bucket) => {
+      const reset = resolveAbsoluteQuotaReset(bucket.resetTime);
+      return {
+        id: `${group.id}:${bucket.id}`,
+        label: `${group.label} · ${bucket.label}`,
+        remainingPercent: clampRemainingPercent(bucket.remainingFraction * 100),
+        resetLabel: formatQuotaResetTime(bucket.resetTime),
+        resetAtMs: reset.resetAtMs,
+        resetAccuracy: reset.resetAccuracy,
+        usageLabel: bucket.description ?? group.description ?? null,
+      };
+    })
   );
 
 const buildKimiAccountQuotaWindows = (rows: KimiQuotaRow[], t: TFunction): AccountQuotaWindow[] =>
@@ -1064,6 +1093,8 @@ const buildKimiAccountQuotaWindows = (rows: KimiQuotaRow[], t: TFunction): Accou
       label: rowLabel,
       remainingPercent,
       resetLabel: resetLabel || '-',
+      resetAtMs: row.resetAtMs ?? null,
+      resetAccuracy: row.resetAccuracy ?? 'unknown',
       usageLabel: null,
     };
   });
@@ -1082,13 +1113,15 @@ const buildXaiAccountQuotaWindows = (
       ? Math.max(0, billing.monthlyLimitCents - billing.includedUsedCents)
       : null;
   const windows: AccountQuotaWindow[] = [];
+  const weeklyReset = resolveAbsoluteQuotaReset(billing.periodEnd);
+  const monthlyReset = resolveAbsoluteQuotaReset(billing.billingPeriodEnd);
+  const productReset = weeklyReset.resetAtMs !== null ? weeklyReset : monthlyReset;
   const hasWeeklyData =
     billing.periodType === 'weekly' &&
     (billing.usagePercent !== null ||
       Boolean(billing.periodEnd) ||
       billing.productUsage.length > 0);
-  const hasMonthlyData =
-    billing.usedPercent !== null || billing.monthlyLimitCents !== null;
+  const hasMonthlyData = billing.usedPercent !== null || billing.monthlyLimitCents !== null;
 
   if (hasWeeklyData) {
     windows.push({
@@ -1096,6 +1129,8 @@ const buildXaiAccountQuotaWindows = (
       label: t('xai_quota.weekly_limit'),
       remainingPercent: buildRemainingFromUsedPercent(billing.usagePercent),
       resetLabel: billing.periodEnd ? formatQuotaResetTime(billing.periodEnd) : '-',
+      resetAtMs: weeklyReset.resetAtMs,
+      resetAccuracy: weeklyReset.resetAccuracy,
       usageLabel: t('xai_quota.used_percent', {
         percent: billing.usagePercent === null ? '--' : `${Math.round(billing.usagePercent)}%`,
       }),
@@ -1107,7 +1142,10 @@ const buildXaiAccountQuotaWindows = (
       id: `product-${index}-${item.product}`,
       label: t('xai_quota.product_usage', { product: item.product }),
       remainingPercent: buildRemainingFromUsedPercent(item.usagePercent),
-      resetLabel: '-',
+      resetLabel:
+        productReset.resetAtMs !== null ? formatQuotaResetTime(productReset.resetAtMs) : '-',
+      resetAtMs: productReset.resetAtMs,
+      resetAccuracy: productReset.resetAccuracy,
       usageLabel: t('xai_quota.used_percent', {
         percent: item.usagePercent === null ? '--' : `${Math.round(item.usagePercent)}%`,
       }),
@@ -1120,6 +1158,8 @@ const buildXaiAccountQuotaWindows = (
       label: t('xai_quota.monthly_credits'),
       remainingPercent: buildRemainingFromUsedPercent(billing.usedPercent),
       resetLabel: billing.billingPeriodEnd ? formatQuotaResetTime(billing.billingPeriodEnd) : '-',
+      resetAtMs: monthlyReset.resetAtMs,
+      resetAccuracy: monthlyReset.resetAccuracy,
       usageLabel: t('xai_quota.usage_amount', {
         remaining: formatXaiCurrency(remainingCents),
         limit: formatXaiCurrency(billing.monthlyLimitCents),
@@ -1136,7 +1176,10 @@ const buildXaiAccountQuotaWindows = (
       id: 'pay-as-you-go',
       label: t('xai_quota.pay_as_you_go_label'),
       remainingPercent: buildRemainingFromUsedPercent(billing.onDemandUsedPercent),
-      resetLabel: '-',
+      resetLabel:
+        monthlyReset.resetAtMs !== null ? formatQuotaResetTime(monthlyReset.resetAtMs) : '-',
+      resetAtMs: monthlyReset.resetAtMs,
+      resetAccuracy: monthlyReset.resetAccuracy,
       usageLabel: t('xai_quota.usage_amount', {
         remaining: formatXaiCurrency(onDemandRemainingCents),
         limit: formatXaiCurrency(billing.onDemandCapCents),
@@ -1284,6 +1327,8 @@ export const buildObservedCodexAccountQuotaEntry = (
               resetLabel: fallbackRecoverAtMS
                 ? new Date(fallbackRecoverAtMS).toLocaleString()
                 : '-',
+              resetAtMs: fallbackRecoverAtMS,
+              resetAccuracy: fallbackRecoverAtMS ? 'exact' : 'unknown',
               usageLabel:
                 fallbackUsedPercent !== null
                   ? t('monitoring.account_quota_observed_used', {

--- a/apps/web/src/utils/quota/formatters.ts
+++ b/apps/web/src/utils/quota/formatters.ts
@@ -12,6 +12,11 @@ export interface QuotaResetResolution {
   resetAccuracy: QuotaResetAccuracy;
 }
 
+export interface QuotaResetTimeFormatOptions {
+  locale?: string;
+  timeZone?: string;
+}
+
 export type CodexQuotaResetSource = 'provider_api' | 'response_header';
 
 const LEGACY_RESET_ROLLOVER_MS = 30 * 24 * 60 * 60 * 1000;
@@ -170,17 +175,21 @@ export function resolveCodexQuotaReset(
   return resolveRelativeQuotaReset(resetAfterSeconds, observedAtMs);
 }
 
-export function formatQuotaResetTime(value?: string | number | null): string {
+export function formatQuotaResetTime(
+  value?: string | number | null,
+  options: QuotaResetTimeFormatOptions = {}
+): string {
   const resetAtMs = parseAbsoluteQuotaResetMs(value);
   if (resetAtMs === null) return '-';
   const date = new Date(resetAtMs);
-  return date.toLocaleString(undefined, {
+  return new Intl.DateTimeFormat(options.locale, {
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
-  });
+    ...(options.timeZone ? { timeZone: options.timeZone } : {}),
+  }).format(date);
 }
 
 export function formatUnixSeconds(value: number | null): string {


### PR DESCRIPTION
## Summary

Fix remaining timezone drift in credential-management and monitoring quota reset displays. Absolute reset timestamps are now preserved through frontend presentation layers and formatted in the browser's local timezone.

> Community and maintenance PRs must target `dev`. Repository automation retargets other pull requests to `dev`; this can change the diff and make existing review comments outdated. `main` accepts only a promotion PR whose source is this repository's `dev` branch.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Preserve `resetAtMs` and `resetAccuracy` for Codex credential health status, account-list health, and monitoring quota windows.
- Prefer canonical timestamps for browser-local display while retaining `resetLabel` for legacy, relative, and provider-specific fallback text.
- Add regression coverage for canonical precedence, legacy fallback, ISO labels, empty reset values, metadata propagation, and monitoring merge behavior.

## User Impact

Users in UTC+8 and other timezones see Codex quota reset times in their browser's local timezone in credential management and monitoring views. Relative and legacy reset labels remain supported.

## Compatibility / Runtime Notes

- CPA panel mode: uses the same browser-local formatting path; no CPA API changes.
- Manager Server mode: consumes the existing `resetAtMs/resetAccuracy` contract; no server configuration or schedule timezone changes.
- Full Docker / native packages: no Docker, OS timezone, packaging, or migration changes.

## Data / Security Notes

N/A. No database schema, auth secret, credential payload, or security behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the three frontend fix commits. The change does not modify quota calculations, inspection decisions, provider requests, or stored database data.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm test
npm run build
npm run manager-server:test
Focused Vitest: 7 files / 310 tests passed
Final focused Vitest: 4 files / 149 tests passed
git diff --check
```

Lint completed with 0 errors and one pre-existing Fast Refresh warning in `AccountHealthBadge.tsx:73`. Manual visual validation was not run because there were no layout changes; automated rendering tests cover the affected reset text.

## Screenshots / Recordings

N/A — no layout changes; the change only corrects displayed reset-time values.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a maintenance bug fix with no new configuration, workflow, or user capability.

## Related

Fixes #577
