### PR TITLE
fix(quota): isolate Codex scoped quota attribution

### DIFF
--- a/apps/manager-server/internal/codexquota/scope.go
+++ b/apps/manager-server/internal/codexquota/scope.go
@@ -1,0 +1,478 @@
+package codexquota
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
+)
+
+const (
+	MainScopeKey              = "codex_main"
+	SparkModelID              = "gpt-5.3-codex-spark"
+	CodeReviewScopeKey        = "code_review"
+	UnknownRequestScopeKey    = "request_scope_unknown"
+	SparkProviderWindowPrefix = "spark"
+)
+
+type ModelScope struct {
+	Kind     string
+	Key      string
+	Models   []string
+	Complete bool
+}
+
+type AdditionalScopeResolution struct {
+	Scope                ModelScope
+	ProviderWindowPrefix string
+	LegacyPrefixes       []string
+}
+
+type AdditionalScopeInput struct {
+	MeteredFeature    string
+	LimitName         string
+	AnonymousIdentity string
+}
+
+type UsageScopeResolution struct {
+	Scope                ModelScope
+	ProviderWindowPrefix string
+}
+
+var sparkQuotaIdentifiers = map[string]struct{}{
+	"spark":               {},
+	"codex_spark":         {},
+	"gpt_5_3_codex_spark": {},
+}
+
+var sparkProviderWindowPrefixes = []string{
+	"gpt-5-3-codex-spark",
+	"codex-spark",
+	SparkProviderWindowPrefix,
+}
+
+// sparkLegacyProviderWindowPrefixes contains identifiers emitted by the
+// pre-scoped additional-rate-limit parser. They are aliases only: keeping
+// them out of CanonicalProviderWindowID prevents a legacy row from being
+// rewritten before the lifecycle can mark it inactive.
+var sparkLegacyProviderWindowPrefixes = []string{
+	"fast-coding",
+}
+
+func MainScope() ModelScope {
+	return ModelScope{Kind: "family", Key: MainScopeKey, Complete: true}
+}
+
+func SparkScope() ModelScope {
+	return ModelScope{Kind: "models", Models: []string{SparkModelID}, Complete: true}
+}
+
+func CodeReviewScope() ModelScope {
+	return ModelScope{Kind: "feature", Key: CodeReviewScopeKey, Complete: false}
+}
+
+func UnknownRequestScope() ModelScope {
+	return ModelScope{Kind: "feature", Key: UnknownRequestScopeKey, Complete: false}
+}
+
+func FeatureScope(key string) ModelScope {
+	key = NormalizeFeatureKey(key)
+	if key == "" {
+		key = "unknown"
+	}
+	return ModelScope{Kind: "feature", Key: key, Complete: false}
+}
+
+func NormalizeScope(scope ModelScope) ModelScope {
+	scope.Kind = strings.ToLower(strings.TrimSpace(scope.Kind))
+	scope.Key = strings.ToLower(strings.TrimSpace(scope.Key))
+	scope.Models = normalizedUniqueModels(scope.Models)
+	return scope
+}
+
+// ScopeFromFields reconstructs the scope completeness that can be represented
+// by the persisted snapshot fields. The snapshot schema does not store the
+// complete bit, so callers must derive it from the kind and its identity.
+func ScopeFromFields(kind, key string, models []string) ModelScope {
+	scope := NormalizeScope(ModelScope{Kind: kind, Key: key, Models: models})
+	switch scope.Kind {
+	case "all":
+		scope.Complete = true
+	case "models":
+		scope.Complete = len(scope.Models) > 0
+	case "family":
+		scope.Complete = scope.Key != "" || len(scope.Models) > 0
+	default:
+		scope.Complete = false
+	}
+	return scope
+}
+
+// ResolveProviderWindowScope applies the provider-window identity as a
+// stronger signal than a legacy, implicit `all` scope. Codex additional and
+// feature windows are never allowed to become account-wide merely because an
+// old client omitted the scoped model information.
+func ResolveProviderWindowScope(providerWindowID, windowKind string, provided ModelScope) ModelScope {
+	provided = NormalizeScope(provided)
+	if provided.Kind != "all" {
+		return provided
+	}
+	canonical := CanonicalProviderWindowID(providerWindowID, windowKind)
+	if IsMainProviderWindowID(canonical) {
+		// Preserve the caller's explicit account-wide representation. The web
+		// view may expose Codex Main as its stable family scope, but legacy
+		// lifecycle rows intentionally retain `all` until an explicit family
+		// observation migrates them in place.
+		return provided
+	}
+	if IsSparkProviderWindowID(providerWindowID) {
+		return SparkScope()
+	}
+	canonical = CanonicalProviderWindowID(providerWindowID, windowKind)
+	if canonical == "code-review" || strings.HasPrefix(canonical, "code-review-") {
+		return CodeReviewScope()
+	}
+	// An arbitrary additional ID is not enough evidence to establish an
+	// account-wide usage mapping. Legacy rows that omitted scope information
+	// therefore fail closed as an incomplete feature scope; the lifecycle layer
+	// can suppress that row once a scoped observation arrives.
+	return FeatureScope(additionalProviderWindowFamily(canonical))
+}
+
+func NormalizeModelID(value string) string {
+	return strings.ToLower(strings.TrimSpace(usageidentity.AnalyticsModel(strings.TrimSpace(value))))
+}
+
+func NormalizeFeatureKey(value string) string {
+	return normalizeIdentifier(value, '_')
+}
+
+func NormalizeProviderWindowPrefix(value string) string {
+	return normalizeIdentifier(value, '-')
+}
+
+func normalizeIdentifier(value string, separator rune) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	var builder strings.Builder
+	pendingSeparator := false
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') {
+			if pendingSeparator && builder.Len() > 0 {
+				builder.WriteRune(separator)
+			}
+			builder.WriteRune(char)
+			pendingSeparator = false
+			continue
+		}
+		pendingSeparator = true
+	}
+	return strings.Trim(builder.String(), string(separator))
+}
+
+func ResolveAdditionalScope(input AdditionalScopeInput) AdditionalScopeResolution {
+	featureKey := NormalizeFeatureKey(input.MeteredFeature)
+	nameKey := NormalizeFeatureKey(input.LimitName)
+	if isSparkQuotaIdentifier(featureKey) || (featureKey == "" && isSparkQuotaIdentifier(nameKey)) {
+		legacyPrefixes := []string{
+			NormalizeProviderWindowPrefix(input.MeteredFeature),
+			NormalizeProviderWindowPrefix(input.LimitName),
+		}
+		legacyPrefixes = append(legacyPrefixes, sparkProviderWindowPrefixes...)
+		legacyPrefixes = append(legacyPrefixes, sparkLegacyProviderWindowPrefixes...)
+		return AdditionalScopeResolution{
+			Scope:                SparkScope(),
+			ProviderWindowPrefix: SparkProviderWindowPrefix,
+			LegacyPrefixes:       normalizedUniqueStrings(legacyPrefixes),
+		}
+	}
+
+	key := featureKey
+	if key == "" {
+		key = nameKey
+	}
+	if key == "" {
+		key = NormalizeFeatureKey(input.AnonymousIdentity)
+	}
+	prefix := NormalizeProviderWindowPrefix(input.LimitName)
+	if featureKey != "" && isSparkQuotaIdentifier(nameKey) {
+		prefix = NormalizeProviderWindowPrefix(input.MeteredFeature)
+	}
+	if prefix == "" {
+		prefix = NormalizeProviderWindowPrefix(input.MeteredFeature)
+	}
+	if prefix == "" {
+		prefix = NormalizeProviderWindowPrefix(input.AnonymousIdentity)
+	}
+	if key == "" || prefix == "" {
+		key = "additional_unknown"
+		prefix = "additional-unknown"
+	}
+	return AdditionalScopeResolution{
+		Scope:                FeatureScope(key),
+		ProviderWindowPrefix: prefix,
+		LegacyPrefixes:       []string{prefix},
+	}
+}
+
+func ResolveUsageScope(model, analyticsModel, requestedModel, resolvedModel string) UsageScopeResolution {
+	if resolved := NormalizeModelID(resolvedModel); resolved != "" {
+		return usageScopeForModel(resolved)
+	}
+	identity := firstNonEmptyModel(analyticsModel, requestedModel, model)
+	if identity == "" {
+		return UsageScopeResolution{
+			Scope:                UnknownRequestScope(),
+			ProviderWindowPrefix: "request-scope-unknown",
+		}
+	}
+	return usageScopeForModel(identity)
+}
+
+func usageScopeForModel(model string) UsageScopeResolution {
+	if IsSparkModel(model) {
+		return UsageScopeResolution{
+			Scope:                SparkScope(),
+			ProviderWindowPrefix: SparkProviderWindowPrefix,
+		}
+	}
+	return UsageScopeResolution{Scope: MainScope()}
+}
+
+func firstNonEmptyModel(values ...string) string {
+	for _, value := range values {
+		if normalized := NormalizeModelID(value); normalized != "" {
+			return normalized
+		}
+	}
+	return ""
+}
+
+func IsSparkModel(value string) bool {
+	return NormalizeModelID(value) == SparkModelID
+}
+
+func IsMainScope(kind, key string) bool {
+	return strings.EqualFold(strings.TrimSpace(kind), "family") &&
+		strings.EqualFold(strings.TrimSpace(key), MainScopeKey)
+}
+
+func IsMainProviderWindowID(providerWindowID string) bool {
+	id := CanonicalProviderWindowID(providerWindowID)
+	switch id {
+	case "five-hour", "weekly", "monthly", "primary", "secondary":
+		return true
+	default:
+		return strings.HasPrefix(id, "window-")
+	}
+}
+
+func IsLegacyAllScopeReplacement(providerWindowID string, scope ModelScope) bool {
+	scope = NormalizeScope(scope)
+	if IsMainProviderWindowID(providerWindowID) {
+		return false
+	}
+	return scope.Kind != "" && (scope.Kind != "all" || !scope.Complete)
+}
+
+func IsLegacyMainAllScopeMigration(providerWindowID string, scope ModelScope) bool {
+	scope = NormalizeScope(scope)
+	return scope.Complete && IsMainProviderWindowID(providerWindowID) && IsMainScope(scope.Kind, scope.Key)
+}
+
+func MatchMainUsage(requestModel, billingModel string) (matched bool, unmatched bool) {
+	modelID := NormalizeModelID(billingModel)
+	if modelID == "" {
+		modelID = NormalizeModelID(requestModel)
+	}
+	if modelID == "" {
+		return false, true
+	}
+	if IsSparkModel(modelID) {
+		return false, false
+	}
+	return true, false
+}
+
+func MatchModelScope(rowModel, billingModel string, models []string) (matched bool, unmatched bool) {
+	modelID := NormalizeModelID(billingModel)
+	if modelID == "" {
+		modelID = NormalizeModelID(rowModel)
+	}
+	if modelID == "" {
+		return false, true
+	}
+	for _, candidate := range normalizedUniqueModels(models) {
+		if modelID == candidate {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+func CanonicalProviderWindowID(value string, windowKind ...string) string {
+	id := strings.ToLower(strings.TrimSpace(value))
+	normalizedWindowKind := ""
+	if len(windowKind) > 0 {
+		normalizedWindowKind = strings.ToLower(strings.TrimSpace(windowKind[0]))
+		normalizedWindowKind = strings.ReplaceAll(normalizedWindowKind, "_", "-")
+	}
+	if id == "primary" {
+		return "five-hour"
+	}
+	if id == "secondary" {
+		if normalizedWindowKind == "monthly" {
+			return "monthly"
+		}
+		return "weekly"
+	}
+	for _, prefix := range sparkProviderWindowPrefixes {
+		if id == prefix {
+			return SparkProviderWindowPrefix
+		}
+		if strings.HasPrefix(id, prefix+"-") {
+			return SparkProviderWindowPrefix + strings.TrimPrefix(id, prefix)
+		}
+	}
+	return id
+}
+
+// IsSparkScope reports whether a persisted/display scope is the verified Spark
+// model scope. It is intentionally stricter than a label or provider-window
+// prefix check.
+func IsSparkScope(scope ModelScope) bool {
+	scope = NormalizeScope(scope)
+	return scope.Kind == "models" && scope.Complete && len(scope.Models) == 1 &&
+		scope.Models[0] == SparkModelID
+}
+
+// CanonicalProviderWindowIDForScope canonicalizes legacy Spark identifiers
+// only when the matching model scope is known. The raw legacy identifier is
+// still retained by lifecycle alias queries so old rows can be suppressed.
+func CanonicalProviderWindowIDForScope(value, windowKind string, scope ModelScope) string {
+	canonical := CanonicalProviderWindowID(value, windowKind)
+	if !IsSparkScope(scope) {
+		return canonical
+	}
+	raw := strings.ToLower(strings.TrimSpace(value))
+	for _, prefix := range append(append([]string{}, sparkProviderWindowPrefixes...), sparkLegacyProviderWindowPrefixes...) {
+		if raw == prefix {
+			return SparkProviderWindowPrefix
+		}
+		if strings.HasPrefix(raw, prefix+"-") {
+			return SparkProviderWindowPrefix + strings.TrimPrefix(raw, prefix)
+		}
+	}
+	return canonical
+}
+
+func ProviderWindowAliases(providerWindowID string, scope ModelScope, additional ...string) []string {
+	canonical := CanonicalProviderWindowID(providerWindowID)
+	aliases := append([]string{strings.ToLower(strings.TrimSpace(providerWindowID)), canonical}, additional...)
+	if scope.Kind == "family" && IsMainScope(scope.Kind, scope.Key) {
+		switch canonical {
+		case "five-hour":
+			// Older response-header observations used the provider's primary
+			// name. Keep the raw alias so lifecycle reclassification can attach
+			// new evidence to that existing logical window.
+			aliases = append(aliases, "primary")
+		case "weekly", "monthly":
+			// Team accounts historically exposed the long window as
+			// `secondary` too, so both long-window candidates can reconcile it.
+			aliases = append(aliases, "secondary")
+		}
+	}
+	if scope.Kind == "models" && len(scope.Models) == 1 && IsSparkModel(scope.Models[0]) &&
+		(canonical == SparkProviderWindowPrefix || strings.HasPrefix(canonical, SparkProviderWindowPrefix+"-")) {
+		suffix := strings.TrimPrefix(canonical, SparkProviderWindowPrefix)
+		for _, prefix := range sparkProviderWindowPrefixes {
+			aliases = append(aliases, prefix+suffix)
+		}
+		for _, prefix := range sparkLegacyProviderWindowPrefixes {
+			aliases = append(aliases, prefix+suffix)
+		}
+	}
+	return normalizedUniqueStrings(aliases)
+}
+
+func InferScopeFromProviderWindowID(providerWindowID string) ModelScope {
+	if IsSparkProviderWindowID(providerWindowID) {
+		return SparkScope()
+	}
+	id := CanonicalProviderWindowID(providerWindowID)
+	if IsMainProviderWindowID(id) {
+		return MainScope()
+	}
+	if id == SparkProviderWindowPrefix || strings.HasPrefix(id, SparkProviderWindowPrefix+"-") {
+		return SparkScope()
+	}
+	if id == "code-review" || strings.HasPrefix(id, "code-review-") {
+		return CodeReviewScope()
+	}
+	return FeatureScope(additionalProviderWindowFamily(id))
+}
+
+func IsSparkProviderWindowID(providerWindowID string) bool {
+	raw := strings.ToLower(strings.TrimSpace(providerWindowID))
+	id := CanonicalProviderWindowID(raw)
+	if id == SparkProviderWindowPrefix || strings.HasPrefix(id, SparkProviderWindowPrefix+"-") {
+		return true
+	}
+	for _, prefix := range sparkLegacyProviderWindowPrefixes {
+		if raw == prefix || strings.HasPrefix(raw, prefix+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+func additionalProviderWindowFamily(providerWindowID string) string {
+	for _, role := range []string{"five-hour", "weekly", "monthly"} {
+		marker := "-" + role + "-"
+		position := strings.LastIndex(providerWindowID, marker)
+		if position <= 0 {
+			continue
+		}
+		if _, err := strconv.Atoi(providerWindowID[position+len(marker):]); err == nil {
+			return NormalizeFeatureKey(providerWindowID[:position])
+		}
+	}
+	if position := strings.Index(providerWindowID, "-window-"); position > 0 {
+		return NormalizeFeatureKey(providerWindowID[:position])
+	}
+	return NormalizeFeatureKey(providerWindowID)
+}
+
+func isSparkQuotaIdentifier(value string) bool {
+	_, ok := sparkQuotaIdentifiers[value]
+	return ok
+}
+
+func normalizedUniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func normalizedUniqueModels(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, NormalizeModelID(value))
+	}
+	return normalizedUniqueStrings(normalized)
+}

--- a/apps/manager-server/internal/codexquota/scope_test.go
+++ b/apps/manager-server/internal/codexquota/scope_test.go
@@ -1,0 +1,270 @@
+package codexquota
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveAdditionalScope(t *testing.T) {
+	tests := []struct {
+		name           string
+		meteredFeature string
+		limitName      string
+		wantScope      ModelScope
+		wantPrefix     string
+	}{
+		{
+			name:           "provider feature identifies spark",
+			meteredFeature: "codex_spark",
+			limitName:      "Fast coding",
+			wantScope:      SparkScope(),
+			wantPrefix:     SparkProviderWindowPrefix,
+		},
+		{
+			name:       "verified model name identifies spark",
+			limitName:  "GPT-5.3-Codex-Spark",
+			wantScope:  SparkScope(),
+			wantPrefix: SparkProviderWindowPrefix,
+		},
+		{
+			name:           "unknown feature fails closed",
+			meteredFeature: "future_feature",
+			limitName:      "Future Feature",
+			wantScope:      FeatureScope("future_feature"),
+			wantPrefix:     "future-feature",
+		},
+		{
+			name:           "provider feature wins over conflicting spark label",
+			meteredFeature: "future_feature",
+			limitName:      "Spark",
+			wantScope:      FeatureScope("future_feature"),
+			wantPrefix:     "future-feature",
+		},
+		{
+			name:       "anonymous feature uses structural identity",
+			wantScope:  FeatureScope("additional_p_18000_s_604800"),
+			wantPrefix: "additional-p-18000-s-604800",
+		},
+		{
+			name:       "non ascii label uses structural identity consistently",
+			limitName:  "未来额度",
+			wantScope:  FeatureScope("additional_p_18000_s_604800"),
+			wantPrefix: "additional-p-18000-s-604800",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			anonymousIdentity := ""
+			if test.name == "anonymous feature uses structural identity" ||
+				test.name == "non ascii label uses structural identity consistently" {
+				anonymousIdentity = "additional-p-18000-s-604800"
+			}
+			got := ResolveAdditionalScope(AdditionalScopeInput{
+				MeteredFeature:    test.meteredFeature,
+				LimitName:         test.limitName,
+				AnonymousIdentity: anonymousIdentity,
+			})
+			if !reflect.DeepEqual(got.Scope, test.wantScope) || got.ProviderWindowPrefix != test.wantPrefix {
+				t.Fatalf("ResolveAdditionalScope() = %#v, want scope=%#v prefix=%q", got, test.wantScope, test.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestResolveUsageScopeUsesRequestAndResolvedIdentity(t *testing.T) {
+	tests := []struct {
+		name           string
+		model          string
+		analyticsModel string
+		requestedModel string
+		resolvedModel  string
+		want           UsageScopeResolution
+	}{
+		{
+			name:  "direct spark",
+			model: SparkModelID,
+			want:  UsageScopeResolution{Scope: SparkScope(), ProviderWindowPrefix: SparkProviderWindowPrefix},
+		},
+		{
+			name:           "alias resolves to spark",
+			model:          "my-spark",
+			analyticsModel: "my-spark",
+			requestedModel: "my-spark",
+			resolvedModel:  SparkModelID,
+			want:           UsageScopeResolution{Scope: SparkScope(), ProviderWindowPrefix: SparkProviderWindowPrefix},
+		},
+		{
+			name:           "ordinary alias stays main",
+			model:          "my-codex",
+			analyticsModel: "my-codex",
+			requestedModel: "my-codex",
+			resolvedModel:  "gpt-5.6-sol",
+			want:           UsageScopeResolution{Scope: MainScope()},
+		},
+		{
+			name:           "resolved main wins over spark-shaped request alias",
+			model:          SparkModelID,
+			analyticsModel: SparkModelID,
+			requestedModel: SparkModelID,
+			resolvedModel:  "gpt-5.6-sol",
+			want:           UsageScopeResolution{Scope: MainScope()},
+		},
+		{
+			name: "missing identity fails closed",
+			want: UsageScopeResolution{Scope: UnknownRequestScope(), ProviderWindowPrefix: "request-scope-unknown"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ResolveUsageScope(test.model, test.analyticsModel, test.requestedModel, test.resolvedModel)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("ResolveUsageScope() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestMatchMainUsageExcludesSparkOnEitherIdentitySide(t *testing.T) {
+	tests := []struct {
+		name          string
+		requestModel  string
+		billingModel  string
+		wantMatched   bool
+		wantUnmatched bool
+	}{
+		{name: "ordinary request", requestModel: "my-codex", billingModel: "gpt-5.6-sol", wantMatched: true},
+		{name: "direct spark request", requestModel: SparkModelID, billingModel: SparkModelID},
+		{name: "alias resolved to spark", requestModel: "my-spark", billingModel: SparkModelID},
+		{name: "spark-shaped request resolved to main", requestModel: SparkModelID, billingModel: "gpt-5.6-sol", wantMatched: true},
+		{name: "missing identity", wantUnmatched: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matched, unmatched := MatchMainUsage(test.requestModel, test.billingModel)
+			if matched != test.wantMatched || unmatched != test.wantUnmatched {
+				t.Fatalf("MatchMainUsage() = (%v, %v), want (%v, %v)", matched, unmatched, test.wantMatched, test.wantUnmatched)
+			}
+		})
+	}
+}
+
+func TestCanonicalProviderWindowIDNormalizesLegacySparkAliases(t *testing.T) {
+	for input, want := range map[string]string{
+		"GPT-5-3-Codex-Spark-Weekly-0": "spark-weekly-0",
+		"codex-spark-five-hour-0":      "spark-five-hour-0",
+		"spark-monthly-0":              "spark-monthly-0",
+		"weekly":                       "weekly",
+	} {
+		if got := CanonicalProviderWindowID(input); got != want {
+			t.Errorf("CanonicalProviderWindowID(%q) = %q, want %q", input, got, want)
+		}
+	}
+	if got := CanonicalProviderWindowID("primary", "five_hour"); got != "five-hour" {
+		t.Fatalf("primary alias canonicalized to %q, want five-hour", got)
+	}
+	if got := CanonicalProviderWindowID("secondary", "weekly"); got != "weekly" {
+		t.Fatalf("weekly secondary alias canonicalized to %q, want weekly", got)
+	}
+	if got := CanonicalProviderWindowID("secondary", "monthly"); got != "monthly" {
+		t.Fatalf("monthly secondary alias canonicalized to %q, want monthly", got)
+	}
+}
+
+func TestResolveProviderWindowScopeFailsClosedForLegacyCodexScopedIDs(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerWindowID string
+		windowKind       string
+		want             ModelScope
+	}{
+		{name: "spark", providerWindowID: "fast-coding-weekly-0", windowKind: "weekly", want: SparkScope()},
+		{name: "code review", providerWindowID: "code-review-weekly-0", windowKind: "weekly", want: CodeReviewScope()},
+		{name: "unknown feature fails closed", providerWindowID: "future-feature-weekly-0", windowKind: "weekly", want: FeatureScope("future_feature")},
+		{name: "main primary", providerWindowID: "primary", windowKind: "five_hour", want: ModelScope{Kind: "all", Models: []string{}, Complete: true}},
+		{name: "main monthly secondary", providerWindowID: "secondary", windowKind: "monthly", want: ModelScope{Kind: "all", Models: []string{}, Complete: true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ResolveProviderWindowScope(test.providerWindowID, test.windowKind, ModelScope{Kind: "all", Complete: true})
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("ResolveProviderWindowScope() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalProviderWindowIDForScopeCollapsesLegacySparkIdentity(t *testing.T) {
+	if got := CanonicalProviderWindowIDForScope("fast-coding-weekly-0", "weekly", SparkScope()); got != "spark-weekly-0" {
+		t.Fatalf("legacy Spark identity = %q, want spark-weekly-0", got)
+	}
+	if got := CanonicalProviderWindowID("fast-coding-weekly-0"); got != "fast-coding-weekly-0" {
+		t.Fatalf("raw legacy lifecycle id = %q, want unchanged", got)
+	}
+}
+
+func TestInferScopeFromLegacyFastCodingWindowID(t *testing.T) {
+	if got := InferScopeFromProviderWindowID("fast-coding-weekly-0"); !reflect.DeepEqual(got, SparkScope()) {
+		t.Fatalf("InferScopeFromProviderWindowID() = %#v, want Spark scope", got)
+	}
+}
+
+func TestProviderWindowAliasesIncludeLegacySparkLabelWithoutCanonicalizingIt(t *testing.T) {
+	aliases := ProviderWindowAliases("spark-weekly-0", SparkScope())
+	want := "fast-coding-weekly-0"
+	if !containsScopeString(aliases, want) {
+		t.Fatalf("Spark provider aliases = %#v, want %q", aliases, want)
+	}
+	if got := CanonicalProviderWindowID(want); got != want {
+		t.Fatalf("legacy Spark alias was canonicalized to %q; lifecycle needs the raw alias", got)
+	}
+}
+
+func TestProviderWindowAliasesIncludeLegacyCodexMainNames(t *testing.T) {
+	tests := map[string]string{
+		"five-hour": "primary",
+		"weekly":    "secondary",
+		"monthly":   "secondary",
+	}
+	for providerWindowID, want := range tests {
+		aliases := ProviderWindowAliases(providerWindowID, MainScope())
+		if !containsScopeString(aliases, want) {
+			t.Fatalf("main provider aliases for %q = %#v, want %q", providerWindowID, aliases, want)
+		}
+	}
+}
+
+func containsScopeString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLegacyAllScopeReplacementUsesKnownQuotaIdentityNotUsageCompleteness(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerWindowID string
+		scope            ModelScope
+		want             bool
+	}{
+		{name: "spark model scope", providerWindowID: "spark-weekly-0", scope: SparkScope(), want: true},
+		{name: "incomplete code review feature", providerWindowID: "code-review-weekly-0", scope: CodeReviewScope(), want: true},
+		{name: "incomplete unknown feature", providerWindowID: "future-feature-weekly-0", scope: FeatureScope("future_feature"), want: true},
+		{name: "main family preserves legacy identity", providerWindowID: "weekly", scope: MainScope()},
+		{name: "all scope does not replace itself", providerWindowID: "future-feature-weekly-0", scope: ModelScope{Kind: "all", Complete: true}},
+		{name: "incomplete all scope fails closed for non-main window", providerWindowID: "future-feature-weekly-0", scope: ModelScope{Kind: "all", Complete: false}, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsLegacyAllScopeReplacement(test.providerWindowID, test.scope); got != test.want {
+				t.Fatalf("IsLegacyAllScopeReplacement(%q, %#v) = %v, want %v", test.providerWindowID, test.scope, got, test.want)
+			}
+		})
+	}
+}

--- a/apps/manager-server/internal/model/account_quota_snapshot.go
+++ b/apps/manager-server/internal/model/account_quota_snapshot.go
@@ -12,6 +12,7 @@ type AccountQuotaSnapshot struct {
 	AccountKey            string
 	Provider              string
 	ProviderWindowID      string
+	ProviderWindowAliases []string
 	WindowKind            string
 	WindowMode            string
 	ModelScopeKind        string

--- a/apps/manager-server/internal/model/codex_inspection.go
+++ b/apps/manager-server/internal/model/codex_inspection.go
@@ -139,14 +139,23 @@ func NormalizeCodexInspectionRunStatus(status string) string {
 }
 
 type CodexInspectionQuotaWindow struct {
-	ID                 string         `json:"id"`
-	LabelKey           string         `json:"labelKey"`
-	LabelParams        map[string]any `json:"labelParams,omitempty"`
-	UsedPercent        *float64       `json:"usedPercent,omitempty"`
-	ResetLabel         string         `json:"resetLabel"`
-	ResetAtMS          int64          `json:"resetAtMs,omitempty"`
-	ResetAccuracy      string         `json:"resetAccuracy,omitempty"`
-	LimitWindowSeconds *float64       `json:"limitWindowSeconds,omitempty"`
+	ID                    string                          `json:"id"`
+	LabelKey              string                          `json:"labelKey"`
+	LabelParams           map[string]any                  `json:"labelParams,omitempty"`
+	UsedPercent           *float64                        `json:"usedPercent,omitempty"`
+	ResetLabel            string                          `json:"resetLabel"`
+	ResetAtMS             int64                           `json:"resetAtMs,omitempty"`
+	ResetAccuracy         string                          `json:"resetAccuracy,omitempty"`
+	LimitWindowSeconds    *float64                        `json:"limitWindowSeconds,omitempty"`
+	ModelScope            *CodexInspectionQuotaModelScope `json:"modelScope,omitempty"`
+	ProviderWindowAliases []string                        `json:"providerWindowAliases,omitempty"`
+}
+
+type CodexInspectionQuotaModelScope struct {
+	Kind     string   `json:"kind"`
+	Key      string   `json:"key,omitempty"`
+	Models   []string `json:"models,omitempty"`
+	Complete bool     `json:"complete"`
 }
 
 type CodexInspectionResult struct {

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 )
 
@@ -121,6 +122,9 @@ func persistObservationSnapshots(ctx context.Context, tx *sql.Tx, write *model.A
 	for snapshotIndex := range write.Snapshots {
 		snapshot := &write.Snapshots[snapshotIndex]
 		snapshot.ObservationID = observationID
+		if err := reclassifyLegacyCodexAllScope(ctx, tx, write.Observation, snapshot); err != nil {
+			return err
+		}
 		window, activationID, lifecycleOwned, err := reconcileReportedWindow(ctx, tx, write.Observation, snapshot)
 		if err != nil {
 			return err
@@ -506,6 +510,148 @@ func reconcileReportedWindow(
 		return logicalWindowRow{}, 0, false, err
 	}
 	return window, activationID, true, nil
+}
+
+func reclassifyLegacyCodexAllScope(
+	ctx context.Context,
+	tx *sql.Tx,
+	observation model.AccountQuotaObservation,
+	snapshot *model.AccountQuotaSnapshot,
+) error {
+	if snapshot == nil || observation.Provider != "codex" || strings.EqualFold(strings.TrimSpace(snapshot.ModelScopeKind), "all") {
+		return nil
+	}
+	scope := codexquota.NormalizeScope(codexquota.ModelScope{
+		Kind:     snapshot.ModelScopeKind,
+		Key:      snapshot.ModelScopeKey,
+		Models:   legacyModelIDs(snapshot.ModelIDsJSON),
+		Complete: false,
+	})
+	scope.Complete = len(scope.Models) > 0 || codexquota.IsMainScope(scope.Kind, scope.Key)
+	migrateMainScope := codexquota.IsLegacyMainAllScopeMigration(snapshot.ProviderWindowID, scope)
+	deactivateLegacyScope := codexquota.IsLegacyAllScopeReplacement(snapshot.ProviderWindowID, scope)
+	if !migrateMainScope && !deactivateLegacyScope {
+		return nil
+	}
+	aliases := codexquota.ProviderWindowAliases(
+		snapshot.ProviderWindowID,
+		scope,
+		snapshot.ProviderWindowAliases...,
+	)
+	if len(aliases) == 0 {
+		return nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(aliases)), ",")
+	args := make([]any, 0, 3+len(aliases))
+	args = append(args, observation.AccountKey, observation.Provider, observation.InventoryScopeKey)
+	for _, alias := range aliases {
+		args = append(args, alias)
+	}
+	rows, err := tx.QueryContext(ctx, `select
+		id, provider_window_id, window_kind, window_mode, scope_fingerprint,
+		inventory_scope_key, availability, generation, absence_count,
+		first_seen_at_ms, last_seen_at_ms, missing_since_ms, deactivated_at_ms,
+		coalesce(relationship_kind, ''), coalesce(container_provider_window_id, '')
+		from account_quota_windows
+		where account_key = ? and provider = ? and inventory_scope_key = ?
+			and lower(trim(model_scope_kind)) = 'all' and availability <> 'inactive'
+			and lower(trim(provider_window_id)) in (`+placeholders+`)`, args...)
+	if err != nil {
+		return err
+	}
+	legacyWindows := make([]logicalWindowRow, 0)
+	for rows.Next() {
+		var window logicalWindowRow
+		if err := rows.Scan(
+			&window.id,
+			&window.providerWindowID,
+			&window.windowKind,
+			&window.windowMode,
+			&window.scopeFingerprint,
+			&window.inventoryScopeKey,
+			&window.availability,
+			&window.generation,
+			&window.absenceCount,
+			&window.firstSeenAtMS,
+			&window.lastSeenAtMS,
+			&window.missingSinceMS,
+			&window.deactivatedAtMS,
+			&window.relationshipKind,
+			&window.containerProviderWindowID,
+		); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		legacyWindows = append(legacyWindows, window)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if migrateMainScope && len(legacyWindows) > 0 {
+		var targetExists int
+		if err := tx.QueryRowContext(ctx, `select exists (
+			select 1 from account_quota_windows
+			where account_key = ? and provider = ? and provider_window_id = ?
+				and scope_fingerprint = ?
+		)`, observation.AccountKey, observation.Provider, snapshot.ProviderWindowID, snapshot.ScopeFingerprint).Scan(&targetExists); err != nil {
+			return err
+		}
+		if targetExists == 0 {
+			keeperIndex := 0
+			for index, window := range legacyWindows {
+				if strings.EqualFold(strings.TrimSpace(window.providerWindowID), strings.TrimSpace(snapshot.ProviderWindowID)) {
+					keeperIndex = index
+					break
+				}
+			}
+			keeper := legacyWindows[keeperIndex]
+			snapshot.ProviderWindowID = keeper.providerWindowID
+			snapshot.ModelScopeKind = "all"
+			snapshot.ModelScopeKey = ""
+			snapshot.ModelIDsJSON = ""
+			snapshot.ScopeFingerprint = keeper.scopeFingerprint
+			for index, window := range legacyWindows {
+				if index == keeperIndex {
+					continue
+				}
+				if err := deactivateWindowWithReason(
+					ctx,
+					tx,
+					window,
+					observation.ID,
+					observation.ObservedAtMS,
+					observation.CreatedAtMS,
+					"scope_reclassified",
+					"scope_reclassified",
+					false,
+				); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+
+	for _, window := range legacyWindows {
+		if err := deactivateWindowWithReason(
+			ctx,
+			tx,
+			window,
+			observation.ID,
+			observation.ObservedAtMS,
+			observation.CreatedAtMS,
+			"scope_reclassified",
+			"scope_reclassified",
+			false,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func restoreSameTimestampRemoval(
@@ -1339,8 +1485,29 @@ func deactivateWindow(
 	window logicalWindowRow,
 	observationID, observedAtMS, updatedAtMS int64,
 ) error {
+	return deactivateWindowWithReason(
+		ctx,
+		tx,
+		window,
+		observationID,
+		observedAtMS,
+		updatedAtMS,
+		"provider_removed",
+		"window_removed",
+		true,
+	)
+}
+
+func deactivateWindowWithReason(
+	ctx context.Context,
+	tx *sql.Tx,
+	window logicalWindowRow,
+	observationID, observedAtMS, updatedAtMS int64,
+	activationReason, cycleReason string,
+	preferMissingSince bool,
+) error {
 	transitionMS := observedAtMS
-	if window.missingSinceMS.Valid {
+	if preferMissingSince && window.missingSinceMS.Valid {
 		transitionMS = window.missingSinceMS.Int64
 	}
 	if _, err := tx.ExecContext(ctx, `update account_quota_windows set
@@ -1357,9 +1524,9 @@ func deactivateWindow(
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, `update account_quota_window_activations set
-		status = 'inactive', deactivated_at_ms = ?, deactivation_reason = 'provider_removed',
+		status = 'inactive', deactivated_at_ms = ?, deactivation_reason = ?,
 		deactivate_observation_id = ?, updated_at_ms = ? where id = ?`,
-		transitionMS, observationID, updatedAtMS, activationID); err != nil {
+		transitionMS, activationReason, observationID, updatedAtMS, activationID); err != nil {
 		return err
 	}
 	active, err := activeCycle(ctx, tx, activationID)
@@ -1374,9 +1541,9 @@ func deactivateWindow(
 		endMS = active.ActualStartMS
 	}
 	_, err = tx.ExecContext(ctx, `update account_quota_cycles set
-		state = 'closed', actual_end_ms = ?, end_reason = 'window_removed',
+		state = 'closed', actual_end_ms = ?, end_reason = ?,
 		last_observation_id = ?, updated_at_ms = ? where id = ?`,
-		endMS, observationID, updatedAtMS, active.ID)
+		endMS, cycleReason, observationID, updatedAtMS, active.ID)
 	return err
 }
 

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -447,6 +447,10 @@ type HeaderSnapshot struct {
 	ID                     int64
 	EventHash              string
 	TimestampMS            int64
+	Model                  string
+	AnalyticsModel         string
+	RequestedModel         string
+	ResolvedModel          string
 	AuthFileSnapshot       string
 	AuthIndex              string
 	AccountSnapshot        string
@@ -2578,6 +2582,10 @@ func (r *repository) LatestHeaderSnapshots(ctx context.Context, sinceMS int64, l
 		id,
 		event_hash,
 		timestamp_ms,
+		coalesce(model, '') as model,
+		`+usageidentity.SQLRequestAnalyticsModelExpression("model", "requested_model")+` as analytics_model,
+		coalesce(requested_model, '') as requested_model,
+		coalesce(resolved_model, '') as resolved_model,
 		coalesce(auth_file_snapshot, '') as auth_file_snapshot,
 		coalesce(auth_index, '') as auth_index,
 		coalesce(account_snapshot, '') as account_snapshot,
@@ -2626,6 +2634,10 @@ select
 	id,
 	event_hash,
 	timestamp_ms,
+	model,
+	analytics_model,
+	requested_model,
+	resolved_model,
 	auth_file_snapshot,
 	auth_index,
 	account_snapshot,
@@ -2658,6 +2670,10 @@ limit ?`, sinceMS, limit)
 			&item.ID,
 			&item.EventHash,
 			&item.TimestampMS,
+			&item.Model,
+			&item.AnalyticsModel,
+			&item.RequestedModel,
+			&item.ResolvedModel,
 			&item.AuthFileSnapshot,
 			&item.AuthIndex,
 			&item.AccountSnapshot,

--- a/apps/manager-server/internal/repository/usagemonitoring/metadata_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/metadata_read.go
@@ -415,15 +415,20 @@ func (r *repository) LoadHeaderSnapshots(ctx context.Context, sinceMS int64, lim
 
 func mergeStoredHeaderRows(ctx context.Context, tx *sql.Tx, sinceMS int64, limit int, grouped map[string]headerRow) error {
 	rows, err := tx.QueryContext(ctx, `select
-		snapshot_key, event_id, event_hash, timestamp_ms, auth_file_snapshot,
-		auth_index, account_snapshot, auth_label_snapshot,
-		auth_provider_snapshot, auth_project_id_snapshot, source, source_hash,
-		response_metadata_json, header_quota_recover_at_ms,
-		header_quota_used_percent, header_quota_plan_type, header_error_kind,
-		header_error_code, header_trace_id
-	from usage_monitoring_header_latest_v1
-	where timestamp_ms >= ?
-	order by timestamp_ms desc, event_id desc
+		stored.snapshot_key, stored.event_id, stored.event_hash, stored.timestamp_ms,
+		coalesce(usage_event.model, ''),
+		`+usageidentity.SQLRequestAnalyticsModelExpression("usage_event.model", "usage_event.requested_model")+`,
+		coalesce(usage_event.requested_model, ''), coalesce(usage_event.resolved_model, ''),
+		stored.auth_file_snapshot,
+		stored.auth_index, stored.account_snapshot, stored.auth_label_snapshot,
+		stored.auth_provider_snapshot, stored.auth_project_id_snapshot, stored.source, stored.source_hash,
+		stored.response_metadata_json, stored.header_quota_recover_at_ms,
+		stored.header_quota_used_percent, stored.header_quota_plan_type, stored.header_error_kind,
+		stored.header_error_code, stored.header_trace_id
+	from usage_monitoring_header_latest_v1 stored
+	left join usage_events usage_event on usage_event.id = stored.event_id
+	where stored.timestamp_ms >= ?
+	order by stored.timestamp_ms desc, stored.event_id desc
 	limit ?`, sinceMS, limit)
 	if err != nil {
 		return err
@@ -438,6 +443,10 @@ func mergeRawHeaderRows(ctx context.Context, tx *sql.Tx, sinceMS, afterID int64,
 			id,
 			event_hash,
 			timestamp_ms,
+			coalesce(model, '') as model,
+			`+usageidentity.SQLRequestAnalyticsModelExpression("model", "requested_model")+` as analytics_model,
+			coalesce(requested_model, '') as requested_model,
+			coalesce(resolved_model, '') as resolved_model,
 			coalesce(auth_file_snapshot, '') as auth_file_snapshot,
 			coalesce(auth_index, '') as auth_index,
 			coalesce(account_snapshot, '') as account_snapshot,
@@ -478,7 +487,9 @@ func mergeRawHeaderRows(ctx context.Context, tx *sql.Tx, sinceMS, afterID int64,
 		from candidates
 	)
 	select
-		snapshot_key, id, event_hash, timestamp_ms, auth_file_snapshot,
+		snapshot_key, id, event_hash, timestamp_ms,
+		model, analytics_model, requested_model, resolved_model,
+		auth_file_snapshot,
 		auth_index, account_snapshot, auth_label_snapshot,
 		auth_provider_snapshot, auth_project_id_snapshot, source, source_hash,
 		response_metadata_json, header_quota_recover_at_ms,
@@ -504,6 +515,10 @@ func scanHeaderRows(rows *sql.Rows, grouped map[string]headerRow) error {
 			&row.Item.ID,
 			&row.Item.EventHash,
 			&row.Item.TimestampMS,
+			&row.Item.Model,
+			&row.Item.AnalyticsModel,
+			&row.Item.RequestedModel,
+			&row.Item.ResolvedModel,
 			&row.Item.AuthFileSnapshot,
 			&row.Item.AuthIndex,
 			&row.Item.AccountSnapshot,

--- a/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	monitoringrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usagemonitoring"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
@@ -1354,6 +1355,48 @@ func TestUsageMonitoringMetadataBackfillRefreshesHistoricalHeadersWithoutReset(t
 	}
 	if !strings.Contains(searchText, "backfilled-trace") {
 		t.Fatalf("event projection search_text was not refreshed: %q", searchText)
+	}
+}
+
+func TestUsageMonitoringHeaderSnapshotsPreserveRequestAndResolvedModelIdentity(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	baseMS := int64(1_800_057_700_000)
+	event := monitoringRepositoryEvent(
+		"header-model-identity",
+		baseMS+1_000,
+		"my-spark",
+		"key-a",
+		"alice@example.com",
+		"auth-a",
+		"source-a",
+		false,
+		10,
+		5,
+		10,
+	)
+	event.RequestedModel = "my-spark"
+	event.ResolvedModel = codexquota.SparkModelID
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert header identity event: %v", err)
+	}
+
+	raw, err := db.LatestHeaderSnapshots(ctx, baseMS, 10)
+	if err != nil {
+		t.Fatalf("load raw header identity: %v", err)
+	}
+	if len(raw) != 1 || raw[0].Model != "my-spark" || raw[0].AnalyticsModel != "my-spark" ||
+		raw[0].RequestedModel != "my-spark" || raw[0].ResolvedModel != codexquota.SparkModelID {
+		t.Fatalf("raw header identity = %#v", raw)
+	}
+
+	catchUpMonitoringRepository(t, ctx, db)
+	rolled, _, available, err := db.UsageMonitoringHeaderSnapshots(ctx, baseMS, 10)
+	if err != nil || !available {
+		t.Fatalf("load rolled header identity: available=%v err=%v", available, err)
+	}
+	if !reflect.DeepEqual(rolled, raw) {
+		t.Fatalf("rolled header identity mismatch\nrolled=%#v\nraw=%#v", rolled, raw)
 	}
 }
 

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	codexinspectionrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/codexinspection"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
@@ -254,6 +255,19 @@ type codexClassifiedWindows struct {
 type codexWindowMeta struct {
 	ID       string
 	LabelKey string
+}
+
+type codexAdditionalRateLimitFamily struct {
+	sourceIndex        int
+	rateInfo           *codexRateLimit
+	limitName          string
+	modelScope         codexquota.ModelScope
+	baseIDPrefix       string
+	featureIDPrefix    string
+	legacyBaseIDPrefix string
+	legacyPrefixes     []string
+	idPrefix           string
+	sortKey            string
 }
 
 func (w codexClassifiedWindows) longWindow() *codexWindow {
@@ -4438,6 +4452,7 @@ func buildCodexInspectionQuotaWindows(payload map[string]any, planType string) [
 		"codex_quota.generic_window",
 		nil,
 		teamPlan,
+		codexquota.MainScope(),
 	)
 	addCodexRateLimitWindows(
 		&windows,
@@ -4449,6 +4464,7 @@ func buildCodexInspectionQuotaWindows(payload map[string]any, planType string) [
 		"codex_quota.code_review_generic_window",
 		nil,
 		teamPlan,
+		codexquota.CodeReviewScope(),
 	)
 	addAdditionalRateLimitWindows(&windows, readMapSlice(payload, "additional_rate_limits", "additionalRateLimits"), teamPlan)
 	return windows
@@ -4490,21 +4506,22 @@ func addCodexRateLimitWindows(
 	genericLabelKey string,
 	genericLabelParams map[string]any,
 	teamPlan bool,
+	modelScope codexquota.ModelScope,
 ) {
 	if limit == nil {
 		return
 	}
 	classified := classifyWindows(limit, codexPlanTypeForTeam(teamPlan))
 	added := make(map[*codexWindow]bool)
-	addCodexWindowInfo(windows, fiveHourMeta.ID, fiveHourMeta.LabelKey, genericLabelParams, classified.FiveHour, limit.LimitReached, limit.Allowed)
+	addCodexWindowInfo(windows, fiveHourMeta.ID, fiveHourMeta.LabelKey, genericLabelParams, classified.FiveHour, limit.LimitReached, limit.Allowed, modelScope)
 	if classified.FiveHour != nil {
 		added[classified.FiveHour] = true
 	}
-	addCodexWindowInfo(windows, weeklyMeta.ID, weeklyMeta.LabelKey, genericLabelParams, classified.Weekly, limit.LimitReached, limit.Allowed)
+	addCodexWindowInfo(windows, weeklyMeta.ID, weeklyMeta.LabelKey, genericLabelParams, classified.Weekly, limit.LimitReached, limit.Allowed, modelScope)
 	if classified.Weekly != nil {
 		added[classified.Weekly] = true
 	}
-	addCodexWindowInfo(windows, monthlyMeta.ID, monthlyMeta.LabelKey, genericLabelParams, classified.Monthly, limit.LimitReached, limit.Allowed)
+	addCodexWindowInfo(windows, monthlyMeta.ID, monthlyMeta.LabelKey, genericLabelParams, classified.Monthly, limit.LimitReached, limit.Allowed, modelScope)
 	if classified.Monthly != nil {
 		added[classified.Monthly] = true
 	}
@@ -4525,6 +4542,7 @@ func addCodexRateLimitWindows(
 			window,
 			limit.LimitReached,
 			limit.Allowed,
+			modelScope,
 		)
 	}
 }
@@ -4551,6 +4569,7 @@ func addCodexWindowInfo(
 	window *codexWindow,
 	limitReached bool,
 	allowed *bool,
+	modelScope codexquota.ModelScope,
 ) {
 	if window == nil {
 		return
@@ -4571,60 +4590,198 @@ func addCodexWindowInfo(
 		ResetAtMS:          resetAtMS,
 		ResetAccuracy:      resetAccuracy,
 		LimitWindowSeconds: window.LimitWindowSeconds,
+		ModelScope:         codexInspectionQuotaModelScope(modelScope),
 	})
 }
 
-func addAdditionalRateLimitWindows(windows *[]model.CodexInspectionQuotaWindow, additionalRateLimits []map[string]any, teamPlan bool) {
-	baseIDPrefixCounts := make(map[string]int)
-	for index, limitItem := range additionalRateLimits {
-		if parseRateLimit(readMap(limitItem, "rate_limit", "rateLimit")) == nil {
-			continue
-		}
-		_, baseIDPrefix, _ := codexAdditionalRateLimitIdentity(limitItem, index)
-		baseIDPrefixCounts[baseIDPrefix]++
+func codexInspectionQuotaModelScope(scope codexquota.ModelScope) *model.CodexInspectionQuotaModelScope {
+	return &model.CodexInspectionQuotaModelScope{
+		Kind:     scope.Kind,
+		Key:      scope.Key,
+		Models:   append([]string(nil), scope.Models...),
+		Complete: scope.Complete,
 	}
+}
 
-	occurrencesByIDPrefix := make(map[string]int)
+func addAdditionalRateLimitWindows(windows *[]model.CodexInspectionQuotaWindow, additionalRateLimits []map[string]any, teamPlan bool) {
+	families := make([]codexAdditionalRateLimitFamily, 0, len(additionalRateLimits))
+	baseIDPrefixCounts := make(map[string]int)
+	legacyBaseIDPrefixCounts := make(map[string]int)
 	for index, limitItem := range additionalRateLimits {
 		rateInfo := parseRateLimit(readMap(limitItem, "rate_limit", "rateLimit"))
 		if rateInfo == nil {
 			continue
 		}
-		limitName, idPrefix, featureIDPrefix := codexAdditionalRateLimitIdentity(limitItem, index)
-		if baseIDPrefixCounts[idPrefix] > 1 && featureIDPrefix != "" && featureIDPrefix != idPrefix {
-			// A normalized provider label cannot contain a double dash, so keep the
-			// feature namespace distinct from another quota whose actual name happens
-			// to equal "<limit name>-<metered feature>".
-			idPrefix += "--" + featureIDPrefix
+		meteredFeature := readString(limitItem, "metered_feature", "meteredFeature")
+		limitName := firstNonEmpty(
+			readString(limitItem, "limit_name", "limitName"),
+			meteredFeature,
+			fmt.Sprintf("additional-%d", index+1),
+		)
+		scopeResolution := codexquota.ResolveAdditionalScope(codexquota.AdditionalScopeInput{
+			MeteredFeature:    meteredFeature,
+			LimitName:         readString(limitItem, "limit_name", "limitName"),
+			AnonymousIdentity: anonymousCodexAdditionalIdentity(rateInfo),
+		})
+		legacyBaseIDPrefix := normalizeCodexWindowID(limitName)
+		if legacyBaseIDPrefix == "" {
+			legacyBaseIDPrefix = fmt.Sprintf("additional-%d", index+1)
 		}
-		familyIndex := occurrencesByIDPrefix[idPrefix]
-		occurrencesByIDPrefix[idPrefix] = familyIndex + 1
+		families = append(families, codexAdditionalRateLimitFamily{
+			sourceIndex:        index,
+			rateInfo:           rateInfo,
+			limitName:          limitName,
+			modelScope:         scopeResolution.Scope,
+			baseIDPrefix:       scopeResolution.ProviderWindowPrefix,
+			featureIDPrefix:    normalizeCodexWindowID(meteredFeature),
+			legacyBaseIDPrefix: legacyBaseIDPrefix,
+			legacyPrefixes:     append([]string(nil), scopeResolution.LegacyPrefixes...),
+			sortKey:            codexAdditionalRateLimitSortKey(rateInfo),
+		})
+		baseIDPrefixCounts[scopeResolution.ProviderWindowPrefix]++
+		legacyBaseIDPrefixCounts[legacyBaseIDPrefix]++
+	}
+
+	familiesByIDPrefix := make(map[string][]int)
+	for index := range families {
+		family := &families[index]
+		family.idPrefix = family.baseIDPrefix
+		if baseIDPrefixCounts[family.baseIDPrefix] > 1 && family.featureIDPrefix != "" && family.featureIDPrefix != family.baseIDPrefix {
+			family.idPrefix += "--" + family.featureIDPrefix
+		}
+		legacyPrefix := family.legacyBaseIDPrefix
+		if legacyBaseIDPrefixCounts[legacyPrefix] > 1 && family.featureIDPrefix != "" && family.featureIDPrefix != legacyPrefix {
+			legacyPrefix += "--" + family.featureIDPrefix
+		}
+		family.legacyPrefixes = append(family.legacyPrefixes, legacyPrefix)
+		familiesByIDPrefix[family.idPrefix] = append(familiesByIDPrefix[family.idPrefix], index)
+	}
+	familyIndexes := make(map[int]int, len(families))
+	for _, indexes := range familiesByIDPrefix {
+		sort.SliceStable(indexes, func(left, right int) bool {
+			leftFamily := families[indexes[left]]
+			rightFamily := families[indexes[right]]
+			if leftFamily.sortKey != rightFamily.sortKey {
+				return leftFamily.sortKey < rightFamily.sortKey
+			}
+			return leftFamily.sourceIndex < rightFamily.sourceIndex
+		})
+		for familyIndex, index := range indexes {
+			familyIndexes[index] = familyIndex
+		}
+	}
+
+	for index, family := range families {
+		familyIndex := familyIndexes[index]
+		start := len(*windows)
 		addCodexRateLimitWindows(
 			windows,
-			rateInfo,
-			codexWindowMeta{ID: fmt.Sprintf("%s-five-hour-%d", idPrefix, familyIndex), LabelKey: "codex_quota.additional_primary_window"},
-			codexWindowMeta{ID: fmt.Sprintf("%s-weekly-%d", idPrefix, familyIndex), LabelKey: "codex_quota.additional_secondary_window"},
-			codexWindowMeta{ID: fmt.Sprintf("%s-monthly-%d", idPrefix, familyIndex), LabelKey: "codex_quota.additional_monthly_window"},
-			fmt.Sprintf("%s-%d", idPrefix, familyIndex),
+			family.rateInfo,
+			codexWindowMeta{ID: fmt.Sprintf("%s-five-hour-%d", family.idPrefix, familyIndex), LabelKey: "codex_quota.additional_primary_window"},
+			codexWindowMeta{ID: fmt.Sprintf("%s-weekly-%d", family.idPrefix, familyIndex), LabelKey: "codex_quota.additional_secondary_window"},
+			codexWindowMeta{ID: fmt.Sprintf("%s-monthly-%d", family.idPrefix, familyIndex), LabelKey: "codex_quota.additional_monthly_window"},
+			fmt.Sprintf("%s-%d", family.idPrefix, familyIndex),
 			"codex_quota.additional_generic_window",
-			map[string]any{"name": limitName},
+			map[string]any{"name": family.limitName},
 			teamPlan,
+			family.modelScope,
 		)
+		applyCodexProviderWindowAliases((*windows)[start:], family.idPrefix, family.legacyPrefixes)
 	}
 }
 
-func codexAdditionalRateLimitIdentity(limitItem map[string]any, index int) (string, string, string) {
-	meteredFeature := readString(limitItem, "metered_feature", "meteredFeature")
-	limitName := firstNonEmpty(
-		readString(limitItem, "limit_name", "limitName"),
-		meteredFeature,
-		fmt.Sprintf("additional-%d", index+1),
-	)
-	idPrefix := normalizeCodexWindowID(limitName)
-	if idPrefix == "" {
-		idPrefix = fmt.Sprintf("additional-%d", index+1)
+func applyCodexProviderWindowAliases(
+	windows []model.CodexInspectionQuotaWindow,
+	providerWindowPrefix string,
+	legacyPrefixes []string,
+) {
+	aliases := make([]string, 0, len(legacyPrefixes))
+	seen := make(map[string]struct{}, len(legacyPrefixes))
+	for _, prefix := range legacyPrefixes {
+		prefix = strings.ToLower(strings.TrimSpace(prefix))
+		if prefix == "" || prefix == providerWindowPrefix {
+			continue
+		}
+		if _, exists := seen[prefix]; exists {
+			continue
+		}
+		seen[prefix] = struct{}{}
+		aliases = append(aliases, prefix)
 	}
-	return limitName, idPrefix, normalizeCodexWindowID(meteredFeature)
+	sort.Strings(aliases)
+	for index := range windows {
+		if !strings.HasPrefix(windows[index].ID, providerWindowPrefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(windows[index].ID, providerWindowPrefix)
+		windows[index].ProviderWindowAliases = make([]string, 0, len(aliases))
+		for _, prefix := range aliases {
+			windows[index].ProviderWindowAliases = append(
+				windows[index].ProviderWindowAliases,
+				prefix+suffix,
+			)
+		}
+	}
+}
+
+func anonymousCodexAdditionalIdentity(rateInfo *codexRateLimit) string {
+	if rateInfo == nil {
+		return "additional-p-none-s-none"
+	}
+	return strings.Join([]string{
+		"additional",
+		"p",
+		codexAdditionalWindowIdentityPart(rateInfo.PrimaryWindow),
+		"s",
+		codexAdditionalWindowIdentityPart(rateInfo.SecondaryWindow),
+	}, "-")
+}
+
+func codexAdditionalWindowIdentityPart(window *codexWindow) string {
+	if window == nil {
+		return "none"
+	}
+	if window.LimitWindowSeconds == nil {
+		return "unknown"
+	}
+	return fmt.Sprintf("%g", *window.LimitWindowSeconds)
+}
+
+func codexAdditionalRateLimitSortKey(rateInfo *codexRateLimit) string {
+	if rateInfo == nil {
+		return ""
+	}
+	allowed := ""
+	if rateInfo.Allowed != nil {
+		allowed = fmt.Sprintf("%t", *rateInfo.Allowed)
+	}
+	return strings.Join([]string{
+		codexAdditionalWindowSortKey(rateInfo.PrimaryWindow),
+		codexAdditionalWindowSortKey(rateInfo.SecondaryWindow),
+		allowed,
+		fmt.Sprintf("%t", rateInfo.LimitReached),
+	}, "|")
+}
+
+func codexAdditionalWindowSortKey(window *codexWindow) string {
+	if window == nil {
+		return "none"
+	}
+	values := []*float64{
+		window.LimitWindowSeconds,
+		window.UsedPercent,
+		window.ResetAfterSeconds,
+		window.ResetAt,
+	}
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == nil {
+			parts = append(parts, "")
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%g", *value))
+	}
+	return strings.Join(parts, ":")
 }
 
 func readMapSlice(record map[string]any, keys ...string) []map[string]any {

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
@@ -483,6 +484,59 @@ func TestBuildCodexInspectionQuotaWindowsKeepsGenericFamiliesDistinct(t *testing
 		}
 		seen[window.ID] = true
 	}
+}
+
+func TestBuildCodexInspectionQuotaWindowsAssignsCodexScopes(t *testing.T) {
+	weekly := func(usedPercent float64) map[string]any {
+		return map[string]any{
+			"secondary_window": map[string]any{
+				"used_percent": usedPercent, "limit_window_seconds": 7 * 24 * 60 * 60,
+			},
+		}
+	}
+	windows := buildCodexInspectionQuotaWindows(map[string]any{
+		"rate_limit":             weekly(36),
+		"code_review_rate_limit": weekly(20),
+		"additional_rate_limits": []any{
+			map[string]any{
+				"limit_name": "Fast coding", "metered_feature": "codex_spark", "rate_limit": weekly(0),
+			},
+			map[string]any{
+				"limit_name": "Future Feature", "metered_feature": "future_feature", "rate_limit": weekly(10),
+			},
+		},
+	}, "")
+	byID := make(map[string]model.CodexInspectionQuotaWindow, len(windows))
+	for _, window := range windows {
+		byID[window.ID] = window
+	}
+	assertScope := func(id, kind, key string, models []string, complete bool) {
+		t.Helper()
+		window, ok := byID[id]
+		if !ok || window.ModelScope == nil {
+			t.Fatalf("quota window %q scope missing: %#v", id, windows)
+		}
+		if window.ModelScope.Kind != kind || window.ModelScope.Key != key ||
+			!reflect.DeepEqual(window.ModelScope.Models, models) || window.ModelScope.Complete != complete {
+			t.Fatalf("quota window %q scope = %#v", id, window.ModelScope)
+		}
+	}
+	assertScope("weekly", "family", codexquota.MainScopeKey, nil, true)
+	assertScope("spark-weekly-0", "models", "", []string{codexquota.SparkModelID}, true)
+	if !containsString(byID["spark-weekly-0"].ProviderWindowAliases, "fast-coding-weekly-0") {
+		t.Fatalf("Spark legacy provider aliases = %#v", byID["spark-weekly-0"].ProviderWindowAliases)
+	}
+	assertScope("code-review-weekly", "feature", codexquota.CodeReviewScopeKey, nil, false)
+	assertScope("future-feature-weekly-0", "feature", "future_feature", nil, false)
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildCodexInspectionQuotaWindowsKeepsDistinctAdditionalFamiliesStableAcrossReorder(t *testing.T) {

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/pricing"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usagehourly"
 	monitoringrollup "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/usagemonitoring"
@@ -292,6 +294,8 @@ type AccountWindowUsageTarget struct {
 	FromMS                int64                   `json:"from_ms"`
 	ToMS                  int64                   `json:"to_ms"`
 	ModelScope            AccountWindowModelScope `json:"model_scope,omitempty"`
+	ModelScopeProvided    bool                    `json:"-"`
+	ModelScopeCompleteSet bool                    `json:"-"`
 	AccountSnapshot       string                  `json:"account_snapshot,omitempty"`
 	AuthLabelSnapshot     string                  `json:"auth_label_snapshot,omitempty"`
 	AuthFileSnapshot      string                  `json:"auth_file_snapshot,omitempty"`
@@ -301,10 +305,61 @@ type AccountWindowUsageTarget struct {
 	Source                string                  `json:"source,omitempty"`
 }
 
+func (target *AccountWindowUsageTarget) UnmarshalJSON(data []byte) error {
+	type alias AccountWindowUsageTarget
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	// This type has a custom unmarshaler so it can distinguish an omitted
+	// legacy model_scope from an explicitly incomplete scope. Keep the
+	// controller's DisallowUnknownFields contract for the target itself while
+	// allowing forward-compatible metadata inside model_scope.
+	knownFields := map[string]struct{}{
+		"request_key": {}, "row_key": {}, "window_key": {}, "provider_window_id": {},
+		"period": {}, "from_ms": {}, "to_ms": {}, "model_scope": {},
+		"account_snapshot": {}, "auth_label_snapshot": {}, "auth_file_snapshot": {},
+		"auth_provider_snapshot": {}, "auth_project_id_snapshot": {}, "auth_index": {},
+		"source": {},
+	}
+	for field := range fields {
+		if _, ok := knownFields[field]; ok {
+			continue
+		}
+		matched := false
+		for known := range knownFields {
+			if strings.EqualFold(field, known) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("json: unknown field %q", field)
+		}
+	}
+	*target = AccountWindowUsageTarget(decoded)
+	rawScope, provided := fields["model_scope"]
+	if !provided || strings.TrimSpace(string(rawScope)) == "null" {
+		return nil
+	}
+	target.ModelScopeProvided = true
+	var scopeFields map[string]json.RawMessage
+	if err := json.Unmarshal(rawScope, &scopeFields); err != nil {
+		return err
+	}
+	_, target.ModelScopeCompleteSet = scopeFields["complete"]
+	return nil
+}
+
 type AccountWindowModelScope struct {
-	Kind   string   `json:"kind,omitempty"`
-	Key    string   `json:"key,omitempty"`
-	Models []string `json:"models,omitempty"`
+	Kind     string   `json:"kind,omitempty"`
+	Key      string   `json:"key,omitempty"`
+	Models   []string `json:"models,omitempty"`
+	Complete bool     `json:"complete,omitempty"`
 }
 
 type AccountWindowUsageResponse struct {
@@ -736,6 +791,10 @@ type RecentFailure struct {
 type HeaderSnapshot struct {
 	EventHash              string                        `json:"event_hash"`
 	TimestampMS            int64                         `json:"timestamp_ms"`
+	Model                  string                        `json:"model,omitempty"`
+	AnalyticsModel         string                        `json:"analytics_model,omitempty"`
+	RequestedModel         string                        `json:"requested_model,omitempty"`
+	ResolvedModel          string                        `json:"resolved_model,omitempty"`
 	AuthFileSnapshot       string                        `json:"auth_file_snapshot,omitempty"`
 	AuthIndex              string                        `json:"auth_index,omitempty"`
 	AccountSnapshot        string                        `json:"account_snapshot,omitempty"`
@@ -1484,7 +1543,16 @@ func (s *Service) accountWindowUsage(ctx context.Context, req AccountWindowUsage
 		if window.Period == "" {
 			return AccountWindowUsageResponse{}, errors.New("period must be current, previous, or previous_equal_range")
 		}
-		window.ModelScope = normalizeAccountWindowModelScope(window.ModelScope)
+		modelScopeProvided := window.ModelScopeProvided ||
+			strings.TrimSpace(window.ModelScope.Kind) != "" ||
+			strings.TrimSpace(window.ModelScope.Key) != "" ||
+			len(window.ModelScope.Models) > 0 || window.ModelScope.Complete
+		modelScopeCompleteSet := window.ModelScopeCompleteSet || window.ModelScope.Complete
+		window.ModelScope = normalizeAccountWindowModelScope(
+			window.ModelScope,
+			modelScopeProvided,
+			modelScopeCompleteSet,
+		)
 		if window.ModelScope.Kind == "" {
 			return AccountWindowUsageResponse{}, errors.New("model_scope is invalid")
 		}
@@ -3417,6 +3485,10 @@ func buildHeaderSnapshots(items []store.HeaderSnapshot) []HeaderSnapshot {
 		result = append(result, HeaderSnapshot{
 			EventHash:              item.EventHash,
 			TimestampMS:            item.TimestampMS,
+			Model:                  item.Model,
+			AnalyticsModel:         item.AnalyticsModel,
+			RequestedModel:         item.RequestedModel,
+			ResolvedModel:          item.ResolvedModel,
 			AuthFileSnapshot:       item.AuthFileSnapshot,
 			AuthIndex:              item.AuthIndex,
 			AccountSnapshot:        item.AccountSnapshot,
@@ -3665,10 +3737,18 @@ func normalizeAccountWindowPeriod(value string) string {
 	}
 }
 
-func normalizeAccountWindowModelScope(scope AccountWindowModelScope) AccountWindowModelScope {
+func normalizeAccountWindowModelScope(
+	scope AccountWindowModelScope,
+	provided bool,
+	completeSet bool,
+) AccountWindowModelScope {
 	scope.Kind = strings.ToLower(strings.TrimSpace(scope.Kind))
 	if scope.Kind == "" {
+		if provided {
+			return AccountWindowModelScope{}
+		}
 		scope.Kind = "all"
+		scope.Complete = true
 	}
 	switch scope.Kind {
 	case "all", "family", "models", "product", "feature":
@@ -3696,6 +3776,12 @@ func normalizeAccountWindowModelScope(scope AccountWindowModelScope) AccountWind
 	if (scope.Kind == "family" || scope.Kind == "product" || scope.Kind == "feature") && scope.Key == "" && len(scope.Models) == 0 {
 		return AccountWindowModelScope{}
 	}
+	if !completeSet {
+		switch scope.Kind {
+		case "all", "family", "models":
+			scope.Complete = true
+		}
+	}
 	return scope
 }
 
@@ -3722,23 +3808,24 @@ func classifyQuotaModelFamily(modelName string) string {
 }
 
 func accountWindowStatMatchesScope(row store.AccountWindowModelStat, scope AccountWindowModelScope) (matched bool, unmatched bool) {
+	if !scope.Complete {
+		return false, false
+	}
 	if scope.Kind == "all" {
 		return true, false
 	}
-	models := map[string]struct{}{}
-	for _, modelName := range scope.Models {
-		models[modelName] = struct{}{}
+	if codexquota.IsMainScope(scope.Kind, scope.Key) {
+		return codexquota.MatchMainUsage(row.Model, row.BillingModel)
+	}
+	if len(scope.Models) > 0 {
+		return codexquota.MatchModelScope(row.Model, row.BillingModel, scope.Models)
 	}
 	rowModels := []string{normalizeQuotaModelName(row.Model), normalizeQuotaModelName(row.BillingModel)}
-	if len(models) > 0 {
-		for _, modelName := range rowModels {
-			if _, ok := models[modelName]; ok {
-				return true, false
-			}
-		}
-		if scope.Kind != "family" {
-			return false, false
-		}
+	if scope.Kind != "family" {
+		return false, false
+	}
+	if len(rowModels) == 2 && rowModels[1] != "" {
+		rowModels = rowModels[1:]
 	}
 	if scope.Kind == "family" {
 		families := map[string]struct{}{}
@@ -3751,7 +3838,7 @@ func accountWindowStatMatchesScope(row store.AccountWindowModelStat, scope Accou
 		_, unknown := families["unknown"]
 		return false, unknown
 	}
-	return false, len(models) == 0
+	return false, true
 }
 
 func buildScopedAccountWindowUsageTotals(
@@ -3763,7 +3850,7 @@ func buildScopedAccountWindowUsageTotals(
 	results := make(map[int]accountWindowScopeResult, len(windows))
 	for index, window := range windows {
 		status := "complete"
-		if window.ModelScope.Kind != "all" {
+		if !window.ModelScope.Complete {
 			status = "unmatched"
 		}
 		results[index] = accountWindowScopeResult{status: status}
@@ -3779,9 +3866,6 @@ func buildScopedAccountWindowUsageTotals(
 		}
 		if matched {
 			filtered = append(filtered, row)
-			if result.status == "unmatched" {
-				result.status = "complete"
-			}
 		}
 		results[row.RequestIndex] = result
 	}

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
@@ -2724,8 +2725,157 @@ func TestAccountWindowUsageSeparatesPeriodsAndAppliesModelScopeAcrossOverlapping
 	if resp.Items[3].RequestKey != "exact-billing-model" || resp.Items[3].TotalRequests != 1 || resp.Items[3].ScopeMatchStatus != "complete" {
 		t.Fatalf("exact billing-model scope = %#v", resp.Items[3])
 	}
-	if resp.Items[4].RequestKey != "exact-unmatched" || resp.Items[4].Matched || resp.Items[4].ScopeMatchStatus != "unmatched" {
+	if resp.Items[4].RequestKey != "exact-unmatched" || resp.Items[4].Matched || resp.Items[4].ScopeMatchStatus != "complete" {
 		t.Fatalf("unmatched exact scope = %#v", resp.Items[4])
+	}
+}
+
+func TestAccountWindowUsageScopeCompletenessCompatibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      string
+		wantKind     string
+		wantComplete bool
+		wantValid    bool
+	}{
+		{name: "omitted legacy scope", payload: `{}`, wantKind: "all", wantComplete: true, wantValid: true},
+		{name: "legacy all without complete", payload: `{"model_scope":{"kind":"all"}}`, wantKind: "all", wantComplete: true, wantValid: true},
+		{name: "legacy models without complete", payload: `{"model_scope":{"kind":"models","models":["gpt-5.6-sol"]}}`, wantKind: "models", wantComplete: true, wantValid: true},
+		{name: "nested scope metadata remains forward compatible", payload: `{"model_scope":{"kind":"all","future_scope_metadata":{"source":"new-client"}}}`, wantKind: "all", wantComplete: true, wantValid: true},
+		{name: "feature defaults incomplete", payload: `{"model_scope":{"kind":"feature","key":"future_feature"}}`, wantKind: "feature", wantComplete: false, wantValid: true},
+		{name: "explicit incomplete all fails closed", payload: `{"model_scope":{"kind":"all","complete":false}}`, wantKind: "all", wantComplete: false, wantValid: true},
+		{name: "explicit incomplete models fail closed", payload: `{"model_scope":{"kind":"models","models":["gpt-5.6-sol"],"complete":false}}`, wantKind: "models", wantComplete: false, wantValid: true},
+		{name: "explicit empty scope is invalid", payload: `{"model_scope":{}}`, wantValid: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var target AccountWindowUsageTarget
+			if err := json.Unmarshal([]byte(test.payload), &target); err != nil {
+				t.Fatalf("unmarshal target: %v", err)
+			}
+			provided := target.ModelScopeProvided ||
+				strings.TrimSpace(target.ModelScope.Kind) != "" ||
+				strings.TrimSpace(target.ModelScope.Key) != "" ||
+				len(target.ModelScope.Models) > 0 || target.ModelScope.Complete
+			completeSet := target.ModelScopeCompleteSet || target.ModelScope.Complete
+			scope := normalizeAccountWindowModelScope(target.ModelScope, provided, completeSet)
+			if !test.wantValid {
+				if scope.Kind != "" {
+					t.Fatalf("scope = %#v, want invalid", scope)
+				}
+				return
+			}
+			if scope.Kind != test.wantKind || scope.Complete != test.wantComplete {
+				t.Fatalf("scope = %#v, want kind=%q complete=%v", scope, test.wantKind, test.wantComplete)
+			}
+		})
+	}
+}
+
+func TestAccountWindowUsageIsolatesCodexMainSparkAndUnknownFeatureScopes(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	baseMS := int64(1_700_100_500_000)
+	events := []usage.Event{
+		monitoringEvent("codex-main-direct", baseMS+1_000, "gpt-5.6-sol", "auth-1", "source-a", false, 60, 40, 0, 0, 100, nil),
+		monitoringEvent("codex-main-alias", baseMS+2_000, "my-codex", "auth-1", "source-a", false, 180, 120, 0, 0, 300, nil),
+		monitoringEvent("codex-spark-direct", baseMS+3_000, codexquota.SparkModelID, "auth-1", "source-a", false, 120, 80, 0, 0, 200, nil),
+		monitoringEvent("codex-spark-alias", baseMS+4_000, "my-spark", "auth-1", "source-a", false, 240, 160, 0, 0, 400, nil),
+	}
+	events[1].RequestedModel = "my-codex"
+	events[1].ResolvedModel = "gpt-5.6-sol"
+	events[3].RequestedModel = "my-spark"
+	events[3].ResolvedModel = codexquota.SparkModelID
+	for index := range events {
+		events[index].AccountSnapshot = "quota@example.com"
+		events[index].AuthFileSnapshot = "codex.json"
+		events[index].AuthProviderSnapshot = "codex"
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert scoped Codex events: %v", err)
+	}
+
+	target := func(requestKey string, fromMS, toMS int64, scope AccountWindowModelScope) AccountWindowUsageTarget {
+		return AccountWindowUsageTarget{
+			RequestKey: requestKey, RowKey: "row-1", ProviderWindowID: requestKey,
+			Period: "current", FromMS: fromMS, ToMS: toMS, ModelScope: scope,
+			AccountSnapshot: "quota@example.com", AuthFileSnapshot: "codex.json",
+			AuthProviderSnapshot: "codex", AuthIndex: "auth-1", Source: "source-a",
+		}
+	}
+	incompleteTarget := func(requestKey string, scope AccountWindowModelScope) AccountWindowUsageTarget {
+		value := target(requestKey, baseMS, baseMS+5_000, scope)
+		value.ModelScopeCompleteSet = true
+		return value
+	}
+	response, err := New(db).AccountWindowUsage(ctx, AccountWindowUsageRequest{Windows: []AccountWindowUsageTarget{
+		target("main", baseMS, baseMS+5_000, AccountWindowModelScope{Kind: "family", Key: codexquota.MainScopeKey, Complete: true}),
+		target("spark", baseMS, baseMS+5_000, AccountWindowModelScope{Kind: "models", Models: []string{codexquota.SparkModelID}, Complete: true}),
+		target("spark-zero", baseMS, baseMS+2_500, AccountWindowModelScope{Kind: "models", Models: []string{codexquota.SparkModelID}, Complete: true}),
+		incompleteTarget("future-feature", AccountWindowModelScope{Kind: "feature", Key: "future_feature"}),
+		incompleteTarget("future-feature-models", AccountWindowModelScope{Kind: "feature", Key: "future_feature", Models: []string{"gpt-5.6-sol"}}),
+		incompleteTarget("incomplete-all", AccountWindowModelScope{Kind: "all"}),
+	}})
+	if err != nil {
+		t.Fatalf("account window usage: %v", err)
+	}
+	if len(response.Items) != 6 {
+		t.Fatalf("items = %#v", response.Items)
+	}
+	if item := response.Items[0]; !item.Matched || item.TotalRequests != 2 || item.TotalTokens != 400 || item.ScopeMatchStatus != "complete" {
+		t.Fatalf("main Codex usage = %#v", item)
+	}
+	if item := response.Items[1]; !item.Matched || item.TotalRequests != 2 || item.TotalTokens != 600 || item.ScopeMatchStatus != "complete" {
+		t.Fatalf("Spark usage = %#v", item)
+	}
+	if item := response.Items[2]; item.Matched || item.SyncStatus != "empty" || item.TotalRequests != 0 || item.TotalTokens != 0 || item.TotalCost != 0 || item.ScopeMatchStatus != "complete" {
+		t.Fatalf("unused Spark window = %#v", item)
+	}
+	if item := response.Items[3]; item.Matched || item.SyncStatus != "empty" || item.TotalRequests != 0 || item.TotalTokens != 0 || item.TotalCost != 0 || item.ScopeMatchStatus != "unmatched" {
+		t.Fatalf("unknown feature usage = %#v", item)
+	}
+	for _, index := range []int{4, 5} {
+		if item := response.Items[index]; item.Matched || item.SyncStatus != "empty" || item.TotalRequests != 0 || item.TotalTokens != 0 || item.TotalCost != 0 || item.ScopeMatchStatus != "unmatched" {
+			t.Fatalf("incomplete scope usage = %#v", item)
+		}
+	}
+}
+
+func TestAccountWindowUsagePrefersResolvedBillingIdentityOverSparkShapedRequestAlias(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	baseMS := int64(1_700_100_750_000)
+	event := monitoringEvent("codex-reverse-alias", baseMS+1_000, codexquota.SparkModelID, "auth-1", "source-a", false, 60, 40, 0, 0, 100, nil)
+	event.RequestedModel = codexquota.SparkModelID
+	event.ResolvedModel = "gpt-5.6-sol"
+	event.AccountSnapshot = "reverse-alias@example.com"
+	event.AuthFileSnapshot = "codex.json"
+	event.AuthProviderSnapshot = "codex"
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert reverse alias event: %v", err)
+	}
+
+	target := func(requestKey string, scope AccountWindowModelScope) AccountWindowUsageTarget {
+		return AccountWindowUsageTarget{
+			RequestKey: requestKey, RowKey: "row-1", ProviderWindowID: requestKey,
+			Period: "current", FromMS: baseMS, ToMS: baseMS + 2_000, ModelScope: scope,
+			AccountSnapshot: "reverse-alias@example.com", AuthFileSnapshot: "codex.json",
+			AuthProviderSnapshot: "codex", AuthIndex: "auth-1", Source: "source-a",
+		}
+	}
+	response, err := New(db).AccountWindowUsage(ctx, AccountWindowUsageRequest{Windows: []AccountWindowUsageTarget{
+		target("main", AccountWindowModelScope{Kind: "family", Key: codexquota.MainScopeKey, Complete: true}),
+		target("spark", AccountWindowModelScope{Kind: "models", Models: []string{codexquota.SparkModelID}, Complete: true}),
+	}})
+	if err != nil {
+		t.Fatalf("account window usage: %v", err)
+	}
+	if item := response.Items[0]; !item.Matched || item.TotalRequests != 1 || item.TotalTokens != 100 || item.ScopeMatchStatus != "complete" {
+		t.Fatalf("main reverse alias usage = %#v", item)
+	}
+	if item := response.Items[1]; item.Matched || item.TotalRequests != 0 || item.TotalTokens != 0 || item.ScopeMatchStatus != "complete" {
+		t.Fatalf("spark reverse alias usage = %#v", item)
 	}
 }
 

--- a/apps/manager-server/internal/service/quotasnapshot/evidence.go
+++ b/apps/manager-server/internal/service/quotasnapshot/evidence.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
@@ -65,6 +66,25 @@ func (s *Service) WriteCodexInspectionResult(ctx context.Context, result model.C
 			continue
 		}
 		duration := roundedPositiveInt64(window.LimitWindowSeconds)
+		windowKind := quotaWindowKind(duration)
+		providerWindowID := codexquota.CanonicalProviderWindowID(window.ID, windowKind)
+		inferredScope := codexquota.InferScopeFromProviderWindowID(providerWindowID)
+		modelScope := inferredScope
+		if window.ModelScope != nil {
+			providedScope := codexquota.NormalizeScope(codexquota.ModelScope{
+				Kind:     window.ModelScope.Kind,
+				Key:      window.ModelScope.Key,
+				Models:   window.ModelScope.Models,
+				Complete: window.ModelScope.Complete,
+			})
+			// Older inspection clients persisted every window as `all`. Stable
+			// Codex provider-window identities are stronger evidence for known
+			// scoped limits, so do not let that legacy value restore account-wide
+			// attribution for Spark or another additional feature.
+			if providedScope.Kind != "all" || inferredScope.Kind == "all" {
+				modelScope = providedScope
+			}
+		}
 		mode := "unknown"
 		accuracy := normalizeInspectionAccuracy(window.ResetAccuracy)
 		var cycleStartMS, cycleEndMS *int64
@@ -84,20 +104,23 @@ func (s *Service) WriteCodexInspectionResult(ctx context.Context, result model.C
 		}
 		usedPercent := validPercent(window.UsedPercent)
 		windows = append(windows, WindowInput{
-			ProviderWindowID:    strings.TrimSpace(window.ID),
-			WindowKind:          quotaWindowKind(duration),
-			WindowMode:          mode,
-			ModelScopeKind:      "all",
-			Source:              "inspection",
-			SourceObservationID: inspectionObservationID(result),
-			ObservedAtMS:        observedAtMS,
-			BoundaryAccuracy:    accuracy,
-			CycleStartMS:        cycleStartMS,
-			CycleEndMS:          cycleEndMS,
-			DurationSeconds:     duration,
-			UsedPercent:         usedPercent,
-			RemainingPercent:    remainingPercent(usedPercent),
-			PlanType:            result.PlanType,
+			ProviderWindowID:      providerWindowID,
+			ProviderWindowAliases: append([]string(nil), window.ProviderWindowAliases...),
+			WindowKind:            windowKind,
+			WindowMode:            mode,
+			ModelScopeKind:        modelScope.Kind,
+			ModelScopeKey:         modelScope.Key,
+			ModelIDs:              append([]string(nil), modelScope.Models...),
+			Source:                "inspection",
+			SourceObservationID:   inspectionObservationID(result),
+			ObservedAtMS:          observedAtMS,
+			BoundaryAccuracy:      accuracy,
+			CycleStartMS:          cycleStartMS,
+			CycleEndMS:            cycleEndMS,
+			DurationSeconds:       duration,
+			UsedPercent:           usedPercent,
+			RemainingPercent:      remainingPercent(usedPercent),
+			PlanType:              result.PlanType,
 		})
 	}
 	if len(windows) == 0 && inventoryMode != "complete" {
@@ -182,9 +205,15 @@ func quotaSnapshotEntryFromUsageEvent(event usage.Event) (WriteEntry, bool) {
 			return WriteEntry{}, false
 		}
 		quota := event.ResponseMetadata.Quota
+		quotaScope := codexquota.ResolveUsageScope(
+			event.Model,
+			event.AnalyticsModel,
+			event.RequestedModel,
+			event.ResolvedModel,
+		)
 		windows := make([]WindowInput, 0, 2)
 		for index, item := range []*usage.HeaderQuotaWindow{quota.Primary, quota.Secondary} {
-			if window, ok := codexHeaderWindowInput(item, index, event.TimestampMS, quota.PlanType, observationID); ok {
+			if window, ok := codexHeaderWindowInput(item, index, event.TimestampMS, quota.PlanType, observationID, quotaScope); ok {
 				windows = append(windows, window)
 			}
 		}
@@ -326,7 +355,14 @@ func codexWindowFamilyRole(providerWindowID string) (string, string, bool) {
 	return "", "", false
 }
 
-func codexHeaderWindowInput(window *usage.HeaderQuotaWindow, index int, observedAtMS int64, planType, observationID string) (WindowInput, bool) {
+func codexHeaderWindowInput(
+	window *usage.HeaderQuotaWindow,
+	index int,
+	observedAtMS int64,
+	planType string,
+	observationID string,
+	quotaScope codexquota.UsageScopeResolution,
+) (WindowInput, bool) {
 	if window == nil {
 		return WindowInput{}, false
 	}
@@ -357,42 +393,58 @@ func codexHeaderWindowInput(window *usage.HeaderQuotaWindow, index int, observed
 	if duration == nil && cycleEndMS == nil && (usedPercent == nil || *usedPercent == 0) {
 		return WindowInput{}, false
 	}
+	providerWindowID := codexHeaderWindowID(duration, index, planType, quotaScope.ProviderWindowPrefix)
 	return WindowInput{
-		ProviderWindowID:    codexWindowID(duration, index),
-		WindowKind:          quotaWindowKind(duration),
-		WindowMode:          mode,
-		ModelScopeKind:      "all",
-		Source:              "response_header",
-		SourceObservationID: observationID,
-		ObservedAtMS:        observedAtMS,
-		BoundaryAccuracy:    accuracy,
-		CycleStartMS:        cycleStartMS,
-		CycleEndMS:          cycleEndMS,
-		DurationSeconds:     duration,
-		UsedPercent:         usedPercent,
-		RemainingPercent:    remainingPercent(usedPercent),
-		PlanType:            planType,
+		ProviderWindowID:      providerWindowID,
+		ProviderWindowAliases: codexquota.ProviderWindowAliases(providerWindowID, quotaScope.Scope),
+		WindowKind:            quotaWindowKind(duration),
+		WindowMode:            mode,
+		ModelScopeKind:        quotaScope.Scope.Kind,
+		ModelScopeKey:         quotaScope.Scope.Key,
+		ModelIDs:              append([]string(nil), quotaScope.Scope.Models...),
+		Source:                "response_header",
+		SourceObservationID:   observationID,
+		ObservedAtMS:          observedAtMS,
+		BoundaryAccuracy:      accuracy,
+		CycleStartMS:          cycleStartMS,
+		CycleEndMS:            cycleEndMS,
+		DurationSeconds:       duration,
+		UsedPercent:           usedPercent,
+		RemainingPercent:      remainingPercent(usedPercent),
+		PlanType:              planType,
 	}, true
 }
 
-func codexWindowID(duration *int64, index int) string {
+func codexHeaderWindowID(duration *int64, index int, planType, scopePrefix string) string {
+	role := ""
 	if duration != nil {
 		switch *duration {
 		case codexFiveHourSeconds:
-			return "five-hour"
+			role = "five-hour"
 		case codexWeekSeconds:
-			return "weekly"
+			role = "weekly"
 		default:
 			if *duration >= 28*24*60*60 && *duration <= 31*24*60*60 {
-				return "monthly"
+				role = "monthly"
+			} else {
+				id := fmt.Sprintf("window-%s-%d", formatDuration(*duration), index)
+				if scopePrefix != "" {
+					return fmt.Sprintf("%s-0-%s", scopePrefix, id)
+				}
+				return id
 			}
-			return fmt.Sprintf("window-%s-%d", formatDuration(*duration), index)
 		}
+	} else if index == 0 {
+		role = "five-hour"
+	} else if strings.EqualFold(strings.TrimSpace(planType), "team") {
+		role = "monthly"
+	} else {
+		role = "weekly"
 	}
-	if index == 0 {
-		return "primary"
+	if scopePrefix != "" {
+		return fmt.Sprintf("%s-%s-0", scopePrefix, role)
 	}
-	return "secondary"
+	return role
 }
 
 func quotaWindowKind(duration *int64) string {

--- a/apps/manager-server/internal/service/quotasnapshot/service.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	quotasnapshotrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/quotasnapshot"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
@@ -63,6 +64,7 @@ type ResetCredit struct {
 
 type WindowInput struct {
 	ProviderWindowID      string        `json:"provider_window_id"`
+	ProviderWindowAliases []string      `json:"provider_window_aliases,omitempty"`
 	WindowKind            string        `json:"window_kind"`
 	WindowMode            string        `json:"window_mode"`
 	ModelScopeKind        string        `json:"model_scope_kind"`
@@ -97,6 +99,7 @@ type ObservationInput struct {
 
 type RemovedWindowInput struct {
 	ProviderWindowID string   `json:"provider_window_id"`
+	WindowKind       string   `json:"window_kind,omitempty"`
 	ModelScopeKind   string   `json:"model_scope_kind,omitempty"`
 	ModelScopeKey    string   `json:"model_scope_key,omitempty"`
 	ModelIDs         []string `json:"model_ids,omitempty"`
@@ -146,6 +149,7 @@ type FieldSource struct {
 
 type Window struct {
 	ProviderWindowID      string                 `json:"provider_window_id"`
+	ProviderWindowAliases []string               `json:"provider_window_aliases,omitempty"`
 	WindowKind            string                 `json:"window_kind"`
 	WindowMode            string                 `json:"window_mode"`
 	ModelScopeKind        string                 `json:"model_scope_kind"`
@@ -261,7 +265,7 @@ func (s *Service) Write(ctx context.Context, req WriteRequest) (WriteResponse, e
 			write.Snapshots = append(write.Snapshots, snapshot)
 		}
 		for _, input := range entry.RemovedWindows {
-			removed, err := normalizeRemovedWindow(input)
+			removed, err := normalizeRemovedWindow(provider, input)
 			if err != nil {
 				return WriteResponse{}, err
 			}
@@ -345,10 +349,17 @@ func normalizeObservationInput(accountKey, provider string, entry WriteEntry, no
 	}, nil
 }
 
-func normalizeRemovedWindow(input RemovedWindowInput) (model.AccountQuotaWindowRemoval, error) {
+func normalizeRemovedWindow(provider string, input RemovedWindowInput) (model.AccountQuotaWindowRemoval, error) {
 	providerWindowID := strings.TrimSpace(input.ProviderWindowID)
 	if providerWindowID == "" {
 		return model.AccountQuotaWindowRemoval{}, errors.New("removed provider_window_id is required")
+	}
+	windowKind := strings.TrimSpace(input.WindowKind)
+	if provider == "codex" {
+		if strings.EqualFold(providerWindowID, "secondary") && windowKind == "" {
+			return model.AccountQuotaWindowRemoval{}, errors.New("removed window_kind is required for Codex secondary windows")
+		}
+		providerWindowID = codexquota.CanonicalProviderWindowID(providerWindowID, windowKind)
 	}
 	scopeKind := strings.ToLower(strings.TrimSpace(input.ModelScopeKind))
 	if scopeKind == "" {
@@ -366,6 +377,16 @@ func normalizeRemovedWindow(input RemovedWindowInput) (model.AccountQuotaWindowR
 	}
 	modelIDsJSON := marshalAllowlist(modelIDs)
 	scopeKey := strings.TrimSpace(input.ModelScopeKey)
+	if provider == "codex" {
+		scope := codexquota.ResolveProviderWindowScope(
+			providerWindowID,
+			windowKind,
+			codexquota.ScopeFromFields(scopeKind, scopeKey, modelIDs),
+		)
+		providerWindowID = codexquota.CanonicalProviderWindowIDForScope(providerWindowID, windowKind, scope)
+		scopeKind, scopeKey, modelIDs = scope.Kind, scope.Key, scope.Models
+		modelIDsJSON = marshalAllowlist(modelIDs)
+	}
 	return model.AccountQuotaWindowRemoval{
 		ProviderWindowID: providerWindowID,
 		ModelScopeKind:   scopeKind,
@@ -502,12 +523,142 @@ func (s *Service) Query(ctx context.Context, req QueryRequest) (QueryResponse, e
 		if err != nil {
 			return QueryResponse{}, err
 		}
+		stateByID := make(map[int64]model.AccountQuotaWindowState, len(states))
+		for _, state := range states {
+			stateByID[state.ID] = state
+		}
+		explicitScopedCandidates := make(map[string]struct{})
+		for _, candidate := range candidates {
+			state, hasState := stateByID[candidate.LogicalWindowID]
+			if hasState && state.Availability == "inactive" {
+				continue
+			}
+			scope := codexquota.ScopeFromFields(
+				candidate.ModelScopeKind,
+				candidate.ModelScopeKey,
+				unmarshalStringList(candidate.ModelIDsJSON),
+			)
+			if provider == "codex" && scope.Kind != "all" {
+				explicitScopedCandidates[codexQueryScopeKey(candidate.ProviderWindowID, candidate.WindowKind, scope)] = struct{}{}
+			}
+		}
+		normalizedCandidates := candidates[:0]
+		for index := range candidates {
+			state, hasState := stateByID[candidates[index].LogicalWindowID]
+			if hasState && state.Availability == "inactive" {
+				normalizedCandidates = append(normalizedCandidates, candidates[index])
+				continue
+			}
+			wasLegacyScoped := normalizeCodexSnapshotForQuery(&candidates[index])
+			if wasLegacyScoped {
+				scope := codexquota.ScopeFromFields(
+					candidates[index].ModelScopeKind,
+					candidates[index].ModelScopeKey,
+					unmarshalStringList(candidates[index].ModelIDsJSON),
+				)
+				if _, exists := explicitScopedCandidates[codexQueryScopeKey(candidates[index].ProviderWindowID, candidates[index].WindowKind, scope)]; exists {
+					continue
+				}
+			}
+			normalizedCandidates = append(normalizedCandidates, candidates[index])
+		}
+		candidates = normalizedCandidates
+		explicitScopedStates := make(map[string]struct{})
+		for _, state := range states {
+			if state.Availability == "inactive" {
+				continue
+			}
+			scope := codexquota.ScopeFromFields(state.ModelScopeKind, state.ModelScopeKey, unmarshalStringList(state.ModelIDsJSON))
+			if provider == "codex" && scope.Kind != "all" {
+				explicitScopedStates[codexQueryScopeKey(state.ProviderWindowID, state.WindowKind, scope)] = struct{}{}
+			}
+		}
+		normalizedStates := states[:0]
+		for index := range states {
+			if states[index].Availability == "inactive" {
+				normalizedStates = append(normalizedStates, states[index])
+				continue
+			}
+			wasLegacyScoped := normalizeCodexWindowStateForQuery(&states[index])
+			if wasLegacyScoped {
+				scope := codexquota.ScopeFromFields(states[index].ModelScopeKind, states[index].ModelScopeKey, unmarshalStringList(states[index].ModelIDsJSON))
+				if _, exists := explicitScopedStates[codexQueryScopeKey(states[index].ProviderWindowID, states[index].WindowKind, scope)]; exists {
+					continue
+				}
+			}
+			normalizedStates = append(normalizedStates, states[index])
+		}
+		states = normalizedStates
 		items = append(items, QueryItem{
 			RowKey: account.RowKey, AccountKey: accountKey, Provider: provider,
 			Windows: mergeLifecycleWindows(selectWindows(candidates, states, nowMS), states, nowMS, req.IncludeInactive),
 		})
 	}
 	return QueryResponse{GeneratedAtMS: nowMS, Items: items}, nil
+}
+
+// normalizeCodexSnapshotForQuery is the read-side compatibility shield for
+// rows written before scoped Codex fields were available. It runs before
+// grouping so an unattached legacy `all` Spark row cannot sit beside the new
+// model-scoped row while deferred lifecycle migration is still pending.
+func normalizeCodexSnapshotForQuery(snapshot *model.AccountQuotaSnapshot) bool {
+	if snapshot == nil || normalizeProvider(snapshot.Provider) != "codex" {
+		return false
+	}
+	modelIDs := unmarshalStringList(snapshot.ModelIDsJSON)
+	providedScope := codexquota.ScopeFromFields(snapshot.ModelScopeKind, snapshot.ModelScopeKey, modelIDs)
+	scope := codexquota.ResolveProviderWindowScope(
+		snapshot.ProviderWindowID,
+		snapshot.WindowKind,
+		codexquota.ScopeFromFields(snapshot.ModelScopeKind, snapshot.ModelScopeKey, modelIDs),
+	)
+	snapshot.ProviderWindowID = codexquota.CanonicalProviderWindowIDForScope(
+		snapshot.ProviderWindowID,
+		snapshot.WindowKind,
+		scope,
+	)
+	snapshot.ModelScopeKind = scope.Kind
+	snapshot.ModelScopeKey = scope.Key
+	snapshot.ModelIDsJSON = marshalAllowlist(scope.Models)
+	snapshot.ScopeFingerprint = quotasnapshotrepo.ScopeFingerprint(scope.Kind, scope.Key, scope.Models)
+	if snapshot.ContainerWindowID != "" {
+		snapshot.ContainerWindowID = codexquota.CanonicalProviderWindowID(snapshot.ContainerWindowID)
+	}
+	return providedScope.Kind == "all" && scope.Kind != "all"
+}
+
+func normalizeCodexWindowStateForQuery(state *model.AccountQuotaWindowState) bool {
+	if state == nil || normalizeProvider(state.Provider) != "codex" {
+		return false
+	}
+	if state.Availability == "inactive" {
+		return false
+	}
+	modelIDs := unmarshalStringList(state.ModelIDsJSON)
+	providedScope := codexquota.ScopeFromFields(state.ModelScopeKind, state.ModelScopeKey, modelIDs)
+	scope := codexquota.ResolveProviderWindowScope(
+		state.ProviderWindowID,
+		state.WindowKind,
+		codexquota.ScopeFromFields(state.ModelScopeKind, state.ModelScopeKey, modelIDs),
+	)
+	state.ProviderWindowID = codexquota.CanonicalProviderWindowIDForScope(
+		state.ProviderWindowID,
+		state.WindowKind,
+		scope,
+	)
+	state.ModelScopeKind = scope.Kind
+	state.ModelScopeKey = scope.Key
+	state.ModelIDsJSON = marshalAllowlist(scope.Models)
+	state.ScopeFingerprint = quotasnapshotrepo.ScopeFingerprint(scope.Kind, scope.Key, scope.Models)
+	if state.ContainerProviderWindowID != "" {
+		state.ContainerProviderWindowID = codexquota.CanonicalProviderWindowID(state.ContainerProviderWindowID)
+	}
+	return providedScope.Kind == "all" && scope.Kind != "all"
+}
+
+func codexQueryScopeKey(providerWindowID, windowKind string, scope codexquota.ModelScope) string {
+	providerWindowID = codexquota.CanonicalProviderWindowIDForScope(providerWindowID, windowKind, scope)
+	return providerWindowID + "\x00" + quotasnapshotrepo.ScopeFingerprint(scope.Kind, scope.Key, scope.Models)
 }
 
 func normalizeWindowInput(accountKey, provider string, input WindowInput, nowMS int64) (model.AccountQuotaSnapshot, error) {
@@ -569,14 +720,47 @@ func normalizeWindowInput(accountKey, provider string, input WindowInput, nowMS 
 	if scopeKind == "models" && len(modelIDs) == 0 {
 		return model.AccountQuotaSnapshot{}, errors.New("model_ids are required for models scope")
 	}
+	scopeKey := strings.TrimSpace(input.ModelScopeKey)
+	if provider == "codex" {
+		scope := codexquota.ResolveProviderWindowScope(
+			providerWindowID,
+			input.WindowKind,
+			codexquota.ScopeFromFields(scopeKind, scopeKey, modelIDs),
+		)
+		providerWindowID = codexquota.CanonicalProviderWindowIDForScope(providerWindowID, input.WindowKind, scope)
+		scopeKind, scopeKey, modelIDs = scope.Kind, scope.Key, scope.Models
+	}
 	modelIDsJSON := marshalAllowlist(modelIDs)
-	scopeFingerprint := quotasnapshotrepo.ScopeFingerprint(scopeKind, input.ModelScopeKey, modelIDs)
+	providerWindowAliases, err := normalizeStringList(input.ProviderWindowAliases, 32)
+	if err != nil {
+		return model.AccountQuotaSnapshot{}, fmt.Errorf("provider_window_aliases: %w", err)
+	}
+	if provider == "codex" {
+		filtered := providerWindowAliases[:0]
+		for _, alias := range providerWindowAliases {
+			rawAlias := strings.ToLower(strings.TrimSpace(alias))
+			canonicalAlias := codexquota.CanonicalProviderWindowIDForScope(alias, input.WindowKind, codexquota.ScopeFromFields(scopeKind, scopeKey, modelIDs))
+			for _, candidate := range []string{rawAlias, canonicalAlias} {
+				if candidate != "" && candidate != providerWindowID {
+					filtered = append(filtered, candidate)
+				}
+			}
+		}
+		providerWindowAliases, err = normalizeStringList(filtered, 32)
+		if err != nil {
+			return model.AccountQuotaSnapshot{}, fmt.Errorf("provider_window_aliases: %w", err)
+		}
+	}
+	scopeFingerprint := quotasnapshotrepo.ScopeFingerprint(scopeKind, scopeKey, modelIDs)
 	resetCredits, err := normalizeResetCredits(input.ResetCredits)
 	if err != nil {
 		return model.AccountQuotaSnapshot{}, err
 	}
 	relationshipKind := strings.ToLower(strings.TrimSpace(input.RelationshipKind))
 	containerWindowID := strings.TrimSpace(input.ContainerWindowID)
+	if provider == "codex" && containerWindowID != "" {
+		containerWindowID = codexquota.CanonicalProviderWindowID(containerWindowID)
+	}
 	if relationshipKind == "" && containerWindowID != "" {
 		return model.AccountQuotaSnapshot{}, errors.New("relationship_kind is required with container_provider_window_id")
 	}
@@ -597,8 +781,9 @@ func normalizeWindowInput(accountKey, provider string, input WindowInput, nowMS 
 	}
 	return model.AccountQuotaSnapshot{
 		AccountKey: accountKey, Provider: provider, ProviderWindowID: providerWindowID,
-		WindowKind: strings.TrimSpace(input.WindowKind), WindowMode: mode,
-		ModelScopeKind: scopeKind, ModelScopeKey: strings.TrimSpace(input.ModelScopeKey),
+		ProviderWindowAliases: providerWindowAliases,
+		WindowKind:            strings.TrimSpace(input.WindowKind), WindowMode: mode,
+		ModelScopeKind: scopeKind, ModelScopeKey: scopeKey,
 		ModelIDsJSON: modelIDsJSON, ScopeFingerprint: scopeFingerprint, Source: source,
 		SourceObservationID: sourceObservationID, ObservedAtMS: observedAtMS,
 		BoundaryAccuracy: accuracy, CycleStartMS: cycleStart, CycleEndMS: cycleEnd,
@@ -692,7 +877,11 @@ func selectWindows(
 	}
 	lifecycleLastSeen := make(map[string]int64, len(states))
 	for _, state := range states {
-		lifecycleLastSeen[state.ProviderWindowID+"\x00"+state.ScopeFingerprint] = state.LastSeenAtMS
+		normalizeCodexWindowStateForQuery(&state)
+		key := state.ProviderWindowID + "\x00" + state.ScopeFingerprint
+		if previous, ok := lifecycleLastSeen[key]; !ok || state.LastSeenAtMS > previous {
+			lifecycleLastSeen[key] = state.LastSeenAtMS
+		}
 	}
 	result := make([]Window, 0, len(groups))
 	for key, group := range groups {
@@ -805,7 +994,13 @@ func mergeLifecycleWindows(
 ) []Window {
 	statesByKey := make(map[string]model.AccountQuotaWindowState, len(states))
 	for _, state := range states {
-		statesByKey[state.ProviderWindowID+"\x00"+state.ScopeFingerprint] = state
+		normalizeCodexWindowStateForQuery(&state)
+		key := state.ProviderWindowID + "\x00" + state.ScopeFingerprint
+		// ListWindowStates is ordered newest-first. Keep the first state when
+		// legacy and scoped rows normalize to one logical identity.
+		if _, exists := statesByKey[key]; !exists {
+			statesByKey[key] = state
+		}
 	}
 	result := make([]Window, 0, len(windows))
 	for _, window := range windows {
@@ -967,9 +1162,13 @@ func copyInt64Pointer(value *int64) *int64 {
 }
 
 func isZeroOnlyHeaderPlaceholder(snapshot model.AccountQuotaSnapshot) bool {
+	providerWindowID := snapshot.ProviderWindowID
+	if snapshot.Provider == "codex" {
+		providerWindowID = codexquota.CanonicalProviderWindowID(providerWindowID, snapshot.WindowKind)
+	}
 	if snapshot.Source != "response_header" ||
 		snapshot.WindowMode != "unknown" ||
-		(snapshot.ProviderWindowID != "primary" && snapshot.ProviderWindowID != "secondary") ||
+		(providerWindowID != "five-hour" && providerWindowID != "weekly" && providerWindowID != "monthly") ||
 		snapshot.CycleStartMS != nil || snapshot.CycleEndMS != nil || snapshot.DurationSeconds != nil ||
 		snapshot.UsedValue != nil || snapshot.LimitValue != nil || strings.TrimSpace(snapshot.QuotaUnit) != "" ||
 		snapshot.UsedPercent == nil || *snapshot.UsedPercent != 0 {
@@ -1018,11 +1217,36 @@ func isStale(snapshot model.AccountQuotaSnapshot, nowMS int64) bool {
 }
 
 func snapshotWindow(snapshot model.AccountQuotaSnapshot, stale bool) Window {
+	modelScopeKind := snapshot.ModelScopeKind
+	modelScopeKey := snapshot.ModelScopeKey
+	modelIDs := unmarshalStringList(snapshot.ModelIDsJSON)
+	if snapshot.Provider == "codex" && strings.EqualFold(strings.TrimSpace(modelScopeKind), "all") &&
+		codexquota.IsMainProviderWindowID(snapshot.ProviderWindowID) {
+		mainScope := codexquota.MainScope()
+		modelScopeKind = mainScope.Kind
+		modelScopeKey = mainScope.Key
+		modelIDs = nil
+	}
+	providerWindowAliases := []string(nil)
+	if snapshot.Provider == "codex" {
+		for _, alias := range codexquota.ProviderWindowAliases(
+			snapshot.ProviderWindowID,
+			codexquota.ModelScope{Kind: modelScopeKind, Key: modelScopeKey, Models: modelIDs, Complete: true},
+		) {
+			if alias != snapshot.ProviderWindowID {
+				providerWindowAliases = append(providerWindowAliases, alias)
+			}
+		}
+	}
 	return Window{
-		ProviderWindowID: snapshot.ProviderWindowID, WindowKind: snapshot.WindowKind,
-		WindowMode: snapshot.WindowMode, ModelScopeKind: snapshot.ModelScopeKind,
-		ModelScopeKey: snapshot.ModelScopeKey, ModelIDs: unmarshalStringList(snapshot.ModelIDsJSON),
-		Source: snapshot.Source, SourceObservationID: snapshot.SourceObservationID,
+		ProviderWindowID:      snapshot.ProviderWindowID,
+		ProviderWindowAliases: providerWindowAliases,
+		WindowKind:            snapshot.WindowKind,
+		WindowMode:            snapshot.WindowMode,
+		ModelScopeKind:        modelScopeKind,
+		ModelScopeKey:         modelScopeKey,
+		ModelIDs:              modelIDs,
+		Source:                snapshot.Source, SourceObservationID: snapshot.SourceObservationID,
 		ObservedAtMS: snapshot.ObservedAtMS, BoundaryAccuracy: snapshot.BoundaryAccuracy,
 		CycleStartMS: snapshot.CycleStartMS, CycleEndMS: snapshot.CycleEndMS,
 		DurationSeconds: snapshot.DurationSeconds, UsedPercent: snapshot.UsedPercent,

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	quotasnapshotrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/quotasnapshot"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
 )
@@ -530,6 +532,27 @@ func TestWriteRejectsConflictingWindowMutations(t *testing.T) {
 	}
 }
 
+func TestNormalizeRemovedWindowRequiresKindForCodexSecondaryAlias(t *testing.T) {
+	if _, err := normalizeRemovedWindow("codex", RemovedWindowInput{
+		ProviderWindowID: "secondary",
+		ModelScopeKind:   "all",
+	}); err == nil || !strings.Contains(err.Error(), "window_kind") {
+		t.Fatalf("secondary removal without window kind error = %v", err)
+	}
+
+	removed, err := normalizeRemovedWindow("codex", RemovedWindowInput{
+		ProviderWindowID: "secondary",
+		WindowKind:       "monthly",
+		ModelScopeKind:   "all",
+	})
+	if err != nil {
+		t.Fatalf("monthly secondary removal: %v", err)
+	}
+	if removed.ProviderWindowID != "monthly" || removed.ScopeFingerprint == "" {
+		t.Fatalf("monthly secondary removal = %#v", removed)
+	}
+}
+
 func TestWriteRejectsTooManyWindowMutations(t *testing.T) {
 	service := newQuotaSnapshotTestService(t, 20_000)
 	_, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{{
@@ -743,6 +766,8 @@ func TestWriteUsageEventsPersistsCodexHeaderWindows(t *testing.T) {
 	event := usage.Event{
 		TimestampMS:          observedAtMS,
 		Provider:             "codex",
+		Model:                "gpt-5.6-sol",
+		AnalyticsModel:       "gpt-5.6-sol",
 		AuthFileSnapshot:     "codex.json",
 		AuthProviderSnapshot: "codex",
 		AuthIndex:            "auth-1",
@@ -782,6 +807,94 @@ func TestWriteUsageEventsPersistsCodexHeaderWindows(t *testing.T) {
 	}
 }
 
+func TestWriteUsageEventsKeepsCodexMainAndSparkHeaderWindowsIndependent(t *testing.T) {
+	const observedAtMS = int64(1_780_000_100_000)
+	service := newQuotaSnapshotTestService(t, observedAtMS+2_000)
+	mainUsed := 36.0
+	sparkUsed := 0.0
+	resetAfter := float64(7 * 24 * 60 * 60)
+	minutes := float64(7 * 24 * 60)
+	mainResetAtMS := observedAtMS + int64(resetAfter*1000)
+	sparkResetAtMS := mainResetAtMS + 1_000
+	events := []usage.Event{
+		{
+			TimestampMS:          observedAtMS,
+			Provider:             "codex",
+			Model:                "gpt-5.6-sol",
+			AnalyticsModel:       "gpt-5.6-sol",
+			AuthFileSnapshot:     "codex.json",
+			AuthProviderSnapshot: "codex",
+			AuthIndex:            "auth-1",
+			AccountSnapshot:      "user@example.com",
+			RequestID:            "req-codex-main-header",
+			ResponseMetadata: &usage.ResponseHeaderMetadata{Quota: &usage.HeaderQuotaMetadata{
+				PlanType: "plus",
+				Primary: &usage.HeaderQuotaWindow{
+					UsedPercent: &mainUsed, ResetAtMS: mainResetAtMS,
+					ResetAfterSeconds: &resetAfter, WindowMinutes: &minutes,
+				},
+			}},
+		},
+		{
+			TimestampMS:          observedAtMS + 1_000,
+			Provider:             "codex",
+			Model:                "my-spark",
+			AnalyticsModel:       "my-spark",
+			RequestedModel:       "my-spark",
+			ResolvedModel:        codexquota.SparkModelID,
+			AuthFileSnapshot:     "codex.json",
+			AuthProviderSnapshot: "codex",
+			AuthIndex:            "auth-1",
+			AccountSnapshot:      "user@example.com",
+			RequestID:            "req-codex-spark-header",
+			ResponseMetadata: &usage.ResponseHeaderMetadata{Quota: &usage.HeaderQuotaMetadata{
+				PlanType: "plus",
+				Primary: &usage.HeaderQuotaWindow{
+					UsedPercent: &sparkUsed, ResetAtMS: sparkResetAtMS,
+					ResetAfterSeconds: &resetAfter, WindowMinutes: &minutes,
+				},
+			}},
+		},
+	}
+	if err := service.WriteUsageEvents(context.Background(), events); err != nil {
+		t.Fatalf("write scoped usage evidence: %v", err)
+	}
+	result, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+		RowKey: "row-1", Provider: "codex", Account: quotaSnapshotTestAccount(),
+	}}})
+	if err != nil {
+		t.Fatalf("query scoped usage evidence: %v", err)
+	}
+	if len(result.Items) != 1 || len(result.Items[0].Windows) != 2 {
+		t.Fatalf("scoped header windows = %#v", result)
+	}
+	byID := make(map[string]Window, len(result.Items[0].Windows))
+	for _, window := range result.Items[0].Windows {
+		byID[window.ProviderWindowID] = window
+	}
+	mainWindow := byID["weekly"]
+	if mainWindow.ModelScopeKind != "family" || mainWindow.ModelScopeKey != codexquota.MainScopeKey ||
+		mainWindow.UsedPercent == nil || *mainWindow.UsedPercent != mainUsed {
+		t.Fatalf("main Header window = %#v", mainWindow)
+	}
+	sparkWindow := byID["spark-weekly-0"]
+	if sparkWindow.ModelScopeKind != "models" || len(sparkWindow.ModelIDs) != 1 ||
+		sparkWindow.ModelIDs[0] != codexquota.SparkModelID || sparkWindow.UsedPercent == nil ||
+		*sparkWindow.UsedPercent != sparkUsed {
+		t.Fatalf("Spark Header window = %#v", sparkWindow)
+	}
+	hasLegacySparkAlias := false
+	for _, alias := range sparkWindow.ProviderWindowAliases {
+		if alias == "fast-coding-weekly-0" {
+			hasLegacySparkAlias = true
+			break
+		}
+	}
+	if !hasLegacySparkAlias {
+		t.Fatalf("Spark Header aliases = %#v, want legacy fast-coding alias", sparkWindow.ProviderWindowAliases)
+	}
+}
+
 func TestWriteUsageEventAndFrontendHeaderObservationUseSameDerivedCycle(t *testing.T) {
 	const observedAtMS = int64(1_780_000_000_638)
 	service, path := newQuotaSnapshotTestServiceWithPath(t, observedAtMS+1_000)
@@ -793,6 +906,8 @@ func TestWriteUsageEventAndFrontendHeaderObservationUseSameDerivedCycle(t *testi
 		EventHash:            "zz-header-event",
 		TimestampMS:          observedAtMS,
 		Provider:             "codex",
+		Model:                "gpt-5.6-sol",
+		AnalyticsModel:       "gpt-5.6-sol",
 		AuthFileSnapshot:     "codex.json",
 		AuthProviderSnapshot: "codex",
 		AuthIndex:            "auth-1",
@@ -823,7 +938,8 @@ func TestWriteUsageEventAndFrontendHeaderObservationUseSameDerivedCycle(t *testi
 		},
 		Windows: []WindowInput{{
 			ProviderWindowID: "five-hour", WindowKind: "five_hour", WindowMode: "fixed",
-			ModelScopeKind: "all", Source: "response_header", SourceObservationID: event.EventHash,
+			ModelScopeKind: "family", ModelScopeKey: "codex_main",
+			Source: "response_header", SourceObservationID: event.EventHash,
 			ObservedAtMS: observedAtMS, BoundaryAccuracy: "derived",
 			CycleStartMS: &cycleStartMS, CycleEndMS: &resetAtMS, DurationSeconds: &durationSeconds,
 			UsedPercent: &used, RemainingPercent: &remaining, PlanType: "plus",
@@ -1030,6 +1146,8 @@ func TestWriteUsageEventsKeepsFirstNonZeroAfterProvisionalBoundaryInCurrentCycle
 		event := usage.Event{
 			TimestampMS:          observedAt[index],
 			Provider:             "codex",
+			Model:                "gpt-5.6-sol",
+			AnalyticsModel:       "gpt-5.6-sol",
 			AuthFileSnapshot:     "codex.json",
 			AuthProviderSnapshot: "codex",
 			AuthIndex:            "auth-1",
@@ -1080,6 +1198,8 @@ func TestWriteUsageEventsKeepsProvisionalZeroCodexBoundaryInOneCycle(t *testing.
 		events = append(events, usage.Event{
 			TimestampMS:          observedAt[index],
 			Provider:             "codex",
+			Model:                "gpt-5.6-sol",
+			AnalyticsModel:       "gpt-5.6-sol",
 			AuthFileSnapshot:     "codex.json",
 			AuthProviderSnapshot: "codex",
 			AuthIndex:            "auth-1",
@@ -1120,6 +1240,8 @@ func TestWriteUsageEventsSkipsZeroOnlyCodexHeaderPlaceholder(t *testing.T) {
 	event := usage.Event{
 		TimestampMS:          observedAtMS,
 		Provider:             "codex",
+		Model:                "gpt-5.6-sol",
+		AnalyticsModel:       "gpt-5.6-sol",
 		AuthFileSnapshot:     "codex.json",
 		AuthProviderSnapshot: "codex",
 		AuthIndex:            "auth-1",
@@ -1275,6 +1397,42 @@ func TestWriteCodexInspectionResultRequiresNormalizedResetBoundary(t *testing.T)
 	}
 	if byID["monthly"].WindowMode != "fixed" || byID["monthly"].BoundaryAccuracy != "derived" {
 		t.Fatalf("estimated reset was not normalized into a derived boundary: %#v", byID["monthly"])
+	}
+}
+
+func TestWriteCodexInspectionResultReclassifiesLegacyScopedAllScope(t *testing.T) {
+	const observedAtMS = int64(1_780_000_000_000)
+	service := newQuotaSnapshotTestService(t, observedAtMS+1_000)
+	statusCode := 200
+	duration := float64(7 * 24 * 60 * 60)
+	used := 0.0
+	result := model.CodexInspectionResult{
+		ID: 8, RunID: 4, Provider: "codex", FileName: "codex.json", AuthIndex: "auth-1",
+		AccountSnapshot: "user@example.com", CreatedAtMS: observedAtMS, PlanType: "plus",
+		StatusCode: &statusCode, QuotaInventoryObserved: true,
+		QuotaWindows: []model.CodexInspectionQuotaWindow{{
+			ID: "gpt-5-3-codex-spark-weekly-0", UsedPercent: &used,
+			ResetAtMS: observedAtMS + 604_800_000, ResetAccuracy: "exact",
+			LimitWindowSeconds: &duration,
+			ModelScope:         &model.CodexInspectionQuotaModelScope{Kind: "all", Complete: true},
+		}},
+	}
+	if err := service.WriteCodexInspectionResult(context.Background(), result); err != nil {
+		t.Fatalf("write legacy scoped inspection evidence: %v", err)
+	}
+	query, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+		RowKey: "row-legacy-scoped", Provider: "codex", Account: quotaSnapshotTestAccount(),
+	}}})
+	if err != nil {
+		t.Fatalf("query legacy scoped inspection evidence: %v", err)
+	}
+	if len(query.Items) != 1 || len(query.Items[0].Windows) != 1 {
+		t.Fatalf("legacy scoped inspection windows = %#v", query)
+	}
+	window := query.Items[0].Windows[0]
+	if window.ProviderWindowID != "spark-weekly-0" || window.ModelScopeKind != "models" ||
+		len(window.ModelIDs) != 1 || window.ModelIDs[0] != codexquota.SparkModelID {
+		t.Fatalf("legacy scoped inspection scope = %#v", window)
 	}
 }
 
@@ -3246,6 +3404,393 @@ func TestQuotaLifecycleRejectsUnreliableScheduledRolloverBoundary(t *testing.T) 
 	}
 }
 
+func TestQuotaLifecycleReclassifiesLegacyCodexSparkAllScope(t *testing.T) {
+	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
+	legacy := quotaLifecycleFixedWindow(
+		"legacy-codex-window",
+		"weekly",
+		quotaLifecycleBaseMS,
+		7*24*60*60,
+		0,
+	)
+	writeQuotaLifecycleObservation(
+		t,
+		service,
+		"complete",
+		quotaLifecycleBaseMS+quotaLifecycleHourMS,
+		[]WindowInput{legacy},
+	)
+	rewriteQuotaLifecycleProviderWindowID(t, path, "legacy-codex-window", "fast-coding-weekly-0")
+
+	scoped := quotaLifecycleFixedWindow(
+		"spark-weekly-0",
+		"weekly",
+		quotaLifecycleBaseMS,
+		7*24*60*60,
+		0,
+	)
+	scoped.ModelScopeKind = "models"
+	scoped.ModelIDs = []string{codexquota.SparkModelID}
+	scoped.ProviderWindowAliases = []string{"fast-coding-weekly-0"}
+	writeQuotaLifecycleObservation(
+		t,
+		service,
+		"complete",
+		quotaLifecycleBaseMS+2*quotaLifecycleHourMS,
+		[]WindowInput{scoped},
+	)
+
+	result, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+		RowKey: "row-lifecycle", Provider: "codex", Account: quotaSnapshotTestAccount(),
+	}}})
+	if err != nil {
+		t.Fatalf("query active reclassified Spark window: %v", err)
+	}
+	if len(result.Items) != 1 || len(result.Items[0].Windows) != 1 {
+		t.Fatalf("active reclassified Spark windows = %#v", result)
+	}
+	active := result.Items[0].Windows[0]
+	if active.ProviderWindowID != "spark-weekly-0" || active.ModelScopeKind != "models" ||
+		len(active.ModelIDs) != 1 || active.ModelIDs[0] != codexquota.SparkModelID || active.Availability != "active" {
+		t.Fatalf("active reclassified Spark window = %#v", active)
+	}
+
+	all, err := service.Query(context.Background(), QueryRequest{
+		Accounts: []QueryAccount{{
+			RowKey: "row-lifecycle", Provider: "codex", Account: quotaSnapshotTestAccount(),
+		}},
+		IncludeInactive: true,
+	})
+	if err != nil {
+		t.Fatalf("query inactive reclassified Spark window: %v", err)
+	}
+	if len(all.Items) != 1 || len(all.Items[0].Windows) != 2 {
+		t.Fatalf("all reclassified Spark windows = %#v", all)
+	}
+	var legacyInactive bool
+	for _, window := range all.Items[0].Windows {
+		if window.ModelScopeKind == "all" && window.Availability == "inactive" {
+			legacyInactive = true
+		}
+	}
+	if !legacyInactive {
+		t.Fatalf("legacy Spark all-scope window was not retained as inactive: %#v", all.Items[0].Windows)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open reclassification database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var activationReason, cycleReason string
+	if err := db.QueryRow(`select a.deactivation_reason
+		from account_quota_window_activations a
+		join account_quota_windows w on w.id = a.window_id
+		where w.provider_window_id = 'fast-coding-weekly-0' and lower(trim(w.model_scope_kind)) = 'all'
+		order by a.id desc limit 1`).Scan(&activationReason); err != nil {
+		t.Fatalf("read Spark reclassification activation reason: %v", err)
+	}
+	if err := db.QueryRow(`select c.end_reason
+		from account_quota_cycles c
+		join account_quota_window_activations a on a.id = c.activation_id
+		join account_quota_windows w on w.id = a.window_id
+		where w.provider_window_id = 'fast-coding-weekly-0' and lower(trim(w.model_scope_kind)) = 'all'
+		order by c.id desc limit 1`).Scan(&cycleReason); err != nil {
+		t.Fatalf("read Spark reclassification cycle reason: %v", err)
+	}
+	if activationReason != "scope_reclassified" || cycleReason != "scope_reclassified" {
+		t.Fatalf("Spark reclassification reasons = activation:%q cycle:%q", activationReason, cycleReason)
+	}
+}
+
+func TestQuotaLifecycleReclassifiesLegacyCodexIncompleteFeatureAllScope(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerWindowID string
+		scopeKey         string
+	}{
+		{name: "code review", providerWindowID: "code-review-weekly-0", scopeKey: codexquota.CodeReviewScopeKey},
+		{name: "unknown additional feature", providerWindowID: "future-feature-weekly-0", scopeKey: "future_feature"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
+			legacy := quotaLifecycleFixedWindow(
+				"legacy-codex-window",
+				"weekly",
+				quotaLifecycleBaseMS,
+				7*24*60*60,
+				50,
+			)
+			unrelated := quotaLifecycleFixedWindow(
+				"unrelated-feature-weekly-0",
+				"weekly",
+				quotaLifecycleBaseMS,
+				7*24*60*60,
+				25,
+			)
+			writeQuotaLifecycleObservation(
+				t,
+				service,
+				"complete",
+				quotaLifecycleBaseMS+quotaLifecycleHourMS,
+				[]WindowInput{legacy, unrelated},
+			)
+			rewriteQuotaLifecycleProviderWindowID(t, path, "legacy-codex-window", test.providerWindowID)
+
+			scoped := quotaLifecycleFixedWindow(
+				test.providerWindowID,
+				"weekly",
+				quotaLifecycleBaseMS,
+				7*24*60*60,
+				0,
+			)
+			scoped.ModelScopeKind = "feature"
+			scoped.ModelScopeKey = test.scopeKey
+			writeQuotaLifecycleObservation(
+				t,
+				service,
+				"partial",
+				quotaLifecycleBaseMS+2*quotaLifecycleHourMS,
+				[]WindowInput{scoped},
+			)
+
+			result, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+				RowKey: "row-lifecycle", Provider: "codex", Account: quotaSnapshotTestAccount(),
+			}}})
+			if err != nil {
+				t.Fatalf("query active reclassified feature window: %v", err)
+			}
+			if len(result.Items) != 1 || len(result.Items[0].Windows) != 2 {
+				t.Fatalf("active reclassified feature windows = %#v", result)
+			}
+			var scopedActive, unrelatedActive bool
+			for _, window := range result.Items[0].Windows {
+				switch window.ProviderWindowID {
+				case test.providerWindowID:
+					scopedActive = window.ModelScopeKind == "feature" &&
+						window.ModelScopeKey == test.scopeKey && window.Availability == "active"
+				case "unrelated-feature-weekly-0":
+					unrelatedActive = window.ModelScopeKind == "feature" &&
+						window.ModelScopeKey == "unrelated_feature" && window.Availability == "active"
+				}
+			}
+			if !scopedActive || !unrelatedActive {
+				t.Fatalf("scoped/unrelated active windows = %#v", result.Items[0].Windows)
+			}
+
+			all, err := service.Query(context.Background(), QueryRequest{
+				Accounts: []QueryAccount{{
+					RowKey: "row-lifecycle", Provider: "codex", Account: quotaSnapshotTestAccount(),
+				}},
+				IncludeInactive: true,
+			})
+			if err != nil {
+				t.Fatalf("query inactive reclassified feature window: %v", err)
+			}
+			if len(all.Items) != 1 || len(all.Items[0].Windows) != 3 {
+				t.Fatalf("all reclassified feature windows = %#v", all)
+			}
+			var legacyInactive bool
+			for _, window := range all.Items[0].Windows {
+				if window.ProviderWindowID == test.providerWindowID &&
+					window.ModelScopeKind == "all" && window.Availability == "inactive" {
+					legacyInactive = true
+				}
+			}
+			if !legacyInactive {
+				t.Fatalf("legacy feature all-scope window was not retained as inactive: %#v", all.Items[0].Windows)
+			}
+		})
+	}
+}
+
+func TestQuerySuppressesUnmigratedLegacyCodexSparkAllScope(t *testing.T) {
+	service, path := newQuotaSnapshotTestServiceWithPath(t, 40_000)
+	scoped := quotaLifecycleFixedWindow(
+		"spark-weekly-0",
+		"weekly",
+		10_000,
+		7*24*60*60,
+		0,
+	)
+	scoped.ModelScopeKind = "models"
+	scoped.ModelIDs = []string{codexquota.SparkModelID}
+	writeQuotaLifecycleObservation(t, service, "partial", 20_000, []WindowInput{scoped})
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open unmigrated quota database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var accountKey string
+	if err := db.QueryRow(`select account_key from account_quota_snapshots limit 1`).Scan(&accountKey); err != nil {
+		t.Fatalf("read quota account key: %v", err)
+	}
+	if _, err := db.Exec(`insert into account_quota_snapshots (
+		account_key, provider, provider_window_id, window_kind, window_mode,
+		model_scope_kind, source, source_observation_id, observed_at_ms,
+		boundary_accuracy, used_percent, remaining_percent, created_at_ms
+	) values (?, 'codex', 'fast-coding-weekly-0', 'weekly', 'unknown', 'all',
+		'inspection', 'legacy-unmigrated', 30_000, 'unknown', 99, 1, 30_000)`, accountKey); err != nil {
+		t.Fatalf("insert unmigrated Spark snapshot: %v", err)
+	}
+
+	result, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+		RowKey: "row-unmigrated", Provider: "codex", Account: quotaSnapshotTestAccount(),
+	}}})
+	if err != nil {
+		t.Fatalf("query unmigrated Spark snapshots: %v", err)
+	}
+	if len(result.Items) != 1 || len(result.Items[0].Windows) != 1 {
+		t.Fatalf("unmigrated Spark snapshots were duplicated: %#v", result)
+	}
+	window := result.Items[0].Windows[0]
+	if window.ProviderWindowID != "spark-weekly-0" || window.ModelScopeKind != "models" ||
+		len(window.ModelIDs) != 1 || window.ModelIDs[0] != codexquota.SparkModelID ||
+		window.UsedPercent == nil || *window.UsedPercent != 0 {
+		t.Fatalf("unmigrated Spark snapshot replaced scoped evidence: %#v", window)
+	}
+}
+
+func TestQuotaLifecycleMigratesLegacyCodexMainAllScopeInPlace(t *testing.T) {
+	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
+	legacy := quotaLifecycleFixedWindow(
+		"weekly",
+		"weekly",
+		quotaLifecycleBaseMS,
+		7*24*60*60,
+		36,
+	)
+	writeQuotaLifecycleObservation(
+		t,
+		service,
+		"complete",
+		quotaLifecycleBaseMS+quotaLifecycleHourMS,
+		[]WindowInput{legacy},
+	)
+	legacyWindow := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if legacyWindow.LogicalWindowID == 0 {
+		t.Fatalf("legacy main logical window = %#v", legacyWindow)
+	}
+
+	scoped := quotaLifecycleFixedWindow(
+		"weekly",
+		"weekly",
+		quotaLifecycleBaseMS,
+		7*24*60*60,
+		36,
+	)
+	scoped.ModelScopeKind = "family"
+	scoped.ModelScopeKey = codexquota.MainScopeKey
+	writeQuotaLifecycleObservation(
+		t,
+		service,
+		"complete",
+		quotaLifecycleBaseMS+2*quotaLifecycleHourMS,
+		[]WindowInput{scoped},
+	)
+
+	windows := queryQuotaLifecycleWindows(t, service, false)
+	window, ok := windows["weekly"]
+	if !ok || window.ModelScopeKind != "family" || window.ModelScopeKey != codexquota.MainScopeKey ||
+		window.Availability != "active" || window.LogicalWindowID == 0 || window.CurrentCycle == nil {
+		t.Fatalf("main window was not migrated in place: %#v", windows)
+	}
+	if window.LogicalWindowID != legacyWindow.LogicalWindowID {
+		t.Fatalf("main logical window changed from %d to %d", legacyWindow.LogicalWindowID, window.LogicalWindowID)
+	}
+	if window.CurrentCycle.ActualStartMS != quotaLifecycleBaseMS {
+		t.Fatalf("main cycle start changed during migration: %#v", window.CurrentCycle)
+	}
+
+	all := queryQuotaLifecycleWindows(t, service, true)
+	if len(all) != 1 {
+		t.Fatalf("main migration created duplicate logical windows: %#v", all)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open main migration database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var storedKind, storedKey string
+	if err := db.QueryRow(`select model_scope_kind, coalesce(model_scope_key, '')
+		from account_quota_windows where id = ?`, window.LogicalWindowID).Scan(&storedKind, &storedKey); err != nil {
+		t.Fatalf("read stored main lifecycle scope: %v", err)
+	}
+	if storedKind != "all" || storedKey != "" {
+		t.Fatalf("stored main lifecycle scope = %q/%q, want legacy all identity", storedKind, storedKey)
+	}
+}
+
+func TestQuotaLifecycleReconcilesLegacyCodexPrimaryAndSecondaryAliases(t *testing.T) {
+	tests := []struct {
+		name       string
+		legacyID   string
+		currentID  string
+		windowKind string
+		duration   int64
+	}{
+		{name: "primary to five hour", legacyID: "primary", currentID: "five-hour", windowKind: "five_hour", duration: 5 * 60 * 60},
+		{name: "secondary to weekly", legacyID: "secondary", currentID: "weekly", windowKind: "weekly", duration: 7 * 24 * 60 * 60},
+		{name: "secondary to team monthly", legacyID: "secondary", currentID: "monthly", windowKind: "monthly", duration: 30 * 24 * 60 * 60},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newQuotaSnapshotTestService(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
+			legacy := quotaLifecycleFixedWindow(
+				test.legacyID,
+				test.windowKind,
+				quotaLifecycleBaseMS,
+				test.duration,
+				40,
+			)
+			writeQuotaLifecycleObservation(
+				t,
+				service,
+				"complete",
+				quotaLifecycleBaseMS+quotaLifecycleHourMS,
+				[]WindowInput{legacy},
+			)
+
+			scoped := quotaLifecycleFixedWindow(
+				test.currentID,
+				test.windowKind,
+				quotaLifecycleBaseMS,
+				test.duration,
+				35,
+			)
+			scoped.ModelScopeKind = "family"
+			scoped.ModelScopeKey = codexquota.MainScopeKey
+			writeQuotaLifecycleObservation(
+				t,
+				service,
+				"complete",
+				quotaLifecycleBaseMS+2*quotaLifecycleHourMS,
+				[]WindowInput{scoped},
+			)
+
+			active := queryQuotaLifecycleWindows(t, service, false)
+			if len(active) != 1 {
+				t.Fatalf("legacy %s produced duplicate active windows: %#v", test.legacyID, active)
+			}
+			for _, window := range active {
+				if window.ModelScopeKind != "family" || window.ModelScopeKey != codexquota.MainScopeKey {
+					t.Fatalf("legacy %s active scope = %#v", test.legacyID, window)
+				}
+			}
+
+			all := queryQuotaLifecycleWindows(t, service, true)
+			if len(all) != 1 {
+				t.Fatalf("legacy %s produced duplicate lifecycle windows: %#v", test.legacyID, all)
+			}
+		})
+	}
+}
+
 func quotaLifecycleFixedWindow(id, kind string, startMS, durationSeconds int64, usedPercent float64) WindowInput {
 	endMS := startMS + durationSeconds*1000
 	return WindowInput{
@@ -3269,6 +3814,26 @@ func writeQuotaLifecycleObservation(t *testing.T, service *Service, inventoryMod
 	}})
 	if err != nil {
 		t.Fatalf("write %s quota lifecycle observation at %d: %v", inventoryMode, observedAtMS, err)
+	}
+}
+
+func rewriteQuotaLifecycleProviderWindowID(t *testing.T, path, from, to string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy quota database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	legacyScopeFingerprint := quotasnapshotrepo.ScopeFingerprint("all", "", nil)
+	if _, err := db.Exec(`update account_quota_windows set
+		provider_window_id = ?, model_scope_kind = 'all', model_scope_key = '',
+		model_ids_json = '', scope_fingerprint = ? where provider_window_id = ?`, to, legacyScopeFingerprint, from); err != nil {
+		t.Fatalf("rewrite legacy quota window state: %v", err)
+	}
+	if _, err := db.Exec(`update account_quota_snapshots set
+		provider_window_id = ?, model_scope_kind = 'all', model_scope_key = '',
+		model_ids_json = '', scope_fingerprint = ? where provider_window_id = ?`, to, legacyScopeFingerprint, from); err != nil {
+		t.Fatalf("rewrite legacy quota snapshot: %v", err)
 	}
 }
 

--- a/apps/web/src/components/quota/quotaConfigs.test.ts
+++ b/apps/web/src/components/quota/quotaConfigs.test.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from 'i18next';
 import { describe, expect, it } from 'vitest';
 import type { CodexQuotaState } from '@/types';
+import { CODEX_SPARK_MODEL_ID } from '@/utils/quota/codexQuota';
 import {
   ANTIGRAVITY_CONFIG,
   buildObservedCodexQuotaState,
@@ -322,6 +323,49 @@ describe('resolveQuotaDisplayState', () => {
     ]);
   });
 
+  it('does not append a legacy Spark alias when the partial inventory already has the canonical window', () => {
+    const sparkScope = {
+      kind: 'models' as const,
+      models: [CODEX_SPARK_MODEL_ID],
+      complete: true,
+    };
+    const activeQuota: CodexQuotaState = {
+      status: 'success',
+      fetchedAtMs: 2_000,
+      quotaInventoryObserved: false,
+      windows: [
+        {
+          id: 'spark-weekly-0',
+          label: 'Spark weekly',
+          resetLabel: '-',
+          usedPercent: 0,
+          modelScope: sparkScope,
+          providerWindowAliases: ['fast-coding-weekly-0'],
+        },
+      ],
+    };
+    const observedQuota: CodexQuotaState = {
+      status: 'success',
+      observedAtMs: 1_000,
+      observedFromUsageHeaders: true,
+      observedModelScope: sparkScope,
+      windows: [
+        {
+          id: 'fast-coding-weekly-0',
+          label: 'Spark weekly',
+          resetLabel: '-',
+          usedPercent: 0,
+          modelScope: sparkScope,
+        },
+      ],
+    };
+
+    const result = resolveQuotaDisplayState(activeQuota, observedQuota) as CodexQuotaState;
+
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0].id).toBe('spark-weekly-0');
+  });
+
   it('merges a newer header snapshot into the manual quota refresh', () => {
     const activeQuota: TestQuotaState = {
       status: 'success',
@@ -619,6 +663,132 @@ describe('resolveQuotaDisplayState', () => {
       resetLabel: '07/01 01:00',
     });
   });
+
+  it('does not let scoped Header scalars replace account-wide Codex state', () => {
+    const activeQuota: CodexQuotaState = {
+      status: 'success',
+      fetchedAtMs: 1_000,
+      activeLimit: 'main',
+      windows: [
+        {
+          id: 'weekly',
+          label: 'Weekly limit',
+          usedPercent: 36,
+          resetLabel: '07/07 00:00',
+          modelScope: { kind: 'family', key: 'codex_main', complete: true },
+        },
+      ],
+    };
+    const sparkScope = {
+      kind: 'models' as const,
+      models: [CODEX_SPARK_MODEL_ID],
+      complete: true,
+    };
+    const observedQuota: CodexQuotaState = {
+      status: 'success',
+      observedFromUsageHeaders: true,
+      observedAtMs: 2_000,
+      observedModelScope: sparkScope,
+      activeLimit: 'spark',
+      windows: [
+        {
+          id: 'spark-weekly-0',
+          label: 'Spark weekly limit',
+          usedPercent: 0,
+          resetLabel: '07/07 00:00',
+          modelScope: sparkScope,
+        },
+      ],
+    };
+
+    const result = resolveQuotaDisplayState(activeQuota, observedQuota) as CodexQuotaState;
+
+    expect(result.activeLimit).toBe('main');
+    expect(result.windows.map((window) => window.id)).toEqual(['weekly', 'spark-weekly-0']);
+  });
+
+  it('merges a legacy Spark window into the canonical header window instead of duplicating it', () => {
+    const sparkScope = {
+      kind: 'models' as const,
+      models: [CODEX_SPARK_MODEL_ID],
+      complete: true,
+    };
+    const result = resolveQuotaDisplayState(
+      {
+        status: 'success',
+        fetchedAtMs: 1_000,
+        quotaInventoryObserved: true,
+        windows: [
+          {
+            id: 'fast-coding-weekly-0',
+            usedPercent: 50,
+            modelScope: sparkScope,
+          },
+        ],
+      },
+      {
+        status: 'success',
+        observedAtMs: 2_000,
+        observedFromUsageHeaders: true,
+        observedModelScope: sparkScope,
+        windows: [
+          {
+            id: 'spark-weekly-0',
+            usedPercent: 0,
+            modelScope: sparkScope,
+            providerWindowAliases: ['fast-coding-weekly-0'],
+          },
+        ],
+      }
+    ) as CodexQuotaState;
+
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0]).toMatchObject({ id: 'spark-weekly-0', usedPercent: 0 });
+    expect(result.windows[0].providerWindowAliases).toContain('fast-coding-weekly-0');
+  });
+
+  it('does not resolve an ambiguous secondary alias between weekly and monthly windows', () => {
+    const result = resolveQuotaDisplayState(
+      {
+        status: 'success',
+        fetchedAtMs: 1_000,
+        quotaInventoryObserved: true,
+        windows: [
+          {
+            id: 'weekly',
+            usedPercent: 36,
+            modelScope: { kind: 'family', key: 'codex_main', complete: true },
+            providerWindowAliases: ['secondary'],
+          },
+          {
+            id: 'monthly',
+            usedPercent: 10,
+            modelScope: { kind: 'family', key: 'codex_main', complete: true },
+            providerWindowAliases: ['secondary'],
+          },
+        ],
+      },
+      {
+        status: 'success',
+        observedAtMs: 2_000,
+        observedFromUsageHeaders: true,
+        observedModelScope: { kind: 'family', key: 'codex_main', complete: true },
+        windows: [
+          {
+            id: 'monthly',
+            usedPercent: 45,
+            modelScope: { kind: 'family', key: 'codex_main', complete: true },
+            providerWindowAliases: ['secondary'],
+          },
+        ],
+      }
+    ) as CodexQuotaState;
+
+    expect(result.windows).toEqual([
+      expect.objectContaining({ id: 'weekly', usedPercent: 36 }),
+      expect.objectContaining({ id: 'monthly', usedPercent: 45 }),
+    ]);
+  });
 });
 
 describe('Codex plan precedence', () => {
@@ -634,6 +804,7 @@ describe('Codex plan precedence', () => {
       {
         event_hash: 'event-1',
         timestamp_ms: 2_000,
+        model: 'gpt-5.6-sol',
         header_quota_plan_type: 'free',
         header_quota_used_percent: 25,
       },
@@ -650,6 +821,7 @@ describe('Codex plan precedence', () => {
       {
         event_hash: 'mixed-window-event',
         timestamp_ms: nowMs - 60_000,
+        model: 'gpt-5.6-sol',
         response_metadata: {
           quota: {
             primary: {
@@ -675,6 +847,49 @@ describe('Codex plan precedence', () => {
         usedPercent: 40,
         observationSource: 'response_header',
         observedAtMs: nowMs - 60_000,
+      },
+    ]);
+  });
+
+  it('builds a Spark-scoped Header observation from an alias-resolved request', () => {
+    const nowMs = 1_800_000_000_000;
+    const state = buildObservedCodexQuotaState(
+      { name: 'spark.codex.json', type: 'codex' },
+      {
+        event_hash: 'spark-alias-event',
+        timestamp_ms: nowMs - 1_000,
+        model: 'my-spark',
+        analytics_model: 'my-spark',
+        requested_model: 'my-spark',
+        resolved_model: CODEX_SPARK_MODEL_ID,
+        response_metadata: {
+          quota: {
+            primary: {
+              used_percent: 0,
+              reset_at_ms: nowMs + 7 * 24 * 60 * 60 * 1000,
+              window_minutes: 10_080,
+            },
+          },
+        },
+      },
+      t,
+      nowMs
+    );
+
+    expect(state?.observedModelScope).toEqual({
+      kind: 'models',
+      models: [CODEX_SPARK_MODEL_ID],
+      complete: true,
+    });
+    expect(state?.windows).toMatchObject([
+      {
+        id: 'spark-weekly-0',
+        usedPercent: 0,
+        modelScope: {
+          kind: 'models',
+          models: [CODEX_SPARK_MODEL_ID],
+          complete: true,
+        },
       },
     ]);
   });

--- a/apps/web/src/components/quota/quotaConfigs.ts
+++ b/apps/web/src/components/quota/quotaConfigs.ts
@@ -28,7 +28,10 @@ import {
   fetchKimiQuota,
   fetchXaiQuota,
   filterFreshCodexQuotaWindows,
+  findCodexProviderWindowMatch,
+  isCodexMainQuotaModelScope,
   isValidQuotaResetAtMs,
+  resolveCodexUsageQuotaScope,
   resolveCodexPlanType,
 } from '@/utils/quota';
 import {
@@ -194,6 +197,10 @@ const mergeCodexQuotaWindow = (
     ...(readFiniteTimestamp(observedWindow.observedAtMs) !== null
       ? { observedAtMs: observedWindow.observedAtMs }
       : {}),
+    ...(observedWindow.modelScope ? { modelScope: observedWindow.modelScope } : {}),
+    ...(observedWindow.providerWindowAliases
+      ? { providerWindowAliases: observedWindow.providerWindowAliases }
+      : {}),
   };
 };
 
@@ -204,14 +211,35 @@ const mergeCodexQuotaWindows = (
   if (!observedWindows || observedWindows.length === 0) return activeWindows;
   if (!activeWindows || activeWindows.length === 0) return observedWindows;
 
-  const observedById = new Map(observedWindows.map((window) => [window.id, window]));
-  const mergedWindows = activeWindows.map((window) => {
-    const observedWindow = observedById.get(window.id);
-    if (!observedWindow) return window;
-    observedById.delete(window.id);
-    return mergeCodexQuotaWindow(window, observedWindow);
+  const usedObserved = new Set<number>();
+  const mergedWindows = activeWindows.map((window, activeIndex) => {
+    const observedIndex = findCodexProviderWindowMatch(
+      activeWindows,
+      observedWindows,
+      activeIndex,
+      usedObserved
+    );
+    if (observedIndex < 0) return window;
+    usedObserved.add(observedIndex);
+    const observedWindow = observedWindows[observedIndex];
+    const merged = mergeCodexQuotaWindow(window, observedWindow);
+    const aliases = Array.from(
+      new Set([
+        ...(window.providerWindowAliases ?? []),
+        ...(observedWindow.providerWindowAliases ?? []),
+        window.id,
+      ])
+    ).filter((alias) => alias && alias !== observedWindow.id);
+    return {
+      ...merged,
+      id: observedWindow.id,
+      ...(aliases.length > 0 ? { providerWindowAliases: aliases } : {}),
+    };
   });
-  return [...mergedWindows, ...observedById.values()];
+  return [
+    ...mergedWindows,
+    ...observedWindows.filter((_, index) => !usedObserved.has(index)),
+  ];
 };
 
 const hasKnownResetCreditCount = (quota: CodexQuotaMergeState): boolean => {
@@ -236,25 +264,33 @@ const mergeObservedQuotaIntoActive = <TState extends DisplayQuotaState>(
     'response_header',
     readFiniteTimestamp(observed.observedAtMs)
   );
+  const scopedObservation =
+    observed.observedFromUsageHeaders === true &&
+    (observed.observedModelScope === undefined ||
+      !isCodexMainQuotaModelScope(observed.observedModelScope));
   const scalarKeys: Array<keyof CodexQuotaMergeState> = [
     'status',
     'planType',
-    'activeLimit',
-    'creditsHasCredits',
-    'creditsUnlimited',
-    'creditsBalance',
-    'creditsOverageLimitReached',
-    'creditsApproxLocalMessages',
-    'creditsApproxCloudMessages',
-    'spendControlReached',
-    'spendControlIndividualLimit',
-    'rateLimitReachedType',
-    'primaryOverSecondaryLimitPercent',
     'observedAtMs',
     'observedTraceId',
     'observedErrorKind',
     'observedErrorCode',
   ];
+  if (!scopedObservation) {
+    scalarKeys.push(
+      'activeLimit',
+      'creditsHasCredits',
+      'creditsUnlimited',
+      'creditsBalance',
+      'creditsOverageLimitReached',
+      'creditsApproxLocalMessages',
+      'creditsApproxCloudMessages',
+      'spendControlReached',
+      'spendControlIndividualLimit',
+      'rateLimitReachedType',
+      'primaryOverSecondaryLimitPercent'
+    );
+  }
   scalarKeys.forEach((key) => {
     const value = observed[key];
     if (hasObservedValue(value)) {
@@ -263,6 +299,7 @@ const mergeObservedQuotaIntoActive = <TState extends DisplayQuotaState>(
   });
   merged.windows = mergeCodexQuotaWindows(activeWindows, observedWindows);
   if (observed.observedFromUsageHeaders === true) merged.observedFromUsageHeaders = true;
+  if (observed.observedModelScope) merged.observedModelScope = observed.observedModelScope;
   if (observed.observedResetCreditsUnknown === true && !hasKnownResetCreditCount(active)) {
     merged.observedResetCreditsUnknown = true;
   }
@@ -284,13 +321,24 @@ const appendMissingObservedQuotaWindows = <TState extends DisplayQuotaState>(
       'response_header',
       readFiniteTimestamp(observed.observedAtMs)
     ) ?? [];
-  const activeWindowIDs = new Set(activeWindows.map((window) => window.id));
-  const missingWindows = observedWindows.filter((window) => !activeWindowIDs.has(window.id));
+  const isAlreadyRepresented = (observedIndex: number): boolean => {
+    return activeWindows.some(
+      (_, activeIndex) =>
+        findCodexProviderWindowMatch(
+          activeWindows,
+          observedWindows,
+          activeIndex,
+          new Set<number>()
+        ) === observedIndex
+    );
+  };
+  const missingWindows = observedWindows.filter((_, observedIndex) => !isAlreadyRepresented(observedIndex));
   if (missingWindows.length === 0) return activeQuota;
   const merged: CodexQuotaMergeState = {
     ...active,
     windows: [...activeWindows, ...missingWindows],
     observedFromUsageHeaders: true,
+    observedModelScope: observed.observedModelScope,
   };
   const observedAtMs = readFiniteTimestamp(observed.observedAtMs);
   if (observedAtMs !== null) merged.observedAtMs = observedAtMs;
@@ -394,6 +442,14 @@ export const buildObservedCodexQuotaState = (
 ): CodexQuotaState | undefined => {
   if (!hasUsageHeaderQuotaSignal(snapshot)) return undefined;
   const observedQuota = buildObservedCodexQuotaFromHeaderSnapshot(snapshot);
+  const observedScope =
+    observedQuota?.quotaScope ??
+    resolveCodexUsageQuotaScope({
+      model: snapshot?.model,
+      analyticsModel: snapshot?.analytics_model,
+      requestedModel: snapshot?.requested_model,
+      resolvedModel: snapshot?.resolved_model,
+    });
   const usedPercent = getHeaderSnapshotUsedPercent(snapshot);
   const recoverAtMS = getHeaderSnapshotRecoverAtMs(snapshot);
   const recoverLabel = recoverAtMS ? new Date(recoverAtMS).toLocaleString() : '-';
@@ -405,7 +461,8 @@ export const buildObservedCodexQuotaState = (
         t,
         planType,
         snapshot?.timestamp_ms ?? nowMs,
-        'response_header'
+        'response_header',
+        observedScope
       )
     : [];
   const observedWindows = filterFreshCodexQuotaWindows(rawObservedWindows, nowMs);
@@ -418,7 +475,9 @@ export const buildObservedCodexQuotaState = (
       : fallbackUsedPercent !== null || fallbackRecoverAtMS
         ? [
             {
-              id: 'usage-header-observed',
+              id: observedScope.providerWindowIdPrefix
+                ? `${observedScope.providerWindowIdPrefix}-observed`
+                : 'usage-header-observed',
               label: t('codex_quota.observed_window', { defaultValue: 'Latest request' }),
               usedPercent: fallbackUsedPercent,
               resetLabel: fallbackRecoverAtMS ? recoverLabel : '-',
@@ -426,6 +485,7 @@ export const buildObservedCodexQuotaState = (
               resetAccuracy: fallbackRecoverAtMS ? 'estimated' : 'unknown',
               observationSource: 'response_header',
               observedAtMs: snapshot?.timestamp_ms ?? null,
+              modelScope: observedScope.modelScope,
             },
           ]
         : [];
@@ -441,6 +501,7 @@ export const buildObservedCodexQuotaState = (
     rateLimitReachedType: observedQuota?.rateLimitReachedType ?? null,
     primaryOverSecondaryLimitPercent: observedQuota?.primaryOverSecondaryLimitPercent ?? null,
     observedFromUsageHeaders: true,
+    observedModelScope: observedScope.modelScope,
     observedResetCreditsUnknown: true,
     observedAtMs: snapshot?.timestamp_ms,
     observedTraceId: getHeaderSnapshotTraceId(snapshot),

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -195,6 +195,9 @@ const makeCodexFile = (name: string, authIndex: string, account: string): AuthFi
     disabled: false,
   }) as AuthFileItem;
 
+const CODEX_MAIN_MODEL = 'gpt-5.6-sol';
+const CODEX_MAIN_SCOPE = { kind: 'family', key: 'codex_main', complete: true } as const;
+
 const makeCodexQuotaData = (): CodexQuotaData => ({
   planType: 'plus',
   windows: [],
@@ -2658,6 +2661,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'mixed-auth-quota-header',
           timestamp_ms: 1_000,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'codex.json',
           auth_index: 'auth-1',
           account_snapshot: 'codex@example.com',
@@ -2978,6 +2982,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'quota-refresh-401-header',
           timestamp_ms: 1_000,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'codex.json',
           auth_index: 'auth-1',
           account_snapshot: 'codex@example.com',
@@ -3054,6 +3059,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'newer-healthy-quota-header',
           timestamp_ms: 2_000,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'codex.json',
           auth_index: 'auth-1',
           account_snapshot: 'codex@example.com',
@@ -3106,6 +3112,7 @@ describe('AccountsPage replacement flows', () => {
           label: 'Weekly',
           usedPercent: 20,
           resetLabel: 'Mon',
+          modelScope: CODEX_MAIN_SCOPE,
         },
       ],
     });
@@ -3181,6 +3188,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'same-time-partial-header',
           timestamp_ms: 2_000,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'codex.json',
           auth_index: 'auth-1',
           account_snapshot: 'codex@example.com',
@@ -3232,6 +3240,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'weekly-limit',
           timestamp_ms: 1_700_000_000_000,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'weekly.json',
           auth_index: 'weekly-auth',
           account_snapshot: 'weekly@example.com',
@@ -3252,6 +3261,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'expired-weekly-limit',
           timestamp_ms: 1_699_000_000_000,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'available.json',
           auth_index: 'available-auth',
           account_snapshot: 'available@example.com',
@@ -3742,9 +3752,9 @@ describe('AccountsPage replacement flows', () => {
       await Promise.resolve();
     });
 
-    expect(findHostButtonByText(renderer, 'accounts.detail_tab_config').props['aria-selected']).toBe(
-      true
-    );
+    expect(
+      findHostButtonByText(renderer, 'accounts.detail_tab_config').props['aria-selected']
+    ).toBe(true);
     expect(mocks.navigate).toHaveBeenCalledWith(
       {
         pathname: '/accounts',
@@ -4674,6 +4684,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'healthy-header-evidence',
           timestamp_ms: observedAtMs,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: file.name,
           auth_index: String(file.authIndex ?? ''),
           account_snapshot: String(file.account ?? ''),
@@ -9058,6 +9069,7 @@ describe('AccountsPage replacement flows', () => {
             resetAtMs,
             resetAccuracy: 'exact',
             limitWindowSeconds: 5 * 60 * 60,
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }),
@@ -9072,6 +9084,7 @@ describe('AccountsPage replacement flows', () => {
             resetAtMs,
             resetAccuracy: 'exact',
             limitWindowSeconds: 5 * 60 * 60,
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }),
@@ -10001,6 +10014,7 @@ describe('AccountsPage replacement flows', () => {
           resetAtMs,
           resetAccuracy: 'exact',
           limitWindowSeconds: 7 * 24 * 60 * 60,
+          modelScope: CODEX_MAIN_SCOPE,
         },
       ],
     });
@@ -10012,6 +10026,7 @@ describe('AccountsPage replacement flows', () => {
         {
           event_hash: 'newer-header-event',
           timestamp_ms: headerTimestampMs,
+          model: CODEX_MAIN_MODEL,
           auth_file_snapshot: 'codex.json',
           auth_index: 'auth-1',
           account_snapshot: 'codex@example.com',

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
@@ -126,6 +126,20 @@ describe('QuotaWindowCard', () => {
     expect(previousText).not.toContain('accounts.detail_used');
   });
 
+  it('treats the Codex main family scope as an account-wide standard quota', () => {
+    const renderer = renderCard(
+      makeWindow({
+        modelScope: { kind: 'family', key: 'codex_main', complete: true },
+      })
+    );
+
+    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'standard' })).toHaveLength(1);
+    expect(renderer.root.findAllByProps({ 'data-quota-standard-comparison': 'true' })).toHaveLength(
+      1
+    );
+    expect(renderer.root.findAllByProps({ 'data-quota-model-comparison': 'true' })).toHaveLength(0);
+  });
+
   it('uses semantic colors for the current usage metric icons', () => {
     const renderer = renderCard(makeWindow());
     const current = renderer.root.findByProps({ 'data-quota-usage-period': 'current' });
@@ -417,13 +431,29 @@ describe('QuotaWindowCard', () => {
   it('explains when provider model scope is not queryable', () => {
     const renderer = renderCard(
       makeWindow({
-        modelScope: { kind: 'models', models: [], complete: false },
+        modelScope: { kind: 'feature', key: 'future_feature', complete: false },
         usage: null,
         currentUsage: null,
         previousUsage: null,
         forecast: null,
       })
     );
+    expect(readText(renderer.root)).toContain('accounts.detail_scope_unknown');
+  });
+
+  it('fails closed for an incomplete all scope instead of rendering account-wide comparison stats', () => {
+    const renderer = renderCard(
+      makeWindow({
+        modelScope: { kind: 'all', complete: false },
+        usage: usage({ totalRequests: 250, totalTokens: 29_000_000, totalCost: 21.23 }),
+        currentUsage: usage({ totalRequests: 250, totalTokens: 29_000_000, totalCost: 21.23 }),
+        previousUsage: usage({ totalRequests: 250, totalTokens: 29_000_000, totalCost: 21.23 }),
+        forecast: { requests: 250, tokens: 29_000_000, cost: 21.23, basis: 'previous' },
+      })
+    );
+
+    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'model' })).toHaveLength(1);
+    expect(renderer.root.findAllByProps({ 'data-quota-model-comparison': 'true' })).toHaveLength(0);
     expect(readText(renderer.root)).toContain('accounts.detail_scope_unknown');
   });
 
@@ -473,6 +503,9 @@ describe('QuotaWindowCard', () => {
     const warnings = renderer.root.findByProps({ 'data-quota-source-warnings': 'true' });
     const text = readText(warnings);
     expect(text).toContain('accounts.detail_quota_snapshot_stale');
-    expect(text).toContain('accounts.detail_scope_unknown');
+    expect(text).not.toContain('accounts.detail_scope_unknown');
+    expect(readText(renderer.root.findByProps({ 'data-quota-model-warning': 'true' }))).toContain(
+      'accounts.detail_scope_unknown'
+    );
   });
 });

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
@@ -31,6 +31,7 @@ import type {
 } from '@/features/accounts/model/accountDetailViewModel';
 import { formatQuotaResetDisplay } from '@/features/accounts/model/accountsPagePresentation';
 import { formatUsd } from '@/utils/usage';
+import { isCodexMainQuotaModelScope } from '@/utils/quota/codexQuota';
 import { QuotaProgressBar } from './QuotaProgressBar';
 import styles from './QuotaWindowCard.module.scss';
 
@@ -141,6 +142,8 @@ const isIntervalWindow = (window: AccountDetailQuotaWindow): boolean =>
 
 const inferCardMode = (window: AccountDetailQuotaWindow): QuotaWindowCardMode => {
   if (!isIntervalWindow(window)) return 'other';
+  if (window.source === 'codex' && isCodexMainQuotaModelScope(window.modelScope)) return 'standard';
+  if (window.modelScope?.complete === false) return 'model';
   return window.modelScope?.kind && window.modelScope.kind !== 'all' ? 'model' : 'standard';
 };
 
@@ -409,7 +412,9 @@ export const QuotaWindowCard = ({
     0
   );
   const modelHasUsableUsage =
-    resolvedMode === 'model' && Boolean(usage?.matched || previousUsage?.matched || q.forecast);
+    resolvedMode === 'model' &&
+    q.modelScope?.complete !== false &&
+    Boolean(usage?.matched || previousUsage?.matched || q.forecast);
   const modelWindowStatsUnavailable = resolvedMode === 'model' && !modelHasUsableUsage;
   const lifecycleUnavailable = q.availability === 'pending_absent' || q.availability === 'inactive';
   const reopened = q.availability === 'active' && (q.activationGeneration ?? 0) > 1;

--- a/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
@@ -18,6 +18,7 @@ import {
   formatQuotaResetTimestamp,
 } from '@/features/accounts/model/accountsPagePresentation';
 import { formatUsd } from '@/utils/usage';
+import { isCodexMainQuotaModelScope } from '@/utils/quota/codexQuota';
 import { QuotaWindowCard } from '../QuotaWindowCard';
 import styles from '@/features/accounts/AccountsPage.module.scss';
 
@@ -27,7 +28,9 @@ const isIntervalQuotaWindow = (window: AccountDetailQuotaWindow): boolean =>
   window.windowMode === 'rolling';
 
 const isModelScopedQuotaWindow = (window: AccountDetailQuotaWindow): boolean =>
-  window.modelScope?.kind !== undefined && window.modelScope.kind !== 'all';
+  window.modelScope?.kind !== undefined &&
+  window.modelScope.kind !== 'all' &&
+  !(window.source === 'codex' && isCodexMainQuotaModelScope(window.modelScope));
 
 type MetricTone = 'blue' | 'green' | 'teal' | 'amber';
 

--- a/apps/web/src/features/accounts/model/accountCredentialEvidence.ts
+++ b/apps/web/src/features/accounts/model/accountCredentialEvidence.ts
@@ -2,6 +2,10 @@ import type { AuthFileItem, CodexQuotaState, CodexQuotaWindow } from '@/types';
 import type { CodexInspectionQuotaWindow } from '@/services/api/usageService';
 import { resolveQuotaDisplayState } from '@/components/quota';
 import { buildQuotaCredentialIdentity } from '@/utils/quota/credentialScope';
+import {
+  canonicalizeCodexProviderWindowId,
+  inferCodexQuotaScopeFromProviderWindowId,
+} from '@/utils/quota/codexQuota';
 import { hasActiveCodexInspectionAuthenticationFailure } from '@/features/authFiles/model/credentialStatus';
 
 export interface AccountInspectionSummary {
@@ -118,20 +122,25 @@ export const stripSupersededAccountInspectionStatus = (
 
 const buildInspectionQuotaWindows = (inspection: AccountInspectionSummary): CodexQuotaWindow[] => {
   const observedAtMs = readFiniteTimestamp(inspection.createdAtMs);
-  const windows = (inspection.quotaWindows ?? []).map((window) => ({
-    id: window.id,
-    label: window.labelKey || window.id,
-    labelKey: window.labelKey || undefined,
-    labelParams: window.labelParams,
-    usedPercent: readFinitePercent(window.usedPercent),
-    resetLabel: window.resetLabel || '-',
-    resetAtMs: readFiniteTimestamp(window.resetAtMs),
-    resetAccuracy:
-      window.resetAccuracy === 'derived' ? 'estimated' : (window.resetAccuracy ?? 'unknown'),
-    limitWindowSeconds: readFinitePercent(window.limitWindowSeconds),
-    observationSource: 'inspection' as const,
-    observedAtMs,
-  }));
+  const windows = (inspection.quotaWindows ?? []).map((window) => {
+    const id = canonicalizeCodexProviderWindowId(window.id);
+    return {
+      id,
+      label: window.labelKey || id,
+      labelKey: window.labelKey || undefined,
+      labelParams: window.labelParams,
+      usedPercent: readFinitePercent(window.usedPercent),
+      resetLabel: window.resetLabel || '-',
+      resetAtMs: readFiniteTimestamp(window.resetAtMs),
+      resetAccuracy:
+        window.resetAccuracy === 'derived' ? 'estimated' : (window.resetAccuracy ?? 'unknown'),
+      limitWindowSeconds: readFinitePercent(window.limitWindowSeconds),
+      observationSource: 'inspection' as const,
+      observedAtMs,
+      modelScope: window.modelScope ?? inferCodexQuotaScopeFromProviderWindowId(id),
+      providerWindowAliases: window.providerWindowAliases,
+    };
+  });
   if (windows.length > 0 || inspection.usedPercent === null) return windows;
   return [
     {
@@ -144,6 +153,11 @@ const buildInspectionQuotaWindows = (inspection: AccountInspectionSummary): Code
       resetAccuracy: 'unknown',
       observationSource: 'inspection',
       observedAtMs,
+      modelScope: {
+        kind: 'feature',
+        key: 'inspection_summary',
+        complete: false,
+      },
     },
   ];
 };

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
@@ -13,6 +13,8 @@ import { buildAccountDetailViewModel } from './accountDetailViewModel';
 import { accountWindowUsageRequestKey } from './accountWindowUsageRows';
 import type { UsageValueRow } from './usageValueRows';
 
+const CODEX_MAIN_SCOPE = { kind: 'family', key: 'codex_main', complete: true } as const;
+
 type AccountRowOverrides = Omit<Partial<AccountRow>, 'quota'> & {
   quota?: Partial<AccountRow['quota']>;
 };
@@ -473,6 +475,69 @@ describe('accountDetailViewModel', () => {
       scopeMatchStatus: 'partial',
       unmatchedRequests: 2,
     });
+    expect(viewModel.quota.windows[0].forecast).toBeNull();
+  });
+
+  it('does not forecast an incomplete quota scope even when cached usage is present', () => {
+    const row = makeRow({ provider: 'codex' });
+    const nowMs = Date.now();
+    const modelScope = { kind: 'feature' as const, key: 'future_feature', complete: false };
+    const currentKey = accountWindowUsageRequestKey(
+      row.selectionKey,
+      'future-feature-weekly-0',
+      'current',
+      modelScope
+    );
+    const previousKey = accountWindowUsageRequestKey(
+      row.selectionKey,
+      'future-feature-weekly-0',
+      'previous',
+      modelScope
+    );
+    const windowUsageByKey = new Map<string, MonitoringAccountWindowUsageItem>([
+      [
+        currentKey,
+        makeWindowUsage({
+          window_key: 'future-feature-weekly-0',
+          total_requests: 250,
+          total_tokens: 29_000_000,
+          total_cost: 21.23,
+        }),
+      ],
+      [
+        previousKey,
+        makeWindowUsage({
+          window_key: 'future-feature-weekly-0',
+          total_requests: 250,
+          total_tokens: 29_000_000,
+          total_cost: 21.23,
+        }),
+      ],
+    ]);
+
+    const viewModel = buildAccountDetailViewModel(row, {
+      quotaWindows: [
+        {
+          key: 'future-feature-weekly-0',
+          providerWindowId: 'future-feature-weekly-0',
+          label: 'Future Feature',
+          kind: 'weekly',
+          remainingPercent: 100,
+          usedPercent: 0,
+          resetLabel: 'later',
+          resetAtMs: nowMs + 7 * 24 * 60 * 60 * 1000,
+          resetAccuracy: 'exact',
+          observedAtMs: nowMs,
+          limitWindowSeconds: 7 * 24 * 60 * 60,
+          windowMode: 'fixed',
+          cycleStartMs: nowMs - 60 * 60 * 1000,
+          cycleEndMs: nowMs + 7 * 24 * 60 * 60 * 1000,
+          modelScope,
+        },
+      ],
+      windowUsageByKey,
+    });
+
     expect(viewModel.quota.windows[0].forecast).toBeNull();
   });
 
@@ -1674,6 +1739,7 @@ describe('accountDetailViewModel', () => {
           resetLabel: '2026-07-30T04:00:00Z',
           resetAtMs: earlierResetAtMs,
           resetAccuracy: 'exact',
+          modelScope: CODEX_MAIN_SCOPE,
         },
         {
           key: 'weekly-model',
@@ -1684,6 +1750,7 @@ describe('accountDetailViewModel', () => {
           resetLabel: '2026-07-30T06:00:00Z',
           resetAtMs: laterResetAtMs,
           resetAccuracy: 'exact',
+          modelScope: CODEX_MAIN_SCOPE,
         },
       ],
     });
@@ -1724,6 +1791,7 @@ describe('accountDetailViewModel', () => {
             resetLabel: '2026-07-30T04:00:00Z',
             resetAtMs: Date.parse('2026-07-30T04:00:00Z'),
             resetAccuracy: 'exact',
+            modelScope: CODEX_MAIN_SCOPE,
           },
           {
             key: 'weekly-unknown',
@@ -1734,6 +1802,7 @@ describe('accountDetailViewModel', () => {
             resetLabel: '-',
             resetAtMs: null,
             resetAccuracy: 'unknown',
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.ts
@@ -14,6 +14,7 @@ import type { AuthFileCodexStatusSummary } from '@/features/authFiles/model/cred
 import { normalizePlanType, parseIdTokenPayload } from '@/utils/quota/parsers';
 import { isValidQuotaResetAtMs } from '@/utils/quota/formatters';
 import { resolveCodexPlanType } from '@/utils/quota/resolvers';
+import { isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
 import { parseTimestampMs } from '@/utils/timestamp';
 import { sumRecentRequests, type RecentRequestBucket } from '@/utils/recentRequests';
 import type { AccountRow } from './accountRows';
@@ -631,8 +632,10 @@ const buildQuotaWindows = (
           kind: window.modelScope.kind,
           key: window.modelScope.key,
           models: window.modelScope.models,
+          complete: window.modelScope.complete,
         }
       : undefined;
+    const scopeAllowsUsage = modelScope?.complete !== false;
     const currentUsage = toWindowUsageSummary(
       windowUsageByKey.get(
         accountWindowUsageRequestKey(row.selectionKey, providerWindowId, 'current', modelScope)
@@ -687,6 +690,7 @@ const buildQuotaWindows = (
           }
         : null;
     const forecast =
+      scopeAllowsUsage &&
       lifecycleActive &&
       (window.windowMode === 'fixed' || window.windowMode === 'calendar') &&
       typeof window.cycleStartMs === 'number' &&
@@ -1517,11 +1521,13 @@ export const buildAccountDetailViewModel = (
       };
     }
   );
+  const accountQuotaWindows =
+    row.provider === 'codex' ? quotaWindows.filter(isCodexMainQuotaWindow) : quotaWindows;
   const listItem = buildAccountListItem(row, {
     recommendation,
     quotaCooldown,
     codexStatus: options.codexStatus ?? null,
-    quotaWindows,
+    quotaWindows: accountQuotaWindows,
     requestEvidence,
   });
   const value = buildValueSummary(row, options.valueRow);
@@ -1553,7 +1559,7 @@ export const buildAccountDetailViewModel = (
   const overviewDecision = buildOverviewDecision(row, listItem, quotaCooldown);
   const overview = {
     decision: overviewDecision,
-    capacity: buildOverviewCapacity(row, quotaWindows, listItem),
+    capacity: buildOverviewCapacity(row, accountQuotaWindows, listItem),
     credential: buildOverviewCredential(row, options.codexQuota),
     recentStatus: buildOverviewRecentStatus(
       row,

--- a/apps/web/src/features/accounts/model/accountListPresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.test.ts
@@ -7,6 +7,8 @@ import { buildAccountListItem, buildRecommendationBySelectionKey } from './accou
 import { summarizeGroupedQuotaAvailability } from './accountQuotaSummary';
 import type { AccountRecommendation } from './quotaRecommendations';
 
+const CODEX_MAIN_SCOPE = { kind: 'family', key: 'codex_main', complete: true } as const;
+
 type AccountRowOverrides = Omit<Partial<AccountRow>, 'quota'> & {
   quota?: Partial<AccountRow['quota']>;
 };
@@ -891,6 +893,7 @@ describe('accountListPresentation', () => {
             remainingPercent: 0,
             usedPercent: 100,
             resetLabel: '-',
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }
@@ -919,6 +922,7 @@ describe('accountListPresentation', () => {
             remainingPercent: 0,
             usedPercent: 100,
             resetLabel: 'month-end',
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }
@@ -1083,6 +1087,7 @@ describe('accountListPresentation', () => {
             resetLabel: '2026-07-30T04:00:00Z',
             resetAtMs: earlierResetAtMs,
             resetAccuracy: 'exact',
+            modelScope: CODEX_MAIN_SCOPE,
           },
           {
             key: 'weekly-model',
@@ -1093,6 +1098,7 @@ describe('accountListPresentation', () => {
             resetLabel: '2026-07-30T06:00:00Z',
             resetAtMs: laterResetAtMs,
             resetAccuracy: 'exact',
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }
@@ -1126,6 +1132,7 @@ describe('accountListPresentation', () => {
             resetLabel: '2026-07-30T04:00:00Z',
             resetAtMs: Date.parse('2026-07-30T04:00:00Z'),
             resetAccuracy: 'exact',
+            modelScope: CODEX_MAIN_SCOPE,
           },
           {
             key: 'weekly-unknown',
@@ -1136,6 +1143,7 @@ describe('accountListPresentation', () => {
             resetLabel: '-',
             resetAtMs: null,
             resetAccuracy: 'unknown',
+            modelScope: CODEX_MAIN_SCOPE,
           },
         ],
       }

--- a/apps/web/src/features/accounts/model/accountListPresentation.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.ts
@@ -6,7 +6,7 @@ import {
   type AccountGroupedQuotaAvailabilitySummary,
 } from './accountQuotaSummary';
 import type { AccountQuotaWindowKind } from './accountQuotaDisplayWindows';
-import type { QuotaResetAccuracy } from '@/types';
+import type { QuotaModelScope, QuotaResetAccuracy } from '@/types';
 import {
   buildAccountRecommendation,
   isAccountRecommendationEvidenceSensitive,
@@ -14,6 +14,7 @@ import {
 } from './quotaRecommendations';
 import type { UsageValueSource } from './usageValueRows';
 import { isValidQuotaResetAtMs } from '@/utils/quota/formatters';
+import { isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
 import {
   classifyAccountCredentialStatusEvidence,
   classifyAccountObservedDiagnosticEvidence,
@@ -77,6 +78,7 @@ export interface AccountListQuotaWindowPresentation {
   resetAtMs: number | null;
   resetAccuracy: QuotaResetAccuracy;
   groupLabel?: string;
+  modelScope?: QuotaModelScope;
 }
 
 export type AccountListQuotaWindowInput = Omit<
@@ -712,10 +714,7 @@ const resolveHealthStatus = (
   const actionableInspection = isAccountInspectionActionable(row, resolvedRequestEvidence)
     ? row.inspection
     : null;
-  const statusInspection = isAccountInspectionStatusEvidenceCurrent(
-    row,
-    resolvedRequestEvidence
-  )
+  const statusInspection = isAccountInspectionStatusEvidenceCurrent(row, resolvedRequestEvidence)
     ? row.inspection
     : null;
   const hasCredentialStatusProblem = isAccountCredentialStatusProblemCurrent(
@@ -735,9 +734,10 @@ const resolveHealthStatus = (
   const quotaRefreshDetail = quotaRefreshProblem
     ? getFirstDetail(row.quota.error, getHttpStatusDetail(row.quota.errorStatus))
     : '';
-  const observedDiagnosticDetail = !exceptionProblem && hasObservedDiagnosticProblem
-    ? [row.quota.observedErrorKind, row.quota.observedErrorCode].filter(Boolean).join(' / ')
-    : '';
+  const observedDiagnosticDetail =
+    !exceptionProblem && hasObservedDiagnosticProblem
+      ? [row.quota.observedErrorKind, row.quota.observedErrorCode].filter(Boolean).join(' / ')
+      : '';
   const resolvedRequestQuotaEvidence = resolveAccountRequestQuotaEvidence(requestEvidenceInput);
   const requestQuotaEvidence = isAccountRequestQuotaEvidenceCurrent(
     row,
@@ -1164,11 +1164,13 @@ export const buildAccountListItem = (
       };
     }
   );
+  const accountQuotaWindows =
+    row.provider === 'codex' ? quotaWindows.filter(isCodexMainQuotaWindow) : quotaWindows;
   const health = resolveHealthStatus(
     row,
     quotaCooldown,
     options.codexStatus ?? null,
-    quotaWindows,
+    accountQuotaWindows,
     options.requestEvidence
   );
 

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
@@ -17,6 +17,7 @@ import {
   parseQuotaResetLabelMs,
   resolveAbsoluteQuotaReset,
 } from '@/utils/quota/formatters';
+import { inferCodexQuotaScopeFromProviderWindowId } from '@/utils/quota/codexQuota';
 import type { AccountRow } from './accountRows';
 import type { AccountQuotaStores } from './accountQuotaSummary';
 
@@ -61,6 +62,7 @@ export interface AccountQuotaDisplayWindow {
   cycleStartMs?: number | null;
   cycleEndMs?: number | null;
   modelScope?: QuotaModelScope;
+  providerWindowAliases?: string[];
 }
 
 export type TranslateQuotaWindowLabel = (
@@ -299,6 +301,7 @@ export const buildAccountQuotaDisplayWindow = ({
   cycleStartMs,
   cycleEndMs,
   modelScope = { kind: 'all', complete: true },
+  providerWindowAliases,
   nowMs,
 }: {
   key: string;
@@ -320,6 +323,7 @@ export const buildAccountQuotaDisplayWindow = ({
   cycleStartMs?: number | null;
   cycleEndMs?: number | null;
   modelScope?: QuotaModelScope;
+  providerWindowAliases?: string[];
   nowMs?: number;
 }): AccountQuotaDisplayWindow => {
   const normalizedResetLabel = resetLabel || '-';
@@ -368,6 +372,7 @@ export const buildAccountQuotaDisplayWindow = ({
     cycleStartMs: cycleStartMs ?? range.fromMs,
     cycleEndMs: cycleEndMs ?? range.resetAtMs,
     modelScope,
+    providerWindowAliases,
     ...range,
   };
 };
@@ -390,6 +395,8 @@ const buildCodexQuotaDisplayWindows = (
       resetAtMs: window.resetAtMs,
       resetAccuracy: window.resetAccuracy,
       limitWindowSeconds: window.limitWindowSeconds ?? null,
+      modelScope: window.modelScope ?? inferCodexQuotaScopeFromProviderWindowId(window.id),
+      providerWindowAliases: window.providerWindowAliases,
       source: 'codex',
       observationSource:
         window.observationSource ??
@@ -590,10 +597,7 @@ const buildXaiQuotaDisplayWindows = (
       ? clampDisplayPercent(billing.usedPercent)
       : null;
 
-  if (
-    monthlyUsedPercent !== null ||
-    billing.monthlyLimitCents !== null
-  ) {
+  if (monthlyUsedPercent !== null || billing.monthlyLimitCents !== null) {
     windows.push(
       buildAccountQuotaDisplayWindow({
         key: 'billing',

--- a/apps/web/src/features/accounts/model/accountQuotaSnapshots.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSnapshots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AccountQuotaSnapshotWindow } from '@/services/api/usageService';
+import { CODEX_SPARK_MODEL_ID } from '@/utils/quota/codexQuota';
 import type { AccountQuotaWindowDefinition } from './accountQuotaWindowDefinitions';
 import {
   buildAccountQuotaSnapshotWriteEntries,
@@ -81,6 +82,85 @@ describe('account quota snapshots', () => {
       stale: true,
       modelScope: { kind: 'all', complete: true },
     });
+  });
+
+  it('merges legacy primary and secondary ids into the current Codex main windows', () => {
+    const primary = makeDefinition({
+      key: 'five-hour',
+      providerWindowId: 'five-hour',
+      kind: 'five_hour',
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    const monthly = makeDefinition({
+      key: 'monthly',
+      providerWindowId: 'monthly',
+      kind: 'monthly',
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [primary, monthly],
+      [
+        makeSnapshot({
+          provider_window_id: 'primary',
+          window_kind: 'five_hour',
+          model_scope_kind: 'all',
+          used_percent: 11,
+        }),
+        makeSnapshot({
+          provider_window_id: 'secondary',
+          window_kind: 'monthly',
+          model_scope_kind: 'all',
+          used_percent: 22,
+        }),
+      ],
+      { provider: 'codex' }
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged.find((window) => window.providerWindowId === 'five-hour')).toMatchObject({
+      usedPercent: 11,
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    expect(merged.find((window) => window.providerWindowId === 'monthly')).toMatchObject({
+      usedPercent: 22,
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+  });
+
+  it('does not apply Codex legacy suppression rules to another provider', () => {
+    const accountWide = makeDefinition({
+      key: 'shared-all',
+      provider: 'antigravity',
+      providerWindowId: 'shared-window',
+      modelScope: { kind: 'all', complete: true },
+    });
+    const scoped = makeDefinition({
+      key: 'shared-model',
+      provider: 'antigravity',
+      providerWindowId: 'shared-window',
+      modelScope: { kind: 'models', models: ['model-alpha'], complete: true },
+    });
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [accountWide, scoped],
+      [
+        makeSnapshot({
+          provider_window_id: 'shared-window',
+          model_scope_kind: 'all',
+          used_percent: 12,
+        }),
+        makeSnapshot({
+          provider_window_id: 'shared-window',
+          model_scope_kind: 'models',
+          model_ids: ['model-alpha'],
+          used_percent: 34,
+        }),
+      ],
+      { provider: 'antigravity' }
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged.find((window) => window.key === 'shared-all')?.usedPercent).toBe(12);
+    expect(merged.find((window) => window.key === 'shared-model')?.usedPercent).toBe(34);
   });
 
   it('keeps newer live quota definitions ahead of an older persisted snapshot', () => {
@@ -242,6 +322,73 @@ describe('account quota snapshots', () => {
     });
   });
 
+  it('encodes an incomplete all scope as fail-closed feature scope', () => {
+    const incomplete = makeDefinition({
+      key: 'unknown-window',
+      providerWindowId: 'future-feature-weekly-0',
+      modelScope: { kind: 'all', complete: false },
+      boundaryAccuracy: 'unknown',
+      windowMode: 'unknown',
+    });
+    const row = {
+      selectionKey: 'codex.json\u0000auth-1',
+      fileName: 'codex.json',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountLabel: 'user@example.com',
+      raw: {
+        name: 'codex.json',
+        provider: 'codex',
+        type: 'codex',
+        auth_index: 'auth-1',
+        account: 'user@example.com',
+      },
+    } as unknown as AccountRow;
+    const [entry] = buildAccountQuotaSnapshotWriteEntries(
+      [row],
+      new Map([[row.selectionKey, [incomplete]]]),
+      { nowMs: 20_000 }
+    );
+
+    expect(entry.windows[0]).toMatchObject({
+      model_scope_kind: 'feature',
+      model_scope_key: 'scope_unknown',
+      model_ids: undefined,
+      window_mode: 'unknown',
+      boundary_accuracy: 'unknown',
+    });
+
+    const merged = mergeAccountQuotaSnapshotWindows([], [makeSnapshot({
+      ...entry.windows[0],
+      provider_window_id: 'future-feature-weekly-0',
+      window_kind: 'weekly',
+      stale: false,
+    })], { provider: 'codex' });
+    expect(merged).toMatchObject([
+      expect.objectContaining({
+        providerWindowId: 'future-feature-weekly-0',
+        modelScope: { kind: 'models', models: [], complete: false },
+      }),
+    ]);
+  });
+
+  it('suppresses a legacy non-main all-scope snapshot when no replacement is complete', () => {
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [],
+      [
+        makeSnapshot({
+          provider_window_id: 'fast-coding-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'all',
+          used_percent: 50,
+        }),
+      ],
+      { provider: 'codex' }
+    );
+
+    expect(merged).toEqual([]);
+  });
+
   it('gives snapshot-only model scopes distinct display keys while preserving provider identity', () => {
     const snapshots = [
       makeSnapshot({
@@ -270,6 +417,148 @@ describe('account quota snapshots', () => {
         .map((item) => item.key)
         .sort()
     ).toEqual([...keys].sort());
+  });
+
+  it('suppresses a legacy Spark all-scope snapshot when scoped evidence exists', () => {
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [],
+      [
+        makeSnapshot({
+          provider_window_id: 'gpt-5-3-codex-spark-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'all',
+          used_percent: 50,
+          observed_at_ms: 10_000,
+        }),
+        makeSnapshot({
+          provider_window_id: 'spark-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'models',
+          model_ids: [CODEX_SPARK_MODEL_ID],
+          used_percent: 0,
+          observed_at_ms: 20_000,
+        }),
+      ],
+      { provider: 'codex' }
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      providerWindowId: 'spark-weekly-0',
+      usedPercent: 0,
+      modelScope: {
+        kind: 'models',
+        models: [CODEX_SPARK_MODEL_ID],
+        complete: true,
+      },
+    });
+  });
+
+  it('suppresses a legacy display-label Spark snapshot through the live alias', () => {
+    const definition = makeDefinition({
+      key: 'spark-weekly-0',
+      providerWindowId: 'spark-weekly-0',
+      provider: 'codex',
+      modelScope: {
+        kind: 'models',
+        models: [CODEX_SPARK_MODEL_ID],
+        complete: true,
+      },
+      providerWindowAliases: ['fast-coding-weekly-0'],
+    });
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [definition],
+      [
+        makeSnapshot({
+          provider_window_id: 'fast-coding-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'all',
+          used_percent: 50,
+          observed_at_ms: 10_000,
+        }),
+      ],
+      { provider: 'codex' }
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      providerWindowId: 'spark-weekly-0',
+      usedPercent: definition.usedPercent,
+      modelScope: definition.modelScope,
+    });
+  });
+
+  it('suppresses only the matching legacy all-scope snapshot for an incomplete feature', () => {
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [],
+      [
+        makeSnapshot({
+          provider_window_id: 'future-feature-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'all',
+          used_percent: 50,
+          observed_at_ms: 10_000,
+        }),
+        makeSnapshot({
+          provider_window_id: 'future-feature-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'feature',
+          model_scope_key: 'future_feature',
+          used_percent: 0,
+          observed_at_ms: 20_000,
+        }),
+        makeSnapshot({
+          provider_window_id: 'other-feature-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'all',
+          used_percent: 25,
+          observed_at_ms: 15_000,
+        }),
+      ],
+      { provider: 'codex' }
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(
+      merged.find((item) => item.providerWindowId === 'future-feature-weekly-0')
+    ).toMatchObject({
+      usedPercent: 0,
+      modelScope: { kind: 'feature', key: 'future_feature', complete: false },
+    });
+    expect(merged.find((item) => item.providerWindowId === 'other-feature-weekly-0')).toMatchObject(
+      {
+        usedPercent: 25,
+        modelScope: { kind: 'all', complete: true },
+      }
+    );
+  });
+
+  it('keeps an explicitly incomplete all-scope replacement from restoring legacy account-wide usage', () => {
+    const definition = makeDefinition({
+      key: 'future-feature-weekly-0',
+      providerWindowId: 'future-feature-weekly-0',
+      provider: 'codex',
+      kind: 'weekly',
+      modelScope: { kind: 'all', complete: false },
+      windowMode: 'unknown',
+      boundaryAccuracy: 'unknown',
+    });
+    const merged = mergeAccountQuotaSnapshotWindows(
+      [definition],
+      [
+        makeSnapshot({
+          provider_window_id: 'future-feature-weekly-0',
+          window_kind: 'weekly',
+          model_scope_kind: 'all',
+          used_percent: 75,
+        }),
+      ],
+      { provider: 'codex' }
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toBe(definition);
+    expect(merged[0].modelScope).toEqual({ kind: 'all', complete: false });
   });
 
   it('adds snapshot-only rolling windows and keeps them ahead of non-window quotas', () => {

--- a/apps/web/src/features/accounts/model/accountQuotaSnapshots.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSnapshots.ts
@@ -20,6 +20,14 @@ import type {
   AccountQuotaWindowKind,
   AccountQuotaWindowSource,
 } from './accountQuotaDisplayWindows';
+import {
+  CODEX_MAIN_QUOTA_SCOPE_KEY,
+  canonicalizeCodexProviderWindowIdForScope,
+  isCodexKnownScopedProviderWindowId,
+  isCodexLegacyAllScopeReplacement,
+  isCodexMainProviderWindowId,
+  inferCodexQuotaScopeFromProviderWindowId,
+} from '@/utils/quota/codexQuota';
 
 const INCOMPLETE_MODEL_SCOPE_KIND = 'feature';
 const INCOMPLETE_MODEL_SCOPE_KEY = 'scope_unknown';
@@ -159,23 +167,34 @@ const toSnapshotWindow = (
   const scopeComplete = definition.modelScope.complete !== false;
   const hasModels =
     definition.modelScope.kind !== 'models' || (definition.modelScope.models?.length ?? 0) > 0;
+  // The snapshot schema predates the explicit `complete` bit. Encode every
+  // incomplete scope as a feature scope so a round-trip cannot silently turn
+  // `all`/`family`/`models` back into a complete account-wide scope.
+  const persistedScopeKind =
+    !scopeComplete && definition.modelScope.kind !== 'feature'
+      ? INCOMPLETE_MODEL_SCOPE_KIND
+      : definition.modelScope.kind === 'models' && !hasModels
+        ? INCOMPLETE_MODEL_SCOPE_KIND
+        : definition.modelScope.kind;
+  const persistedScopeKey =
+    !scopeComplete && definition.modelScope.kind !== 'feature'
+      ? INCOMPLETE_MODEL_SCOPE_KEY
+      : definition.modelScope.kind === 'models' && !hasModels
+        ? INCOMPLETE_MODEL_SCOPE_KEY
+        : definition.modelScope.key;
+  const persistedModelIDs = scopeComplete && hasModels ? definition.modelScope.models : undefined;
   const boundaryAccuracy =
     scopeComplete && hasModels ? definition.boundaryAccuracy : ('unknown' as const);
   const windowMode = scopeComplete && hasModels ? definition.windowMode : ('unknown' as const);
   const resetCredits = definition.provider === 'codex' ? toResetCredits(codexQuota) : [];
   return {
     provider_window_id: definition.providerWindowId,
+    provider_window_aliases: definition.providerWindowAliases,
     window_kind: definition.kind,
     window_mode: windowMode,
-    model_scope_kind:
-      definition.modelScope.kind === 'models' && !hasModels
-        ? INCOMPLETE_MODEL_SCOPE_KIND
-        : definition.modelScope.kind,
-    model_scope_key:
-      definition.modelScope.kind === 'models' && !hasModels
-        ? INCOMPLETE_MODEL_SCOPE_KEY
-        : definition.modelScope.key,
-    model_ids: hasModels ? definition.modelScope.models : undefined,
+    model_scope_kind: persistedScopeKind,
+    model_scope_key: persistedScopeKey,
+    model_ids: persistedModelIDs,
     source: observation?.source ?? definition.observationSource,
     source_observation_id: observation?.source_observation_id,
     observed_at_ms: observation?.observed_at_ms ?? definition.observedAtMs ?? nowMs,
@@ -354,29 +373,31 @@ const normalizedSnapshotModelIDs = (modelIDs: string[] | undefined): string[] =>
     new Set((modelIDs ?? []).map((model) => model.trim().toLowerCase()).filter(Boolean))
   ).sort();
 
-const snapshotScopeParts = (window: {
-  provider_window_id: string;
-  model_scope_kind: string;
-  model_scope_key?: string;
-  model_ids?: string[];
-}) => {
+const snapshotScopeParts = (
+  window: {
+    provider_window_id: string;
+    model_scope_kind: string;
+    model_scope_key?: string;
+    model_ids?: string[];
+  }
+) => {
   if (isIncompleteModelScopeSnapshot(window)) {
     return [window.provider_window_id.trim(), 'models', ''];
   }
-  return [
-    window.provider_window_id.trim(),
-    window.model_scope_kind.trim().toLowerCase(),
-    window.model_scope_key?.trim().toLowerCase() ?? '',
-    ...normalizedSnapshotModelIDs(window.model_ids),
-  ];
+  const kind = window.model_scope_kind.trim().toLowerCase();
+  const key = window.model_scope_key?.trim().toLowerCase() ?? '';
+  const models = normalizedSnapshotModelIDs(window.model_ids);
+  return [window.provider_window_id.trim(), kind, key, ...models];
 };
 
-const snapshotScopeKey = (window: {
-  provider_window_id: string;
-  model_scope_kind: string;
-  model_scope_key?: string;
-  model_ids?: string[];
-}) => snapshotScopeParts(window).join('\u0000');
+const snapshotScopeKey = (
+  window: {
+    provider_window_id: string;
+    model_scope_kind: string;
+    model_scope_key?: string;
+    model_ids?: string[];
+  }
+) => snapshotScopeParts(window).join('\u0000');
 
 const snapshotDisplayKey = (snapshot: AccountQuotaSnapshotWindow): string =>
   [
@@ -412,8 +433,119 @@ export const mergeAccountQuotaSnapshotWindows = (
     getLabel?: (snapshot: AccountQuotaSnapshotWindow) => string;
   } = {}
 ): AccountQuotaWindowDefinition[] => {
+  const canonicalProviderWindowId = (
+    providerWindowId: string,
+    windowKind?: string,
+    modelScope?: QuotaModelScope
+  ) => {
+    if (options.provider !== 'codex') return providerWindowId;
+    return canonicalizeCodexProviderWindowIdForScope(providerWindowId, windowKind, modelScope);
+  };
+  const canonicalDefinitions = definitions.map((definition) => {
+    const modelScope =
+      options.provider === 'codex' &&
+      definition.modelScope.kind === 'all' &&
+      definition.modelScope.complete !== false &&
+      isCodexKnownScopedProviderWindowId(definition.providerWindowId) &&
+      !isCodexMainProviderWindowId(definition.providerWindowId)
+        ? inferCodexQuotaScopeFromProviderWindowId(definition.providerWindowId)
+        : definition.modelScope;
+    const providerWindowId = canonicalProviderWindowId(
+      definition.providerWindowId,
+      definition.kind,
+      modelScope
+    );
+    const providerWindowAliases = Array.from(
+      new Set(
+        (definition.providerWindowAliases ?? [])
+          .map((alias) => alias.trim().toLowerCase())
+          .filter((alias) => alias && alias !== providerWindowId)
+      )
+    ).sort();
+    return providerWindowId === definition.providerWindowId &&
+      providerWindowAliases.length === 0 &&
+      modelScope === definition.modelScope
+      ? definition
+      : {
+          ...definition,
+          providerWindowId,
+          modelScope,
+          display:
+            modelScope === definition.modelScope
+              ? definition.display
+              : { ...definition.display, modelScope },
+          providerWindowAliases:
+            providerWindowAliases.length > 0 ? providerWindowAliases : undefined,
+        };
+  });
+  const canonicalSnapshots = snapshots.map((snapshot) => {
+    const inferredScope =
+      options.provider === 'codex' &&
+      snapshot.model_scope_kind.trim().toLowerCase() === 'all' &&
+      isCodexKnownScopedProviderWindowId(snapshot.provider_window_id)
+        ? inferCodexQuotaScopeFromProviderWindowId(snapshot.provider_window_id)
+        : options.provider === 'codex'
+          ? snapshotModelScope(snapshot)
+          : undefined;
+    const providerWindowId = canonicalProviderWindowId(
+      snapshot.provider_window_id,
+      snapshot.window_kind,
+      inferredScope
+    );
+    const normalizedSnapshot =
+      options.provider === 'codex' &&
+      isCodexMainProviderWindowId(providerWindowId) &&
+      snapshot.model_scope_kind.trim().toLowerCase() === 'all'
+        ? {
+            ...snapshot,
+            model_scope_kind: 'family' as const,
+            model_scope_key: CODEX_MAIN_QUOTA_SCOPE_KEY,
+            model_ids: undefined,
+          }
+        : snapshot;
+    return providerWindowId === snapshot.provider_window_id && normalizedSnapshot === snapshot
+      ? snapshot
+      : { ...normalizedSnapshot, provider_window_id: providerWindowId };
+  });
+  const scopedProviderWindowIds = new Set<string>();
+  const scopedProviderWindowAliases = new Set<string>();
+  if (options.provider === 'codex') {
+    canonicalDefinitions
+      .filter((definition) =>
+        isCodexLegacyAllScopeReplacement(definition.providerWindowId, definition.modelScope)
+      )
+      .forEach((definition) => {
+        scopedProviderWindowIds.add(definition.providerWindowId);
+        for (const alias of definition.providerWindowAliases ?? []) {
+          scopedProviderWindowAliases.add(alias);
+        }
+      });
+    canonicalSnapshots
+      .filter((snapshot) => snapshot.model_scope_kind.trim().toLowerCase() !== 'all')
+      .forEach((snapshot) => scopedProviderWindowIds.add(snapshot.provider_window_id));
+  }
+  const compatibleDefinitions = canonicalDefinitions.filter(
+    (definition) =>
+      definition.modelScope.kind !== 'all' ||
+      definition.modelScope.complete === false ||
+      !scopedProviderWindowIds.has(definition.providerWindowId)
+  );
+  const compatibleSnapshots = canonicalSnapshots.filter(
+    (snapshot) => {
+      if (snapshot.model_scope_kind.trim().toLowerCase() !== 'all') return true;
+      if (options.provider !== 'codex') return true;
+      const isKnownScopedLegacy = isCodexKnownScopedProviderWindowId(
+        snapshot.provider_window_id
+      );
+      return (
+        !isKnownScopedLegacy &&
+        !scopedProviderWindowIds.has(snapshot.provider_window_id) &&
+        !scopedProviderWindowAliases.has(snapshot.provider_window_id)
+      );
+    }
+  );
   const snapshotsByKey = new Map<string, AccountQuotaSnapshotWindow>();
-  snapshots.forEach((snapshot) => {
+  compatibleSnapshots.forEach((snapshot) => {
     const key = snapshotScopeKey(snapshot);
     const current = snapshotsByKey.get(key);
     if (!current || compareSnapshotFreshness(current, snapshot) < 0) {
@@ -421,13 +553,18 @@ export const mergeAccountQuotaSnapshotWindows = (
     }
   });
   const matchedSnapshotKeys = new Set<string>();
-  const merged = definitions.map((definition) => {
-    const key = snapshotScopeKey({
-      provider_window_id: definition.providerWindowId,
-      model_scope_kind: definition.modelScope.kind,
-      model_scope_key: definition.modelScope.key,
-      model_ids: definition.modelScope.models,
-    });
+  const merged = compatibleDefinitions.map((definition) => {
+    if (definition.modelScope.kind === 'all' && definition.modelScope.complete === false) {
+      return definition;
+    }
+    const key = snapshotScopeKey(
+      {
+        provider_window_id: definition.providerWindowId,
+        model_scope_kind: definition.modelScope.kind,
+        model_scope_key: definition.modelScope.key,
+        model_ids: definition.modelScope.models,
+      },
+    );
     const snapshot = snapshotsByKey.get(key);
     if (!snapshot) return definition;
     matchedSnapshotKeys.add(key);
@@ -465,7 +602,7 @@ export const mergeAccountQuotaSnapshotWindows = (
       (appendedProviderCounts.get(snapshot.provider_window_id) ?? 0) + 1
     );
   });
-  const usedDisplayKeys = new Set(definitions.map((definition) => definition.key));
+  const usedDisplayKeys = new Set(compatibleDefinitions.map((definition) => definition.key));
   const appended = unmatchedSnapshots.map((snapshot) => {
     const providerKey = snapshot.provider_window_id;
     const requiresScopedKey =
@@ -482,15 +619,27 @@ export const mergeAccountQuotaSnapshotWindows = (
   });
 };
 
-const snapshotModelScope = (snapshot: AccountQuotaSnapshotWindow): QuotaModelScope =>
-  isIncompleteModelScopeSnapshot(snapshot)
-    ? { kind: 'models', models: [], complete: false }
-    : {
-        kind: snapshot.model_scope_kind,
-        key: snapshot.model_scope_key,
-        models: snapshot.model_ids,
-        complete: snapshot.model_scope_kind !== 'models' || (snapshot.model_ids?.length ?? 0) > 0,
-      };
+const snapshotModelScope = (
+  snapshot: AccountQuotaSnapshotWindow
+): QuotaModelScope => {
+  if (isIncompleteModelScopeSnapshot(snapshot)) {
+    return { kind: 'models', models: [], complete: false };
+  }
+  const kind = snapshot.model_scope_kind.trim().toLowerCase() as QuotaModelScope['kind'];
+  const key = snapshot.model_scope_key?.trim();
+  const models = normalizedSnapshotModelIDs(snapshot.model_ids);
+  const complete =
+    kind === 'all' ||
+    (kind === 'models' && models.length > 0) ||
+    (kind === 'family' && (Boolean(key) || models.length > 0)) ||
+    ((kind === 'product' || kind === 'feature') && models.length > 0);
+  return {
+    kind,
+    key: key || undefined,
+    models: models.length > 0 ? models : undefined,
+    complete,
+  };
+};
 
 const snapshotCycleDefinition = (
   cycle: AccountQuotaSnapshotCycle | undefined
@@ -612,6 +761,7 @@ const snapshotDefinition = (
     cycleStartMs: currentStartMs,
     cycleEndMs: currentEndMs,
     modelScope,
+    providerWindowAliases: snapshot.provider_window_aliases,
   };
   return {
     key,
@@ -621,6 +771,7 @@ const snapshotDefinition = (
     kind: display.kind ?? 'unknown',
     windowMode: snapshot.window_mode,
     modelScope,
+    providerWindowAliases: snapshot.provider_window_aliases,
     observationSource: snapshot.source,
     observedAtMs: snapshot.observed_at_ms,
     boundaryAccuracy: snapshot.boundary_accuracy,

--- a/apps/web/src/features/accounts/model/accountQuotaSummary.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSummary.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthFileItem, CodexQuotaState } from '@/types';
+import { getAuthFileSelectionKey } from '@/features/authFiles/model/credentialStatus';
+import { CODEX_SPARK_MODEL_ID } from '@/utils/quota/codexQuota';
+import { resolveAccountQuota, type AccountQuotaStores } from './accountQuotaSummary';
+
+const emptyStores = (): AccountQuotaStores => ({
+  antigravityQuota: {},
+  claudeQuota: {},
+  codexQuota: {},
+  kimiQuota: {},
+  xaiQuota: {},
+});
+
+describe('resolveAccountQuota', () => {
+  it('keeps the account summary on Codex Main when Spark is more constrained', () => {
+    const file = {
+      name: 'codex.json',
+      type: 'codex',
+      authIndex: 'auth-1',
+    } as AuthFileItem;
+    const quota: CodexQuotaState = {
+      status: 'success',
+      windows: [
+        {
+          id: 'weekly',
+          label: 'Weekly',
+          usedPercent: 36,
+          resetLabel: 'main-reset',
+          modelScope: { kind: 'family', key: 'codex_main', complete: true },
+        },
+        {
+          id: 'spark-weekly-0',
+          label: 'Spark Weekly',
+          usedPercent: 95,
+          resetLabel: 'spark-reset',
+          modelScope: {
+            kind: 'models',
+            models: [CODEX_SPARK_MODEL_ID],
+            complete: true,
+          },
+        },
+      ],
+    };
+
+    const summary = resolveAccountQuota(file, emptyStores(), {
+      codexQuotaBySelectionKey: new Map([[getAuthFileSelectionKey(file), quota]]),
+    });
+
+    expect(summary).toMatchObject({
+      usedPercent: 36,
+      remainingPercent: 64,
+      resetLabel: 'main-reset',
+    });
+  });
+
+  it('does not treat a scoped Header observation as fresh account-wide quota evidence', () => {
+    const file = {
+      name: 'codex.json',
+      type: 'codex',
+      authIndex: 'auth-1',
+    } as AuthFileItem;
+    const quota: CodexQuotaState = {
+      status: 'success',
+      fetchedAtMs: 1_000,
+      observedAtMs: 2_000,
+      observedFromUsageHeaders: true,
+      observedModelScope: {
+        kind: 'models',
+        models: [CODEX_SPARK_MODEL_ID],
+        complete: true,
+      },
+      observedTraceId: 'spark-trace',
+      activeLimit: 'main',
+      windows: [
+        {
+          id: 'weekly',
+          label: 'Weekly',
+          usedPercent: 36,
+          resetLabel: 'main-reset',
+          modelScope: { kind: 'family', key: 'codex_main', complete: true },
+        },
+        {
+          id: 'spark-weekly-0',
+          label: 'Spark Weekly',
+          usedPercent: 0,
+          resetLabel: 'spark-reset',
+          modelScope: {
+            kind: 'models',
+            models: [CODEX_SPARK_MODEL_ID],
+            complete: true,
+          },
+        },
+      ],
+    };
+
+    const summary = resolveAccountQuota(file, emptyStores(), {
+      codexQuotaBySelectionKey: new Map([[getAuthFileSelectionKey(file), quota]]),
+    });
+
+    expect(summary).toMatchObject({
+      source: 'cache',
+      fetchedAtMs: 1_000,
+      observedAtMs: 2_000,
+      observedTraceId: 'spark-trace',
+      activeLimit: 'main',
+      usedPercent: 36,
+      remainingPercent: 64,
+    });
+    expect(summary.observedQuotaAtMs).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/accounts/model/accountQuotaSummary.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSummary.ts
@@ -25,6 +25,7 @@ import {
 } from '@/utils/usageHeaderSnapshots';
 import { resolveCodexPlanType } from '@/utils/quota/resolvers';
 import { getCredentialScopedQuotaState } from '@/utils/quota/credentialScope';
+import { isCodexMainQuotaModelScope, isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
 
 export type AccountQuotaStatus =
   | 'unknown'
@@ -536,6 +537,9 @@ const quotaFromUsedWindows = (
     options
   );
 
+const codexMainQuotaWindows = (quota: CodexQuotaState) =>
+  quota.windows.filter(isCodexMainQuotaWindow);
+
 const quotaFromXaiBilling = (
   billing: XaiBillingSummary | null | undefined,
   planType: string | null,
@@ -673,25 +677,48 @@ const quotaFromXaiBilling = (
 };
 
 const quotaObservationFields = (quota: CodexQuotaState): AccountQuotaObservationFields => {
+  const scopedHeaderObservation =
+    quota.observedFromUsageHeaders === true &&
+    (quota.observedModelScope === undefined ||
+      !isCodexMainQuotaModelScope(quota.observedModelScope));
+  const hasProviderSnapshot = quota.fetchedAtMs !== undefined;
+  const suppressAccountFields = scopedHeaderObservation && !hasProviderSnapshot;
   return {
-    source: quota.observedFromUsageHeaders ? 'observed-header' : 'cache',
+    source: scopedHeaderObservation
+      ? hasProviderSnapshot
+        ? 'cache'
+        : 'none'
+      : quota.observedFromUsageHeaders
+        ? 'observed-header'
+        : 'cache',
     fetchedAtMs: quota.fetchedAtMs,
     observedAtMs: quota.observedAtMs,
-    observedQuotaAtMs: quota.observedFromUsageHeaders ? quota.observedAtMs : undefined,
+    observedQuotaAtMs:
+      quota.observedFromUsageHeaders && !scopedHeaderObservation ? quota.observedAtMs : undefined,
     observedTraceId: quota.observedTraceId,
     observedErrorKind: quota.observedErrorKind,
     observedErrorCode: quota.observedErrorCode,
-    activeLimit: quota.activeLimit,
-    creditsBalance: quota.creditsBalance,
-    creditsHasCredits: quota.creditsHasCredits,
-    creditsUnlimited: quota.creditsUnlimited,
-    creditsOverageLimitReached: quota.creditsOverageLimitReached,
-    creditsApproxLocalMessages: quota.creditsApproxLocalMessages,
-    creditsApproxCloudMessages: quota.creditsApproxCloudMessages,
-    spendControlReached: quota.spendControlReached,
-    spendControlIndividualLimit: quota.spendControlIndividualLimit,
-    rateLimitReachedType: quota.rateLimitReachedType,
-    primaryOverSecondaryLimitPercent: quota.primaryOverSecondaryLimitPercent,
+    activeLimit: suppressAccountFields ? undefined : quota.activeLimit,
+    creditsBalance: suppressAccountFields ? undefined : quota.creditsBalance,
+    creditsHasCredits: suppressAccountFields ? undefined : quota.creditsHasCredits,
+    creditsUnlimited: suppressAccountFields ? undefined : quota.creditsUnlimited,
+    creditsOverageLimitReached: suppressAccountFields
+      ? undefined
+      : quota.creditsOverageLimitReached,
+    creditsApproxLocalMessages: suppressAccountFields
+      ? undefined
+      : quota.creditsApproxLocalMessages,
+    creditsApproxCloudMessages: suppressAccountFields
+      ? undefined
+      : quota.creditsApproxCloudMessages,
+    spendControlReached: suppressAccountFields ? undefined : quota.spendControlReached,
+    spendControlIndividualLimit: suppressAccountFields
+      ? undefined
+      : quota.spendControlIndividualLimit,
+    rateLimitReachedType: suppressAccountFields ? undefined : quota.rateLimitReachedType,
+    primaryOverSecondaryLimitPercent: suppressAccountFields
+      ? undefined
+      : quota.primaryOverSecondaryLimitPercent,
   };
 };
 
@@ -700,19 +727,31 @@ const quotaObservationFieldsFromSnapshot = (
 ): AccountQuotaObservationFields => {
   if (!hasUsageHeaderDiagnosticSignal(snapshot)) return {};
   const observedQuota = buildObservedCodexQuotaFromHeaderSnapshot(snapshot);
+  const accountQuotaObservation =
+    observedQuota !== null && isCodexMainQuotaModelScope(observedQuota.quotaScope.modelScope);
   return {
-    source: 'observed-header',
+    source: observedQuota === null || accountQuotaObservation ? 'observed-header' : undefined,
     observedAtMs: snapshot?.timestamp_ms,
-    observedQuotaAtMs: observedQuota ? snapshot?.timestamp_ms : undefined,
+    observedQuotaAtMs: accountQuotaObservation ? snapshot?.timestamp_ms : undefined,
     observedTraceId: getHeaderSnapshotTraceId(snapshot) || undefined,
     observedErrorKind: getHeaderSnapshotErrorKind(snapshot) || undefined,
     observedErrorCode: getHeaderSnapshotErrorCode(snapshot) || undefined,
-    activeLimit: observedQuota?.activeLimit ?? undefined,
-    creditsBalance: observedQuota?.creditsBalance ?? undefined,
-    creditsHasCredits: observedQuota?.creditsHasCredits ?? undefined,
-    creditsUnlimited: observedQuota?.creditsUnlimited ?? undefined,
-    rateLimitReachedType: observedQuota?.rateLimitReachedType ?? undefined,
-    primaryOverSecondaryLimitPercent: observedQuota?.primaryOverSecondaryLimitPercent ?? undefined,
+    activeLimit: accountQuotaObservation ? (observedQuota?.activeLimit ?? undefined) : undefined,
+    creditsBalance: accountQuotaObservation
+      ? (observedQuota?.creditsBalance ?? undefined)
+      : undefined,
+    creditsHasCredits: accountQuotaObservation
+      ? (observedQuota?.creditsHasCredits ?? undefined)
+      : undefined,
+    creditsUnlimited: accountQuotaObservation
+      ? (observedQuota?.creditsUnlimited ?? undefined)
+      : undefined,
+    rateLimitReachedType: accountQuotaObservation
+      ? (observedQuota?.rateLimitReachedType ?? undefined)
+      : undefined,
+    primaryOverSecondaryLimitPercent: accountQuotaObservation
+      ? (observedQuota?.primaryOverSecondaryLimitPercent ?? undefined)
+      : undefined,
   };
 };
 
@@ -851,7 +890,10 @@ export const resolveAccountQuota = (
       if (quota.windows.length > 0) {
         return mergeQuotaObservationFields(
           {
-            ...quotaFromUsedWindows(quota.windows, quota.planType ?? observedPlanType),
+            ...quotaFromUsedWindows(
+              codexMainQuotaWindows(quota),
+              quota.planType ?? observedPlanType
+            ),
             error: quota.error,
             errorStatus: quota.errorStatus,
             fetchedAtMs: quota.fetchedAtMs,
@@ -880,7 +922,7 @@ export const resolveAccountQuota = (
       return mergeQuotaObservationFields(
         {
           ...quotaFromUsedWindows(
-            quota.windows,
+            codexMainQuotaWindows(quota),
             quota.planType ?? observedPlanType,
             quotaObservationFields(quota)
           ),
@@ -891,7 +933,7 @@ export const resolveAccountQuota = (
     }
     return mergeQuotaObservationFields(
       quotaFromUsedWindows(
-        quota.windows,
+        codexMainQuotaWindows(quota),
         quota.planType ?? observedPlanType,
         quotaObservationFields(quota)
       ),

--- a/apps/web/src/features/accounts/model/accountQuotaWindowDefinitions.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaWindowDefinitions.ts
@@ -31,6 +31,7 @@ export interface AccountQuotaWindowDefinition {
   kind: AccountQuotaWindowKind;
   windowMode: QuotaWindowMode;
   modelScope: QuotaModelScope;
+  providerWindowAliases?: string[];
   observationSource: QuotaObservationSource;
   observedAtMs: number | null;
   boundaryAccuracy: AccountQuotaBoundaryAccuracy;
@@ -105,6 +106,7 @@ export const buildAccountQuotaWindowDefinitions = (
         kind: window.kind ?? 'unknown',
         windowMode: window.windowMode ?? 'unknown',
         modelScope: window.modelScope ?? { kind: 'all', complete: false },
+        providerWindowAliases: window.providerWindowAliases,
         observationSource: window.observationSource ?? 'api_query',
         observedAtMs: window.observedAtMs ?? null,
         boundaryAccuracy,

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -26,6 +26,8 @@ import {
 } from '@/utils/quota/credentialScope';
 import type { AccountCredentialEvidenceBoundary } from './accountCredentialEvidence';
 
+const CODEX_MAIN_SCOPE = { kind: 'family', key: 'codex_main', complete: true } as const;
+
 const emptyStores = (): AccountQuotaStores => ({
   antigravityQuota: {},
   claudeQuota: {},
@@ -428,6 +430,7 @@ describe('accountRows', () => {
               resetLabel: '2026-07-30T04:00:00Z',
               resetAtMs: earlierResetAtMs,
               resetAccuracy: 'exact',
+              modelScope: CODEX_MAIN_SCOPE,
             },
             {
               id: 'weekly-model',
@@ -436,6 +439,7 @@ describe('accountRows', () => {
               resetLabel: '2026-07-30T06:00:00Z',
               resetAtMs: laterResetAtMs,
               resetAccuracy: 'exact',
+              modelScope: CODEX_MAIN_SCOPE,
             },
           ],
         },
@@ -464,6 +468,7 @@ describe('accountRows', () => {
               resetLabel: '2026-07-30T04:00:00Z',
               resetAtMs: Date.parse('2026-07-30T04:00:00Z'),
               resetAccuracy: 'exact',
+              modelScope: CODEX_MAIN_SCOPE,
             },
             {
               id: 'weekly-unknown',
@@ -472,6 +477,7 @@ describe('accountRows', () => {
               resetLabel: '-',
               resetAtMs: null,
               resetAccuracy: 'unknown',
+              modelScope: CODEX_MAIN_SCOPE,
             },
           ],
         },
@@ -652,9 +658,11 @@ describe('accountRows', () => {
                 label: 'Latest request',
                 usedPercent: 100,
                 resetLabel: '2026-06-25 10:00',
+                modelScope: CODEX_MAIN_SCOPE,
               },
             ],
             observedFromUsageHeaders: true,
+            observedModelScope: CODEX_MAIN_SCOPE,
             observedAtMs: 1000,
             observedTraceId: 'trace-observed',
             observedErrorKind: 'rate_limit',
@@ -752,15 +760,32 @@ describe('accountRows', () => {
             'shared.codex.json\u00000',
             {
               status: 'success',
-              windows: [{ id: 'a', label: 'A', usedPercent: 10, resetLabel: 'A reset' }],
+              windows: [
+                {
+                  id: 'a',
+                  label: 'A',
+                  usedPercent: 10,
+                  resetLabel: 'A reset',
+                  modelScope: CODEX_MAIN_SCOPE,
+                },
+              ],
             },
           ],
           [
             'shared.codex.json\u00001',
             {
               status: 'success',
-              windows: [{ id: 'b', label: 'B', usedPercent: 90, resetLabel: 'B reset' }],
+              windows: [
+                {
+                  id: 'b',
+                  label: 'B',
+                  usedPercent: 90,
+                  resetLabel: 'B reset',
+                  modelScope: CODEX_MAIN_SCOPE,
+                },
+              ],
               observedFromUsageHeaders: true,
+              observedModelScope: CODEX_MAIN_SCOPE,
               observedTraceId: 'trace-auth-index-1',
             },
           ],

--- a/apps/web/src/features/accounts/model/accountWindowUsageRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountWindowUsageRows.test.ts
@@ -41,7 +41,10 @@ describe('accountWindowUsageRows', () => {
     expect(entries[0]).toMatchObject({
       rowKey: row.selectionKey,
       windowKey: '5h',
-      requestKey: accountWindowUsageRequestKey(row.selectionKey, '5h'),
+      requestKey: accountWindowUsageRequestKey(row.selectionKey, '5h', 'current', {
+        kind: 'all',
+        complete: true,
+      }),
       target: {
         row_key: row.selectionKey,
         window_key: '5h',
@@ -108,7 +111,14 @@ describe('accountWindowUsageRows', () => {
       },
     ]);
 
-    expect(byKey.get(accountWindowUsageRequestKey(row.selectionKey, '5h'))).toMatchObject({
+    expect(
+      byKey.get(
+        accountWindowUsageRequestKey(row.selectionKey, '5h', 'current', {
+          kind: 'all',
+          complete: true,
+        })
+      )
+    ).toMatchObject({
       matched: true,
       total_requests: 32,
       total_cost: 5.2,
@@ -285,7 +295,7 @@ describe('accountWindowUsageRows', () => {
     expect(byKey).toHaveLength(0);
   });
 
-  it('skips an incomplete model scope without dropping other quota windows', () => {
+  it('skips incomplete model and feature scopes without dropping other quota windows', () => {
     const row = makeRow({});
     const incompleteDefinition = {
       key: 'weekly-scoped-label-only',
@@ -317,11 +327,31 @@ describe('accountWindowUsageRows', () => {
         toMs: 5_000,
       },
     } satisfies AccountQuotaWindowDefinition;
+    const incompleteFeatureDefinition = {
+      ...incompleteDefinition,
+      key: 'future-feature-weekly-0',
+      providerWindowId: 'future-feature-weekly-0',
+      provider: 'codex',
+      label: 'Future Feature',
+      modelScope: { kind: 'feature', key: 'future_feature', complete: false },
+      display: {
+        ...incompleteDefinition.display,
+        key: 'future-feature-weekly-0',
+        label: 'Future Feature',
+      },
+    } satisfies AccountQuotaWindowDefinition;
 
     const entries = buildAccountWindowUsageTargetEntries(
       [row],
       new Map([
-        [row.selectionKey, [{ key: '5h', fromMs: 1000, toMs: 2000 }, incompleteDefinition]],
+        [
+          row.selectionKey,
+          [
+            { key: '5h', fromMs: 1000, toMs: 2000 },
+            incompleteDefinition,
+            incompleteFeatureDefinition,
+          ],
+        ],
       ]),
       5_000
     );

--- a/apps/web/src/features/accounts/model/accountWindowUsageRows.ts
+++ b/apps/web/src/features/accounts/model/accountWindowUsageRows.ts
@@ -33,6 +33,7 @@ const modelScopeRequestPart = (scope: MonitoringAccountWindowModelScope | undefi
   JSON.stringify([
     (scope?.kind ?? 'all').trim().toLowerCase(),
     scope?.key?.trim().toLowerCase() ?? '',
+    scope?.complete !== false,
     ...Array.from(
       new Set((scope?.models ?? []).map((model) => model.trim().toLowerCase()).filter(Boolean))
     ).sort(),
@@ -105,8 +106,9 @@ export const buildAccountWindowUsageTargetEntries = (
             kind: window.modelScope.kind,
             key: window.modelScope.key,
             models: window.modelScope.models,
+            complete: window.modelScope.complete !== false,
           }
-        : (window.modelScope ?? { kind: 'all' });
+        : (window.modelScope ?? { kind: 'all', complete: true });
       const ranges = isQuotaWindowDefinition(window)
         ? buildAccountQuotaUsageRanges(window, nowMs)
         : window.fromMs && window.toMs && window.fromMs < window.toMs

--- a/apps/web/src/features/authFiles/model/credentialStatus.test.ts
+++ b/apps/web/src/features/authFiles/model/credentialStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AuthFileItem, CodexQuotaState } from '@/types';
 import type { UsageHeaderSnapshot } from '@/services/api/usageService';
 import { formatQuotaResetTime } from '@/utils/quota/formatters';
+import { CODEX_SPARK_MODEL_ID } from '@/utils/quota/codexQuota';
 import {
   authFileMatchesCodexStatusFilter,
   buildAuthFileCodexInspectionMap,
@@ -33,6 +34,9 @@ const codexFile = (overrides: Partial<AuthFileItem> = {}): AuthFileItem => ({
   ...overrides,
 });
 
+const CODEX_MAIN_MODEL = 'gpt-5.6-sol';
+const CODEX_MAIN_SCOPE = { kind: 'family', key: 'codex_main', complete: true } as const;
+
 const codexQuota = (overrides: Partial<CodexQuotaState> = {}): CodexQuotaState => ({
   status: 'success',
   windows: [
@@ -42,6 +46,7 @@ const codexQuota = (overrides: Partial<CodexQuotaState> = {}): CodexQuotaState =
       usedPercent: 10,
       resetLabel: '06/01 17:00',
       limitWindowSeconds: 18_000,
+      modelScope: CODEX_MAIN_SCOPE,
     },
     {
       id: 'weekly',
@@ -49,6 +54,7 @@ const codexQuota = (overrides: Partial<CodexQuotaState> = {}): CodexQuotaState =
       usedPercent: 100,
       resetLabel: '06/04 12:00',
       limitWindowSeconds: 604_800,
+      modelScope: CODEX_MAIN_SCOPE,
     },
   ],
   ...overrides,
@@ -468,6 +474,7 @@ describe('auth file Codex status helpers', () => {
     const usageLimitSnapshot: UsageHeaderSnapshot = {
       event_hash: 'usage-limit',
       timestamp_ms: 1_700_000_000_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           rate_limit_reached_type: 'workspace_member_credits_depleted',
@@ -496,6 +503,7 @@ describe('auth file Codex status helpers', () => {
       const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, {
         event_hash: `quota-error-${errorCode}`,
         timestamp_ms: 1_700_000_000_000,
+        model: CODEX_MAIN_MODEL,
         header_error_kind: 'rate_limit',
         header_error_code: errorCode,
       });
@@ -505,10 +513,40 @@ describe('auth file Codex status helpers', () => {
     }
   );
 
+  it('does not promote Spark-only quota headers to account credential status', () => {
+    const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, {
+      event_hash: 'spark-quota-error',
+      timestamp_ms: 1_700_000_000_000,
+      model: CODEX_SPARK_MODEL_ID,
+      header_error_kind: 'rate_limit',
+      header_error_code: 'insufficient_quota',
+    });
+
+    expect(status.isQuotaLimited).toBe(false);
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_quota');
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_error');
+  });
+
+  it('does not promote quota metadata without model identity to account credential status', () => {
+    const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, {
+      event_hash: 'unknown-scope-quota-error',
+      timestamp_ms: 1_700_000_000_000,
+      header_quota_used_percent: 100,
+      header_quota_recover_at_ms: 1_700_000_060_000,
+      header_error_kind: 'rate_limit',
+      header_error_code: 'insufficient_quota',
+    });
+
+    expect(status.isQuotaLimited).toBe(false);
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_quota');
+    expect(status.badges.map((badge) => badge.kind)).not.toContain('observed_error');
+  });
+
   it('uses observed reached window metadata for specific quota status filters', () => {
     const usageLimitSnapshot: UsageHeaderSnapshot = {
       event_hash: 'usage-limit-weekly',
       timestamp_ms: 1_700_000_000_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           rate_limit_reached_type: 'secondary',
@@ -536,6 +574,7 @@ describe('auth file Codex status helpers', () => {
     const usageLimitSnapshot: UsageHeaderSnapshot = {
       event_hash: 'usage-limit-five-hour-under-limit',
       timestamp_ms: 1_700_000_000_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           rate_limit_reached_type: 'primary',
@@ -567,6 +606,7 @@ describe('auth file Codex status helpers', () => {
     const usageLimitSnapshot: UsageHeaderSnapshot = {
       event_hash: 'usage-limit-weekly-under-limit',
       timestamp_ms: 1_700_000_000_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           rate_limit_reached_type: 'secondary',
@@ -598,6 +638,7 @@ describe('auth file Codex status helpers', () => {
     const usageLimitSnapshot: UsageHeaderSnapshot = {
       event_hash: 'usage-limit-monthly-under-limit',
       timestamp_ms: 1_700_000_000_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           rate_limit_reached_type: 'secondary',
@@ -629,6 +670,7 @@ describe('auth file Codex status helpers', () => {
     const usageLimitSnapshot: UsageHeaderSnapshot = {
       event_hash: 'usage-limit-five-hour-full',
       timestamp_ms: 1_700_000_000_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           rate_limit_reached_type: 'primary',
@@ -1030,6 +1072,7 @@ describe('auth file Codex status helpers', () => {
     const headerSnapshot: UsageHeaderSnapshot = {
       event_hash: 'newer-authenticated-quota',
       timestamp_ms: 1_700_000_001_000,
+      model: CODEX_MAIN_MODEL,
       header_quota_used_percent: 100,
       header_quota_recover_at_ms: 1_700_000_100_000,
     };
@@ -1198,6 +1241,7 @@ describe('auth file Codex status helpers', () => {
     const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, {
       event_hash: 'rate-limit-reached',
       timestamp_ms: 1_000,
+      model: CODEX_MAIN_MODEL,
       header_error_kind: 'rate_limit',
       header_error_code: 'rate_limit_reached',
     });
@@ -1215,6 +1259,7 @@ describe('auth file Codex status helpers', () => {
       const status = getAuthFileCodexStatus(codexFile(), undefined, undefined, {
         event_hash: code,
         timestamp_ms: 1_000,
+        model: CODEX_MAIN_MODEL,
         header_error_kind: 'rate_limit',
         header_error_code: code,
       });
@@ -1229,6 +1274,7 @@ describe('auth file Codex status helpers', () => {
     const headerSnapshot: UsageHeaderSnapshot = {
       event_hash: 'mixed-auth-quota-header',
       timestamp_ms: 1_000,
+      model: CODEX_MAIN_MODEL,
       header_error_kind: 'auth',
       header_error_code: 'invalid_api_key',
       header_quota_used_percent: 100,
@@ -1320,6 +1366,7 @@ describe('auth file Codex status helpers', () => {
     const headerSnapshot: UsageHeaderSnapshot = {
       event_hash: 'older-quota-header',
       timestamp_ms: 1_000,
+      model: CODEX_MAIN_MODEL,
       header_error_kind: 'rate_limit',
       header_error_code: 'quota_exceeded',
     };
@@ -1348,6 +1395,7 @@ describe('auth file Codex status helpers', () => {
     const headerSnapshot: UsageHeaderSnapshot = {
       event_hash: 'same-time-mixed-header',
       timestamp_ms: 2_000,
+      model: CODEX_MAIN_MODEL,
       header_error_kind: 'auth',
       header_error_code: 'invalid_api_key',
       header_quota_used_percent: 100,
@@ -1546,6 +1594,7 @@ describe('auth file Codex status helpers', () => {
     const headerSnapshot: UsageHeaderSnapshot = {
       event_hash: 'unknown-window-exhausted',
       timestamp_ms: 2_000,
+      model: CODEX_MAIN_MODEL,
       response_metadata: {
         quota: {
           primary: { used_percent: 100, window_minutes: 60 },

--- a/apps/web/src/features/authFiles/model/credentialStatus.ts
+++ b/apps/web/src/features/authFiles/model/credentialStatus.ts
@@ -14,6 +14,11 @@ import {
   hasUsageHeaderQuotaSignal,
 } from '@/utils/usageHeaderSnapshots';
 import {
+  isCodexMainQuotaModelScope,
+  isCodexMainQuotaWindow,
+  resolveCodexUsageQuotaScope,
+} from '@/utils/quota/codexQuota';
+import {
   getAuthFileStatusMessage,
   isHealthyAuthFileStatusMessage,
   isRuntimeOnlyAuthFile,
@@ -290,13 +295,52 @@ const findCodexQuotaWindow = (
   preferredMatch: (window: CodexQuotaState['windows'][number]) => boolean,
   limitWindowSeconds: number
 ) => {
-  const windows = quota?.windows ?? [];
+  const windows = (quota?.windows ?? []).filter(isCodexMainQuotaWindow);
   return (
     windows.find(preferredMatch) ??
     windows.find(
       (window) => normalizeWindowSeconds(window.limitWindowSeconds) === limitWindowSeconds
     ) ??
     null
+  );
+};
+
+const isMainCodexHeaderQuota = (snapshot: UsageHeaderSnapshot | undefined): boolean => {
+  if (!snapshot) return true;
+  const hasModelIdentity = [
+    snapshot.model,
+    snapshot.analytics_model,
+    snapshot.requested_model,
+    snapshot.resolved_model,
+  ].some((value) => typeof value === 'string' && value.trim() !== '');
+  if (!hasModelIdentity) {
+    // Preserve neutral diagnostics such as Retry-After/request errors, but do
+    // not let any quota-bearing or quota-limit header without model identity
+    // become account-wide Codex evidence.
+    const hasQuotaMetadata =
+      (snapshot.header_quota_used_percent !== null &&
+        snapshot.header_quota_used_percent !== undefined) ||
+      (snapshot.header_quota_recover_at_ms !== null &&
+        snapshot.header_quota_recover_at_ms !== undefined) ||
+      Boolean(snapshot.header_quota_plan_type?.trim()) ||
+      Boolean(snapshot.response_metadata?.quota) ||
+      Boolean(snapshot.response_metadata?.rate_limit) ||
+      Boolean(snapshot.response_metadata?.provider_usage);
+    return (
+      !hasQuotaMetadata &&
+      !isObservedQuotaLimitError(
+        getHeaderSnapshotErrorKind(snapshot),
+        getHeaderSnapshotErrorCode(snapshot)
+      )
+    );
+  }
+  return isCodexMainQuotaModelScope(
+    resolveCodexUsageQuotaScope({
+      model: snapshot.model,
+      analyticsModel: snapshot.analytics_model,
+      requestedModel: snapshot.requested_model,
+      resolvedModel: snapshot.resolved_model,
+    }).modelScope
   );
 };
 
@@ -812,7 +856,8 @@ const getQuotaCredentialEvidence = (
 
 const getHeaderCredentialEvidence = (
   headerSnapshot: UsageHeaderSnapshot | undefined,
-  nowMs: number
+  nowMs: number,
+  isCodex: boolean
 ): AuthFileCredentialEvidence | null => {
   if (!headerSnapshot) return null;
   const errorKind = getHeaderSnapshotErrorKind(headerSnapshot);
@@ -825,6 +870,10 @@ const getHeaderCredentialEvidence = (
   if (authorizationError || isObservedAuthError(errorKind, `${errorCode} ${authorizationError}`)) {
     return { direction: 'negative', observedAtMs, statusCode };
   }
+  // A scoped Codex response can legitimately report its own quota state. It
+  // must not become positive credential evidence or suppress a real account
+  // failure; explicit authentication errors above remain credential-wide.
+  if (isCodex && !isMainCodexHeaderQuota(headerSnapshot)) return null;
   if (isQualifiedHeaderCredentialStatusSource(headerSnapshot, nowMs)) {
     return { direction: 'positive', observedAtMs, statusCode };
   }
@@ -1135,34 +1184,41 @@ export const getAuthFileCodexStatus = (
   const inspectionUsedPercent =
     inspection?.isQuota === true ? normalizeNumber(inspection?.usedPercent) : null;
   const action = typeof inspection?.action === 'string' ? inspection.action : '';
-  const providerUsage = headerSnapshot?.response_metadata?.provider_usage;
+  const accountHeaderSnapshot =
+    !isCodex || isMainCodexHeaderQuota(headerSnapshot) ? headerSnapshot : undefined;
+  const providerUsage = accountHeaderSnapshot?.response_metadata?.provider_usage;
   const observedProviderUsageLimited = isProviderUsageQuotaLimited(providerUsage, nowMs);
-  const observedUsedPercent = getHeaderSnapshotUsedPercent(headerSnapshot);
+  const observedUsedPercent = getHeaderSnapshotUsedPercent(accountHeaderSnapshot);
   const observedRecoverAtMS =
-    getHeaderSnapshotRecoverAtMs(headerSnapshot) ??
+    getHeaderSnapshotRecoverAtMs(accountHeaderSnapshot) ??
     (observedProviderUsageLimited ? normalizeNumber(providerUsage?.recover_at_ms) : null);
   const observedRecoverLabel = formatObservedRecoverLabel(observedRecoverAtMS);
-  const observedErrorKind = getHeaderSnapshotErrorKind(headerSnapshot);
-  const observedErrorCode = getHeaderSnapshotErrorCode(headerSnapshot);
-  const observedTraceID = getHeaderSnapshotTraceId(headerSnapshot);
-  const observedReachedWindowKind = getHeaderSnapshotReachedWindowKind(headerSnapshot);
-  const observedSummaryWindowKind = getHeaderSnapshotSummaryWindowKind(headerSnapshot);
+  const observedErrorKind = getHeaderSnapshotErrorKind(accountHeaderSnapshot);
+  const observedErrorCode = getHeaderSnapshotErrorCode(accountHeaderSnapshot);
+  const observedTraceID = getHeaderSnapshotTraceId(accountHeaderSnapshot);
+  const observedAccountQuotaErrorKind = getHeaderSnapshotErrorKind(accountHeaderSnapshot);
+  const observedAccountQuotaErrorCode = getHeaderSnapshotErrorCode(accountHeaderSnapshot);
+  const observedReachedWindowKind = getHeaderSnapshotReachedWindowKind(accountHeaderSnapshot);
+  const observedSummaryWindowKind = getHeaderSnapshotSummaryWindowKind(accountHeaderSnapshot);
   const observedRateLimitReachedType =
-    typeof headerSnapshot?.response_metadata?.quota?.rate_limit_reached_type === 'string'
-      ? headerSnapshot.response_metadata.quota.rate_limit_reached_type.trim()
+    typeof accountHeaderSnapshot?.response_metadata?.quota?.rate_limit_reached_type === 'string'
+      ? accountHeaderSnapshot.response_metadata.quota.rate_limit_reached_type.trim()
       : '';
-  const observedUnknownUsedPercent = getHeaderSnapshotWindowUsedPercent(headerSnapshot, 'unknown');
+  const observedUnknownUsedPercent = getHeaderSnapshotWindowUsedPercent(
+    accountHeaderSnapshot,
+    'unknown'
+  );
   const observedQuotaLimited =
     (observedUsedPercent !== null && observedUsedPercent >= 100) ||
     (observedUnknownUsedPercent !== null && observedUnknownUsedPercent >= 100) ||
     observedProviderUsageLimited ||
     Boolean(observedRateLimitReachedType) ||
-    isObservedQuotaLimitError(observedErrorKind, observedErrorCode);
+    isObservedQuotaLimitError(observedAccountQuotaErrorKind, observedAccountQuotaErrorCode);
   const observedLimitWindowKind =
     observedReachedWindowKind ??
     (observedUsedPercent !== null && observedUsedPercent >= 100 ? observedSummaryWindowKind : null);
   const getObservedWindowUsedPercent = (windowKind: 'five_hour' | 'weekly' | 'monthly') =>
-    getHeaderSnapshotWindowUsedPercent(headerSnapshot, windowKind) ??
+    getHeaderSnapshotWindowUsedPercent(accountHeaderSnapshot, windowKind) ??
     (observedLimitWindowKind === windowKind ? observedUsedPercent : null);
   const observedFiveHourUsedPercent = getObservedWindowUsedPercent('five_hour');
   const observedWeeklyUsedPercent = getObservedWindowUsedPercent('weekly');
@@ -1196,7 +1252,7 @@ export const getAuthFileCodexStatus = (
     options.ignoreRawStatusCode ? null : getAuthFileCredentialEvidence(file),
     getInspectionCredentialEvidence(inspection),
     getQuotaCredentialEvidence(file, quota),
-    getHeaderCredentialEvidence(headerSnapshot, nowMs),
+    getHeaderCredentialEvidence(headerSnapshot, nowMs, isCodex),
   ];
   const currentAuthenticationFailure = selectCurrentAuthenticationFailure(credentialEvidences);
   const inspectionErrorKind =

--- a/apps/web/src/features/demo/demoFixtures.ts
+++ b/apps/web/src/features/demo/demoFixtures.ts
@@ -5611,7 +5611,7 @@ export const getDemoAccountWindowUsage = (
           success_rate: null,
           last_seen_ms: null,
           sync_status: 'empty',
-          scope_match_status: window.model_scope?.kind === 'all' ? 'complete' : 'unmatched',
+          scope_match_status: window.model_scope?.complete === false ? 'unmatched' : 'complete',
           unmatched_requests: 0,
         };
       }
@@ -6559,6 +6559,8 @@ export const getDemoCodexInspectionLocalRun = (baseNow = now()): CodexInspection
         resetAtMs: window.resetAtMs ?? null,
         resetAccuracy: window.resetAccuracy,
         limitWindowSeconds: window.limitWindowSeconds ?? null,
+        modelScope: window.modelScope,
+        providerWindowAliases: window.providerWindowAliases,
       })),
       errorKind: item.errorKind,
       errorDetail: item.errorDetail,

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
@@ -635,6 +635,8 @@ export function toServerResultItem(
       resetAtMs: window.resetAtMs ?? null,
       resetAccuracy: window.resetAccuracy,
       limitWindowSeconds: window.limitWindowSeconds ?? null,
+      modelScope: window.modelScope,
+      providerWindowAliases: window.providerWindowAliases,
     })),
     quotaInventoryObserved: item.quotaInventoryObserved,
     errorKind: item.errorKind,

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -4888,6 +4888,14 @@ describe('Codex inspection last-run cache', () => {
               resetAtMs: Date.parse('2026-06-18T04:00:00Z'),
               resetAccuracy: 'exact',
               limitWindowSeconds: 2_592_000,
+              modelScope: { kind: 'family', key: 'codex_main', complete: true },
+            },
+            {
+              id: 'gpt-5-3-codex-spark-weekly-0',
+              labelKey: 'codex_quota.additional_secondary_window',
+              usedPercent: 0,
+              resetLabel: '06/20 12:00',
+              limitWindowSeconds: 604_800,
             },
           ],
           error: 'HTTP 402',
@@ -4912,10 +4920,104 @@ describe('Codex inspection last-run cache', () => {
         resetAtMs: Date.parse('2026-06-18T04:00:00Z'),
         resetAccuracy: 'exact',
         limitWindowSeconds: 2_592_000,
+        modelScope: { kind: 'family', key: 'codex_main', models: undefined, complete: true },
+      },
+      {
+        id: 'spark-weekly-0',
+        labelKey: 'codex_quota.additional_secondary_window',
+        labelParams: undefined,
+        usedPercent: 0,
+        resetLabel: '06/20 12:00',
+        limitWindowSeconds: 604_800,
+        modelScope: {
+          kind: 'models',
+          key: undefined,
+          models: ['gpt-5.3-codex-spark'],
+          complete: true,
+        },
       },
     ]);
     expect(loaded?.result.results[0].errorKind).toBe('http_status');
     expect(loaded?.result.results[0].errorDetail).toContain('limit reached');
+  });
+
+  it('reclassifies legacy Spark inspection windows that were persisted as account-wide', () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const baseResult = createRunResult();
+
+    storage.setItem(
+      CODEX_INSPECTION_LAST_RUN_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: 2000,
+        result: {
+          ...baseResult,
+          results: [
+            createResultItem('keep', {
+              quotaWindows: [
+                {
+                  id: 'fast-coding-weekly-0',
+                  labelKey: 'codex_quota.additional_secondary_window',
+                  usedPercent: 0,
+                  resetLabel: '06/20 12:00',
+                  limitWindowSeconds: 604_800,
+                  modelScope: { kind: 'all', complete: true },
+                },
+              ],
+            }),
+          ],
+        },
+        logs: [],
+      })
+    );
+
+    const loaded = loadCodexInspectionLastRun();
+    expect(loaded?.result.results[0].quotaWindows).toEqual([
+      expect.objectContaining({
+        id: 'fast-coding-weekly-0',
+        modelScope: {
+          kind: 'models',
+          models: ['gpt-5.3-codex-spark'],
+          complete: true,
+        },
+      }),
+    ]);
+  });
+
+  it('restores a legacy Team monthly secondary window using its duration', () => {
+    const baseResult = createRunResult();
+    const restored = hydrateCodexInspectionLastRun({
+      version: 1,
+      savedAt: 2000,
+      result: {
+        ...baseResult,
+        results: [
+          createResultItem('keep', {
+            planType: 'team',
+            quotaWindows: [
+              {
+                id: 'secondary',
+                labelKey: 'codex_quota.monthly_window',
+                usedPercent: 12,
+                resetLabel: '07/20 12:00',
+                limitWindowSeconds: 2_592_000,
+                modelScope: { kind: 'all', complete: true },
+              },
+            ],
+          }),
+        ],
+      },
+      logs: [],
+    });
+
+    expect(restored?.result.results[0].quotaWindows).toEqual([
+      expect.objectContaining({
+        id: 'monthly',
+        limitWindowSeconds: 2_592_000,
+        modelScope: { kind: 'family', key: 'codex_main', complete: true },
+      }),
+    ]);
   });
 
   it('stores and restores terminal local action handling state', () => {

--- a/apps/web/src/features/monitoring/codexInspection.ts
+++ b/apps/web/src/features/monitoring/codexInspection.ts
@@ -2,7 +2,7 @@ import { authFilesApi, type AuthFilesApiRequestScope } from '@/services/api/auth
 import { createScopedApiRequestConfig } from '@/services/api/client';
 import type { TFunction } from 'i18next';
 import { getApiCallErrorMessage } from '@/services/api/apiCall';
-import type { AuthFileItem, Config } from '@/types';
+import type { AuthFileItem, Config, QuotaModelScope } from '@/types';
 import {
   CODEX_INSPECTION_AUTO_ACTION_MODES,
   CODEX_INSPECTION_SETTINGS_STORAGE_KEY,
@@ -155,6 +155,8 @@ export interface CodexInspectionQuotaWindow {
   resetAtMs?: number | null;
   resetAccuracy?: 'exact' | 'derived' | 'estimated' | 'unknown';
   limitWindowSeconds: number | null;
+  modelScope?: QuotaModelScope;
+  providerWindowAliases?: string[];
 }
 
 export interface CodexInspectionResultItem extends CodexInspectionAccount {

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -2,7 +2,7 @@ import type { TFunction } from 'i18next';
 import type { MonitoringAccountAuthState } from '@/features/monitoring/accountOverviewState';
 import type { MonitoringAccountQuotaProvider } from '@/features/monitoring/accountOverviewQuotaTargets';
 import type { MonitoringAccountRow } from '@/features/monitoring/hooks/useMonitoringData';
-import type { QuotaResetAccuracy } from '@/types';
+import type { QuotaModelScope, QuotaResetAccuracy } from '@/types';
 import { normalizePlanType } from '@/utils/quota';
 import {
   formatQuotaResetTime,
@@ -21,6 +21,8 @@ export type AccountQuotaWindow = {
   resetAtMs?: number | null;
   resetAccuracy?: QuotaResetAccuracy;
   usageLabel: string | null;
+  modelScope?: QuotaModelScope;
+  providerWindowAliases?: string[];
 };
 
 export type AccountQuotaEntry = {

--- a/apps/web/src/features/monitoring/model/codexInspectionStorage.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionStorage.ts
@@ -11,6 +11,12 @@ import type {
 } from '@/features/monitoring/codexInspection';
 import { normalizeNumberValue } from '@/utils/quota';
 import {
+  canonicalizeCodexProviderWindowId,
+  inferCodexQuotaScopeFromProviderWindowId,
+  normalizeCodexModelId,
+} from '@/utils/quota/codexQuota';
+import type { QuotaModelScope, QuotaModelScopeKind } from '@/types';
+import {
   DEFAULT_CODEX_INSPECTION_SETTINGS,
   clampPositiveInteger,
   isRecord,
@@ -140,25 +146,127 @@ const normalizeQuotaResetAccuracy = (
   }
 };
 
+const QUOTA_MODEL_SCOPE_KINDS = new Set<QuotaModelScopeKind>([
+  'all',
+  'family',
+  'models',
+  'product',
+  'feature',
+]);
+
+const inferStoredCodexWindowKind = (
+  providerWindowId: string,
+  limitWindowSeconds: number | null,
+  labelKey?: string
+): string | undefined => {
+  if (limitWindowSeconds !== null) {
+    if (limitWindowSeconds === 18_000) return 'five_hour';
+    if (limitWindowSeconds === 604_800) return 'weekly';
+    if (limitWindowSeconds >= 28 * 24 * 60 * 60 && limitWindowSeconds <= 31 * 24 * 60 * 60) {
+      return 'monthly';
+    }
+  }
+  const identity = `${providerWindowId} ${labelKey ?? ''}`.toLowerCase();
+  if (/(^|[-_.])five[-_ ]?hour($|[-_.])/.test(identity)) return 'five_hour';
+  if (/(^|[-_.])weekly($|[-_.])/.test(identity)) return 'weekly';
+  if (/(^|[-_.])monthly($|[-_.])/.test(identity)) return 'monthly';
+  return undefined;
+};
+
+const canonicalizeStoredCodexProviderWindowId = (
+  value: string,
+  windowKind?: string
+): string => {
+  const raw = value.trim().toLowerCase();
+  // `secondary` was used for both weekly and Team monthly windows. Preserve
+  // it when no duration/label evidence is available instead of silently
+  // assigning the legacy record to weekly.
+  if (raw === 'secondary' && !windowKind) return raw;
+  return canonicalizeCodexProviderWindowId(raw, windowKind);
+};
+
+const normalizeStoredQuotaModelScope = (
+  value: unknown,
+  providerWindowId: string
+): QuotaModelScope => {
+  const inferredScope = inferCodexQuotaScopeFromProviderWindowId(providerWindowId);
+  if (!isRecord(value)) return inferredScope;
+  const kind = readString(value.kind) as QuotaModelScopeKind;
+  if (!QUOTA_MODEL_SCOPE_KINDS.has(kind)) {
+    return inferredScope;
+  }
+  // Pre-scope inspection records explicitly persisted every quota as `all`.
+  // Reinterpret that legacy value from the stable provider window identity so
+  // Spark/additional windows cannot regain account-wide usage on restore.
+  if (kind === 'all' && inferredScope.kind !== 'all') return inferredScope;
+  const models = Array.isArray(value.models)
+    ? Array.from(
+        new Set(value.models.map(readString).map(normalizeCodexModelId).filter(Boolean))
+      ).sort()
+    : undefined;
+  const key = readString(value.key).trim().toLowerCase() || undefined;
+  const defaultComplete =
+    kind === 'all' ||
+    (kind === 'models' && (models?.length ?? 0) > 0) ||
+    (kind === 'family' && (Boolean(key) || (models?.length ?? 0) > 0)) ||
+    ((kind === 'product' || kind === 'feature') && (models?.length ?? 0) > 0);
+  return {
+    kind,
+    key,
+    models,
+    complete: readBoolean(value.complete, defaultComplete),
+  };
+};
+
+const normalizeProviderWindowAliases = (
+  value: unknown,
+  providerWindowId: string,
+  windowKind?: string
+): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const aliases = Array.from(
+    new Set(
+      value
+        .map(readString)
+        .map((alias) => canonicalizeStoredCodexProviderWindowId(alias, windowKind))
+        .filter((alias) => alias && alias !== providerWindowId)
+    )
+  ).sort();
+  return aliases.length > 0 ? aliases : undefined;
+};
+
 const serializeQuotaWindow = (window: CodexInspectionQuotaWindow): CodexInspectionQuotaWindow => {
+  const rawId = readString(window.id);
+  const limitWindowSeconds = readNullableNumber(window.limitWindowSeconds);
+  const windowKind = inferStoredCodexWindowKind(rawId, limitWindowSeconds, window.labelKey);
+  const id = canonicalizeStoredCodexProviderWindowId(rawId, windowKind);
   const resetAtMs = readNullableNumber(window.resetAtMs);
   const resetAccuracy = normalizeQuotaResetAccuracy(window.resetAccuracy);
   return {
-    id: readString(window.id),
+    id,
     labelKey: readString(window.labelKey),
     labelParams: normalizeQuotaWindowLabelParams(window.labelParams),
     usedPercent: readNullableNumber(window.usedPercent),
     resetLabel: readString(window.resetLabel),
     ...(resetAtMs !== null ? { resetAtMs } : {}),
     ...(resetAccuracy ? { resetAccuracy } : {}),
-    limitWindowSeconds: readNullableNumber(window.limitWindowSeconds),
+    limitWindowSeconds,
+    modelScope: normalizeStoredQuotaModelScope(window.modelScope, id),
+    providerWindowAliases: normalizeProviderWindowAliases(
+      window.providerWindowAliases,
+      id,
+      windowKind
+    ),
   };
 };
 
 const hydrateQuotaWindow = (value: unknown): CodexInspectionQuotaWindow | null => {
   if (!isRecord(value)) return null;
-  const id = readString(value.id);
+  const rawId = readString(value.id);
   const labelKey = readString(value.labelKey);
+  const limitWindowSeconds = readNullableNumber(value.limitWindowSeconds);
+  const windowKind = inferStoredCodexWindowKind(rawId, limitWindowSeconds, labelKey);
+  const id = canonicalizeStoredCodexProviderWindowId(rawId, windowKind);
   if (!id || !labelKey) return null;
   const resetAtMs = readNullableNumber(value.resetAtMs);
   const resetAccuracy = normalizeQuotaResetAccuracy(value.resetAccuracy);
@@ -171,7 +279,13 @@ const hydrateQuotaWindow = (value: unknown): CodexInspectionQuotaWindow | null =
     resetLabel: readString(value.resetLabel),
     ...(resetAtMs !== null ? { resetAtMs } : {}),
     ...(resetAccuracy ? { resetAccuracy } : {}),
-    limitWindowSeconds: readNullableNumber(value.limitWindowSeconds),
+    limitWindowSeconds,
+    modelScope: normalizeStoredQuotaModelScope(value.modelScope, id),
+    providerWindowAliases: normalizeProviderWindowAliases(
+      value.providerWindowAliases,
+      id,
+      windowKind
+    ),
   };
 };
 

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -21,6 +21,7 @@ import {
   buildApiKeyOptionsFromRows,
   buildChannelOptionsFromValues,
   buildAccountQuotaRefreshFailureEntry,
+  buildObservedCodexAccountQuotaEntry,
   buildMonitoringInitialStateFromQuery,
   buildModelOptionsFromValues,
   buildProviderOptionsFromValues,
@@ -516,6 +517,211 @@ describe('monitoringCenterPageModel account quota', () => {
         },
       ],
     });
+  });
+
+  it('does not let the ambiguous secondary alias move monthly data onto weekly', () => {
+    const activeEntry = {
+      key: 'codex::2::codex.json',
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: 'Auth',
+      fileName: 'codex.json',
+      planType: 'team',
+      windows: [
+        {
+          id: 'weekly',
+          label: 'Weekly limit',
+          remainingPercent: 64,
+          resetLabel: '07/01 02:00',
+          usageLabel: '2.5d / 7d used',
+          providerWindowAliases: ['secondary'],
+        },
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 90,
+          resetLabel: '07/15 02:00',
+          usageLabel: '3d / 30d used',
+          providerWindowAliases: ['secondary'],
+        },
+      ],
+    };
+    const observedEntry = {
+      ...activeEntry,
+      windows: [
+        {
+          id: 'monthly',
+          label: 'Monthly limit',
+          remainingPercent: 55,
+          resetLabel: '07/20 02:00',
+          usageLabel: '13.5d / 30d used',
+          providerWindowAliases: ['secondary'],
+        },
+      ],
+    };
+
+    const merged = mergeObservedAccountQuotaEntry(activeEntry, observedEntry);
+
+    expect(merged?.windows).toEqual([
+      expect.objectContaining({ id: 'weekly', remainingPercent: 64 }),
+      expect.objectContaining({ id: 'monthly', remainingPercent: 55 }),
+    ]);
+  });
+
+  it('keeps Spark header quota separate from the active Main weekly quota', () => {
+    const target = createTarget({
+      provider: 'codex',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const activeEntry = {
+      key: target.key,
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: target.authLabel,
+      fileName: target.fileName,
+      planType: 'plus',
+      windows: [
+        {
+          id: 'weekly',
+          label: 'Weekly limit',
+          remainingPercent: 64,
+          resetLabel: '07/01 02:00',
+          usageLabel: '2.5d / 7d used',
+        },
+      ],
+    };
+    const observedEntry = buildObservedCodexAccountQuotaEntry(
+      target,
+      {
+        event_hash: 'spark-header',
+        timestamp_ms: 1_700_000_000_000,
+        requested_model: 'my-spark',
+        resolved_model: 'gpt-5.3-codex-spark',
+        response_metadata: {
+          quota: {
+            plan_type: 'plus',
+            secondary: {
+              used_percent: 0,
+              window_minutes: 10_080,
+              reset_at_ms: 1_700_604_800_000,
+            },
+          },
+        },
+      },
+      t,
+      1_700_000_000_000
+    );
+
+    expect(observedEntry?.windows).toEqual([
+      expect.objectContaining({
+        id: 'spark-weekly-0',
+        remainingPercent: 100,
+        modelScope: {
+          kind: 'models',
+          models: ['gpt-5.3-codex-spark'],
+          complete: true,
+        },
+      }),
+    ]);
+    const merged = mergeObservedAccountQuotaEntry(activeEntry, observedEntry!);
+    expect(merged).not.toBeNull();
+    expect(merged!.windows).toEqual([
+      expect.objectContaining({ id: 'weekly', remainingPercent: 64 }),
+      expect.objectContaining({ id: 'spark-weekly-0', remainingPercent: 100 }),
+    ]);
+  });
+
+  it('does not duplicate a legacy Spark window when merging header evidence', () => {
+    const target = createTarget({ provider: 'codex', authIndex: '2', fileName: 'codex.json' });
+    const sparkScope = {
+      kind: 'models' as const,
+      models: ['gpt-5.3-codex-spark'],
+      complete: true,
+    };
+    const activeEntry = {
+      key: target.key,
+      provider: 'codex' as const,
+      providerLabel: 'Codex Quota',
+      authLabel: target.authLabel,
+      fileName: target.fileName,
+      planType: 'plus',
+      windows: [
+        {
+          id: 'fast-coding-weekly-0',
+          label: 'Fast coding',
+          remainingPercent: 50,
+          resetLabel: '-',
+          usageLabel: '3.5d / 7d used',
+          modelScope: sparkScope,
+        },
+      ],
+    };
+    const observedEntry = {
+      ...activeEntry,
+      observedAtMs: 2_000,
+      observedFromUsageHeaders: true,
+      windows: [
+        {
+          id: 'spark-weekly-0',
+          label: 'Spark weekly',
+          remainingPercent: 100,
+          resetLabel: '-',
+          usageLabel: '0d / 7d used',
+          modelScope: sparkScope,
+          providerWindowAliases: ['fast-coding-weekly-0'],
+        },
+      ],
+    };
+
+    const merged = mergeObservedAccountQuotaEntry(activeEntry, observedEntry);
+    expect(merged?.windows).toHaveLength(1);
+    expect(merged?.windows[0]).toMatchObject({
+      id: 'spark-weekly-0',
+      remainingPercent: 100,
+      providerWindowAliases: expect.arrayContaining(['fast-coding-weekly-0']),
+    });
+  });
+
+  it('keeps a scoped header fallback separate when only provider usage metadata exists', () => {
+    const target = createTarget({
+      provider: 'codex',
+      authIndex: '2',
+      fileName: 'codex.json',
+    });
+    const observedEntry = buildObservedCodexAccountQuotaEntry(
+      target,
+      {
+        event_hash: 'spark-provider-usage-only',
+        timestamp_ms: 1_700_000_000_000,
+        requested_model: 'my-spark',
+        resolved_model: 'gpt-5.3-codex-spark',
+        header_quota_used_percent: 0,
+        header_quota_recover_at_ms: 1_700_604_800_000,
+        response_metadata: {
+          provider_usage: {
+            provider: 'codex',
+            state: 'available',
+            actual: 0,
+            limit: 100,
+            recover_at_ms: 1_700_604_800_000,
+          },
+        },
+      },
+      t,
+      1_700_000_000_000
+    );
+
+    expect(observedEntry?.windows).toEqual([
+      expect.objectContaining({
+        id: 'spark-observed',
+        modelScope: {
+          kind: 'models',
+          models: ['gpt-5.3-codex-spark'],
+          complete: true,
+        },
+      }),
+    ]);
   });
 
   it('marks manual quota refresh failures instead of treating cached entries as success', () => {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -46,6 +46,8 @@ import {
   formatKimiResetHint,
   formatQuotaResetTime,
   resolveAbsoluteQuotaReset,
+  findCodexProviderWindowMatch,
+  resolveCodexUsageQuotaScope,
 } from '@/utils/quota';
 import {
   buildObservedCodexQuotaFromHeaderSnapshot,
@@ -803,6 +805,8 @@ const buildCodexAccountQuotaWindows = (
       resetAtMs: window.resetAtMs ?? null,
       resetAccuracy: window.resetAccuracy ?? 'unknown',
       usageLabel,
+      modelScope: window.modelScope,
+      providerWindowAliases: window.providerWindowAliases,
     };
   });
 
@@ -850,6 +854,10 @@ const mergeAccountQuotaWindow = (
     ...(observedWindow.usageLabel && observedWindow.usageLabel.trim()
       ? { usageLabel: observedWindow.usageLabel }
       : {}),
+    ...(observedWindow.modelScope ? { modelScope: observedWindow.modelScope } : {}),
+    ...(observedWindow.providerWindowAliases
+      ? { providerWindowAliases: observedWindow.providerWindowAliases }
+      : {}),
   };
 };
 
@@ -860,15 +868,35 @@ const mergeAccountQuotaWindows = (
   if (observedWindows.length === 0) return activeWindows;
   if (activeWindows.length === 0) return observedWindows;
 
-  const observedById = new Map(observedWindows.map((window) => [window.id, window]));
-  const mergedWindows = activeWindows.map((window) => {
-    const observedWindow = observedById.get(window.id);
-    if (!observedWindow) return window;
-    observedById.delete(window.id);
-    return mergeAccountQuotaWindow(window, observedWindow);
+  const usedObserved = new Set<number>();
+  const mergedWindows = activeWindows.map((window, activeIndex) => {
+    const observedIndex = findCodexProviderWindowMatch(
+      activeWindows,
+      observedWindows,
+      activeIndex,
+      usedObserved
+    );
+    if (observedIndex < 0) return window;
+    usedObserved.add(observedIndex);
+    const observedWindow = observedWindows[observedIndex];
+    const aliases = Array.from(
+      new Set([
+        ...(window.providerWindowAliases ?? []),
+        ...(observedWindow.providerWindowAliases ?? []),
+        window.id,
+      ])
+    ).filter((alias) => alias && alias !== observedWindow.id);
+    return {
+      ...mergeAccountQuotaWindow(window, observedWindow),
+      id: observedWindow.id,
+      ...(aliases.length > 0 ? { providerWindowAliases: aliases } : {}),
+    };
   });
 
-  return [...mergedWindows, ...observedById.values()];
+  return [
+    ...mergedWindows,
+    ...observedWindows.filter((_, index) => !usedObserved.has(index)),
+  ];
 };
 
 const mergeAccountQuotaMetaLabels = (
@@ -1269,6 +1297,14 @@ export const buildObservedCodexAccountQuotaEntry = (
   if (target.provider !== 'codex' || !hasUsageHeaderQuotaSignal(snapshot)) return null;
   const planType = target.planType ?? getHeaderSnapshotPlanType(snapshot) ?? null;
   const observedQuota = buildObservedCodexQuotaFromHeaderSnapshot(snapshot);
+  const observedScope =
+    observedQuota?.quotaScope ??
+    resolveCodexUsageQuotaScope({
+      model: snapshot?.model,
+      analyticsModel: snapshot?.analytics_model,
+      requestedModel: snapshot?.requested_model,
+      resolvedModel: snapshot?.resolved_model,
+    });
   const planLabel = getCodexPlanLabel(planType, t);
   const observedAtMs = readFiniteTimestamp(snapshot?.timestamp_ms) ?? undefined;
   const observedAt = observedAtMs ? new Date(observedAtMs).toLocaleString() : '';
@@ -1296,6 +1332,7 @@ export const buildObservedCodexAccountQuotaEntry = (
         planType,
         observedAtMs,
         source: 'response_header',
+        rateLimitScope: observedScope,
       })
     : [];
   const observedWindows: CodexQuotaWindow[] = filterFreshCodexQuotaWindows(
@@ -1313,6 +1350,8 @@ export const buildObservedCodexAccountQuotaEntry = (
     limitWindowSeconds: window.limitWindowSeconds,
     observationSource: 'response_header',
     observedAtMs,
+    modelScope: window.modelScope,
+    providerWindowAliases: window.providerWindowAliases,
   }));
   const fallbackExpired = recoverAtMS !== null && recoverAtMS <= nowMs;
   const fallbackUsedPercent = fallbackExpired ? null : usedPercent;
@@ -1323,7 +1362,9 @@ export const buildObservedCodexAccountQuotaEntry = (
       : fallbackUsedPercent !== null || fallbackRecoverAtMS
         ? [
             {
-              id: 'usage-header-observed',
+              id: observedScope.providerWindowIdPrefix
+                ? `${observedScope.providerWindowIdPrefix}-observed`
+                : 'usage-header-observed',
               label: t('codex_quota.observed_window', { defaultValue: 'Latest request' }),
               remainingPercent: buildRemainingFromUsedPercent(fallbackUsedPercent),
               resetLabel: fallbackRecoverAtMS
@@ -1338,6 +1379,7 @@ export const buildObservedCodexAccountQuotaEntry = (
                       defaultValue: `Observed used ${Math.round(fallbackUsedPercent)}%`,
                     })
                   : null,
+              modelScope: observedScope.modelScope,
             },
           ]
         : [];

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -21,7 +21,7 @@ import {
 } from '@/features/demo/demoFixtures';
 import { isDemoMode } from '@/features/demo/demoMode';
 import { hasCodexInspectionStableIdentity } from '@/features/monitoring/model/codexInspectionOwnership';
-import type { AuthFileItem } from '@/types';
+import type { AuthFileItem, QuotaModelScope } from '@/types';
 import { normalizeApiBase } from '@/utils/connection';
 import {
   getAuthFileStatusIdentityKey,
@@ -286,6 +286,8 @@ export interface CodexInspectionQuotaWindow {
   resetAtMs?: number | null;
   resetAccuracy?: 'exact' | 'derived' | 'estimated' | 'unknown';
   limitWindowSeconds?: number | null;
+  modelScope?: QuotaModelScope;
+  providerWindowAliases?: string[];
 }
 
 export interface CodexInspectionResult {
@@ -896,6 +898,7 @@ export interface MonitoringAccountWindowModelScope {
   kind: 'all' | 'family' | 'models' | 'product' | 'feature';
   key?: string;
   models?: string[];
+  complete?: boolean;
 }
 
 export interface MonitoringAccountWindowUsageRequest {
@@ -967,6 +970,7 @@ export interface AccountQuotaSnapshotObservationInput {
 
 export interface AccountQuotaSnapshotRemovedWindowInput {
   provider_window_id: string;
+  window_kind?: string;
   model_scope_kind?: MonitoringAccountWindowModelScope['kind'];
   model_scope_key?: string;
   model_ids?: string[];
@@ -974,6 +978,7 @@ export interface AccountQuotaSnapshotRemovedWindowInput {
 
 export interface AccountQuotaSnapshotWindowInput {
   provider_window_id: string;
+  provider_window_aliases?: string[];
   window_kind: string;
   window_mode: AccountQuotaSnapshotWindowMode;
   model_scope_kind: MonitoringAccountWindowModelScope['kind'];
@@ -1723,6 +1728,10 @@ export interface ResponseHeaderMetadata {
 export interface UsageHeaderSnapshot {
   event_hash: string;
   timestamp_ms: number;
+  model?: string;
+  analytics_model?: string;
+  requested_model?: string;
+  resolved_model?: string;
   auth_file_snapshot?: string;
   auth_index?: string;
   account_snapshot?: string;

--- a/apps/web/src/types/quota.ts
+++ b/apps/web/src/types/quota.ts
@@ -368,6 +368,8 @@ export interface CodexQuotaWindow {
   limitWindowSeconds?: number | null;
   observationSource?: QuotaObservationSource;
   observedAtMs?: number | null;
+  modelScope?: QuotaModelScope;
+  providerWindowAliases?: string[];
 }
 
 export interface CodexQuotaState extends CredentialScopedQuotaState {
@@ -393,6 +395,7 @@ export interface CodexQuotaState extends CredentialScopedQuotaState {
   error?: string;
   errorStatus?: number;
   observedFromUsageHeaders?: boolean;
+  observedModelScope?: QuotaModelScope;
   observedResetCreditsUnknown?: boolean;
   observedAtMs?: number;
   observedTraceId?: string;

--- a/apps/web/src/utils/analyticsModel.ts
+++ b/apps/web/src/utils/analyticsModel.ts
@@ -1,0 +1,34 @@
+const REASONING_MODEL_SUFFIXES = new Set([
+  'none',
+  'auto',
+  '-1',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
+
+const isReasoningModelSuffix = (value: string): boolean => {
+  if (REASONING_MODEL_SUFFIXES.has(value.toLowerCase())) return true;
+  if (!/^[+-]?\d+$/.test(value)) return false;
+  try {
+    return BigInt(value) >= 0n && BigInt(value) <= 9_223_372_036_854_775_807n;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Returns the canonical model identity used by usage aggregation and pricing.
+ * Only reasoning-configuration suffixes recognized by CPA are removed.
+ */
+export const normalizeAnalyticsModel = (value: unknown): string => {
+  const model = value === null || value === undefined ? '' : String(value);
+  const open = model.lastIndexOf('(');
+  if (open <= 0 || !model.endsWith(')')) return model;
+  const suffix = model.slice(open + 1, -1);
+  if (!isReasoningModelSuffix(suffix)) return model;
+  return model.slice(0, open) || model;
+};

--- a/apps/web/src/utils/quota/codexQuota.test.ts
+++ b/apps/web/src/utils/quota/codexQuota.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CODEX_CODE_REVIEW_SCOPE_KEY,
+  CODEX_MAIN_QUOTA_SCOPE_KEY,
+  CODEX_SPARK_MODEL_ID,
   classifyCodexRateLimitWindows,
   deriveCodexRateLimitUsedPercent,
   isCodexRateLimitReached,
   buildCodexQuotaWindowInfos,
+  canonicalizeCodexProviderWindowId,
+  inferCodexQuotaScopeFromProviderWindowId,
+  isCodexLegacyAllScopeReplacement,
+  isCodexMainQuotaWindow,
+  normalizeCodexModelId,
+  resolveCodexUsageQuotaScope,
 } from './codexQuota';
 import type { CodexQuotaWindowInfo } from './codexQuota';
 
@@ -329,6 +338,204 @@ describe('buildCodexQuotaWindowInfos', () => {
     ]);
   });
 
+  it('assigns account-wide, model, and fail-closed feature scopes', () => {
+    const windows = buildCodexQuotaWindowInfos({
+      rate_limit: {
+        secondary_window: { used_percent: 36, limit_window_seconds: 604_800 },
+      },
+      code_review_rate_limit: {
+        secondary_window: { used_percent: 20, limit_window_seconds: 604_800 },
+      },
+      additional_rate_limits: [
+        {
+          limit_name: 'Spark',
+          metered_feature: 'codex_spark',
+          rate_limit: {
+            secondary_window: { used_percent: 0, limit_window_seconds: 604_800 },
+          },
+        },
+        {
+          limit_name: 'Future Feature',
+          metered_feature: 'future_feature',
+          rate_limit: {
+            secondary_window: { used_percent: 10, limit_window_seconds: 604_800 },
+          },
+        },
+      ],
+    });
+    const byId = new Map(windows.map((window) => [window.id, window]));
+
+    expect(byId.get('weekly')?.modelScope).toEqual({
+      kind: 'family',
+      key: CODEX_MAIN_QUOTA_SCOPE_KEY,
+      complete: true,
+    });
+    expect(byId.get('weekly')?.providerWindowAliases).toContain('secondary');
+    expect(byId.get('spark-weekly-0')?.modelScope).toEqual({
+      kind: 'models',
+      models: [CODEX_SPARK_MODEL_ID],
+      complete: true,
+    });
+    expect(byId.get('spark-weekly-0')?.providerWindowAliases).toContain('codex-spark-weekly-0');
+    expect(byId.get('code-review-weekly')?.modelScope).toEqual({
+      kind: 'feature',
+      key: CODEX_CODE_REVIEW_SCOPE_KEY,
+      complete: false,
+    });
+    expect(byId.get('future-feature-weekly-0')?.modelScope).toEqual({
+      kind: 'feature',
+      key: 'future_feature',
+      complete: false,
+    });
+  });
+
+  it('keeps the legacy display-label id as a Spark snapshot alias', () => {
+    const [window] = buildCodexQuotaWindowInfos({
+      additional_rate_limits: [
+        {
+          limit_name: 'Fast coding',
+          metered_feature: 'codex_spark',
+          rate_limit: {
+            secondary_window: { used_percent: 0, limit_window_seconds: 604_800 },
+          },
+        },
+      ],
+    });
+
+    expect(window).toMatchObject({
+      id: 'spark-weekly-0',
+      providerWindowAliases: expect.arrayContaining(['fast-coding-weekly-0']),
+    });
+  });
+
+  it('emits the legacy primary alias for the Codex five-hour window', () => {
+    const [window] = buildCodexQuotaWindowInfos({
+      rate_limit: {
+        primary_window: { used_percent: 0, limit_window_seconds: 18_000 },
+      },
+    });
+
+    expect(window).toMatchObject({
+      id: 'five-hour',
+      providerWindowAliases: expect.arrayContaining(['primary']),
+    });
+  });
+
+  it('restores a legacy fast-coding window as Spark without rewriting its identity', () => {
+    expect(inferCodexQuotaScopeFromProviderWindowId('fast-coding-weekly-0')).toEqual({
+      kind: 'models',
+      models: [CODEX_SPARK_MODEL_ID],
+      complete: true,
+    });
+  });
+
+  it('canonicalizes legacy primary and secondary ids without confusing team monthly windows', () => {
+    expect(canonicalizeCodexProviderWindowId('primary')).toBe('five-hour');
+    expect(canonicalizeCodexProviderWindowId('secondary', 'weekly')).toBe('weekly');
+    expect(canonicalizeCodexProviderWindowId('secondary', 'monthly')).toBe('monthly');
+  });
+
+  it('replaces non-main legacy all scopes even when the replacement remains incomplete', () => {
+    expect(
+      isCodexLegacyAllScopeReplacement('future-feature-weekly-0', {
+        kind: 'all',
+        complete: false,
+      })
+    ).toBe(true);
+    expect(
+      isCodexLegacyAllScopeReplacement('future-feature-weekly-0', {
+        kind: 'all',
+        complete: true,
+      })
+    ).toBe(false);
+    expect(
+      isCodexLegacyAllScopeReplacement('weekly', {
+        kind: 'all',
+        complete: false,
+      })
+    ).toBe(false);
+  });
+
+  it('does not treat an explicitly incomplete main-shaped scope as account-wide', () => {
+    expect(
+      isCodexMainQuotaWindow({
+        id: 'weekly',
+        modelScope: { kind: 'all', complete: false },
+      })
+    ).toBe(false);
+  });
+
+  it('resolves direct and aliased Spark usage from the full model identity', () => {
+    expect(resolveCodexUsageQuotaScope({ model: CODEX_SPARK_MODEL_ID })).toMatchObject({
+      providerWindowIdPrefix: 'spark',
+      modelScope: { kind: 'models', models: [CODEX_SPARK_MODEL_ID], complete: true },
+    });
+    expect(
+      resolveCodexUsageQuotaScope({
+        model: 'my-spark',
+        analyticsModel: 'my-spark',
+        requestedModel: 'my-spark',
+        resolvedModel: CODEX_SPARK_MODEL_ID,
+      })
+    ).toMatchObject({
+      providerWindowIdPrefix: 'spark',
+      modelScope: { kind: 'models', models: [CODEX_SPARK_MODEL_ID], complete: true },
+    });
+    expect(
+      resolveCodexUsageQuotaScope({
+        model: 'my-codex',
+        requestedModel: 'my-codex',
+        resolvedModel: 'gpt-5.6-sol',
+      })
+    ).toEqual({
+      providerWindowIdPrefix: '',
+      modelScope: { kind: 'family', key: CODEX_MAIN_QUOTA_SCOPE_KEY, complete: true },
+    });
+    expect(
+      resolveCodexUsageQuotaScope({
+        model: CODEX_SPARK_MODEL_ID,
+        analyticsModel: CODEX_SPARK_MODEL_ID,
+        requestedModel: CODEX_SPARK_MODEL_ID,
+        resolvedModel: 'gpt-5.6-sol',
+      })
+    ).toEqual({
+      providerWindowIdPrefix: '',
+      modelScope: { kind: 'family', key: CODEX_MAIN_QUOTA_SCOPE_KEY, complete: true },
+    });
+    expect(resolveCodexUsageQuotaScope({}).modelScope).toEqual({
+      kind: 'feature',
+      key: 'request_scope_unknown',
+      complete: false,
+    });
+  });
+
+  it('uses the shared analytics model normalizer for scoped model identity', () => {
+    expect(normalizeCodexModelId(`${CODEX_SPARK_MODEL_ID}(+12)`)).toBe(CODEX_SPARK_MODEL_ID);
+    expect(normalizeCodexModelId('custom-model(9223372036854775808)')).toBe(
+      'custom-model(9223372036854775808)'
+    );
+  });
+
+  it('lets a stable provider feature override a conflicting Spark display label', () => {
+    const windows = buildCodexQuotaWindowInfos({
+      additional_rate_limits: [
+        {
+          limit_name: 'Spark',
+          metered_feature: 'future_feature',
+          rate_limit: {
+            secondary_window: { used_percent: 10, limit_window_seconds: 604_800 },
+          },
+        },
+      ],
+    });
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      id: 'future-feature-weekly-0',
+      modelScope: { kind: 'feature', key: 'future_feature', complete: false },
+    });
+  });
+
   it('keeps generic windows unique across main, code-review, and repeated additional families', () => {
     const genericWindow = (usedPercent: number) => ({
       primary_window: {
@@ -422,6 +629,32 @@ describe('buildCodexQuotaWindowInfos', () => {
       30: 'credits--chat-completions-five-hour-0',
       40: 'credits--code-review-five-hour-0',
       50: 'credits-chat-completions-five-hour-0',
+    });
+    expect(idsByUsage(reverse)).toEqual(idsByUsage(forward));
+  });
+
+  it('keeps anonymous and otherwise ambiguous additional limits stable across reorder', () => {
+    const family = (usedPercent: number, seconds: number) => ({
+      rate_limit: {
+        primary_window: {
+          used_percent: usedPercent,
+          limit_window_seconds: seconds,
+        },
+      },
+    });
+    const forward = buildCodexQuotaWindowInfos({
+      additional_rate_limits: [family(30, 18_000), family(40, 18_000), family(50, 604_800)],
+    });
+    const reverse = buildCodexQuotaWindowInfos({
+      additional_rate_limits: [family(50, 604_800), family(40, 18_000), family(30, 18_000)],
+    });
+
+    const idsByUsage = (windows: CodexQuotaWindowInfo[]) =>
+      Object.fromEntries(windows.map((window) => [window.usedPercent, window.id]));
+    expect(idsByUsage(forward)).toEqual({
+      30: 'additional-p-18000-s-none-five-hour-0',
+      40: 'additional-p-18000-s-none-five-hour-1',
+      50: 'additional-p-604800-s-none-weekly-0',
     });
     expect(idsByUsage(reverse)).toEqual(idsByUsage(forward));
   });

--- a/apps/web/src/utils/quota/codexQuota.ts
+++ b/apps/web/src/utils/quota/codexQuota.ts
@@ -3,6 +3,7 @@ import type {
   CodexRateLimitInfo,
   CodexUsagePayload,
   CodexUsageWindow,
+  QuotaModelScope,
 } from '@/types';
 import {
   formatCodexResetLabel,
@@ -10,12 +11,34 @@ import {
   type CodexQuotaResetSource,
 } from './formatters';
 import { normalizeNumberValue, normalizePlanType, normalizeStringValue } from './parsers';
+import { normalizeAnalyticsModel } from '@/utils/analyticsModel';
 
 const FIVE_HOUR_SECONDS = 18_000;
 const WEEK_SECONDS = 604_800;
 const MONTH_SECONDS = 2_592_000;
 const MIN_MONTH_SECONDS = 28 * 24 * 60 * 60;
 const MAX_MONTH_SECONDS = 31 * 24 * 60 * 60;
+
+export const CODEX_MAIN_QUOTA_SCOPE_KEY = 'codex_main';
+export const CODEX_SPARK_MODEL_ID = 'gpt-5.3-codex-spark';
+export const CODEX_CODE_REVIEW_SCOPE_KEY = 'code_review';
+export const CODEX_UNKNOWN_REQUEST_SCOPE_KEY = 'request_scope_unknown';
+
+const CODEX_SPARK_PROVIDER_WINDOW_PREFIX = 'spark';
+const CODEX_SPARK_QUOTA_IDENTIFIERS = new Set(['spark', 'codex_spark', 'gpt_5_3_codex_spark']);
+const CODEX_SPARK_PROVIDER_WINDOW_PREFIXES = [
+  'gpt-5-3-codex-spark',
+  'codex-spark',
+  CODEX_SPARK_PROVIDER_WINDOW_PREFIX,
+];
+const CODEX_SPARK_LEGACY_PROVIDER_WINDOW_PREFIXES = ['fast-coding'];
+const CODEX_MAIN_PROVIDER_WINDOW_IDS = new Set([
+  'five-hour',
+  'weekly',
+  'monthly',
+  'primary',
+  'secondary',
+]);
 
 type CodexQuotaWindowMeta = {
   id: string;
@@ -49,12 +72,29 @@ export type CodexQuotaWindowInfo = {
   resetAtMs: number | null;
   resetAccuracy: 'exact' | 'estimated' | 'unknown';
   limitWindowSeconds: number | null;
+  modelScope: QuotaModelScope;
+  providerWindowAliases?: string[];
+};
+
+export type CodexQuotaScopeResolution = {
+  modelScope: QuotaModelScope;
+  providerWindowIdPrefix: string;
+  legacyProviderWindowIdPrefixes?: string[];
+  labelName?: string;
+};
+
+export type CodexUsageModelIdentity = {
+  model?: string | null;
+  analyticsModel?: string | null;
+  requestedModel?: string | null;
+  resolvedModel?: string | null;
 };
 
 export type CodexQuotaWindowBuildOptions = {
   planType?: string | null;
   observedAtMs?: number;
   source?: CodexQuotaResetSource;
+  rateLimitScope?: CodexQuotaScopeResolution;
 };
 
 export const isCodexQuotaWindowExpired = (
@@ -85,6 +125,398 @@ const normalizeWindowId = (raw: string) =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+
+const normalizeFeatureKey = (raw: string | null | undefined) =>
+  (raw ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+const codexAdditionalWindowIdentityPart = (window?: CodexUsageWindow | null): string => {
+  if (!window) return 'none';
+  const seconds = getWindowSeconds(window);
+  return seconds === null ? 'unknown' : String(seconds);
+};
+
+const anonymousCodexAdditionalIdentity = (limitItem: CodexAdditionalRateLimit): string => {
+  const rateInfo = limitItem.rate_limit ?? limitItem.rateLimit;
+  return [
+    'additional',
+    'p',
+    codexAdditionalWindowIdentityPart(rateInfo?.primary_window ?? rateInfo?.primaryWindow),
+    's',
+    codexAdditionalWindowIdentityPart(rateInfo?.secondary_window ?? rateInfo?.secondaryWindow),
+  ].join('-');
+};
+
+const codexAdditionalWindowSortKey = (window?: CodexUsageWindow | null): string => {
+  if (!window) return 'none';
+  const values = [
+    getWindowSeconds(window),
+    normalizeNumberValue(window.used_percent ?? window.usedPercent),
+    normalizeNumberValue(window.reset_after_seconds ?? window.resetAfterSeconds),
+    normalizeNumberValue(window.reset_at ?? window.resetAt),
+  ];
+  return values.map((value) => (value === null ? '' : String(value))).join(':');
+};
+
+const codexAdditionalRateLimitSortKey = (rateInfo: CodexRateLimitInfo): string =>
+  [
+    codexAdditionalWindowSortKey(rateInfo.primary_window ?? rateInfo.primaryWindow),
+    codexAdditionalWindowSortKey(rateInfo.secondary_window ?? rateInfo.secondaryWindow),
+    rateInfo.allowed === undefined ? '' : String(rateInfo.allowed),
+    String(rateInfo.limit_reached === true || rateInfo.limitReached === true),
+  ].join('|');
+
+const mainCodexQuotaScope = (): QuotaModelScope => ({
+  kind: 'family',
+  key: CODEX_MAIN_QUOTA_SCOPE_KEY,
+  complete: true,
+});
+
+const sparkCodexQuotaScope = (): QuotaModelScope => ({
+  kind: 'models',
+  models: [CODEX_SPARK_MODEL_ID],
+  complete: true,
+});
+
+const incompleteCodexFeatureScope = (key: string): QuotaModelScope => ({
+  kind: 'feature',
+  key: normalizeFeatureKey(key) || 'unknown',
+  complete: false,
+});
+
+const normalizedUniqueWindowIds = (values: Array<string | null | undefined>): string[] =>
+  Array.from(new Set(values.map((value) => normalizeWindowId(value ?? '')).filter(Boolean))).sort();
+
+export const normalizeCodexModelId = (value: string | null | undefined): string => {
+  return normalizeAnalyticsModel(value ?? '')
+    .trim()
+    .toLowerCase();
+};
+
+export const canonicalizeCodexProviderWindowId = (
+  value: string,
+  windowKind?: string
+): string => {
+  const id = value.trim().toLowerCase();
+  const normalizedWindowKind = windowKind?.trim().toLowerCase().replace(/_/g, '-');
+  if (id === 'primary') return 'five-hour';
+  if (id === 'secondary') return normalizedWindowKind === 'monthly' ? 'monthly' : 'weekly';
+  for (const prefix of CODEX_SPARK_PROVIDER_WINDOW_PREFIXES) {
+    if (id === prefix) return CODEX_SPARK_PROVIDER_WINDOW_PREFIX;
+    if (id.startsWith(`${prefix}-`)) {
+      return `${CODEX_SPARK_PROVIDER_WINDOW_PREFIX}${id.slice(prefix.length)}`;
+    }
+  }
+  return id;
+};
+
+export type CodexProviderWindowIdentity = {
+  id: string;
+  providerWindowAliases?: string[];
+};
+
+const normalizeCodexProviderWindowToken = (value: string): string =>
+  value.trim().toLowerCase();
+
+const inferCodexProviderWindowKind = (value: string): string | undefined => {
+  const id = normalizeCodexProviderWindowToken(value);
+  if (id === 'primary' || id === 'five-hour' || /(?:^|-)five-hour(?:-|$)/.test(id)) {
+    return 'five_hour';
+  }
+  if (id === 'weekly' || /(?:^|-)weekly(?:-|$)/.test(id)) return 'weekly';
+  if (id === 'monthly' || /(?:^|-)monthly(?:-|$)/.test(id)) return 'monthly';
+  return undefined;
+};
+
+const codexProviderWindowIdsEquivalent = (left: string, right: string): boolean => {
+  const leftToken = normalizeCodexProviderWindowToken(left);
+  const rightToken = normalizeCodexProviderWindowToken(right);
+  if (!leftToken || !rightToken) return false;
+  if (leftToken === rightToken) return true;
+
+  const kinds = Array.from(
+    new Set([
+      inferCodexProviderWindowKind(leftToken),
+      inferCodexProviderWindowKind(rightToken),
+      undefined,
+    ])
+  );
+  return kinds.some(
+    (kind) =>
+      canonicalizeCodexProviderWindowId(leftToken, kind) ===
+      canonicalizeCodexProviderWindowId(rightToken, kind)
+  );
+};
+
+const CODEX_AMBIGUOUS_PROVIDER_WINDOW_ALIASES = new Set(['secondary']);
+
+const providerWindowAliasMatches = (
+  active: CodexProviderWindowIdentity,
+  observed: CodexProviderWindowIdentity
+): string[] => {
+  const activeID = normalizeCodexProviderWindowToken(active.id);
+  const observedID = normalizeCodexProviderWindowToken(observed.id);
+  const activeAliases = new Set(
+    (active.providerWindowAliases ?? []).map(normalizeCodexProviderWindowToken).filter(Boolean)
+  );
+  const observedAliases = new Set(
+    (observed.providerWindowAliases ?? []).map(normalizeCodexProviderWindowToken).filter(Boolean)
+  );
+  const matches = new Set<string>();
+
+  activeAliases.forEach((alias) => {
+    if (alias === observedID || observedAliases.has(alias)) matches.add(alias);
+  });
+  observedAliases.forEach((alias) => {
+    if (alias === activeID || activeAliases.has(alias)) matches.add(alias);
+  });
+  return Array.from(matches);
+};
+
+/**
+ * Finds a safe active/observed Codex window match. Provider aliases are only
+ * used after exact/canonical IDs fail, and an alias must identify exactly one
+ * active and one observed window. In particular, `secondary` is deliberately
+ * treated as ambiguous because both weekly and Team monthly windows used it.
+ */
+export const findCodexProviderWindowMatch = (
+  activeWindows: readonly CodexProviderWindowIdentity[],
+  observedWindows: readonly CodexProviderWindowIdentity[],
+  activeIndex: number,
+  usedObserved: ReadonlySet<number> = new Set()
+): number => {
+  const activeWindow = activeWindows[activeIndex];
+  if (!activeWindow) return -1;
+  const available = observedWindows
+    .map((window, index) => ({ window, index }))
+    .filter(({ index }) => !usedObserved.has(index));
+
+  const exactCandidates = available.filter(
+    ({ window }) =>
+      normalizeCodexProviderWindowToken(window.id) ===
+      normalizeCodexProviderWindowToken(activeWindow.id)
+  );
+  if (exactCandidates.length === 1) return exactCandidates[0].index;
+
+  const canonicalCandidates = available.filter(({ window }) =>
+    codexProviderWindowIdsEquivalent(activeWindow.id, window.id)
+  );
+  if (canonicalCandidates.length === 1) {
+    const observed = canonicalCandidates[0].window;
+    const matchingActiveWindows = activeWindows.filter((candidate) =>
+      codexProviderWindowIdsEquivalent(candidate.id, observed.id)
+    );
+    if (matchingActiveWindows.length === 1) return canonicalCandidates[0].index;
+  }
+
+  const aliasCandidates = available
+    .map(({ window, index }) => ({
+      window,
+      index,
+      aliases: providerWindowAliasMatches(activeWindow, window),
+    }))
+    .filter(({ aliases }) =>
+      aliases.some((alias) => !CODEX_AMBIGUOUS_PROVIDER_WINDOW_ALIASES.has(alias))
+    );
+  if (aliasCandidates.length !== 1) return -1;
+
+  const candidate = aliasCandidates[0];
+  const usableAliases = candidate.aliases.filter(
+    (alias) => !CODEX_AMBIGUOUS_PROVIDER_WINDOW_ALIASES.has(alias)
+  );
+  const matchingActiveWindows = activeWindows.filter((window) =>
+    usableAliases.some((alias) => providerWindowAliasMatches(window, candidate.window).includes(alias))
+  );
+  if (matchingActiveWindows.length !== 1) return -1;
+  return candidate.index;
+};
+
+const isCodexSparkProviderWindowId = (value: string): boolean => {
+  const raw = value.trim().toLowerCase();
+  const id = canonicalizeCodexProviderWindowId(raw);
+  return (
+    id === CODEX_SPARK_PROVIDER_WINDOW_PREFIX ||
+    id.startsWith(`${CODEX_SPARK_PROVIDER_WINDOW_PREFIX}-`) ||
+    CODEX_SPARK_LEGACY_PROVIDER_WINDOW_PREFIXES.some(
+      (prefix) => raw === prefix || raw.startsWith(`${prefix}-`)
+    )
+  );
+};
+
+export const isCodexMainQuotaModelScope = (scope: QuotaModelScope | null | undefined): boolean =>
+  scope?.kind === 'family' &&
+  scope.key?.trim().toLowerCase() === CODEX_MAIN_QUOTA_SCOPE_KEY &&
+  scope.complete !== false;
+
+export const isCodexSparkModelScope = (
+  scope: QuotaModelScope | null | undefined
+): boolean =>
+  scope?.kind === 'models' &&
+  scope.complete !== false &&
+  (scope.models ?? []).some((model) => normalizeCodexModelId(model) === CODEX_SPARK_MODEL_ID);
+
+export const canonicalizeCodexProviderWindowIdForScope = (
+  providerWindowId: string,
+  windowKind?: string,
+  modelScope?: QuotaModelScope
+): string => {
+  const raw = providerWindowId.trim().toLowerCase();
+  const canonical = canonicalizeCodexProviderWindowId(raw, windowKind);
+  if (isCodexSparkModelScope(modelScope) && raw.startsWith('fast-coding-')) {
+    return `spark${raw.slice('fast-coding'.length)}`;
+  }
+  return canonical;
+};
+
+const codexMainProviderWindowAliases = (
+  providerWindowId: string,
+  modelScope: QuotaModelScope
+): string[] => {
+  if (!isCodexMainQuotaModelScope(modelScope)) return [];
+  switch (canonicalizeCodexProviderWindowId(providerWindowId)) {
+    case 'five-hour':
+      return ['primary'];
+    case 'weekly':
+    case 'monthly':
+      return ['secondary'];
+    default:
+      return [];
+  }
+};
+
+export const isCodexMainProviderWindowId = (providerWindowId: string): boolean => {
+  const id = canonicalizeCodexProviderWindowId(providerWindowId);
+  return CODEX_MAIN_PROVIDER_WINDOW_IDS.has(id) || id.startsWith('window-');
+};
+
+export const isCodexLegacyAllScopeReplacement = (
+  providerWindowId: string,
+  modelScope: QuotaModelScope
+): boolean => {
+  if (isCodexMainProviderWindowId(providerWindowId)) return false;
+  return modelScope.kind !== 'all' || modelScope.complete === false;
+};
+
+export const isCodexMainQuotaWindow = (window: {
+  id?: string;
+  key?: string;
+  providerWindowId?: string;
+  modelScope?: QuotaModelScope;
+}): boolean => {
+  if (isCodexMainQuotaModelScope(window.modelScope)) return true;
+  // An explicitly incomplete scope must never regain account-wide meaning
+  // merely because a legacy/provider window id happens to be `five-hour`,
+  // `weekly`, or `monthly`.
+  if (window.modelScope?.complete === false) return false;
+  if (window.modelScope && window.modelScope.kind !== 'all') return false;
+  const providerWindowId = canonicalizeCodexProviderWindowId(
+    window.providerWindowId ?? window.id ?? window.key ?? ''
+  );
+  return isCodexMainProviderWindowId(providerWindowId);
+};
+
+export const resolveCodexAdditionalQuotaScope = (
+  limitItem: CodexAdditionalRateLimit
+): CodexQuotaScopeResolution => {
+  const meteredFeature = normalizeStringValue(
+    limitItem?.metered_feature ?? limitItem?.meteredFeature
+  );
+  const limitName = normalizeStringValue(limitItem?.limit_name ?? limitItem?.limitName);
+  const featureKey = normalizeFeatureKey(meteredFeature);
+  const nameKey = normalizeFeatureKey(limitName);
+  if (
+    CODEX_SPARK_QUOTA_IDENTIFIERS.has(featureKey) ||
+    (!featureKey && CODEX_SPARK_QUOTA_IDENTIFIERS.has(nameKey))
+  ) {
+    return {
+      modelScope: sparkCodexQuotaScope(),
+      providerWindowIdPrefix: CODEX_SPARK_PROVIDER_WINDOW_PREFIX,
+      legacyProviderWindowIdPrefixes: normalizedUniqueWindowIds([
+        meteredFeature,
+        limitName,
+        ...CODEX_SPARK_PROVIDER_WINDOW_PREFIXES,
+        ...CODEX_SPARK_LEGACY_PROVIDER_WINDOW_PREFIXES,
+      ]),
+      labelName: limitName ?? meteredFeature ?? CODEX_SPARK_MODEL_ID,
+    };
+  }
+
+  const anonymousIdentity = anonymousCodexAdditionalIdentity(limitItem);
+  const key =
+    featureKey || nameKey || normalizeFeatureKey(anonymousIdentity) || 'additional_unknown';
+  const conflictingKnownName = Boolean(featureKey && CODEX_SPARK_QUOTA_IDENTIFIERS.has(nameKey));
+  return {
+    modelScope: incompleteCodexFeatureScope(key),
+    providerWindowIdPrefix:
+      (conflictingKnownName ? normalizeWindowId(meteredFeature ?? '') : '') ||
+      normalizeWindowId(limitName ?? '') ||
+      normalizeWindowId(meteredFeature ?? '') ||
+      normalizeWindowId(anonymousIdentity) ||
+      'additional-unknown',
+    labelName: limitName ?? meteredFeature ?? anonymousIdentity,
+  };
+};
+
+export const resolveCodexUsageQuotaScope = (
+  identity: CodexUsageModelIdentity
+): CodexQuotaScopeResolution => {
+  const resolvedModel = normalizeCodexModelId(identity.resolvedModel);
+  const effectiveModel =
+    resolvedModel ||
+    normalizeCodexModelId(identity.analyticsModel) ||
+    normalizeCodexModelId(identity.requestedModel) ||
+    normalizeCodexModelId(identity.model);
+  if (effectiveModel === CODEX_SPARK_MODEL_ID) {
+    return {
+      modelScope: sparkCodexQuotaScope(),
+      providerWindowIdPrefix: CODEX_SPARK_PROVIDER_WINDOW_PREFIX,
+      legacyProviderWindowIdPrefixes: CODEX_SPARK_LEGACY_PROVIDER_WINDOW_PREFIXES,
+      labelName: CODEX_SPARK_MODEL_ID,
+    };
+  }
+  if (!effectiveModel) {
+    return {
+      modelScope: incompleteCodexFeatureScope(CODEX_UNKNOWN_REQUEST_SCOPE_KEY),
+      providerWindowIdPrefix: 'request-scope-unknown',
+      labelName: CODEX_UNKNOWN_REQUEST_SCOPE_KEY,
+    };
+  }
+  return { modelScope: mainCodexQuotaScope(), providerWindowIdPrefix: '' };
+};
+
+export const inferCodexQuotaScopeFromProviderWindowId = (
+  providerWindowId: string
+): QuotaModelScope => {
+  const id = canonicalizeCodexProviderWindowId(providerWindowId);
+  if (isCodexMainProviderWindowId(id)) {
+    return mainCodexQuotaScope();
+  }
+  if (isCodexSparkProviderWindowId(providerWindowId)) {
+    return sparkCodexQuotaScope();
+  }
+  if (id === 'code-review' || id.startsWith('code-review-')) {
+    return incompleteCodexFeatureScope(CODEX_CODE_REVIEW_SCOPE_KEY);
+  }
+  const familyMatch = id.match(/^(.*)-(?:five-hour|weekly|monthly)-(\d+)$/);
+  const genericMatch = id.match(/^(.*)-window-/);
+  return incompleteCodexFeatureScope(familyMatch?.[1] ?? genericMatch?.[1] ?? id);
+};
+
+export const isCodexKnownScopedProviderWindowId = (providerWindowId: string): boolean => {
+  const raw = providerWindowId.trim().toLowerCase();
+  const id = canonicalizeCodexProviderWindowId(raw);
+  return (
+    isCodexSparkProviderWindowId(raw) ||
+    id === 'code-review' ||
+    id.startsWith('code-review-') ||
+    CODEX_SPARK_LEGACY_PROVIDER_WINDOW_PREFIXES.some(
+      (prefix) => raw === prefix || raw.startsWith(`${prefix}-`)
+    )
+  );
+};
 
 const formatWindowDuration = (seconds: number | null): string => {
   if (seconds === null || seconds <= 0) return 'unknown';
@@ -207,6 +639,8 @@ const addCodexWindowInfo = (
   id: string,
   labelKey: string,
   labelParams: Record<string, string | number> | undefined,
+  modelScope: QuotaModelScope,
+  providerWindowAliases: string[] | undefined,
   window?: CodexUsageWindow | null,
   limitReached?: boolean,
   allowed?: boolean,
@@ -220,6 +654,9 @@ const addCodexWindowInfo = (
   const usedPercentRaw = getCodexQuotaWindowUsedPercent(window);
   const isLimitReached = Boolean(limitReached) || allowed === false;
   const usedPercent = usedPercentRaw ?? (isLimitReached && resetLabel !== '-' ? 100 : null);
+  const aliases = Array.from(
+    new Set([...(providerWindowAliases ?? []), ...codexMainProviderWindowAliases(id, modelScope)])
+  ).sort();
 
   windows.push({
     id,
@@ -230,6 +667,8 @@ const addCodexWindowInfo = (
     resetAtMs: reset.resetAtMs,
     resetAccuracy: reset.resetAccuracy,
     limitWindowSeconds: getWindowSeconds(window),
+    modelScope,
+    ...(aliases.length ? { providerWindowAliases: aliases } : {}),
   });
 };
 
@@ -246,18 +685,35 @@ const addCodexRateLimitWindows = (
     observedAtMs?: number;
     source?: CodexQuotaResetSource;
     genericIdPrefix?: string;
+    modelScope: QuotaModelScope;
+    providerWindowAliasesById?: ReadonlyMap<string, string[]>;
+    providerWindowAliasPrefixes?: string[];
+    providerWindowAliasBasePrefix?: string;
   }
 ) => {
   const limitReached = limitInfo?.limit_reached ?? limitInfo?.limitReached;
   const allowed = limitInfo?.allowed;
   const classified = pickClassifiedWindows(limitInfo, { teamPlan: options?.teamPlan });
   const added = new Set<CodexUsageWindow>();
+  const aliasesForWindow = (id: string): string[] | undefined => {
+    const explicit = options?.providerWindowAliasesById?.get(id);
+    if (explicit !== undefined) return explicit;
+    const basePrefix = normalizeWindowId(options?.providerWindowAliasBasePrefix ?? '');
+    const aliasPrefixes = (options?.providerWindowAliasPrefixes ?? [])
+      .map((prefix) => normalizeWindowId(prefix))
+      .filter((prefix) => prefix && prefix !== basePrefix);
+    if (!basePrefix || !aliasPrefixes.length || !id.startsWith(basePrefix)) return undefined;
+    const suffix = id.slice(basePrefix.length);
+    return normalizedUniqueWindowIds(aliasPrefixes.map((prefix) => `${prefix}${suffix}`));
+  };
 
   addCodexWindowInfo(
     windows,
     fiveHourMeta.id,
     fiveHourMeta.labelKey,
     genericLabelParams,
+    options?.modelScope ?? incompleteCodexFeatureScope('scope_unknown'),
+    aliasesForWindow(fiveHourMeta.id),
     classified.fiveHourWindow,
     limitReached,
     allowed,
@@ -270,6 +726,8 @@ const addCodexRateLimitWindows = (
     weeklyMeta.id,
     weeklyMeta.labelKey,
     genericLabelParams,
+    options?.modelScope ?? incompleteCodexFeatureScope('scope_unknown'),
+    aliasesForWindow(weeklyMeta.id),
     classified.weeklyWindow,
     limitReached,
     allowed,
@@ -282,6 +740,8 @@ const addCodexRateLimitWindows = (
     monthlyMeta.id,
     monthlyMeta.labelKey,
     genericLabelParams,
+    options?.modelScope ?? incompleteCodexFeatureScope('scope_unknown'),
+    aliasesForWindow(monthlyMeta.id),
     classified.monthlyWindow,
     limitReached,
     allowed,
@@ -300,6 +760,8 @@ const addCodexRateLimitWindows = (
       `${genericIdPrefix ? `${genericIdPrefix}-` : ''}window-${duration}-${index}`,
       genericLabelKey,
       { ...genericLabelParams, duration },
+      options?.modelScope ?? incompleteCodexFeatureScope('scope_unknown'),
+      aliasesForWindow(`${genericIdPrefix ? `${genericIdPrefix}-` : ''}window-${duration}-${index}`),
       window,
       limitReached,
       allowed,
@@ -326,50 +788,128 @@ const addAdditionalRateLimitWindows = (
       normalizeStringValue(limitItem?.limit_name ?? limitItem?.limitName) ??
       meteredFeature ??
       `additional-${index + 1}`;
+    const legacyBaseIdPrefix = normalizeWindowId(limitName) || `additional-${index + 1}`;
+    const scopeResolution = resolveCodexAdditionalQuotaScope(limitItem);
     return [
       {
+        sourceIndex: index,
         rateInfo,
         limitName,
-        baseIdPrefix: normalizeWindowId(limitName) || `additional-${index + 1}`,
+        modelScope: scopeResolution.modelScope,
+        baseIdPrefix:
+          scopeResolution.providerWindowIdPrefix ||
+          normalizeWindowId(limitName) ||
+          `additional-${index + 1}`,
         featureIdPrefix: normalizeWindowId(meteredFeature ?? ''),
+        legacyBaseIdPrefix,
+        sortKey: codexAdditionalRateLimitSortKey(rateInfo),
+        legacyIdPrefixes: scopeResolution.legacyProviderWindowIdPrefixes ?? [],
       },
     ];
   });
   const baseIdPrefixCounts = new Map<string, number>();
+  const legacyBaseIdPrefixCounts = new Map<string, number>();
   families.forEach(({ baseIdPrefix }) => {
     baseIdPrefixCounts.set(baseIdPrefix, (baseIdPrefixCounts.get(baseIdPrefix) ?? 0) + 1);
   });
-  const occurrencesByIdPrefix = new Map<string, number>();
-  families.forEach(({ rateInfo, limitName, baseIdPrefix, featureIdPrefix }) => {
-    const idPrefix =
-      (baseIdPrefixCounts.get(baseIdPrefix) ?? 0) > 1 &&
-      featureIdPrefix &&
-      featureIdPrefix !== baseIdPrefix
-        ? `${baseIdPrefix}--${featureIdPrefix}`
-        : baseIdPrefix;
-    const familyIndex = occurrencesByIdPrefix.get(idPrefix) ?? 0;
-    occurrencesByIdPrefix.set(idPrefix, familyIndex + 1);
-
-    addCodexRateLimitWindows(
-      windows,
-      rateInfo,
-      {
-        id: `${idPrefix}-five-hour-${familyIndex}`,
-        labelKey: 'codex_quota.additional_primary_window',
-      },
-      {
-        id: `${idPrefix}-weekly-${familyIndex}`,
-        labelKey: 'codex_quota.additional_secondary_window',
-      },
-      {
-        id: `${idPrefix}-monthly-${familyIndex}`,
-        labelKey: 'codex_quota.additional_monthly_window',
-      },
-      'codex_quota.additional_generic_window',
-      { name: limitName },
-      { ...options, genericIdPrefix: `${idPrefix}-${familyIndex}` }
+  families.forEach(({ legacyBaseIdPrefix }) => {
+    legacyBaseIdPrefixCounts.set(
+      legacyBaseIdPrefix,
+      (legacyBaseIdPrefixCounts.get(legacyBaseIdPrefix) ?? 0) + 1
     );
   });
+  const resolvedFamilies = families.map((family) => ({
+    ...family,
+    idPrefix:
+      (baseIdPrefixCounts.get(family.baseIdPrefix) ?? 0) > 1 &&
+      family.featureIdPrefix &&
+      family.featureIdPrefix !== family.baseIdPrefix
+        ? `${family.baseIdPrefix}--${family.featureIdPrefix}`
+        : family.baseIdPrefix,
+    legacyIdPrefixes: [
+      ...family.legacyIdPrefixes,
+      (legacyBaseIdPrefixCounts.get(family.legacyBaseIdPrefix) ?? 0) > 1 &&
+      family.featureIdPrefix &&
+      family.featureIdPrefix !== family.legacyBaseIdPrefix
+        ? `${family.legacyBaseIdPrefix}--${family.featureIdPrefix}`
+        : family.legacyBaseIdPrefix,
+    ],
+  }));
+  const familiesByIdPrefix = new Map<string, typeof resolvedFamilies>();
+  resolvedFamilies.forEach((family) => {
+    const group = familiesByIdPrefix.get(family.idPrefix) ?? [];
+    group.push(family);
+    familiesByIdPrefix.set(family.idPrefix, group);
+  });
+  const familyIndexes = new Map<number, number>();
+  familiesByIdPrefix.forEach((group) => {
+    [...group]
+      .sort((left, right) => {
+        if (left.sortKey !== right.sortKey) return left.sortKey.localeCompare(right.sortKey);
+        return left.sourceIndex - right.sourceIndex;
+      })
+      .forEach((family, familyIndex) => familyIndexes.set(family.sourceIndex, familyIndex));
+  });
+  resolvedFamilies.forEach(
+    ({ sourceIndex, rateInfo, limitName, modelScope, idPrefix, legacyIdPrefixes }) => {
+      const familyIndex = familyIndexes.get(sourceIndex) ?? 0;
+      const aliasPrefixes = normalizedUniqueWindowIds(legacyIdPrefixes).filter(
+        (prefix) => prefix !== idPrefix
+      );
+      const providerWindowAliasesById = new Map<string, string[]>();
+      const addAliases = (id: string) => {
+        if (!aliasPrefixes.length || !id.startsWith(idPrefix)) return;
+        const suffix = id.slice(idPrefix.length);
+        providerWindowAliasesById.set(
+          id,
+          aliasPrefixes.map((prefix) => `${prefix}${suffix}`)
+        );
+      };
+      const fiveHourId = `${idPrefix}-five-hour-${familyIndex}`;
+      const weeklyId = `${idPrefix}-weekly-${familyIndex}`;
+      const monthlyId = `${idPrefix}-monthly-${familyIndex}`;
+      addAliases(fiveHourId);
+      addAliases(weeklyId);
+      addAliases(monthlyId);
+      const classified = pickClassifiedWindows(rateInfo, { teamPlan: options?.teamPlan });
+      classified.windows.forEach((window, index) => {
+        if (
+          window === classified.fiveHourWindow ||
+          window === classified.weeklyWindow ||
+          window === classified.monthlyWindow
+        ) {
+          return;
+        }
+        const duration = formatWindowDuration(getWindowSeconds(window));
+        addAliases(`${idPrefix}-${familyIndex}-window-${duration}-${index}`);
+      });
+
+      addCodexRateLimitWindows(
+        windows,
+        rateInfo,
+        {
+          id: fiveHourId,
+          labelKey: 'codex_quota.additional_primary_window',
+        },
+        {
+          id: weeklyId,
+          labelKey: 'codex_quota.additional_secondary_window',
+        },
+        {
+          id: monthlyId,
+          labelKey: 'codex_quota.additional_monthly_window',
+        },
+        'codex_quota.additional_generic_window',
+        { name: limitName },
+        {
+          ...options,
+          genericIdPrefix: `${idPrefix}-${familyIndex}`,
+          modelScope,
+          providerWindowAliasesById,
+        }
+      );
+    }
+  );
 };
 
 export const buildCodexQuotaWindowInfos = (
@@ -385,16 +925,50 @@ export const buildCodexQuotaWindowInfos = (
   const teamPlan = planType === 'team';
   const observedAtMs = options?.observedAtMs ?? Date.now();
   const source = options?.source ?? 'provider_api';
+  const rateLimitScope = options?.rateLimitScope ?? {
+    modelScope: mainCodexQuotaScope(),
+    providerWindowIdPrefix: '',
+  };
+  const scopedRateLimit = Boolean(rateLimitScope.providerWindowIdPrefix);
+  const rateLimitPrefix = normalizeWindowId(rateLimitScope.providerWindowIdPrefix);
+  const rateLimitLabelParams = scopedRateLimit
+    ? { name: rateLimitScope.labelName ?? rateLimitScope.providerWindowIdPrefix }
+    : undefined;
 
   addCodexRateLimitWindows(
     windows,
     rateLimit,
-    CODEX_WINDOW_META.codeFiveHour,
-    CODEX_WINDOW_META.codeWeekly,
-    CODEX_WINDOW_META.codeMonthly,
-    'codex_quota.generic_window',
-    undefined,
-    { teamPlan, observedAtMs, source }
+    scopedRateLimit
+      ? {
+          id: `${rateLimitPrefix}-five-hour-0`,
+          labelKey: 'codex_quota.additional_primary_window',
+        }
+      : CODEX_WINDOW_META.codeFiveHour,
+    scopedRateLimit
+      ? {
+          id: `${rateLimitPrefix}-weekly-0`,
+          labelKey: 'codex_quota.additional_secondary_window',
+        }
+      : CODEX_WINDOW_META.codeWeekly,
+    scopedRateLimit
+      ? {
+          id: `${rateLimitPrefix}-monthly-0`,
+          labelKey: 'codex_quota.additional_monthly_window',
+        }
+      : CODEX_WINDOW_META.codeMonthly,
+    scopedRateLimit ? 'codex_quota.additional_generic_window' : 'codex_quota.generic_window',
+    rateLimitLabelParams,
+    {
+      teamPlan,
+      observedAtMs,
+      source,
+      genericIdPrefix: scopedRateLimit ? `${rateLimitPrefix}-0` : undefined,
+      modelScope: rateLimitScope.modelScope,
+      providerWindowAliasPrefixes: scopedRateLimit
+        ? rateLimitScope.legacyProviderWindowIdPrefixes
+        : undefined,
+      providerWindowAliasBasePrefix: scopedRateLimit ? rateLimitPrefix : undefined,
+    }
   );
   addCodexRateLimitWindows(
     windows,
@@ -404,7 +978,13 @@ export const buildCodexQuotaWindowInfos = (
     CODEX_WINDOW_META.codeReviewMonthly,
     'codex_quota.code_review_generic_window',
     undefined,
-    { teamPlan, observedAtMs, source, genericIdPrefix: 'code-review' }
+    {
+      teamPlan,
+      observedAtMs,
+      source,
+      genericIdPrefix: 'code-review',
+      modelScope: incompleteCodexFeatureScope(CODEX_CODE_REVIEW_SCOPE_KEY),
+    }
   );
   addAdditionalRateLimitWindows(windows, additionalRateLimits, { teamPlan, observedAtMs, source });
 

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -75,7 +75,7 @@ import {
   parseXaiBillingPayload,
 } from './parsers';
 import { resolveCodexChatgptAccountId, resolveCodexPlanType } from './resolvers';
-import { buildCodexQuotaWindowInfos } from './codexQuota';
+import { buildCodexQuotaWindowInfos, type CodexQuotaScopeResolution } from './codexQuota';
 import {
   buildCodexResetCreditsRequestHeaders,
   buildCodexUsageRequestHeaders,
@@ -347,21 +347,26 @@ export const buildCodexQuotaWindows = (
   t: TFunction,
   planType?: string | null,
   observedAtMs = Date.now(),
-  source: CodexQuotaResetSource = 'provider_api'
+  source: CodexQuotaResetSource = 'provider_api',
+  rateLimitScope?: CodexQuotaScopeResolution
 ): CodexQuotaWindow[] =>
-  buildCodexQuotaWindowInfos(payload, { planType, observedAtMs, source }).map((window) => ({
-    id: window.id,
-    label: t(window.labelKey, window.labelParams),
-    labelKey: window.labelKey,
-    labelParams: window.labelParams,
-    usedPercent: window.usedPercent,
-    resetLabel: window.resetLabel,
-    resetAtMs: window.resetAtMs,
-    resetAccuracy: window.resetAccuracy,
-    limitWindowSeconds: window.limitWindowSeconds,
-    observationSource: source === 'response_header' ? 'response_header' : 'api_query',
-    observedAtMs,
-  }));
+  buildCodexQuotaWindowInfos(payload, { planType, observedAtMs, source, rateLimitScope }).map(
+    (window) => ({
+      id: window.id,
+      label: t(window.labelKey, window.labelParams),
+      labelKey: window.labelKey,
+      labelParams: window.labelParams,
+      usedPercent: window.usedPercent,
+      resetLabel: window.resetLabel,
+      resetAtMs: window.resetAtMs,
+      resetAccuracy: window.resetAccuracy,
+      limitWindowSeconds: window.limitWindowSeconds,
+      observationSource: source === 'response_header' ? 'response_header' : 'api_query',
+      observedAtMs,
+      modelScope: window.modelScope,
+      providerWindowAliases: window.providerWindowAliases,
+    })
+  );
 
 const resolveCodexRateLimitResetCreditsAvailableCount = (
   payload: CodexUsagePayload

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -2,8 +2,10 @@ import i18n from '@/i18n';
 import { maskApiKey } from './format';
 import { normalizeAuthIndex } from './authIndex';
 import { parseTimestampMs } from './timestamp';
+import { normalizeAnalyticsModel } from './analyticsModel';
 
 export { normalizeAuthIndex };
+export { normalizeAnalyticsModel } from './analyticsModel';
 
 export interface ModelPriceContextTier {
   thresholdTokens: number;
@@ -325,37 +327,6 @@ const readDetailString = (value: unknown): string | undefined => {
   if (value === null || value === undefined) return undefined;
   const text = String(value).trim();
   return text || undefined;
-};
-
-const REASONING_MODEL_SUFFIXES = new Set([
-  'none',
-  'auto',
-  '-1',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
-]);
-
-const isReasoningModelSuffix = (value: string): boolean => {
-  if (REASONING_MODEL_SUFFIXES.has(value.toLowerCase())) return true;
-  if (!/^[+-]?\d+$/.test(value)) return false;
-  try {
-    return BigInt(value) >= 0n && BigInt(value) <= 9_223_372_036_854_775_807n;
-  } catch {
-    return false;
-  }
-};
-
-export const normalizeAnalyticsModel = (value: unknown): string => {
-  const model = value === null || value === undefined ? '' : String(value);
-  const open = model.lastIndexOf('(');
-  if (open <= 0 || !model.endsWith(')')) return model;
-  const suffix = model.slice(open + 1, -1);
-  if (!isReasoningModelSuffix(suffix)) return model;
-  return model.slice(0, open) || model;
 };
 
 const readResponseHeaderMetadata = (value: unknown): UsageResponseHeaderMetadata | undefined =>
@@ -1545,9 +1516,7 @@ export function formatCompactNumber(value: number): string {
 
 export function formatUsd(value: number, fractionDigits = 2): string {
   const num = Number(value);
-  const digits = Number.isInteger(fractionDigits)
-    ? Math.max(0, Math.min(6, fractionDigits))
-    : 2;
+  const digits = Number.isInteger(fractionDigits) ? Math.max(0, Math.min(6, fractionDigits)) : 2;
   if (!Number.isFinite(num)) return `$${(0).toFixed(digits)}`;
 
   const fixed = num.toFixed(digits);

--- a/apps/web/src/utils/usageHeaderSnapshots.test.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AuthFileItem } from '@/types';
 import type { UsageHeaderSnapshot } from '@/services/api/usageService';
-import { buildCodexQuotaWindowInfos } from './quota/codexQuota';
+import { buildCodexQuotaWindowInfos, CODEX_SPARK_MODEL_ID } from './quota/codexQuota';
 import {
   buildObservedCodexQuotaFromHeaderSnapshot,
   buildUsageHeaderSnapshotLookup,
@@ -23,6 +23,7 @@ describe('buildObservedCodexQuotaFromHeaderSnapshot', () => {
     const snapshot: UsageHeaderSnapshot = {
       event_hash: 'event-test',
       timestamp_ms: 1_700_000_000_000,
+      model: 'gpt-5.6-sol',
       response_metadata: {
         quota: {
           plan_type: 'free',
@@ -93,6 +94,7 @@ describe('buildObservedCodexQuotaFromHeaderSnapshot', () => {
     const snapshot: UsageHeaderSnapshot = {
       event_hash: 'event-multi-window',
       timestamp_ms: 1_700_000_000_000,
+      model: 'gpt-5.6-sol',
       response_metadata: {
         quota: {
           plan_type: 'plus',
@@ -138,6 +140,46 @@ describe('buildObservedCodexQuotaFromHeaderSnapshot', () => {
         labelKey: 'codex_quota.secondary_window',
         usedPercent: 25,
         limitWindowSeconds: 604_800,
+      },
+    ]);
+  });
+
+  it('binds Spark header quota evidence to the resolved request model scope', () => {
+    const snapshot: UsageHeaderSnapshot = {
+      event_hash: 'event-spark-alias',
+      timestamp_ms: 1_700_000_000_000,
+      model: 'my-spark',
+      analytics_model: 'my-spark',
+      requested_model: 'my-spark',
+      resolved_model: CODEX_SPARK_MODEL_ID,
+      response_metadata: {
+        quota: {
+          primary: {
+            used_percent: 0,
+            reset_at_ms: 1_700_604_800_000,
+            window_minutes: 10_080,
+          },
+        },
+      },
+    };
+
+    const observed = buildObservedCodexQuotaFromHeaderSnapshot(snapshot);
+    expect(observed?.quotaScope).toMatchObject({
+      providerWindowIdPrefix: 'spark',
+      modelScope: { kind: 'models', models: [CODEX_SPARK_MODEL_ID], complete: true },
+    });
+    expect(
+      buildCodexQuotaWindowInfos(observed?.payload ?? {}, {
+        observedAtMs: snapshot.timestamp_ms,
+        source: 'response_header',
+        rateLimitScope: observed?.quotaScope,
+      })
+    ).toMatchObject([
+      {
+        id: 'spark-weekly-0',
+        usedPercent: 0,
+        modelScope: { kind: 'models', models: [CODEX_SPARK_MODEL_ID], complete: true },
+        providerWindowAliases: expect.arrayContaining(['fast-coding-weekly-0']),
       },
     ]);
   });

--- a/apps/web/src/utils/usageHeaderSnapshots.ts
+++ b/apps/web/src/utils/usageHeaderSnapshots.ts
@@ -5,6 +5,10 @@ import type {
 } from '@/services/api/usageService';
 import type { AuthFileItem, CodexUsagePayload, CodexUsageWindow } from '@/types';
 import { normalizeAuthIndex } from '@/utils/authIndex';
+import {
+  resolveCodexUsageQuotaScope,
+  type CodexQuotaScopeResolution,
+} from '@/utils/quota/codexQuota';
 
 export type UsageHeaderSnapshotLookup = {
   byFileName: Map<string, UsageHeaderSnapshot>;
@@ -485,6 +489,7 @@ export type ObservedCodexHeaderQuota = {
   reachedWindowKind: string | null;
   reachedWindowSource: string | null;
   primaryOverSecondaryLimitPercent: number | null;
+  quotaScope: CodexQuotaScopeResolution;
 };
 
 const buildCodexWindowFromHeaderQuota = (
@@ -517,6 +522,12 @@ export const buildObservedCodexQuotaFromHeaderSnapshot = (
 ): ObservedCodexHeaderQuota | null => {
   const quota = getHeaderSnapshotQuotaMetadata(snapshot);
   if (!quota) return null;
+  const quotaScope = resolveCodexUsageQuotaScope({
+    model: snapshot?.model,
+    analyticsModel: snapshot?.analytics_model,
+    requestedModel: snapshot?.requested_model,
+    resolvedModel: snapshot?.resolved_model,
+  });
 
   const planType = readString(quota.plan_type) || null;
   const activeLimit = readString(quota.active_limit) || null;
@@ -587,6 +598,7 @@ export const buildObservedCodexQuotaFromHeaderSnapshot = (
     reachedWindowKind,
     reachedWindowSource,
     primaryOverSecondaryLimitPercent,
+    quotaScope,
   };
 };
 


### PR DESCRIPTION
## Summary

Fixes Issue #570 by enforcing a matching scope between Codex quota evidence, usage attribution, and forecast calculations. Spark quota windows no longer inherit account-wide Codex usage, and account summaries remain based on the Codex main scope.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add generic Codex scope resolution using the existing QuotaModelScope model: main family, Spark model scope, and incomplete feature scopes for unknown limits.
- Carry requested, analytics, and resolved/billing model identity through header observations, snapshots, monitoring targets, and usage aggregation.
- Exclude Spark from main usage and fail closed for incomplete scopes instead of aggregating account-wide requests, tokens, cost, success rate, or forecast.
- Keep account summaries on account-wide/main quota semantics while retaining scoped quota detail cards.
- Reconcile legacy all-scope Spark snapshots through canonical IDs and aliases without deleting usage history.

## User Impact

Spark quota cards show only Spark usage; an unused Spark quota remains at zero usage. The account summary is no longer replaced by the lowest model-scoped quota. Unknown additional features remain visible as provider quota evidence, but do not show unreliable usage or forecast values.

## Compatibility / Runtime Notes

- CPA panel mode: frontend scope and usage contracts remain backward-compatible; legacy omitted targets retain their prior account-wide interpretation, while explicit incomplete scopes fail closed.
- Manager Server mode: usage events remain authoritative and are not rewritten; header/model identity is read from existing usage event fields.
- Full Docker / native packages: no packaging or runtime schema changes; the same Manager Server quota lifecycle is used.

## Data / Security Notes

No database schema migration is required. Existing quota snapshot scope fields are reused, legacy incorrect scoped rows are suppressed or deactivated after reliable scoped evidence, and usage_events are not deleted or rewritten. No credentials, raw response bodies, or secrets are exposed.

## Risk / Rollback

Risk level: Medium

Rollback notes: revert the two commits in order or close the PR; no destructive data migration is introduced. Existing usage events remain available for re-aggregation.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint (0 errors; one pre-existing Fast Refresh warning)
npm run test (194 files, 2431 tests)
npm run build
npm run manager-server:test
GOCACHE=/tmp/cpamp-go-cache go test -race ./internal/codexquota ./internal/service/monitoring ./internal/service/quotasnapshot ./internal/repository/usageevent ./internal/repository/usagemonitoring
git diff --check

Full go test -race ./... passed with elevated execution (all packages).
```

## Screenshots / Recordings

N/A — quota behavior was validated through parser, view-model, snapshot, monitoring, and regression tests; no manual browser recording was produced.

## Docs

- [x] Not needed — this is a quota semantics and attribution fix; no new user-facing setup or operational procedure is introduced.

Docs decision: no documentation update required.

## Related

Fixes #570