### PR TITLE
chore(release): prepare v1.12.2

### DIFF
--- a/docs/release-notes/v1.12.2-en.md
+++ b/docs/release-notes/v1.12.2-en.md
@@ -1,0 +1,64 @@
+# CPA Manager Plus v1.12.2
+
+> 34 commits · 117 files changed · +8870 / -485
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.2/docs/release-notes/v1.12.2-zh.md)
+
+## Overview
+
+`v1.12.2` focuses on quota attribution, reset-time accuracy, and upgrade operability for large historical databases. Codex Spark usage no longer mixes with the main quota, absolute quota reset times are shown in the browser's local timezone, Manager Server exposes deferred database maintenance to users, and account-history reads bound candidates per credential when the required indexes are available. The listener-first startup boundary remains intact, and authoritative `usage_events` is not rewritten.
+
+## Highlights
+
+### Features
+
+- Codex quota attribution is separated across the main product, Spark, and additional feature scopes. Spark no longer inherits account-wide or main-quota usage, while incomplete scopes fail closed instead of showing unreliable usage or forecast values.
+- `GET /status` now exposes a sanitized `databaseMaintenance` state, with a metadata-bounded `?scope=database-maintenance` view reporting maintenance requirements, query-performance risk, deferred-index counts, offline-job counts, and stable reason codes.
+- The Manager Server panel, System Info, and Request Monitoring show maintenance warnings, pending counts, and long-range query hints, with Docker Compose and native `cleanup-derived` instructions.
+
+### Fixes
+
+- Codex quota evidence, usage attribution, forecasts, and summaries now use the same resolved/billing scope. Spark no longer contaminates main-quota statistics, and legacy incorrect scoped snapshots are suppressed or deactivated when reliable evidence is available.
+- Codex credential health, Accounts, monitoring, and Server Codex inspection display absolute reset times in the browser's local timezone while preserving legacy reset labels and reset accuracy.
+- xAI quota displays preserve product-specific reset semantics instead of allowing a unified reset format to hide provider-specific meaning.
+- Accounts account-history reads use bounded per-credential top-N queries when the composite indexes are available, while preserving NULL, empty `auth_index`, snapshot, and legacy-source compatibility; incomplete indexes keep the safe fallback path.
+- Deferred-index decisions are persisted in a bounded metadata ledger and recomputed with SQLite schema, derived-cleanup, and quota-migration metadata, so a temporarily empty derived table cannot hide an index that is still missing.
+- `databaseMaintenance` exposes only stable reason codes, counts, and command hints; it does not expose absolute database paths, raw SQL, index names, or low-level migration errors, and existing `/status` fields remain compatible.
+
+### Performance
+
+- Request Monitoring includes a 100k projection regression covering query plans with and without the timestamp index, preventing historical queries from silently degrading to expensive temporary sorts.
+- Indexed account-history reads limit each credential's candidates before merging the global top-N, avoiding a window sort or full scan over every historical row for a credential.
+- The listener-first startup strategy remains unchanged: populated-table indexes are not unconditionally created before listening, and the web UI never runs offline cleanup online.
+
+### Docs
+
+- Chinese and English Manager Server, Docker, and upgrade guides now document maintenance state, the stop-service requirement, complete cleanup commands, and the `usage_events` safety boundary.
+- Chinese and English README and documentation home screenshots now reflect the current panel.
+
+## Upgrade Notes
+
+- Back up SQLite, WAL, SHM, and `data.key` together before upgrading. Manager Server binds HTTP first and continues bounded background maintenance.
+- If the UI warning or `/status.databaseMaintenance.required` is `true`, stop Manager Server first. Docker Compose users should run:
+
+```bash
+docker compose stop cpa-manager-plus
+
+docker compose run --rm --no-deps \
+  cpa-manager-plus \
+  cleanup-derived --db-path /data/usage.sqlite
+
+docker compose start cpa-manager-plus
+```
+
+- Native installations use `cpa-manager-plus cleanup-derived`; append `--db-path /path/to/usage.sqlite` for a non-default database.
+- `cleanup-derived` requires exclusive SQLite access and must not be run from the web UI. After offline maintenance and a restart, the status and UI warning return to normal based on the actual SQLite metadata.
+- `usage_events` remains the authoritative source; this release does not delete, rebuild, or rewrite it, and introduces no destructive data migration.
+
+## Acknowledgements
+
+- [@HuiCheng](https://github.com/HuiCheng) - Improved account-history recent-request reads for large historical databases by avoiding a full scan of every credential's history.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.1...v1.12.2

--- a/docs/release-notes/v1.12.2-zh.md
+++ b/docs/release-notes/v1.12.2-zh.md
@@ -1,0 +1,64 @@
+# CPA Manager Plus v1.12.2
+
+> 34 commits · 117 files changed · +8870 / -485
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.2/docs/release-notes/v1.12.2-en.md)
+
+## Overview
+
+`v1.12.2` 聚焦配额归属、重置时间和大型历史数据库的升级可运维性：Codex Spark 与主配额使用量不再混算，配额重置时间在浏览器本地时区正确显示，Manager Server 会把延后的数据库维护状态展示给用户，并让账户历史查询在索引可用时按凭证限制候选行。此版本保留 listener-first 启动边界，不改写 authoritative `usage_events`。
+
+## Highlights
+
+### Features
+
+- Codex 配额按主产品、Spark 和其他 feature scope 分开归属，Spark 不再继承账户级或主配额使用量；无法完整解析的 scope 会 fail closed，不显示不可靠的 usage 或 forecast。
+- `GET /status` 新增脱敏的 `databaseMaintenance` 状态，并提供 `?scope=database-maintenance` 的 metadata-bounded 读取，报告维护要求、查询性能风险、deferred index 数量、offline job 数量和稳定 reason code。
+- Manager Server 面板、System Info 和 Request Monitoring 会显示数据库维护 Warning、待处理数量和长时间范围查询提示，并提供 Docker Compose 与原生 `cleanup-derived` 操作指引。
+
+### Fixes
+
+- Codex quota evidence、usage attribution、forecast 和 summary 现在使用相同的 resolved/billing scope，Spark 不再污染主配额统计；历史错误 scoped snapshot 会在有可靠证据时被抑制或停用。
+- Codex credential health、Accounts、monitoring 和 Server Codex inspection 会按浏览器本地时区显示绝对 reset time，同时保留旧版 reset label 和 reset accuracy 兼容路径。
+- xAI 配额展示保留产品级 reset 语义，避免统一重置时间格式覆盖 provider-specific 信息。
+- Accounts 的 account-history 最近请求在复合索引可用时按凭证执行有界 top-N 读取，保留 NULL、空 `auth_index`、snapshot 和 legacy source 的兼容语义；索引不完整时继续使用原有安全回退。
+- deferred-index 决策会持久化到有界 metadata ledger，并与 SQLite schema、derived cleanup 和 quota migration metadata 重新计算；即使派生表暂时为空，也不会错误隐藏仍缺失的索引。
+- `databaseMaintenance` 只暴露稳定 reason code、计数和命令提示，不暴露数据库绝对路径、原始 SQL、索引名称或底层迁移错误；既有 `/status` 字段保持兼容。
+
+### Performance
+
+- Request Monitoring 的 100k projection 回归覆盖索引可用和缺失时的 query plan，避免历史数据查询静默退化为昂贵的临时排序。
+- account-history 查询在索引路径上先限制每个凭证的候选行，再合并全局 top-N，避免对单个凭证的全部历史执行窗口排序或 full scan。
+- 启动策略保持 listener-first：不会在监听前对非空大表无条件创建索引，Web UI 也不会在线运行离线清理。
+
+### Docs
+
+- 中英文 Manager Server、Docker 和更新文档补充 maintenance 状态、停止服务要求、完整 cleanup 命令和 `usage_events` 数据安全边界。
+- 中英文 README 和文档首页更新为当前面板截图。
+
+## Upgrade Notes
+
+- 升级前请一起备份 SQLite、WAL、SHM 和 `data.key`。Manager Server 会先监听 HTTP，再继续执行有界后台维护。
+- 如果 UI Warning 或 `/status.databaseMaintenance.required` 为 `true`，请先停止 Manager Server。Docker Compose 用户执行：
+
+```bash
+docker compose stop cpa-manager-plus
+
+docker compose run --rm --no-deps \
+  cpa-manager-plus \
+  cleanup-derived --db-path /data/usage.sqlite
+
+docker compose start cpa-manager-plus
+```
+
+- 原生安装使用 `cpa-manager-plus cleanup-derived`；非默认数据库可追加 `--db-path /path/to/usage.sqlite`。
+- `cleanup-derived` 需要独占 SQLite 进程锁，不能从 Web UI 在线执行。完成离线维护并重启后，状态和 UI Warning 会根据真实 SQLite metadata 自动恢复正常。
+- `usage_events` 仍是 authoritative source；本版本不会删除、重建或改写它，也没有破坏性数据迁移。
+
+## Acknowledgements
+
+- [@HuiCheng](https://github.com/HuiCheng) - 改进大历史数据库中的 Accounts 最近请求读取，避免为展示最新请求扫描每个凭证的全部历史。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.1...v1.12.2

--- a/docs/release-posts/v1.12.2-telegram.html
+++ b/docs/release-posts/v1.12.2-telegram.html
@@ -1,0 +1,19 @@
+🚀 <b>8 月 21 日 · v1.12.2</b>
+
+✨ <b>更新内容</b>
+
+• Codex Spark 配额只统计 Spark 使用量，主配额与未知功能范围不会相互污染。
+• Codex 和 xAI 配额重置时间按浏览器本地时区显示，并保留准确的产品重置语义。
+• Manager Server 会在 <code>/status</code> 和面板中显示 deferred indexes、offline cleanup 与查询性能降级状态。
+• Request Monitoring 和 System Info 会提示历史查询风险，Accounts 最近请求改为有界读取以减少大历史数据库扫描。
+• 中英文 README 和文档首页更新为当前面板截图。
+
+⚠️ <b>注意事项</b>
+
+• 升级前请备份 SQLite、WAL、SHM 与 <code>data.key</code>。
+• 若维护状态为 required，请先停止 Manager Server，再运行 <code>cleanup-derived</code>；Docker Compose 用户按操作文档执行一次性容器命令。
+• 不要从 Web UI 在线执行 cleanup；离线命令需要独占 SQLite，且不会删除或改写 <code>usage_events</code>。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/HuiCheng">@HuiCheng</a> - 改进大历史数据库中的 Accounts 最近请求读取。


### PR DESCRIPTION
## Summary

Prepare the finalized v1.12.2 release materials on the dedicated release branch. The release notes document quota-scope attribution, browser-local reset times, deferred database maintenance visibility, bounded account-history reads, and the SQLite/WAL/SHM/data.key upgrade safety boundary.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.2 release notes.
- Add the v1.12.2 Telegram release post.
- Record the v1.12.2 changelog and upgrade guidance for database maintenance and authoritative usage data.

## User Impact

No runtime behavior changes are introduced by this PR. These files provide the finalized release documentation for behavior already integrated on `dev`.

## Compatibility / Runtime Notes

- CPA panel mode: Release documentation covers browser-local reset-time display and existing CPA panel compatibility.
- Manager Server mode: Release documentation covers sanitized database-maintenance status, bounded history reads, and listener-first startup.
- Full Docker / native packages: Release documentation includes backup requirements and offline `cleanup-derived` instructions.

## Data / Security Notes

The notes explicitly preserve SQLite, WAL, SHM, and `data.key` backup requirements. They state that `usage_events` remains authoritative and is not deleted, rebuilt, or rewritten. No secrets, runtime data, or generated runtime files are included.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert or close this release-materials PR before merge; after merge, revert the release-materials commit if required. No application code or runtime data is changed.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Release content validator: npm run release:validate -- --tag v1.12.2 --content-only
Release branch base: dev b666374b2c6b7c3874d2aecb863dff5af3fa6588
Release commit: d96fa681b53d293cb140c41fc4a17169484f5003
Changed paths: exactly the three release-note/Telegram files
SHA-256 verified for all three files against the approved draft digests
```

## Screenshots / Recordings

N/A — release documentation and Telegram HTML only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

This PR is the dedicated v1.12.2 release-materials change. The release notes include the user-facing upgrade and data-safety guidance; the Telegram HTML is the corresponding publication draft.

## Related

N/A