### PR TITLE
chore(release): prepare v1.12.3

### DIFF
--- a/docs/release-notes/v1.12.3-en.md
+++ b/docs/release-notes/v1.12.3-en.md
@@ -1,0 +1,37 @@
+# CPA Manager Plus v1.12.3
+
+> 13 commits · 13 files changed · +1206 / -126
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.3/docs/release-notes/v1.12.3-zh.md)
+
+## Overview
+
+`v1.12.3` focuses on reliable Codex reset-credit actions, accurate model-price sync feedback, and efficient repeat loads of the embedded management panel. Accounts uses displayed evidence to expose the reset entry point, then requires a fresh live quota check before consuming a reset credit. Model Prices sync counts now include only models without a stored price, and the Full Docker and native Manager Server embedded panel supports content-based HTTP revalidation. This release has no database schema, configuration, or persisted-data migration.
+
+## Highlights
+
+### Fixes
+
+- Codex credentials with visible reset-credit evidence can start a quota reset in Accounts, including disabled credentials that remain recoverable; runtime-only credentials and incomplete identities without `auth_index` continue to fail closed.
+- Codex resets perform a fresh quota check before consumption and use credential-scoped guards against repeated clicks, concurrent transactions, and stale request overwrites. If consumption succeeds but the latest quota refresh fails, the UI reports partial success instead of treating the completed operation as a failure.
+- Model Prices sync results exclude models with stored prices from pending candidates and unmatched entries, so completion-notification counts match the rows users can act on while matched, imported, skipped, and price-write behavior remain unchanged.
+
+### Performance
+
+- The Full Docker and native Manager Server embedded `management.html` now uses a content-hash ETag, `Cache-Control: no-cache`, and standard conditional requests. Repeat loads can return `304 Not Modified` while preserving HEAD, Range, and external `PANEL_PATH` behavior.
+
+## Upgrade Notes
+
+- No configuration change, database migration, or data backfill is required; upgrade normally.
+- Displayed Codex reset-credit snapshots only expose the action entry point. Consumption always requires fresh live verification, and no reset occurs if verification fails or no credit remains.
+- The first embedded-panel load is unchanged; only later requests can use ETag revalidation. External panels served through `PANEL_PATH` retain their existing `Last-Modified` semantics.
+
+## Acknowledgements
+
+- [@riba2534](https://github.com/riba2534) - Diagnosed repeated embedded-panel transfers and provided the supporting measurements.
+- [@YogaSakti](https://github.com/YogaSakti) - Added HTTP cache revalidation for the embedded panel to reduce repeat-load transfers.
+- [@Lxcardoza993](https://github.com/Lxcardoza993) - Corrected model-price sync feedback so its counts match actionable entries.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.2...v1.12.3

--- a/docs/release-notes/v1.12.3-zh.md
+++ b/docs/release-notes/v1.12.3-zh.md
@@ -1,0 +1,37 @@
+# CPA Manager Plus v1.12.3
+
+> 13 commits · 13 files changed · +1206 / -126
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.3/docs/release-notes/v1.12.3-en.md)
+
+## Overview
+
+`v1.12.3` 聚焦 Codex reset credit 操作可靠性、模型价格同步反馈准确性和内嵌管理面板的重复加载效率。Accounts 会先用当前展示证据开放重置入口，再以实时配额校验决定是否消耗 reset credit；Model Prices 的同步计数只保留尚未保存价格的模型；Full Docker 与原生 Manager Server 的内嵌面板支持基于内容的 HTTP 缓存复验。本版本不包含数据库 schema、配置或持久化数据迁移。
+
+## Highlights
+
+### Fixes
+
+- Accounts 中显示有效 reset credit 的 Codex 凭证可以发起额度重置，包括仍可恢复的 disabled credential；runtime-only 凭证与缺少 `auth_index` 的不完整身份继续 fail closed。
+- Codex 重置在消耗前执行实时配额校验，并按凭证阻止重复点击、并发事务和旧请求覆盖；消耗成功但最新配额刷新失败时会报告 partial success，避免把已完成操作误报为失败。
+- Model Prices 同步结果会从 pending candidates 和 unmatched 中排除已保存价格的模型，使完成通知的计数与页面中实际可处理的条目一致，同时保留 matched、imported、skipped 和价格写入行为。
+
+### Performance
+
+- Full Docker 与原生 Manager Server 的内嵌 `management.html` 使用内容哈希 ETag、`Cache-Control: no-cache` 和标准条件请求；重复加载可返回 `304 Not Modified`，并保留 HEAD、Range 与 `PANEL_PATH` 外部文件行为。
+
+## Upgrade Notes
+
+- 不需要配置变更、数据库迁移或数据回填，可按常规方式升级。
+- Codex reset credit 的展示快照只用于开放操作入口；实际消耗始终以实时校验为准。校验失败或已无可用次数时不会执行重置。
+- 内嵌面板首次加载行为不变；仅后续请求可利用 ETag 复验。`PANEL_PATH` 指向的外部面板及其 `Last-Modified` 语义保持不变。
+
+## Acknowledgements
+
+- [@riba2534](https://github.com/riba2534) - 定位内嵌面板重复传输问题并提供测量依据。
+- [@YogaSakti](https://github.com/YogaSakti) - 为内嵌面板补全 HTTP 缓存复验，减少重复加载传输。
+- [@Lxcardoza993](https://github.com/Lxcardoza993) - 修正模型价格同步反馈，让统计与可处理条目一致。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.2...v1.12.3

--- a/docs/release-posts/v1.12.3-telegram.html
+++ b/docs/release-posts/v1.12.3-telegram.html
@@ -1,0 +1,18 @@
+🚀 <b>8 月 23 日 · v1.12.3</b>
+
+✨ <b>更新内容</b>
+
+• Accounts 中显示 <code>reset credit</code> 的 Codex 凭证可直接发起重置，并会在消耗前实时校验可用次数。
+• Codex 重置会拦截重复点击与并发操作，成功后刷新失败时会明确提示手动刷新。
+• Model Prices 同步结果会排除已保存价格的模型，pending 和 unmatched 数量与可处理条目保持一致。
+• Full Docker 与原生 Manager Server 的内嵌面板支持 ETag 复验，重复打开可返回 304，避免重复传输完整页面。
+
+⚠️ <b>注意事项</b>
+
+• Codex 重置仍以实时校验结果为准；若校验失败或已无可用次数，不会消耗 <code>reset credit</code>。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/riba2534">@riba2534</a> - 定位内嵌面板重复传输问题并提供测量依据。
+• <a href="https://github.com/YogaSakti">@YogaSakti</a> - 为内嵌面板补全 HTTP 缓存复验，减少重复加载传输。
+• <a href="https://github.com/Lxcardoza993">@Lxcardoza993</a> - 修正模型价格同步反馈，让统计与可处理条目一致。


### PR DESCRIPTION
## Summary

Prepare the finalized v1.12.3 release materials on the dedicated release branch. The release notes document reliable Codex reset-credit verification, accurate Model Prices sync feedback, and HTTP cache revalidation for the embedded management panel.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.3 release notes.
- Add the reviewed v1.12.3 Telegram release post.
- Record upgrade and compatibility guidance for reset-credit verification, model-price sync feedback, and embedded-panel caching.

## User Impact

No runtime behavior changes are introduced by this PR. These files provide the finalized release documentation for behavior already integrated on `dev`.

## Compatibility / Runtime Notes

- CPA panel mode: The notes cover Codex reset-credit verification and transaction behavior in Accounts.
- Manager Server mode: The notes cover model-price sync feedback and embedded-panel HTTP revalidation.
- Full Docker / native packages: The notes document ETag revalidation for the embedded panel and confirm that the first load and external `PANEL_PATH` behavior remain unchanged.

## Data / Security Notes

No schema, configuration, persisted-data, credential, or authentication changes are introduced by these release files. The notes preserve the fail-closed reset authorization boundary: displayed snapshots expose the action, while fresh live verification authorizes consumption. No secrets or runtime data are included.

## Risk / Rollback

Risk level: Low

Rollback notes: Close this PR before merge, or revert its release-materials merge before promotion. No application code or persisted data is changed by this PR.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Release branch base: dev 4ec85e5f7e712942fdc8e1aca3f9f926c62a47d9
Release commit: ee19f59bfd9d3c51ee696feafb050e6316660ce8
Changed paths: exactly the three v1.12.3 release-note/Telegram files
npm run release:validate -- --tag v1.12.3 --content-only: passed
Chinese SHA-256: 76eef2a067a0f0d814f196ed79ce657b6c9dee340ceb2e3398fb9b25ffe9c043
English SHA-256: 4da886018859cb6e174368f3b038cf3eefbe696edfad4655ef249da539dab325
Telegram SHA-256: 485c325542d381aa1b446ea4a7ed001ba76c113db4552064417e3e248be36f81
Reciprocal language links are tag-pinned; Telegram HTML is 647 characters and uses only the allowed tags.
```

## Screenshots / Recordings

N/A — release documentation and Telegram HTML only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

This PR is the dedicated v1.12.3 release-materials change. The formal notes and Telegram post cover the reviewed user-visible behavior and upgrade guidance.

## Related

N/A