### PR TITLE
fix(monitoring): scope account identity by provider

### DIFF
--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2017,12 +2018,15 @@ func countAPIKeySelectors(values store.FilterSelectorValues) int {
 func buildAccountSelectorStats(values store.FilterSelectorValues) []AccountStatRow {
 	grouped := map[string]*accountStatAccumulator{}
 	for _, selector := range values.AccountSelectors {
-		id := accountGroupKey(
-			selector.AccountSnapshot,
-			selector.AuthLabelSnapshot,
-			selector.Source,
-			selector.AuthIndex,
-		)
+		identity := monitoringAccountIdentity{
+			Provider:          selector.AuthProviderSnapshot,
+			AccountSnapshot:   selector.AccountSnapshot,
+			AuthLabelSnapshot: selector.AuthLabelSnapshot,
+			Source:            selector.Source,
+			AuthIndex:         selector.AuthIndex,
+			SourceHash:        selector.SourceHash,
+		}
+		id := identity.key()
 		if id == "-" && strings.TrimSpace(selector.SourceHash) == "" {
 			continue
 		}
@@ -2033,7 +2037,7 @@ func buildAccountSelectorStats(values store.FilterSelectorValues) []AccountStatR
 					ID:                   id,
 					AccountSnapshot:      selector.AccountSnapshot,
 					AuthLabelSnapshot:    selector.AuthLabelSnapshot,
-					AuthProviderSnapshot: selector.AuthProviderSnapshot,
+					AuthProviderSnapshot: identity.provider(),
 					SuccessRate:          1,
 				},
 				authIndices:  map[string]struct{}{},
@@ -2647,7 +2651,15 @@ type credentialStatAccumulator struct {
 func buildAccountStats(stats []store.AccountModelStat, prices map[string]store.ModelPrice) []AccountStatRow {
 	grouped := map[string]*accountStatAccumulator{}
 	for _, stat := range stats {
-		id := accountGroupKey(stat.AccountSnapshot, stat.AuthLabelSnapshot, stat.Source, stat.AuthIndex)
+		identity := monitoringAccountIdentity{
+			Provider:          stat.AuthProviderSnapshot,
+			AccountSnapshot:   stat.AccountSnapshot,
+			AuthLabelSnapshot: stat.AuthLabelSnapshot,
+			Source:            stat.Source,
+			AuthIndex:         stat.AuthIndex,
+			SourceHash:        stat.SourceHash,
+		}
+		id := identity.key()
 		entry := grouped[id]
 		if entry == nil {
 			entry = &accountStatAccumulator{
@@ -2655,7 +2667,7 @@ func buildAccountStats(stats []store.AccountModelStat, prices map[string]store.M
 					ID:                   id,
 					AccountSnapshot:      stat.AccountSnapshot,
 					AuthLabelSnapshot:    stat.AuthLabelSnapshot,
-					AuthProviderSnapshot: stat.AuthProviderSnapshot,
+					AuthProviderSnapshot: identity.provider(),
 				},
 				authIndices:  map[string]struct{}{},
 				sources:      map[string]struct{}{},
@@ -3026,20 +3038,48 @@ func fillChannelShareSnapshots(row *ChannelShareRow, stat store.ChannelModelStat
 	}
 }
 
-func accountGroupKey(accountSnapshot, authLabelSnapshot, source, authIndex string) string {
-	if strings.TrimSpace(accountSnapshot) != "" {
-		return accountSnapshot
+type monitoringAccountIdentity struct {
+	Provider          string
+	AccountSnapshot   string
+	AuthLabelSnapshot string
+	Source            string
+	AuthIndex         string
+	SourceHash        string
+}
+
+func (identity monitoringAccountIdentity) provider() string {
+	return usageidentity.CanonicalProvider(identity.Provider)
+}
+
+func (identity monitoringAccountIdentity) key() string {
+	kind := ""
+	value := ""
+	for _, candidate := range []struct {
+		kind  string
+		value string
+	}{
+		{kind: "account", value: identity.AccountSnapshot},
+		{kind: "label", value: identity.AuthLabelSnapshot},
+		{kind: "source", value: identity.Source},
+		{kind: "auth", value: identity.AuthIndex},
+		{kind: "source-hash", value: identity.SourceHash},
+	} {
+		if trimmed := strings.TrimSpace(candidate.value); trimmed != "" {
+			kind = candidate.kind
+			value = trimmed
+			break
+		}
 	}
-	if strings.TrimSpace(authLabelSnapshot) != "" {
-		return authLabelSnapshot
+	if kind == "" {
+		return "-"
 	}
-	if strings.TrimSpace(source) != "" {
-		return source
-	}
-	if strings.TrimSpace(authIndex) != "" {
-		return authIndex
-	}
-	return "-"
+	return strings.Join([]string{
+		"monitoring-account",
+		"1",
+		kind,
+		strings.ToUpper(hex.EncodeToString([]byte(identity.provider()))),
+		strings.ToUpper(hex.EncodeToString([]byte(value))),
+	}, ":")
 }
 
 func apiKeyGroupKey(apiKeyHash, sourceHash, authIndex, source, provider string) string {

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -3048,11 +3048,11 @@ type monitoringAccountIdentity struct {
 }
 
 // normalizeMonitoringProvider applies the minimal normalization used by the
-// monitoring account identity (trim, lowercase, '_'->'-'). It deliberately
-// does NOT fold provider aliases such as x-ai/grok -> xai, which remain
-// distinct providers in the monitoring identity scope.
+// monitoring account identity (trim, lowercase). It deliberately does NOT
+// replace '_' with '-' or fold provider aliases such as x-ai/grok -> xai,
+// matching the backend provider filter which only lowercases provider values.
 func normalizeMonitoringProvider(value string) string {
-	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func (identity monitoringAccountIdentity) provider() string {

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -3047,8 +3047,16 @@ type monitoringAccountIdentity struct {
 	SourceHash        string
 }
 
+// normalizeMonitoringProvider applies the minimal normalization used by the
+// monitoring account identity (trim, lowercase, '_'->'-'). It deliberately
+// does NOT fold provider aliases such as x-ai/grok -> xai, which remain
+// distinct providers in the monitoring identity scope.
+func normalizeMonitoringProvider(value string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+}
+
 func (identity monitoringAccountIdentity) provider() string {
-	return usageidentity.CanonicalProvider(identity.Provider)
+	return normalizeMonitoringProvider(identity.Provider)
 }
 
 func (identity monitoringAccountIdentity) key() string {

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -1368,7 +1368,7 @@ func TestAnalyticsAccountStatsProviderScopeFallbackIdentity(t *testing.T) {
 	}
 }
 
-func TestBuildAccountStatsCanonicalizesProviderAliases(t *testing.T) {
+func TestBuildAccountStatsDoesNotMergeProviderAliasesAcrossMonitoringIdentity(t *testing.T) {
 	stats := []store.AccountModelStat{
 		{
 			AccountSnapshot:      "same@example.com",
@@ -1391,11 +1391,21 @@ func TestBuildAccountStatsCanonicalizesProviderAliases(t *testing.T) {
 	}
 
 	rows := buildAccountStats(stats, nil)
-	if len(rows) != 1 || rows[0].AuthProviderSnapshot != "xai" || rows[0].Calls != 2 || rows[0].TotalTokens != 30 {
-		t.Fatalf("canonical provider account rows = %#v", rows)
+	// Monitoring identity deliberately keeps x-ai and grok distinct (no alias
+	// folding); the persisted Account History contract (usageidentity) still
+	// folds them, but monitoring account identity does not.
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 distinct monitoring account rows, got %d: %#v", len(rows), rows)
 	}
-	if rows[0].ID != "monitoring-account:1:account:786169:73616D65406578616D706C652E636F6D" {
-		t.Fatalf("monitoring account id = %q", rows[0].ID)
+	if rows[0].ID == rows[1].ID {
+		t.Fatalf("expected distinct monitoring account ids, got duplicate %q", rows[0].ID)
+	}
+	providers := map[string]bool{}
+	for _, row := range rows {
+		providers[row.AuthProviderSnapshot] = true
+	}
+	if !providers["x-ai"] || !providers["grok"] {
+		t.Fatalf("expected x-ai and grok to remain distinct, got %#v", providers)
 	}
 }
 

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -1214,6 +1214,191 @@ func TestAnalyticsAppliesFilters(t *testing.T) {
 	}
 }
 
+func TestAnalyticsAccountStatsUseProviderScopedLogicalAccountIdentity(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_025_000_000)
+	toMS := fromMS + 60*60*1000
+	events := make([]usage.Event, 0, 214)
+	for index := range 197 {
+		authIndex := "codex-auth-a"
+		if index >= 100 {
+			authIndex = "codex-auth-b"
+		}
+		event := monitoringEvent(
+			fmt.Sprintf("provider-account-codex-%03d", index),
+			fromMS+int64(index+1),
+			"model-x",
+			authIndex,
+			"codex.json",
+			false,
+			10,
+			5,
+			0,
+			0,
+			15,
+			nil,
+		)
+		event.AccountSnapshot = "same@example.com"
+		event.AuthLabelSnapshot = "Shared Account"
+		event.AuthProviderSnapshot = "codex"
+		event.Provider = "codex"
+		events = append(events, event)
+	}
+	for index := range 17 {
+		event := monitoringEvent(
+			fmt.Sprintf("provider-account-antigravity-%03d", index),
+			fromMS+int64(1_000+index),
+			"model-x",
+			"antigravity-auth",
+			"antigravity.json",
+			false,
+			20,
+			10,
+			0,
+			0,
+			30,
+			nil,
+		)
+		event.AccountSnapshot = "same@example.com"
+		event.AuthLabelSnapshot = "Shared Account"
+		event.AuthProviderSnapshot = ""
+		event.Provider = "antigravity"
+		events = append(events, event)
+	}
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert provider-scoped account events: %v", err)
+	}
+
+	run := func(t *testing.T, providers []string, wantProvider string, wantCalls int64) Response {
+		t.Helper()
+		resp, err := New(db).Analytics(ctx, Request{
+			FromMS:  fromMS,
+			ToMS:    toMS,
+			Filters: Filters{Providers: providers},
+			Include: Include{
+				Summary:         true,
+				AccountStats:    true,
+				FilterOptions:   true,
+				FilterSelectors: true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("analytics providers=%v: %v", providers, err)
+		}
+		if resp.Summary == nil || resp.Summary.TotalCalls != wantCalls {
+			t.Fatalf("summary providers=%v = %#v, want calls=%d", providers, resp.Summary, wantCalls)
+		}
+		if wantProvider != "" {
+			if len(resp.AccountStats) != 1 {
+				t.Fatalf("account stats providers=%v = %#v", providers, resp.AccountStats)
+			}
+			row := resp.AccountStats[0]
+			if row.AuthProviderSnapshot != wantProvider || row.Calls != wantCalls || len(row.Models) != 1 || row.Models[0].Calls != wantCalls {
+				t.Fatalf("account row providers=%v = %#v", providers, row)
+			}
+		}
+		return resp
+	}
+
+	resp := run(t, nil, "", 214)
+	if len(resp.AccountStats) != 2 {
+		t.Fatalf("provider-scoped account stats = %#v, want two rows", resp.AccountStats)
+	}
+	byProvider := make(map[string]AccountStatRow, len(resp.AccountStats))
+	for _, row := range resp.AccountStats {
+		if _, exists := byProvider[row.AuthProviderSnapshot]; exists {
+			t.Fatalf("duplicate provider bucket %q: %#v", row.AuthProviderSnapshot, resp.AccountStats)
+		}
+		byProvider[row.AuthProviderSnapshot] = row
+	}
+	codex := byProvider["codex"]
+	antigravity := byProvider["antigravity"]
+	if codex.Calls != 197 || !slices.Equal(codex.AuthIndices, []string{"codex-auth-a", "codex-auth-b"}) || len(codex.Models) != 1 || codex.Models[0].Calls != 197 {
+		t.Fatalf("codex account row = %#v", codex)
+	}
+	if antigravity.Calls != 17 || !slices.Equal(antigravity.AuthIndices, []string{"antigravity-auth"}) || len(antigravity.Models) != 1 || antigravity.Models[0].Calls != 17 {
+		t.Fatalf("antigravity account row = %#v", antigravity)
+	}
+	if codex.ID == antigravity.ID || codex.AccountSnapshot != antigravity.AccountSnapshot {
+		t.Fatalf("provider-scoped ids/accounts = codex:%#v antigravity:%#v", codex, antigravity)
+	}
+	if resp.FilterOptions == nil || len(resp.FilterOptions.AccountStats) != 2 {
+		t.Fatalf("provider-scoped account selectors = %#v", resp.FilterOptions)
+	}
+
+	run(t, []string{"codex"}, "codex", 197)
+	run(t, []string{"antigravity"}, "antigravity", 17)
+}
+
+func TestAnalyticsAccountStatsProviderScopeFallbackIdentity(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_778_045_000_000)
+	toMS := fromMS + 60*60*1000
+	events := []usage.Event{
+		monitoringEvent("provider-label-codex", fromMS+1_000, "model-x", "codex-auth", "codex.json", false, 1, 1, 0, 0, 2, nil),
+		monitoringEvent("provider-label-antigravity", fromMS+2_000, "model-x", "antigravity-auth", "antigravity.json", false, 1, 1, 0, 0, 2, nil),
+	}
+	for index := range events {
+		events[index].AccountSnapshot = ""
+		events[index].AuthLabelSnapshot = "Shared Label"
+	}
+	events[0].AuthProviderSnapshot = "codex"
+	events[0].Provider = "codex"
+	events[1].AuthProviderSnapshot = ""
+	events[1].Provider = "antigravity"
+	if _, err := db.InsertEvents(ctx, events); err != nil {
+		t.Fatalf("insert provider label events: %v", err)
+	}
+
+	resp, err := New(db).Analytics(ctx, Request{
+		FromMS:  fromMS,
+		ToMS:    toMS,
+		Include: Include{AccountStats: true, FilterOptions: true, FilterSelectors: true},
+	})
+	if err != nil {
+		t.Fatalf("analytics: %v", err)
+	}
+	if len(resp.AccountStats) != 2 || resp.AccountStats[0].ID == resp.AccountStats[1].ID {
+		t.Fatalf("provider-scoped label account stats = %#v", resp.AccountStats)
+	}
+	if resp.FilterOptions == nil || len(resp.FilterOptions.AccountStats) != 2 {
+		t.Fatalf("provider-scoped label selectors = %#v", resp.FilterOptions)
+	}
+}
+
+func TestBuildAccountStatsCanonicalizesProviderAliases(t *testing.T) {
+	stats := []store.AccountModelStat{
+		{
+			AccountSnapshot:      "same@example.com",
+			AuthProviderSnapshot: "x-ai",
+			AuthIndex:            "xai-auth-a",
+			Model:                "grok-model",
+			Calls:                1,
+			SuccessCalls:         1,
+			TotalTokens:          10,
+		},
+		{
+			AccountSnapshot:      "same@example.com",
+			AuthProviderSnapshot: "grok",
+			AuthIndex:            "xai-auth-b",
+			Model:                "grok-model",
+			Calls:                1,
+			SuccessCalls:         1,
+			TotalTokens:          20,
+		},
+	}
+
+	rows := buildAccountStats(stats, nil)
+	if len(rows) != 1 || rows[0].AuthProviderSnapshot != "xai" || rows[0].Calls != 2 || rows[0].TotalTokens != 30 {
+		t.Fatalf("canonical provider account rows = %#v", rows)
+	}
+	if rows[0].ID != "monitoring-account:1:account:786169:73616D65406578616D706C652E636F6D" {
+		t.Fatalf("monitoring account id = %q", rows[0].ID)
+	}
+}
+
 func TestBuildFilterIncludesCredentialIDs(t *testing.T) {
 	filter := buildFilter(Request{
 		FromMS: 100,

--- a/apps/manager-server/internal/usageidentity/identity.go
+++ b/apps/manager-server/internal/usageidentity/identity.go
@@ -32,7 +32,7 @@ type Fields struct {
 func AccountKey(fields Fields) (string, bool) {
 	authFile := effectiveAuthFile(fields)
 	authIndex := strings.TrimSpace(fields.AuthIndex)
-	provider := CanonicalProvider(fields.AuthProviderSnapshot)
+	provider := normalizeProvider(fields.AuthProviderSnapshot)
 	projectID := strings.TrimSpace(fields.AuthProjectIDSnapshot)
 	account := strings.TrimSpace(fields.AccountSnapshot)
 	label := strings.TrimSpace(fields.AuthLabelSnapshot)
@@ -138,9 +138,9 @@ func effectiveAuthFile(fields Fields) string {
 	return source
 }
 
-// CanonicalProvider normalizes provider namespaces shared by persisted
-// credential identity and monitoring account identity.
-func CanonicalProvider(value string) string {
+// normalizeProvider normalizes provider namespaces for persisted credential
+// identity and account history identity keys.
+func normalizeProvider(value string) string {
 	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
 	switch normalized {
 	case "x-ai", "grok":

--- a/apps/manager-server/internal/usageidentity/identity.go
+++ b/apps/manager-server/internal/usageidentity/identity.go
@@ -32,7 +32,7 @@ type Fields struct {
 func AccountKey(fields Fields) (string, bool) {
 	authFile := effectiveAuthFile(fields)
 	authIndex := strings.TrimSpace(fields.AuthIndex)
-	provider := normalizeProvider(fields.AuthProviderSnapshot)
+	provider := CanonicalProvider(fields.AuthProviderSnapshot)
 	projectID := strings.TrimSpace(fields.AuthProjectIDSnapshot)
 	account := strings.TrimSpace(fields.AccountSnapshot)
 	label := strings.TrimSpace(fields.AuthLabelSnapshot)
@@ -138,7 +138,9 @@ func effectiveAuthFile(fields Fields) string {
 	return source
 }
 
-func normalizeProvider(value string) string {
+// CanonicalProvider normalizes provider namespaces shared by persisted
+// credential identity and monitoring account identity.
+func CanonicalProvider(value string) string {
 	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
 	switch normalized {
 	case "x-ai", "grok":

--- a/apps/manager-server/internal/usageidentity/identity_test.go
+++ b/apps/manager-server/internal/usageidentity/identity_test.go
@@ -37,22 +37,6 @@ func TestAccountKeyRejectsMissingIdentity(t *testing.T) {
 	}
 }
 
-func TestCanonicalProvider(t *testing.T) {
-	testCases := map[string]string{
-		" Codex ": "codex",
-		"OPEN_AI": "open-ai",
-		"x-ai":    "xai",
-		"X_AI":    "xai",
-		"grok":    "xai",
-		"":        "",
-	}
-	for input, want := range testCases {
-		if got := CanonicalProvider(input); got != want {
-			t.Fatalf("CanonicalProvider(%q) = %q, want %q", input, got, want)
-		}
-	}
-}
-
 func TestSQLAccountKeyExpressionMatchesGo(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {

--- a/apps/manager-server/internal/usageidentity/identity_test.go
+++ b/apps/manager-server/internal/usageidentity/identity_test.go
@@ -37,6 +37,22 @@ func TestAccountKeyRejectsMissingIdentity(t *testing.T) {
 	}
 }
 
+func TestCanonicalProvider(t *testing.T) {
+	testCases := map[string]string{
+		" Codex ": "codex",
+		"OPEN_AI": "open-ai",
+		"x-ai":    "xai",
+		"X_AI":    "xai",
+		"grok":    "xai",
+		"":        "",
+	}
+	for input, want := range testCases {
+		if got := CanonicalProvider(input); got != want {
+			t.Fatalf("CanonicalProvider(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func TestSQLAccountKeyExpressionMatchesGo(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { TFunction } from 'i18next';
 import { AccountExpandedDetails, AccountOverviewCard } from './MonitoringCenterPage';
 import monitoringCenterPageSource from './MonitoringCenterPage.tsx?raw';
+import accountOverviewPanelSource from './components/AccountOverviewPanel.tsx?raw';
 import { MonitoringSummarySection } from '@/features/monitoring/components/MonitoringSummarySection';
 import {
   buildPrimarySummaryCards,
@@ -144,8 +145,25 @@ describe('MonitoringCenterPage quota refresh wiring', () => {
       'targets.map((target) => requestAccountQuota(target, t))'
     );
     expect(monitoringCenterPageSource).toContain('useHeaderSnapshotsLoader({');
-    expect(monitoringCenterPageSource).toContain('const accounts = new Set([');
-    expect(monitoringCenterPageSource).toContain('...accountQuotaTargetsByAccount.keys()');
+    expect(monitoringCenterPageSource).toContain('const rowIds = new Set([');
+    expect(monitoringCenterPageSource).toContain('...accountQuotaTargetsByRowId.keys()');
+    expect(monitoringCenterPageSource).toContain(
+      'resolveMonitoringAccountFocusAction(focusedAccountId, row)'
+    );
+    expect(monitoringCenterPageSource).toContain('accountQuotaTargetsByRowId.get(rowId)');
+    expect(monitoringCenterPageSource).toContain('accountQuotaRequestIdsByRowIdRef.current[rowId]');
+    expect(monitoringCenterPageSource).toContain('commitAccountQuotaState(rowId, {');
+    expect(monitoringCenterPageSource).toContain(
+      '${accountQuotaContextKey}\\u0000${rowId}\\u0000${targetKey}'
+    );
+    expect(monitoringCenterPageSource).toContain('setFocusedAccountId(action.rowId)');
+    expect(monitoringCenterPageSource).not.toContain('focusedAccount === account');
+    expect(monitoringCenterPageSource).not.toContain('accountQuotaTargetsByAccount');
+    expect(accountOverviewPanelSource).toContain('expandedAccounts[row.id]');
+    expect(accountOverviewPanelSource).toContain('focusedAccountId === row.id');
+    expect(accountOverviewPanelSource).toContain('accountAuthStateByRowId.get(row.id)');
+    expect(accountOverviewPanelSource).toContain('accountQuotaStatesByRowId[row.id]');
+    expect(accountOverviewPanelSource).not.toContain('accountQuotaStates[row.account]');
     expect(monitoringCenterPageSource).not.toContain('onResponse: (response) =>');
   });
 });

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -32,6 +32,7 @@ import {
   shouldResetAccountOverviewPage,
   sortAccountRows,
   readAccountOverviewUiState,
+  resolveMonitoringAccountFocusAction,
   writeAccountOverviewUiState,
   type AccountDisplayMode,
   type AccountOverviewPageResetState,
@@ -39,7 +40,7 @@ import {
   type AccountSortState,
   type MonitoringAccountOverviewMode,
 } from '@/features/monitoring/accountOverviewState';
-import { buildMonitoringAccountQuotaTargetsByAccount } from '@/features/monitoring/accountOverviewQuotaTargets';
+import { buildMonitoringAccountQuotaTargetsByRowId } from '@/features/monitoring/accountOverviewQuotaTargets';
 import {
   AccountExpandedDetails,
   AccountOverviewCard,
@@ -97,6 +98,7 @@ import {
   mergeObservedAccountQuotaState,
   parseDateTimeLocalValue,
   requestAccountQuota,
+  updateMonitoringAccountQuotaStateByRowId,
   type FocusSnapshot,
   type StatusFilter,
 } from '@/features/monitoring/model/monitoringCenterPageModel';
@@ -264,7 +266,7 @@ export function MonitoringCenterPage() {
   );
   const [expandedAccounts, setExpandedAccounts] = useState<Record<string, boolean>>({});
   const [expandedApiKeys, setExpandedApiKeys] = useState<Record<string, boolean>>({});
-  const [focusedAccount, setFocusedAccount] = useState<string | null>(null);
+  const [focusedAccountId, setFocusedAccountId] = useState<string | null>(null);
   const [isCustomRangeModalOpen, setIsCustomRangeModalOpen] = useState(false);
   const [usageExporting, setUsageExporting] = useState(false);
   const [usageImporting, setUsageImporting] = useState(false);
@@ -273,9 +275,9 @@ export function MonitoringCenterPage() {
     file: File;
     progress: UsageImportProgress;
   } | null>(null);
-  const [accountQuotaStates, setAccountQuotaStates] = useState<Record<string, AccountQuotaState>>(
-    {}
-  );
+  const [accountQuotaStatesByRowId, setAccountQuotaStatesByRowId] = useState<
+    Record<string, AccountQuotaState>
+  >({});
   const [activeDataTab, setActiveDataTab] = useState<MonitoringDataTab>(
     initialMonitoringCenterUiState.current.activeDataTab
   );
@@ -306,8 +308,8 @@ export function MonitoringCenterPage() {
   );
   const focusSnapshotRef = useRef<FocusSnapshot | null>(null);
   const previousAccountPageResetStateRef = useRef<AccountOverviewPageResetState | null>(null);
-  const accountQuotaStatesRef = useRef<Record<string, AccountQuotaState>>({});
-  const accountQuotaRequestIdsRef = useRef<Record<string, number>>({});
+  const accountQuotaStatesByRowIdRef = useRef<Record<string, AccountQuotaState>>({});
+  const accountQuotaRequestIdsByRowIdRef = useRef<Record<string, number>>({});
   const accountQuotaContextGenerationRef = useRef(0);
   const accountQuotaContextKeyRef = useRef(accountQuotaContextKey);
   const [accountQuotaRefreshQueue] = useState(() => createKeyedSerialTaskQueue());
@@ -460,15 +462,15 @@ export function MonitoringCenterPage() {
     if (accountQuotaContextKeyRef.current === accountQuotaContextKey) return;
     accountQuotaContextKeyRef.current = accountQuotaContextKey;
     accountQuotaContextGenerationRef.current += 1;
-    accountQuotaRequestIdsRef.current = {};
-    accountQuotaStatesRef.current = {};
-    setAccountQuotaStates((current) => (Object.keys(current).length === 0 ? current : {}));
+    accountQuotaRequestIdsByRowIdRef.current = {};
+    accountQuotaStatesByRowIdRef.current = {};
+    setAccountQuotaStatesByRowId((current) => (Object.keys(current).length === 0 ? current : {}));
   }, [accountQuotaContextKey]);
 
   useEffect(
     () => () => {
       accountQuotaContextGenerationRef.current += 1;
-      accountQuotaRequestIdsRef.current = {};
+      accountQuotaRequestIdsByRowIdRef.current = {};
     },
     []
   );
@@ -538,8 +540,8 @@ export function MonitoringCenterPage() {
   const hasPrices = Object.keys(modelPrices).length > 0;
 
   useEffect(() => {
-    accountQuotaStatesRef.current = accountQuotaStates;
-  }, [accountQuotaStates]);
+    accountQuotaStatesByRowIdRef.current = accountQuotaStatesByRowId;
+  }, [accountQuotaStatesByRowId]);
 
   useEffect(() => {
     writeAccountOverviewUiState({
@@ -684,8 +686,8 @@ export function MonitoringCenterPage() {
     ]
   );
   const accountStatusDataByRowId = useMemo(
-    () => buildMonitoringAccountStatusDataMap(scopedRows, accountStatusBounds),
-    [accountStatusBounds, scopedRows]
+    () => buildMonitoringAccountStatusDataMap(scopedRows, accountStatusBounds, accountRows),
+    [accountRows, accountStatusBounds, scopedRows]
   );
   const emptyAccountStatusData = useMemo(() => {
     const resolvedBounds = resolveMonitoringStatusRangeBounds(scopedRows, accountStatusBounds);
@@ -783,8 +785,8 @@ export function MonitoringCenterPage() {
     setCurrentAccountPage(accountPagination.currentPage);
   }, [accountPage, accountPagination.currentPage, overallLoading, setCurrentAccountPage]);
 
-  const accountQuotaTargetsByAccount = useMemo(
-    () => buildMonitoringAccountQuotaTargetsByAccount(accountRows, accountAuthStateByRowId),
+  const accountQuotaTargetsByRowId = useMemo(
+    () => buildMonitoringAccountQuotaTargetsByRowId(accountRows, accountAuthStateByRowId),
     [accountAuthStateByRowId, accountRows]
   );
   const headerSnapshotLookup = useMemo(
@@ -795,16 +797,16 @@ export function MonitoringCenterPage() {
     [headerSnapshotGeneratedAtMs, headerSnapshots]
   );
   const scopedFailureCount = scopedSummary.failureCalls;
-  const accountQuotaStatesWithObservedHeaders = useMemo(() => {
+  const accountQuotaStatesByRowIdWithObservedHeaders = useMemo(() => {
     let changed = false;
     const nextStates: Record<string, AccountQuotaState> = {};
-    const accounts = new Set([
-      ...accountQuotaTargetsByAccount.keys(),
-      ...Object.keys(accountQuotaStates),
+    const rowIds = new Set([
+      ...accountQuotaTargetsByRowId.keys(),
+      ...Object.keys(accountQuotaStatesByRowId),
     ]);
-    accounts.forEach((account) => {
-      const state = accountQuotaStates[account];
-      const targets = accountQuotaTargetsByAccount.get(account) ?? [];
+    rowIds.forEach((rowId) => {
+      const state = accountQuotaStatesByRowId[rowId];
+      const targets = accountQuotaTargetsByRowId.get(rowId) ?? [];
       const observedEntries = targets
         .map((target) =>
           buildObservedCodexAccountQuotaEntry(
@@ -815,11 +817,11 @@ export function MonitoringCenterPage() {
         )
         .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
       const nextState = mergeObservedAccountQuotaState(state, targets, observedEntries);
-      if (nextState) nextStates[account] = nextState;
+      if (nextState) nextStates[rowId] = nextState;
       changed = changed || nextState !== state;
     });
-    return changed ? nextStates : accountQuotaStates;
-  }, [accountQuotaStates, accountQuotaTargetsByAccount, headerSnapshotLookup, t]);
+    return changed ? nextStates : accountQuotaStatesByRowId;
+  }, [accountQuotaStatesByRowId, accountQuotaTargetsByRowId, headerSnapshotLookup, t]);
 
   const hasSearchFilter = Boolean(deferredSearch.trim());
   const hasScopeFilter =
@@ -930,7 +932,7 @@ export function MonitoringCenterPage() {
   const restoreFocusSnapshot = useCallback(() => {
     const snapshot = focusSnapshotRef.current;
     focusSnapshotRef.current = null;
-    setFocusedAccount(null);
+    setFocusedAccountId(null);
 
     if (!snapshot) {
       setSelectedAccount('all');
@@ -949,7 +951,7 @@ export function MonitoringCenterPage() {
 
   const clearFilters = useCallback(() => {
     focusSnapshotRef.current = null;
-    setFocusedAccount(null);
+    setFocusedAccountId(null);
     setSearchInput('');
     setSelectedAccount('all');
     setSelectedProvider('all');
@@ -1027,24 +1029,25 @@ export function MonitoringCenterPage() {
     }));
   }, []);
 
-  const commitAccountQuotaState = useCallback((account: string, state: AccountQuotaState) => {
-    accountQuotaStatesRef.current = {
-      ...accountQuotaStatesRef.current,
-      [account]: state,
-    };
-    setAccountQuotaStates((previous) => {
-      const next = { ...previous, [account]: state };
-      accountQuotaStatesRef.current = next;
+  const commitAccountQuotaState = useCallback((rowId: string, state: AccountQuotaState) => {
+    accountQuotaStatesByRowIdRef.current = updateMonitoringAccountQuotaStateByRowId(
+      accountQuotaStatesByRowIdRef.current,
+      rowId,
+      state
+    );
+    setAccountQuotaStatesByRowId((previous) => {
+      const next = updateMonitoringAccountQuotaStateByRowId(previous, rowId, state);
+      accountQuotaStatesByRowIdRef.current = next;
       return next;
     });
   }, []);
 
   const loadAccountQuota = useCallback(
-    (account: string, force: boolean = false): Promise<void> => {
-      const currentState = accountQuotaStatesRef.current[account];
-      const targets = accountQuotaTargetsByAccount.get(account) ?? [];
+    (rowId: string, force: boolean = false): Promise<void> => {
+      const currentState = accountQuotaStatesByRowIdRef.current[rowId];
+      const targets = accountQuotaTargetsByRowId.get(rowId) ?? [];
       const targetKey = targets.map((target) => target.key).join('|');
-      const requestKey = `${accountQuotaContextKey}\u0000${account}\u0000${targetKey}`;
+      const requestKey = `${accountQuotaContextKey}\u0000${rowId}\u0000${targetKey}`;
       if (accountQuotaRefreshQueue.isPending(requestKey)) {
         return accountQuotaRefreshQueue.run(requestKey, async () => undefined);
       }
@@ -1074,13 +1077,13 @@ export function MonitoringCenterPage() {
       }
 
       const contextGeneration = accountQuotaContextGenerationRef.current;
-      const requestId = (accountQuotaRequestIdsRef.current[account] ?? 0) + 1;
-      accountQuotaRequestIdsRef.current[account] = requestId;
+      const requestId = (accountQuotaRequestIdsByRowIdRef.current[rowId] ?? 0) + 1;
+      accountQuotaRequestIdsByRowIdRef.current[rowId] = requestId;
       const isCurrentRequest = () =>
         accountQuotaContextGenerationRef.current === contextGeneration &&
-        accountQuotaRequestIdsRef.current[account] === requestId;
+        accountQuotaRequestIdsByRowIdRef.current[rowId] === requestId;
 
-      commitAccountQuotaState(account, {
+      commitAccountQuotaState(rowId, {
         status: 'loading',
         targetKey,
         entries: currentState?.targetKey === targetKey ? currentState.entries : observedEntries,
@@ -1090,7 +1093,7 @@ export function MonitoringCenterPage() {
       return accountQuotaRefreshQueue.run(requestKey, async () => {
         if (!isCurrentRequest()) return;
         if (targets.length === 0) {
-          commitAccountQuotaState(account, {
+          commitAccountQuotaState(rowId, {
             status: 'success',
             targetKey,
             entries: [],
@@ -1158,7 +1161,7 @@ export function MonitoringCenterPage() {
 
         const hasSuccess = entries.some((entry) => !entry.error);
         const firstError = entries.find((entry) => entry.error)?.error;
-        commitAccountQuotaState(account, {
+        commitAccountQuotaState(rowId, {
           status: hasFailure ? 'error' : hasSuccess ? 'success' : 'error',
           targetKey,
           entries,
@@ -1171,7 +1174,7 @@ export function MonitoringCenterPage() {
     [
       accountQuotaContextKey,
       accountQuotaRefreshQueue,
-      accountQuotaTargetsByAccount,
+      accountQuotaTargetsByRowId,
       commitAccountQuotaState,
       headerSnapshotLookup,
       t,
@@ -1187,9 +1190,8 @@ export function MonitoringCenterPage() {
 
   const focusAccount = useCallback(
     (row: MonitoringAccountRow) => {
-      const account = row.account;
-      const accountFilterValue = row.filterValue || row.account;
-      if (focusedAccount === account) {
+      const action = resolveMonitoringAccountFocusAction(focusedAccountId, row);
+      if (action.type === 'restore') {
         restoreFocusSnapshot();
         return;
       }
@@ -1207,11 +1209,11 @@ export function MonitoringCenterPage() {
         };
       }
 
-      setFocusedAccount(account);
-      setSelectedAccount(accountFilterValue);
+      setFocusedAccountId(action.rowId);
+      setSelectedAccount(action.filterValue);
     },
     [
-      focusedAccount,
+      focusedAccountId,
       restoreFocusSnapshot,
       searchInput,
       selectedAccount,
@@ -1228,12 +1230,12 @@ export function MonitoringCenterPage() {
     (value: string) => {
       setSelectedAccount(value);
 
-      if (focusedAccount && value !== focusedAccount) {
+      if (focusedAccountId) {
         focusSnapshotRef.current = null;
-        setFocusedAccount(null);
+        setFocusedAccountId(null);
       }
     },
-    [focusedAccount]
+    [focusedAccountId]
   );
 
   const handleAccountPageSizeChange = useCallback(
@@ -1731,11 +1733,11 @@ export function MonitoringCenterPage() {
                 accountSort={accountSort}
                 accountSortOptions={accountSortOptions}
                 expandedAccounts={expandedAccounts}
-                focusedAccount={focusedAccount}
+                focusedAccountId={focusedAccountId}
                 accountAuthStateByRowId={accountAuthStateByRowId}
                 accountStatusDataByRowId={accountStatusDataByRowId}
                 emptyAccountStatusData={emptyAccountStatusData}
-                accountQuotaStates={accountQuotaStatesWithObservedHeaders}
+                accountQuotaStatesByRowId={accountQuotaStatesByRowIdWithObservedHeaders}
                 accountPageSize={accountPageSize}
                 accountPageSizeOptions={accountPageSizeOptions}
                 accountOverviewScopeText={accountOverviewScopeText}

--- a/apps/web/src/features/monitoring/accountOverviewQuotaTargets.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewQuotaTargets.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { MonitoringAccountRow } from './hooks/useMonitoringData';
 import type { MonitoringAccountAuthState } from './accountOverviewState';
-import { buildMonitoringAccountQuotaTargetsByAccount } from './accountOverviewQuotaTargets';
+import { buildMonitoringAccountQuotaTargetsByRowId } from './accountOverviewQuotaTargets';
 
 const createAccountRow = (overrides: Partial<MonitoringAccountRow> = {}): MonitoringAccountRow => ({
   id: overrides.id ?? 'account@example.com',
   account: overrides.account ?? 'account@example.com',
+  provider: overrides.provider,
   displayAccount: overrides.displayAccount ?? overrides.account ?? 'account@example.com',
   accountMasked: overrides.accountMasked ?? 'acc***@example.com',
   authLabels: overrides.authLabels ?? [],
@@ -65,7 +66,7 @@ describe('accountOverviewQuotaTargets', () => {
       ],
     ]);
 
-    const result = buildMonitoringAccountQuotaTargetsByAccount(
+    const result = buildMonitoringAccountQuotaTargetsByRowId(
       [
         createAccountRow({
           id: 'account@example.com',
@@ -102,7 +103,7 @@ describe('accountOverviewQuotaTargets', () => {
       ],
     ]);
 
-    const result = buildMonitoringAccountQuotaTargetsByAccount(
+    const result = buildMonitoringAccountQuotaTargetsByRowId(
       [
         createAccountRow({
           id: 'account@example.com',
@@ -155,7 +156,7 @@ describe('accountOverviewQuotaTargets', () => {
       ],
     ]);
 
-    const result = buildMonitoringAccountQuotaTargetsByAccount(
+    const result = buildMonitoringAccountQuotaTargetsByRowId(
       [
         createAccountRow({
           id: 'account@example.com',
@@ -198,7 +199,7 @@ describe('accountOverviewQuotaTargets', () => {
       ],
     ]);
 
-    const result = buildMonitoringAccountQuotaTargetsByAccount(
+    const result = buildMonitoringAccountQuotaTargetsByRowId(
       [
         createAccountRow({
           id: 'account@example.com',
@@ -212,5 +213,64 @@ describe('accountOverviewQuotaTargets', () => {
     expect(result.get('account@example.com')).toMatchObject([
       { provider: 'codex', authIndex: '1', fileName: 'codex.json' },
     ]);
+  });
+
+  it('keeps same-email provider quota targets in independent row-id buckets', () => {
+    const codexRowId = 'monitoring-account:codex';
+    const antigravityRowId = 'monitoring-account:antigravity';
+    const authStateByRowId = new Map<string, MonitoringAccountAuthState>([
+      [
+        codexRowId,
+        createAuthState({
+          files: [
+            {
+              name: 'codex.json',
+              type: 'codex',
+              authIndex: 'codex-auth',
+              account: 'same@example.com',
+            },
+          ],
+          enabledState: 'enabled',
+        }),
+      ],
+      [
+        antigravityRowId,
+        createAuthState({
+          files: [
+            {
+              name: 'antigravity.json',
+              type: 'antigravity',
+              authIndex: 'antigravity-auth',
+              account: 'same@example.com',
+            },
+          ],
+          enabledState: 'enabled',
+        }),
+      ],
+    ]);
+
+    const result = buildMonitoringAccountQuotaTargetsByRowId(
+      [
+        createAccountRow({
+          id: codexRowId,
+          account: 'same@example.com',
+          provider: 'codex',
+          authIndices: ['codex-auth'],
+        }),
+        createAccountRow({
+          id: antigravityRowId,
+          account: 'same@example.com',
+          provider: 'antigravity',
+          authIndices: ['antigravity-auth'],
+        }),
+      ],
+      authStateByRowId
+    );
+
+    expect(result.get(codexRowId)).toMatchObject([{ provider: 'codex', fileName: 'codex.json' }]);
+    expect(result.get(antigravityRowId)).toMatchObject([
+      { provider: 'antigravity', fileName: 'antigravity.json' },
+    ]);
+    expect(result.get('same@example.com')).toBeUndefined();
   });
 });

--- a/apps/web/src/features/monitoring/accountOverviewQuotaTargets.ts
+++ b/apps/web/src/features/monitoring/accountOverviewQuotaTargets.ts
@@ -12,7 +12,6 @@ import {
 } from '@/utils/quota';
 import type { MonitoringAccountAuthState } from './accountOverviewState';
 import type { MonitoringAccountRow } from './hooks/useMonitoringData';
-import { normalizeMonitoringProvider } from './model/accountIdentity';
 
 export type MonitoringAccountQuotaProvider = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
 
@@ -63,7 +62,6 @@ const resolveActiveQuotaProvidersForRow = (
 ): Set<MonitoringAccountQuotaProvider> => {
   const activeProviders = new Set<MonitoringAccountQuotaProvider>();
   if (!authState) return activeProviders;
-  const rowProvider = normalizeMonitoringProvider(row.provider);
 
   const rowAuthIndices = new Set(
     row.authIndices
@@ -77,7 +75,7 @@ const resolveActiveQuotaProvidersForRow = (
     if (!authIndex || !rowAuthIndices.has(authIndex)) return;
 
     const provider = resolveMonitoringAccountQuotaProvider(file);
-    if (provider && (!rowProvider || provider === rowProvider)) activeProviders.add(provider);
+    if (provider) activeProviders.add(provider);
   });
 
   return activeProviders;

--- a/apps/web/src/features/monitoring/accountOverviewQuotaTargets.ts
+++ b/apps/web/src/features/monitoring/accountOverviewQuotaTargets.ts
@@ -12,13 +12,9 @@ import {
 } from '@/utils/quota';
 import type { MonitoringAccountAuthState } from './accountOverviewState';
 import type { MonitoringAccountRow } from './hooks/useMonitoringData';
+import { normalizeMonitoringProvider } from './model/accountIdentity';
 
-export type MonitoringAccountQuotaProvider =
-  | 'antigravity'
-  | 'claude'
-  | 'codex'
-  | 'kimi'
-  | 'xai';
+export type MonitoringAccountQuotaProvider = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
 
 export type MonitoringAccountQuotaTarget = {
   key: string;
@@ -67,6 +63,7 @@ const resolveActiveQuotaProvidersForRow = (
 ): Set<MonitoringAccountQuotaProvider> => {
   const activeProviders = new Set<MonitoringAccountQuotaProvider>();
   if (!authState) return activeProviders;
+  const rowProvider = normalizeMonitoringProvider(row.provider);
 
   const rowAuthIndices = new Set(
     row.authIndices
@@ -80,13 +77,13 @@ const resolveActiveQuotaProvidersForRow = (
     if (!authIndex || !rowAuthIndices.has(authIndex)) return;
 
     const provider = resolveMonitoringAccountQuotaProvider(file);
-    if (provider) activeProviders.add(provider);
+    if (provider && (!rowProvider || provider === rowProvider)) activeProviders.add(provider);
   });
 
   return activeProviders;
 };
 
-export const buildMonitoringAccountQuotaTargetsByAccount = (
+export const buildMonitoringAccountQuotaTargetsByRowId = (
   rows: MonitoringAccountRow[],
   authStateByRowId: Map<string, MonitoringAccountAuthState>
 ) =>
@@ -118,7 +115,7 @@ export const buildMonitoringAccountQuotaTargetsByAccount = (
       });
 
       return [
-        row.account,
+        row.id,
         Array.from(bucket.values()).sort(
           (left, right) =>
             left.authLabel.localeCompare(right.authLabel) ||

--- a/apps/web/src/features/monitoring/accountOverviewState.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.test.ts
@@ -584,7 +584,7 @@ describe('accountOverviewState', () => {
     expect(accountState?.enabledState).toBe('enabled');
   });
 
-  it('filters account auth state by the row provider namespace', () => {
+  it('resolves auth state from the row authIndices (provider-scoped by backend grouping)', () => {
     const authFilesByIndex = new Map<string, AuthFileItem>([
       [
         'codex-auth',
@@ -605,14 +605,13 @@ describe('accountOverviewState', () => {
         },
       ],
     ]);
-    const sharedAuthIndices = ['codex-auth', 'antigravity-auth'];
     const states = buildMonitoringAccountAuthStateMap(
       [
-        createAccountRow({ id: 'codex-row', provider: 'codex', authIndices: sharedAuthIndices }),
+        createAccountRow({ id: 'codex-row', provider: 'codex', authIndices: ['codex-auth'] }),
         createAccountRow({
           id: 'antigravity-row',
           provider: 'antigravity',
-          authIndices: sharedAuthIndices,
+          authIndices: ['antigravity-auth'],
         }),
       ],
       authFilesByIndex

--- a/apps/web/src/features/monitoring/accountOverviewState.test.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.test.ts
@@ -16,13 +16,17 @@ import {
   normalizeAccountOverviewUiState,
   normalizeAccountSortState,
   resolveAccountDisplayText,
+  resolveMonitoringAccountFocusAction,
   sortAccountRows,
 } from './accountOverviewState';
+import { buildMonitoringAccountRowId } from './model/accountIdentity';
 import type { AuthFileItem } from '@/types';
 
 const createAccountRow = (overrides: Partial<MonitoringAccountRow> = {}): MonitoringAccountRow => ({
   id: overrides.id ?? 'account',
   account: overrides.account ?? 'account@example.com',
+  provider: overrides.provider ?? 'codex',
+  filterValue: overrides.filterValue,
   displayAccount: overrides.displayAccount ?? overrides.account ?? 'account@example.com',
   accountMasked: overrides.accountMasked ?? 'acc***@example.com',
   authLabels: overrides.authLabels ?? [],
@@ -58,17 +62,23 @@ const createEventRow = (overrides: Partial<MonitoringEventRow> = {}): Monitoring
   endpointPath: overrides.endpointPath ?? '/v1/chat/completions',
   sourceKey: overrides.sourceKey ?? 'source-1',
   source: overrides.source ?? 'source-1',
+  sourceIdentity: overrides.sourceIdentity,
+  sourceHashIdentity: overrides.sourceHashIdentity,
   sourceMasked: overrides.sourceMasked ?? 'source-1',
   account: overrides.account ?? 'account@example.com',
+  accountIdentity: overrides.accountIdentity,
   accountMasked: overrides.accountMasked ?? 'acc***@example.com',
   authIndex: overrides.authIndex ?? '1',
+  authIndexIdentity: overrides.authIndexIdentity,
   authIndexMasked: overrides.authIndexMasked ?? '1',
   authLabel: overrides.authLabel ?? 'account@example.com',
+  authLabelIdentity: overrides.authLabelIdentity,
   projectId: overrides.projectId ?? 'project-1',
   apiKeyHash: overrides.apiKeyHash ?? 'api-key-hash',
   apiKeyLabel: overrides.apiKeyLabel ?? 'ak********sh',
   apiKeyMasked: overrides.apiKeyMasked ?? 'ak********sh',
   provider: overrides.provider ?? 'codex',
+  providerIdentity: overrides.providerIdentity,
   planType: overrides.planType ?? 'plus',
   channel: overrides.channel ?? 'default',
   channelHost: overrides.channelHost ?? 'localhost',
@@ -166,6 +176,33 @@ describe('accountOverviewState', () => {
     expect(resolveAccountDisplayText(row, 'full')).toMatchObject({
       primary: 'Primary Channel',
       secondary: 'account@example.com',
+    });
+  });
+
+  it('uses provider metadata to disambiguate same-email account rows', () => {
+    const codex = resolveAccountDisplayText(
+      createAccountRow({
+        account: 'same@example.com',
+        accountMasked: 'sam***@example.com',
+        provider: 'codex',
+        channels: ['Codex'],
+      }),
+      'full'
+    );
+    const antigravity = resolveAccountDisplayText(
+      createAccountRow({
+        account: 'same@example.com',
+        accountMasked: 'sam***@example.com',
+        provider: 'antigravity',
+        channels: ['Antigravity'],
+      }),
+      'full'
+    );
+
+    expect(codex).toMatchObject({ primary: 'same@example.com', secondary: 'Codex' });
+    expect(antigravity).toMatchObject({
+      primary: 'same@example.com',
+      secondary: 'Antigravity',
     });
   });
 
@@ -547,6 +584,71 @@ describe('accountOverviewState', () => {
     expect(accountState?.enabledState).toBe('enabled');
   });
 
+  it('filters account auth state by the row provider namespace', () => {
+    const authFilesByIndex = new Map<string, AuthFileItem>([
+      [
+        'codex-auth',
+        {
+          name: 'codex.json',
+          type: 'codex',
+          authIndex: 'codex-auth',
+          account: 'same@example.com',
+        },
+      ],
+      [
+        'antigravity-auth',
+        {
+          name: 'antigravity.json',
+          type: 'antigravity',
+          authIndex: 'antigravity-auth',
+          account: 'same@example.com',
+        },
+      ],
+    ]);
+    const sharedAuthIndices = ['codex-auth', 'antigravity-auth'];
+    const states = buildMonitoringAccountAuthStateMap(
+      [
+        createAccountRow({ id: 'codex-row', provider: 'codex', authIndices: sharedAuthIndices }),
+        createAccountRow({
+          id: 'antigravity-row',
+          provider: 'antigravity',
+          authIndices: sharedAuthIndices,
+        }),
+      ],
+      authFilesByIndex
+    );
+
+    expect(states.get('codex-row')?.files.map((file) => file.name)).toEqual(['codex.json']);
+    expect(states.get('antigravity-row')?.files.map((file) => file.name)).toEqual([
+      'antigravity.json',
+    ]);
+  });
+
+  it('uses row id for focus toggle while preserving filter value as query scope', () => {
+    const codex = createAccountRow({
+      id: 'codex-row',
+      account: 'same@example.com',
+      filterValue: 'auth:codex-auth',
+    });
+    const antigravity = createAccountRow({
+      id: 'antigravity-row',
+      account: 'same@example.com',
+      filterValue: 'auth:antigravity-auth',
+    });
+
+    expect(resolveMonitoringAccountFocusAction(null, codex)).toEqual({
+      type: 'focus',
+      rowId: 'codex-row',
+      filterValue: 'auth:codex-auth',
+    });
+    expect(resolveMonitoringAccountFocusAction('codex-row', antigravity)).toEqual({
+      type: 'focus',
+      rowId: 'antigravity-row',
+      filterValue: 'auth:antigravity-auth',
+    });
+    expect(resolveMonitoringAccountFocusAction('codex-row', codex)).toEqual({ type: 'restore' });
+  });
+
   it('builds account health status from filtered monitoring rows within the selected range', () => {
     const startMs = Date.UTC(2026, 4, 10, 0, 0, 0);
     const endMs = Date.UTC(2026, 4, 17, 0, 0, 0) - 1;
@@ -578,7 +680,13 @@ describe('accountOverviewState', () => {
       }),
     ];
 
-    const result = buildMonitoringAccountStatusDataMap(rows, { startMs, endMs });
+    const result = buildMonitoringAccountStatusDataMap(rows, { startMs, endMs }, [
+      createAccountRow({ id: 'account@example.com' }),
+      createAccountRow({
+        id: 'other@example.com',
+        account: 'other@example.com',
+      }),
+    ]);
     const accountStatus = result.get('account@example.com');
     const otherStatus = result.get('other@example.com');
 
@@ -591,6 +699,74 @@ describe('accountOverviewState', () => {
 
     expect(otherStatus?.totalSuccess).toBe(1);
     expect(otherStatus?.totalFailure).toBe(0);
+  });
+
+  it('keeps same-email account health state isolated by provider row id', () => {
+    const startMs = Date.UTC(2026, 4, 10, 0, 0, 0);
+    const endMs = startMs + 60_000;
+    const result = buildMonitoringAccountStatusDataMap(
+      [
+        createEventRow({
+          id: 'codex-success',
+          timestampMs: startMs,
+          account: 'same@example.com',
+          provider: 'codex',
+          failed: false,
+        }),
+        createEventRow({
+          id: 'antigravity-failure',
+          timestampMs: startMs + 1,
+          account: 'same@example.com',
+          provider: 'antigravity',
+          failed: true,
+        }),
+      ],
+      { startMs, endMs },
+      [
+        createAccountRow({ id: 'codex-row', account: 'same@example.com', provider: 'codex' }),
+        createAccountRow({
+          id: 'antigravity-row',
+          account: 'same@example.com',
+          provider: 'antigravity',
+        }),
+      ]
+    );
+
+    expect(result.get('codex-row')).toMatchObject({ totalSuccess: 1, totalFailure: 0 });
+    expect(result.get('antigravity-row')).toMatchObject({ totalSuccess: 0, totalFailure: 1 });
+  });
+
+  it('maps label-scoped status to the backend row id when display account is enriched', () => {
+    const startMs = Date.UTC(2026, 4, 10, 0, 0, 0);
+    const rowId = buildMonitoringAccountRowId({
+      provider: 'codex',
+      authLabel: 'Shared Label',
+    });
+    const result = buildMonitoringAccountStatusDataMap(
+      [
+        createEventRow({
+          id: 'label-scoped-event',
+          timestampMs: startMs,
+          account: 'metadata@example.com',
+          accountIdentity: '',
+          authLabel: 'Shared Label',
+          authLabelIdentity: 'Shared Label',
+          provider: 'codex',
+          failed: false,
+        }),
+      ],
+      { startMs, endMs: startMs + 60_000 },
+      [
+        createAccountRow({
+          id: rowId,
+          account: 'metadata@example.com',
+          authLabels: ['Shared Label'],
+          provider: 'codex',
+        }),
+      ]
+    );
+
+    expect(result.get(rowId)).toMatchObject({ totalSuccess: 1, totalFailure: 0 });
   });
 
   it('builds 20 idle buckets for empty account health fallback data', () => {
@@ -632,10 +808,14 @@ describe('accountOverviewState', () => {
       }),
     ];
 
-    const result = buildMonitoringAccountStatusDataMap(rows, {
-      startMs: Number.NEGATIVE_INFINITY,
-      endMs,
-    });
+    const result = buildMonitoringAccountStatusDataMap(
+      rows,
+      {
+        startMs: Number.NEGATIVE_INFINITY,
+        endMs,
+      },
+      [createAccountRow({ id: 'account@example.com' })]
+    );
     const accountStatus = result.get('account@example.com');
 
     expect(accountStatus).toBeDefined();

--- a/apps/web/src/features/monitoring/accountOverviewState.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.ts
@@ -1,7 +1,9 @@
 import type { AuthFileItem } from '@/types';
 import type { SourceProviderEnabledState } from '@/types/sourceInfo';
+import { readAuthFileStatusProvider } from '@/utils/authFileCredentialIdentity';
 import { isDisabledAuthFile } from '@/utils/quota';
 import { normalizeRecentRequestAuthIndex, type StatusBarData } from '@/utils/recentRequests';
+import { buildMonitoringAccountRowId, normalizeMonitoringProvider } from './model/accountIdentity';
 import type {
   MonitoringAccountRow,
   MonitoringEventRow,
@@ -75,6 +77,18 @@ export type MonitoringAccountOverviewUiState = {
   sort: AccountSortState;
   cardPagination: MonitoringAccountOverviewCardPaginationState;
 };
+
+export type MonitoringAccountFocusAction =
+  | { type: 'restore' }
+  | { type: 'focus'; rowId: string; filterValue: string };
+
+export const resolveMonitoringAccountFocusAction = (
+  focusedAccountId: string | null,
+  row: Pick<MonitoringAccountRow, 'id' | 'filterValue' | 'account'>
+): MonitoringAccountFocusAction =>
+  focusedAccountId === row.id
+    ? { type: 'restore' }
+    : { type: 'focus', rowId: row.id, filterValue: row.filterValue || row.account };
 
 export type MonitoringAccountAuthState = {
   files: AuthFileItem[];
@@ -226,7 +240,7 @@ const isRedundantAccountLabel = (
 export const resolveAccountDisplayText = (
   row: Pick<
     MonitoringAccountRow,
-    'account' | 'accountMasked' | 'displayAccount' | 'authLabels' | 'channels'
+    'account' | 'accountMasked' | 'displayAccount' | 'authLabels' | 'channels' | 'provider'
   >,
   displayMode: AccountDisplayMode
 ) => {
@@ -244,10 +258,16 @@ export const resolveAccountDisplayText = (
   const primary = primaryIsAccount
     ? firstReadableAccountValue(maskedAccount, fullAccount, configuredPrimary, '-')
     : configuredPrimary;
+  const provider = normalizeMonitoringProvider(row.provider);
+  const providerLabel =
+    row.channels.find(
+      (label) => normalizeMonitoringProvider(label) === provider && hasReadableAccountValue(label)
+    ) || row.provider;
   const secondaryCandidates = primaryIsAccount
     ? [
-        ...row.authLabels.filter((label) => label && label !== primary && label !== fullAccount),
+        providerLabel,
         ...row.channels.filter((label) => label && label !== '-' && label !== primary),
+        ...row.authLabels.filter((label) => label && label !== primary && label !== fullAccount),
       ]
     : [maskedAccount, fullAccount];
   const secondary =
@@ -547,10 +567,24 @@ const buildStatusDataForRows = (
 
 export const buildMonitoringAccountStatusDataMap = (
   rows: MonitoringEventRow[],
-  bounds: MonitoringStatusRangeBounds | null | undefined
+  bounds: MonitoringStatusRangeBounds | null | undefined,
+  accountRows: MonitoringAccountRow[] = []
 ) => {
   const resolvedBounds = resolveMonitoringStatusRangeBounds(rows, bounds);
   const grouped = new Map<string, MonitoringEventRow[]>();
+  const rowIdByFallbackIdentity = new Map<string, string>();
+  accountRows.forEach((row) => {
+    rowIdByFallbackIdentity.set(row.id, row.id);
+    rowIdByFallbackIdentity.set(
+      buildMonitoringAccountRowId({
+        provider: row.provider,
+        account: row.account,
+        authLabel: row.authLabels[0],
+        authIndex: row.authIndices[0],
+      }),
+      row.id
+    );
+  });
 
   if (!resolvedBounds) {
     return new Map<string, StatusBarData>();
@@ -561,10 +595,18 @@ export const buildMonitoringAccountStatusDataMap = (
       return;
     }
 
-    const accountKey = row.account || row.authLabel || row.source;
-    const existing = grouped.get(accountKey) ?? [];
+    const fallbackIdentity = buildMonitoringAccountRowId({
+      provider: row.providerIdentity ?? row.provider,
+      account: row.accountIdentity ?? row.account,
+      authLabel: row.authLabelIdentity ?? row.authLabel,
+      source: row.sourceIdentity ?? row.source,
+      authIndex: row.authIndexIdentity ?? row.authIndex,
+      sourceHash: row.sourceHashIdentity,
+    });
+    const rowId = rowIdByFallbackIdentity.get(fallbackIdentity) || fallbackIdentity;
+    const existing = grouped.get(rowId) ?? [];
     existing.push(row);
-    grouped.set(accountKey, existing);
+    grouped.set(rowId, existing);
   });
 
   return new Map(
@@ -589,7 +631,8 @@ export const buildMonitoringAccountAuthStateMap = (
             row.authIndices,
             authFilesByAuthIndex,
             row.sourceKeys ?? [],
-            sourceProviderStateBySourceKey
+            sourceProviderStateBySourceKey,
+            row.provider
           ),
         ] as const
     )
@@ -599,8 +642,10 @@ export const buildMonitoringAccountAuthState = (
   authIndices: string[],
   authFilesByAuthIndex: Map<string, AuthFileItem>,
   sourceKeys: string[] = [],
-  sourceProviderStateBySourceKey: Map<string, SourceProviderEnabledState> = new Map()
+  sourceProviderStateBySourceKey: Map<string, SourceProviderEnabledState> = new Map(),
+  provider?: string
 ): MonitoringAccountAuthState => {
+  const canonicalProvider = normalizeMonitoringProvider(provider);
   const files = Array.from(
     authIndices.reduce<Map<string, AuthFileItem>>((map, authIndex) => {
       const normalizedAuthIndex = normalizeRecentRequestAuthIndex(authIndex);
@@ -608,6 +653,10 @@ export const buildMonitoringAccountAuthState = (
 
       const file = authFilesByAuthIndex.get(normalizedAuthIndex);
       if (!file || map.has(file.name)) return map;
+      const fileProvider = normalizeMonitoringProvider(readAuthFileStatusProvider(file));
+      if (canonicalProvider && fileProvider && fileProvider !== canonicalProvider) {
+        return map;
+      }
 
       map.set(file.name, file);
       return map;

--- a/apps/web/src/features/monitoring/accountOverviewState.ts
+++ b/apps/web/src/features/monitoring/accountOverviewState.ts
@@ -1,6 +1,5 @@
 import type { AuthFileItem } from '@/types';
 import type { SourceProviderEnabledState } from '@/types/sourceInfo';
-import { readAuthFileStatusProvider } from '@/utils/authFileCredentialIdentity';
 import { isDisabledAuthFile } from '@/utils/quota';
 import { normalizeRecentRequestAuthIndex, type StatusBarData } from '@/utils/recentRequests';
 import { buildMonitoringAccountRowId, normalizeMonitoringProvider } from './model/accountIdentity';
@@ -631,8 +630,7 @@ export const buildMonitoringAccountAuthStateMap = (
             row.authIndices,
             authFilesByAuthIndex,
             row.sourceKeys ?? [],
-            sourceProviderStateBySourceKey,
-            row.provider
+            sourceProviderStateBySourceKey
           ),
         ] as const
     )
@@ -642,10 +640,8 @@ export const buildMonitoringAccountAuthState = (
   authIndices: string[],
   authFilesByAuthIndex: Map<string, AuthFileItem>,
   sourceKeys: string[] = [],
-  sourceProviderStateBySourceKey: Map<string, SourceProviderEnabledState> = new Map(),
-  provider?: string
+  sourceProviderStateBySourceKey: Map<string, SourceProviderEnabledState> = new Map()
 ): MonitoringAccountAuthState => {
-  const canonicalProvider = normalizeMonitoringProvider(provider);
   const files = Array.from(
     authIndices.reduce<Map<string, AuthFileItem>>((map, authIndex) => {
       const normalizedAuthIndex = normalizeRecentRequestAuthIndex(authIndex);
@@ -653,10 +649,6 @@ export const buildMonitoringAccountAuthState = (
 
       const file = authFilesByAuthIndex.get(normalizedAuthIndex);
       if (!file || map.has(file.name)) return map;
-      const fileProvider = normalizeMonitoringProvider(readAuthFileStatusProvider(file));
-      if (canonicalProvider && fileProvider && fileProvider !== canonicalProvider) {
-        return map;
-      }
 
       map.set(file.name, file);
       return map;

--- a/apps/web/src/features/monitoring/components/AccountOverviewPanel.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewPanel.tsx
@@ -66,11 +66,11 @@ type AccountOverviewPanelProps = {
   accountSort: AccountSortState;
   accountSortOptions: ReadonlyArray<SelectOption>;
   expandedAccounts: Record<string, boolean>;
-  focusedAccount: string | null;
+  focusedAccountId: string | null;
   accountAuthStateByRowId: ReadonlyMap<string, MonitoringAccountAuthState>;
   accountStatusDataByRowId: ReadonlyMap<string, StatusBarData>;
   emptyAccountStatusData: StatusBarData;
-  accountQuotaStates: Record<string, AccountQuotaState>;
+  accountQuotaStatesByRowId: Record<string, AccountQuotaState>;
   accountPageSize: number;
   accountPageSizeOptions: readonly number[];
   accountOverviewScopeText: string;
@@ -85,8 +85,8 @@ type AccountOverviewPanelProps = {
   onModeChange: (mode: MonitoringAccountOverviewMode) => void;
   onAccountDisplayModeChange: (mode: AccountDisplayMode) => void;
   onAccountSort: (sortKey: AccountSortKey) => void;
-  onLoadAccountQuota: (account: string, force: boolean) => void | Promise<void>;
-  onToggleExpanded: (rowId: string, account: string) => void;
+  onLoadAccountQuota: (rowId: string, force: boolean) => void | Promise<void>;
+  onToggleExpanded: (rowId: string) => void;
   onFocusAccount: (row: MonitoringAccountRow) => void;
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
@@ -123,13 +123,7 @@ const getAccountColumnInfo = (columnKey: string, t: TFunction) => {
   return '';
 };
 
-function AccountColumnLabel({
-  column,
-  t,
-}: {
-  column: AccountOverviewColumn;
-  t: TFunction;
-}) {
+function AccountColumnLabel({ column, t }: { column: AccountOverviewColumn; t: TFunction }) {
   const info = getAccountColumnInfo(column.key, t);
   const labelTitle = column.fullLabel ?? column.label;
 
@@ -258,11 +252,11 @@ export function AccountOverviewPanel({
   accountSort,
   accountSortOptions,
   expandedAccounts,
-  focusedAccount,
+  focusedAccountId,
   accountAuthStateByRowId,
   accountStatusDataByRowId,
   emptyAccountStatusData,
-  accountQuotaStates,
+  accountQuotaStatesByRowId,
   accountPageSize,
   accountPageSizeOptions,
   accountOverviewScopeText,
@@ -364,7 +358,7 @@ export function AccountOverviewPanel({
             <tbody>
               {pagination.pageItems.map((row) => {
                 const isExpanded = Boolean(expandedAccounts[row.id]);
-                const isFocused = focusedAccount === row.account;
+                const isFocused = focusedAccountId === row.id;
                 const authState = accountAuthStateByRowId.get(row.id) ?? EMPTY_ACCOUNT_AUTH_STATE;
                 const statusTone = getAccountStatusTone(authState);
                 const summaryMetrics = buildAccountSummaryMetrics(row, hasPrices, locale, t);
@@ -381,7 +375,7 @@ export function AccountOverviewPanel({
                   {
                     key: 'refresh-quota',
                     label: t('monitoring.account_overview_row_menu_refresh_quota'),
-                    onClick: () => void onLoadAccountQuota(row.account, true),
+                    onClick: () => void onLoadAccountQuota(row.id, true),
                   },
                 ];
 
@@ -392,7 +386,7 @@ export function AccountOverviewPanel({
                         <AccountSummaryPrimary
                           row={row}
                           expanded={isExpanded}
-                          onToggle={() => onToggleExpanded(row.id, row.account)}
+                          onToggle={() => onToggleExpanded(row.id)}
                           accountDisplayMode={accountDisplayMode}
                           statusTone={statusTone}
                         />
@@ -445,8 +439,8 @@ export function AccountOverviewPanel({
                             locale={locale}
                             t={t}
                             summaryMetrics={summaryMetrics}
-                            quotaState={accountQuotaStates[row.account]}
-                            onRefreshQuota={() => void onLoadAccountQuota(row.account, true)}
+                            quotaState={accountQuotaStatesByRowId[row.id]}
+                            onRefreshQuota={() => void onLoadAccountQuota(row.id, true)}
                             variant="table"
                           />
                         </td>
@@ -478,13 +472,13 @@ export function AccountOverviewPanel({
                 t={t}
                 accountDisplayMode={accountDisplayMode}
                 isExpanded={Boolean(expandedAccounts[row.id])}
-                isFocused={focusedAccount === row.account}
+                isFocused={focusedAccountId === row.id}
                 statusData={accountStatusDataByRowId.get(row.id) ?? emptyAccountStatusData}
                 scopeText={accountOverviewScopeText}
-                quotaState={accountQuotaStates[row.account]}
-                onToggle={() => onToggleExpanded(row.id, row.account)}
+                quotaState={accountQuotaStatesByRowId[row.id]}
+                onToggle={() => onToggleExpanded(row.id)}
                 onFocus={() => onFocusAccount(row)}
-                onRefreshQuota={() => void onLoadAccountQuota(row.account, true)}
+                onRefreshQuota={() => void onLoadAccountQuota(row.id, true)}
               />
             );
           })}

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -19,6 +19,7 @@ import {
   buildAccountRowsFromAnalytics,
   buildApiKeyRowsFromAnalytics,
 } from '../model/analyticsAdapters';
+import { buildMonitoringAccountRowId } from '../model/accountIdentity';
 import type { MonitoringAnalyticsEventRow } from '@/services/api/usageService';
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { sha256Hex } from '@/utils/apiKeyHash';
@@ -39,17 +40,23 @@ const createMonitoringEventRow = (
   endpointPath: overrides.endpointPath ?? '/v1/chat/completions',
   sourceKey: overrides.sourceKey ?? 'source:alpha',
   source: overrides.source ?? 'alpha.json',
+  sourceIdentity: overrides.sourceIdentity,
+  sourceHashIdentity: overrides.sourceHashIdentity,
   sourceMasked: overrides.sourceMasked ?? 'a***',
   account: overrides.account ?? 'amount-myth-resend@duck.com',
+  accountIdentity: overrides.accountIdentity,
   accountMasked: overrides.accountMasked ?? 'amo***@duck.com',
   authIndex: overrides.authIndex ?? 'auth-123456',
+  authIndexIdentity: overrides.authIndexIdentity,
   authIndexMasked: overrides.authIndexMasked ?? 'auth...3456',
   authLabel: overrides.authLabel ?? 'alpha.json',
+  authLabelIdentity: overrides.authLabelIdentity,
   projectId: overrides.projectId ?? 'project-alpha',
   apiKeyHash: overrides.apiKeyHash ?? 'api-key-hash',
   apiKeyLabel: overrides.apiKeyLabel ?? 'ak********sh',
   apiKeyMasked: overrides.apiKeyMasked ?? 'ak********sh',
   provider: overrides.provider ?? 'codex',
+  providerIdentity: overrides.providerIdentity,
   planType: overrides.planType ?? 'pro',
   channel: overrides.channel ?? 'codex',
   channelHost: overrides.channelHost ?? 'example.com',
@@ -192,6 +199,95 @@ describe('analytics aggregate row adapters', () => {
     expect(rows[0].models[0]).toMatchObject({ model: 'gpt-4.1', totalCalls: 3 });
   });
 
+  it('preserves provider-scoped backend account ids for the same account display value', () => {
+    const base = {
+      account_snapshot: 'same@example.com',
+      auth_label_snapshot: 'Shared Account',
+      sources: [] as string[],
+      source_hashes: [] as string[],
+      success_calls: 1,
+      failure_calls: 0,
+      success_rate: 1,
+      input_tokens: 10,
+      output_tokens: 5,
+      cached_tokens: 0,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+      total_tokens: 15,
+      cost: 0,
+      average_latency_ms: null,
+      last_seen_ms: 1_768_759_000_000,
+      models: [],
+    };
+    const rows = buildAccountRowsFromAnalytics(
+      [
+        {
+          ...base,
+          id: 'codex-specific-id',
+          auth_provider_snapshot: 'codex',
+          auth_indices: ['codex-auth'],
+          calls: 197,
+          success_calls: 197,
+        },
+        {
+          ...base,
+          id: 'antigravity-specific-id',
+          auth_provider_snapshot: 'antigravity',
+          auth_indices: ['antigravity-auth'],
+          calls: 17,
+          success_calls: 17,
+        },
+      ],
+      new Map(),
+      new Map(),
+      sourceInfoMap,
+      new Map()
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(['codex-specific-id', 'antigravity-specific-id']);
+    expect(rows.map((row) => row.account)).toEqual(['same@example.com', 'same@example.com']);
+    expect(rows.map((row) => row.provider)).toEqual(['codex', 'antigravity']);
+  });
+
+  it('builds a legacy analytics fallback id from persisted identity rather than display metadata', () => {
+    const rows = buildAccountRowsFromAnalytics(
+      [
+        {
+          id: '',
+          account_snapshot: '',
+          auth_label_snapshot: 'Team Account',
+          auth_provider_snapshot: 'codex',
+          auth_indices: ['auth-123456'],
+          sources: ['team.json'],
+          source_hashes: ['source-hash'],
+          calls: 1,
+          success_calls: 1,
+          failure_calls: 0,
+          success_rate: 1,
+          input_tokens: 1,
+          output_tokens: 1,
+          cached_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          total_tokens: 2,
+          cost: 0,
+          average_latency_ms: null,
+          last_seen_ms: 1,
+          models: [],
+        },
+      ],
+      authMetaMap,
+      authFileMap,
+      sourceInfoMap,
+      channelByAuthIndex
+    );
+
+    expect(rows[0]).toMatchObject({
+      id: buildMonitoringAccountRowId({ provider: 'codex', authLabel: 'Team Account' }),
+      account: 'team@example.com',
+    });
+  });
+
   it('builds api key rows from full backend aggregates and keeps aliases', () => {
     const rows = buildApiKeyRowsFromAnalytics(
       [
@@ -261,6 +357,127 @@ describe('buildAccountRows', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].authIndices).toEqual(['auth-123456', 'auth-999999']);
     expect(rows[0].sourceKeys).toEqual(['source:alpha', 'source:beta']);
+  });
+
+  it('uses provider-scoped logical account identity in the fallback path', () => {
+    const rows = buildAccountRows([
+      createMonitoringEventRow({
+        id: 'codex-a',
+        account: 'same@example.com',
+        provider: 'codex',
+        authIndex: 'codex-auth-a',
+        model: 'model-x',
+      }),
+      createMonitoringEventRow({
+        id: 'codex-b',
+        account: 'same@example.com',
+        provider: 'codex',
+        authIndex: 'codex-auth-b',
+        model: 'model-x',
+      }),
+      createMonitoringEventRow({
+        id: 'antigravity',
+        account: 'same@example.com',
+        provider: 'antigravity',
+        authIndex: 'antigravity-auth',
+        model: 'model-x',
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    const byProvider = new Map(rows.map((row) => [row.provider, row]));
+    expect(byProvider.get('codex')).toMatchObject({
+      account: 'same@example.com',
+      totalCalls: 2,
+      authIndices: ['codex-auth-a', 'codex-auth-b'],
+    });
+    expect(byProvider.get('codex')?.models).toMatchObject([{ model: 'model-x', totalCalls: 2 }]);
+    expect(byProvider.get('antigravity')).toMatchObject({
+      account: 'same@example.com',
+      totalCalls: 1,
+      authIndices: ['antigravity-auth'],
+    });
+    expect(byProvider.get('codex')?.id).not.toBe(byProvider.get('antigravity')?.id);
+  });
+
+  it('uses persisted fallback identity instead of an enriched display account', () => {
+    const rows = buildAccountRows([
+      createMonitoringEventRow({
+        id: 'codex-label',
+        account: 'metadata@example.com',
+        accountIdentity: '',
+        authLabel: 'Shared Label',
+        authLabelIdentity: 'Shared Label',
+        provider: 'codex',
+        providerIdentity: 'codex',
+        authIndex: 'codex-auth',
+      }),
+      createMonitoringEventRow({
+        id: 'antigravity-label',
+        account: 'metadata@example.com',
+        accountIdentity: '',
+        authLabel: 'Shared Label',
+        authLabelIdentity: 'Shared Label',
+        provider: 'antigravity',
+        providerIdentity: 'antigravity',
+        authIndex: 'antigravity-auth',
+      }),
+    ]);
+
+    expect(rows.map((row) => row.id).sort()).toEqual(
+      [
+        buildMonitoringAccountRowId({ provider: 'codex', authLabel: 'Shared Label' }),
+        buildMonitoringAccountRowId({ provider: 'antigravity', authLabel: 'Shared Label' }),
+      ].sort()
+    );
+  });
+
+  it('keeps provider scope when only a persisted source hash identifies the account', () => {
+    const rows = buildAccountRows([
+      createMonitoringEventRow({
+        id: 'codex-source-hash',
+        account: '-',
+        accountIdentity: '',
+        authLabel: '-',
+        authLabelIdentity: '',
+        source: '-',
+        sourceIdentity: '',
+        sourceHashIdentity: 'codex-source-hash',
+        authIndex: '-',
+        authIndexIdentity: '',
+        provider: 'codex',
+        providerIdentity: 'codex',
+      }),
+      createMonitoringEventRow({
+        id: 'antigravity-source-hash',
+        account: '-',
+        accountIdentity: '',
+        authLabel: '-',
+        authLabelIdentity: '',
+        source: '-',
+        sourceIdentity: '',
+        sourceHashIdentity: 'antigravity-source-hash',
+        authIndex: '-',
+        authIndexIdentity: '',
+        provider: 'antigravity',
+        providerIdentity: 'antigravity',
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.id).sort()).toEqual(
+      [
+        buildMonitoringAccountRowId({ provider: 'codex', sourceHash: 'codex-source-hash' }),
+        buildMonitoringAccountRowId({
+          provider: 'antigravity',
+          sourceHash: 'antigravity-source-hash',
+        }),
+      ].sort()
+    );
+    expect(rows.map((row) => row.filterValue).sort()).toEqual([
+      'source:antigravity-source-hash',
+      'source:codex-source-hash',
+    ]);
   });
 });
 
@@ -489,9 +706,8 @@ describe('buildScopeFilteredRows', () => {
 
   it('clamps local summary cache rates and respects resolved GPT-5.6 aliases', () => {
     expect(
-      buildMonitoringSummary([
-        createMonitoringEventRow({ inputTokens: 10, cachedTokens: 100 }),
-      ]).cacheHitRate
+      buildMonitoringSummary([createMonitoringEventRow({ inputTokens: 10, cachedTokens: 100 })])
+        .cacheHitRate
     ).toBe(1);
 
     expect(

--- a/apps/web/src/features/monitoring/model/accountIdentity.test.ts
+++ b/apps/web/src/features/monitoring/model/accountIdentity.test.ts
@@ -24,10 +24,14 @@ describe('monitoring account identity', () => {
     expect(codexA).toBe('monitoring-account:1:account:636F646578:73616D65406578616D706C652E636F6D');
   });
 
-  it('normalizes provider aliases and encodes fallback values without delimiter collisions', () => {
-    expect(normalizeMonitoringProvider(' X_AI ')).toBe('xai');
-    expect(normalizeMonitoringProvider('grok')).toBe('xai');
-    expect(buildMonitoringAccountRowId({ provider: 'x-ai', authLabel: 'a:b' })).toBe(
+  it('normalizes provider values without alias folding and avoids delimiter collisions', () => {
+    expect(normalizeMonitoringProvider(' CODEX ')).toBe('codex');
+    expect(normalizeMonitoringProvider('foo_bar')).toBe('foo-bar');
+    // Monitoring identity deliberately does NOT fold x-ai/grok -> xai.
+    expect(normalizeMonitoringProvider('x-ai')).toBe('x-ai');
+    expect(normalizeMonitoringProvider('grok')).toBe('grok');
+    expect(normalizeMonitoringProvider('x-ai')).not.toBe(normalizeMonitoringProvider('grok'));
+    expect(buildMonitoringAccountRowId({ provider: 'x-ai', authLabel: 'a:b' })).not.toBe(
       buildMonitoringAccountRowId({ provider: 'grok', authLabel: 'a:b' })
     );
     expect(buildMonitoringAccountRowId({ provider: 'a:b', authLabel: 'c' })).not.toBe(

--- a/apps/web/src/features/monitoring/model/accountIdentity.test.ts
+++ b/apps/web/src/features/monitoring/model/accountIdentity.test.ts
@@ -26,7 +26,8 @@ describe('monitoring account identity', () => {
 
   it('normalizes provider values without alias folding and avoids delimiter collisions', () => {
     expect(normalizeMonitoringProvider(' CODEX ')).toBe('codex');
-    expect(normalizeMonitoringProvider('foo_bar')).toBe('foo-bar');
+    expect(normalizeMonitoringProvider('foo_bar')).toBe('foo_bar');
+    expect(normalizeMonitoringProvider(' Provider_Name ')).toBe('provider_name');
     // Monitoring identity deliberately does NOT fold x-ai/grok -> xai.
     expect(normalizeMonitoringProvider('x-ai')).toBe('x-ai');
     expect(normalizeMonitoringProvider('grok')).toBe('grok');

--- a/apps/web/src/features/monitoring/model/accountIdentity.test.ts
+++ b/apps/web/src/features/monitoring/model/accountIdentity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildMonitoringAccountRowId, normalizeMonitoringProvider } from './accountIdentity';
+
+describe('monitoring account identity', () => {
+  it('uses provider-scoped logical account identity without auth-index splitting', () => {
+    const codexA = buildMonitoringAccountRowId({
+      provider: 'codex',
+      account: 'same@example.com',
+      authIndex: 'auth-a',
+    });
+    const codexB = buildMonitoringAccountRowId({
+      provider: 'codex',
+      account: 'same@example.com',
+      authIndex: 'auth-b',
+    });
+    const antigravity = buildMonitoringAccountRowId({
+      provider: 'antigravity',
+      account: 'same@example.com',
+      authIndex: 'auth-a',
+    });
+
+    expect(codexA).toBe(codexB);
+    expect(codexA).not.toBe(antigravity);
+    expect(codexA).toBe('monitoring-account:1:account:636F646578:73616D65406578616D706C652E636F6D');
+  });
+
+  it('normalizes provider aliases and encodes fallback values without delimiter collisions', () => {
+    expect(normalizeMonitoringProvider(' X_AI ')).toBe('xai');
+    expect(normalizeMonitoringProvider('grok')).toBe('xai');
+    expect(buildMonitoringAccountRowId({ provider: 'x-ai', authLabel: 'a:b' })).toBe(
+      buildMonitoringAccountRowId({ provider: 'grok', authLabel: 'a:b' })
+    );
+    expect(buildMonitoringAccountRowId({ provider: 'a:b', authLabel: 'c' })).not.toBe(
+      buildMonitoringAccountRowId({ provider: 'a', authLabel: 'b:c' })
+    );
+  });
+});

--- a/apps/web/src/features/monitoring/model/accountIdentity.ts
+++ b/apps/web/src/features/monitoring/model/accountIdentity.ts
@@ -9,11 +9,8 @@ export type MonitoringAccountIdentityInput = {
 
 const normalizeIdentityValue = (value: string | null | undefined) => String(value || '').trim();
 
-export const normalizeMonitoringProvider = (value: string | null | undefined) => {
-  const normalized = normalizeIdentityValue(value).toLowerCase().replace(/_/g, '-');
-  if (normalized === 'x-ai' || normalized === 'grok') return 'xai';
-  return normalized;
-};
+export const normalizeMonitoringProvider = (value: string | null | undefined) =>
+  normalizeIdentityValue(value).toLowerCase().replace(/_/g, '-');
 
 const encodeIdentityPart = (value: string) =>
   Array.from(new TextEncoder().encode(value), (byte) => byte.toString(16).padStart(2, '0'))

--- a/apps/web/src/features/monitoring/model/accountIdentity.ts
+++ b/apps/web/src/features/monitoring/model/accountIdentity.ts
@@ -1,0 +1,41 @@
+export type MonitoringAccountIdentityInput = {
+  provider?: string | null;
+  account?: string | null;
+  authLabel?: string | null;
+  source?: string | null;
+  authIndex?: string | null;
+  sourceHash?: string | null;
+};
+
+const normalizeIdentityValue = (value: string | null | undefined) => String(value || '').trim();
+
+export const normalizeMonitoringProvider = (value: string | null | undefined) => {
+  const normalized = normalizeIdentityValue(value).toLowerCase().replace(/_/g, '-');
+  if (normalized === 'x-ai' || normalized === 'grok') return 'xai';
+  return normalized;
+};
+
+const encodeIdentityPart = (value: string) =>
+  Array.from(new TextEncoder().encode(value), (byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase();
+
+export const buildMonitoringAccountRowId = (identity: MonitoringAccountIdentityInput) => {
+  const candidate = [
+    ['account', identity.account],
+    ['label', identity.authLabel],
+    ['source', identity.source],
+    ['auth', identity.authIndex],
+    ['source-hash', identity.sourceHash],
+  ].find(([, value]) => normalizeIdentityValue(value));
+  if (!candidate) return '-';
+
+  const [kind, rawValue] = candidate;
+  return [
+    'monitoring-account',
+    '1',
+    kind,
+    encodeIdentityPart(normalizeMonitoringProvider(identity.provider)),
+    encodeIdentityPart(normalizeIdentityValue(rawValue)),
+  ].join(':');
+};

--- a/apps/web/src/features/monitoring/model/accountIdentity.ts
+++ b/apps/web/src/features/monitoring/model/accountIdentity.ts
@@ -10,7 +10,7 @@ export type MonitoringAccountIdentityInput = {
 const normalizeIdentityValue = (value: string | null | undefined) => String(value || '').trim();
 
 export const normalizeMonitoringProvider = (value: string | null | undefined) =>
-  normalizeIdentityValue(value).toLowerCase().replace(/_/g, '-');
+  normalizeIdentityValue(value).toLowerCase();
 
 const encodeIdentityPart = (value: string) =>
   Array.from(new TextEncoder().encode(value), (byte) => byte.toString(16).padStart(2, '0'))

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
@@ -324,6 +324,60 @@ describe('buildAnalyticsFilters', () => {
     expect(filters.accounts).toEqual(['same@example.com']);
     expect(filters.providers).toEqual(['codex']);
   });
+
+  it('bypasses authMeta expansion for account-provider selectors to avoid excluding historical events', () => {
+    const codexFilter = buildMonitoringAccountFilterValue({
+      provider: 'codex',
+      account: 'same@example.com',
+    });
+    const authMetaMap = new Map([
+      [
+        'current-auth',
+        {
+          authIndex: 'current-auth',
+          label: 'Current',
+          account: 'same@example.com',
+          provider: 'codex',
+          status: 'active',
+          disabled: false,
+          unavailable: false,
+          runtimeOnly: false,
+          planType: 'pro',
+          updatedAt: '',
+        },
+      ],
+    ]);
+
+    const filters = buildAnalyticsFilters({ account: codexFilter }, authMetaMap, []);
+
+    expect(filters.accounts).toEqual(['same@example.com']);
+    expect(filters.providers).toEqual(['codex']);
+    expect(filters.auth_indices).toBeUndefined();
+  });
+
+  it('keeps legacy account: authMeta expansion for backward compatibility', () => {
+    const authMetaMap = new Map([
+      [
+        'auth-1',
+        {
+          authIndex: 'auth-1',
+          label: 'Legacy',
+          account: 'legacy@example.com',
+          provider: 'codex',
+          status: 'active',
+          disabled: false,
+          unavailable: false,
+          runtimeOnly: false,
+          planType: 'pro',
+          updatedAt: '',
+        },
+      ],
+    ]);
+
+    const filters = buildAnalyticsFilters({ account: 'account:legacy@example.com' }, authMetaMap, []);
+
+    expect(filters.auth_indices).toEqual(['auth-1']);
+  });
 });
 
 describe('buildFilterOptionsFromAnalytics', () => {
@@ -630,6 +684,46 @@ describe('buildFilterOptionsFromAnalytics', () => {
       'source:source-b',
     ]);
     expect(options.accountRows[0].sourceKeys).toContain('openai:0:0');
+  });
+
+  it('uses persisted identity for filterValue when display fallback would differ from snapshots', () => {
+    const options = buildFilterOptionsFromAnalytics(
+      {
+        account_stats: [
+          {
+            id: 'backend-row-id',
+            account_snapshot: '',
+            auth_label_snapshot: 'Shared Label',
+            auth_provider_snapshot: 'codex',
+            auth_indices: [],
+            sources: [],
+            source_hashes: [],
+            calls: 1,
+            success_calls: 1,
+            failure_calls: 0,
+            success_rate: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 2,
+            cost: 0,
+            average_latency_ms: null,
+            last_seen_ms: 1,
+            models: [],
+          },
+        ],
+      },
+      new Map(),
+      new Map(),
+      buildSourceInfoMap({}),
+      new Map(),
+      new Map()
+    );
+
+    const row = options.accountRows[0];
+    expect(row.filterValue).toBe('account-provider:codex|Shared%20Label');
   });
 });
 

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.test.ts
@@ -12,6 +12,7 @@ import {
   buildFailureSourceRowsFromAnalytics,
   buildFilterOptionsFromAnalytics,
   buildUsageDetailsFromAnalyticsEvents,
+  parseMonitoringAccountFilterValue,
 } from './analyticsAdapters';
 
 describe('buildUsageDetailsFromAnalyticsEvents', () => {
@@ -283,6 +284,45 @@ describe('buildAnalyticsFilters', () => {
       min_latency_ms: 10_000,
       cache_status: 'hit',
     });
+  });
+
+  it('scopes account fallback filterValue by provider so same-email rows do not collide', () => {
+    const codexFilter = buildMonitoringAccountFilterValue({
+      provider: 'codex',
+      account: 'same@example.com',
+    });
+    const antigravityFilter = buildMonitoringAccountFilterValue({
+      provider: 'antigravity',
+      account: 'same@example.com',
+    });
+
+    expect(codexFilter).not.toBe(antigravityFilter);
+    expect(codexFilter.startsWith('account-provider:')).toBe(true);
+
+    const codexCriteria = parseMonitoringAccountFilterValue(codexFilter);
+    expect(codexCriteria.provider).toBe('codex');
+    expect(codexCriteria.accounts).toEqual(['same@example.com']);
+
+    const antigravityCriteria = parseMonitoringAccountFilterValue(antigravityFilter);
+    expect(antigravityCriteria.provider).toBe('antigravity');
+    expect(antigravityCriteria.accounts).toEqual(['same@example.com']);
+  });
+
+  it('still parses legacy account: selectors without a provider', () => {
+    const criteria = parseMonitoringAccountFilterValue('account:same@example.com');
+    expect(criteria.accounts).toEqual(['same@example.com']);
+    expect(criteria.provider).toBeUndefined();
+  });
+
+  it('emits provider-scoped account AND provider backend filters when no exact selector matches', () => {
+    const codexFilter = buildMonitoringAccountFilterValue({
+      provider: 'codex',
+      account: 'same@example.com',
+    });
+    const filters = buildAnalyticsFilters({ account: codexFilter }, new Map(), []);
+
+    expect(filters.accounts).toEqual(['same@example.com']);
+    expect(filters.providers).toEqual(['codex']);
   });
 });
 

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -376,23 +376,24 @@ export const buildAnalyticsFilters = (
       accountCriteria.sourceHashes.length === 0 &&
       accountCriteria.apiKeyHashes.length === 0
     ) {
-      const legacyAccount = accountCriteria.accounts[0] || account;
-      const normalizedAccount = normalizeFilterText(legacyAccount);
-      const normalizedCriteriaProvider = normalizeFilterText(accountCriteria.provider);
-      const accountAuthIndices = Array.from(authMetaMap.entries())
-        .filter(
-          ([, meta]) =>
-            normalizeFilterText(meta.account) === normalizedAccount &&
-            (!normalizedCriteriaProvider ||
-              normalizeFilterText(meta.provider) === normalizedCriteriaProvider)
-        )
-        .map(([authIndex]) => authIndex);
-      authIndices = addAuthIndexConstraint(authIndices, accountAuthIndices);
-      if (accountAuthIndices.length === 0) {
+      if (accountCriteria.provider) {
+        // Provider-scoped logical account selector (account-provider:...).
+        // Query persisted data directly; do not re-interpret through current
+        // auth metadata, whose auth indices may differ from historical events.
         filters.accounts =
           accountCriteria.accounts.length > 0 ? accountCriteria.accounts : [account];
-        if (normalizedCriteriaProvider) {
-          filters.providers = [normalizedCriteriaProvider];
+        filters.providers = [accountCriteria.provider];
+      } else {
+        // Legacy account selector (account:...) keeps authMeta-based expansion.
+        const legacyAccount = accountCriteria.accounts[0] || account;
+        const normalizedAccount = normalizeFilterText(legacyAccount);
+        const accountAuthIndices = Array.from(authMetaMap.entries())
+          .filter(([, meta]) => normalizeFilterText(meta.account) === normalizedAccount)
+          .map(([authIndex]) => authIndex);
+        authIndices = addAuthIndexConstraint(authIndices, accountAuthIndices);
+        if (accountAuthIndices.length === 0) {
+          filters.accounts =
+            accountCriteria.accounts.length > 0 ? accountCriteria.accounts : [account];
         }
       }
     }
@@ -644,6 +645,12 @@ export const buildAccountRowsFromAnalytics = (
         firstReadableValue(row.auth_provider_snapshot, display.provider)
       );
       const displayAccount = firstReadableValue(display.primary, account);
+      const filterAccount = firstReadableValue(
+        row.account_snapshot,
+        row.auth_label_snapshot,
+        row.sources?.[0],
+        account
+      );
       const authLabels = uniqueReadableValues([
         ...authMetas.map((meta) => meta.label),
         row.auth_label_snapshot,
@@ -692,7 +699,7 @@ export const buildAccountRowsFromAnalytics = (
         recentPattern: [],
         filterValue:
           buildMonitoringAccountFilterValue({
-            account,
+            account: filterAccount,
             provider,
             authIndices: row.auth_indices,
             sourceHashes: row.source_hashes,

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -107,6 +107,7 @@ const ACCOUNT_FILTER_PREFIXES = {
   source: 'source:',
   apiKey: 'api-key:',
   account: 'account:',
+  accountProvider: 'account-provider:',
 } as const;
 
 const NO_MATCH_FILTER_VALUE = '__no_matching_filter_value__';
@@ -116,6 +117,7 @@ export type MonitoringAccountFilterCriteria = {
   authIndices: string[];
   sourceHashes: string[];
   apiKeyHashes: string[];
+  provider?: string;
 };
 
 const normalizeAccountFilterValues = (values: Array<string | null | undefined> = []) =>
@@ -156,11 +158,13 @@ const buildAccountFilterToken = (prefix: string, values: string[]) =>
 
 export const buildMonitoringAccountFilterValue = ({
   account,
+  provider,
   authIndices,
   sourceHashes,
   apiKeyHashes,
 }: {
   account?: string | null;
+  provider?: string | null;
   authIndices?: Array<string | null | undefined>;
   sourceHashes?: Array<string | null | undefined>;
   apiKeyHashes?: Array<string | null | undefined>;
@@ -180,7 +184,11 @@ export const buildMonitoringAccountFilterValue = ({
     return buildAccountFilterToken(ACCOUNT_FILTER_PREFIXES.apiKey, normalizedApiKeyHashes);
   }
 
+  const normalizedProvider = normalizeMonitoringProvider(provider);
   const normalizedAccounts = normalizeAccountFilterValues([account]);
+  if (normalizedProvider && normalizedAccounts.length > 0) {
+    return `${ACCOUNT_FILTER_PREFIXES.accountProvider}${encodeURIComponent(normalizedProvider)}|${encodeAccountFilterValues(normalizedAccounts)}`;
+  }
   return buildAccountFilterToken(ACCOUNT_FILTER_PREFIXES.account, normalizedAccounts);
 };
 
@@ -220,6 +228,19 @@ export const parseMonitoringAccountFilterValue = (
       apiKeyHashes: normalizeApiKeyHashValues(
         decodeAccountFilterValues(text.slice(ACCOUNT_FILTER_PREFIXES.apiKey.length))
       ),
+    };
+  }
+
+  if (text.startsWith(ACCOUNT_FILTER_PREFIXES.accountProvider)) {
+    const body = text.slice(ACCOUNT_FILTER_PREFIXES.accountProvider.length);
+    const delimiter = body.indexOf('|');
+    const providerPart = delimiter >= 0 ? body.slice(0, delimiter) : '';
+    const accountPart = delimiter >= 0 ? body.slice(delimiter + 1) : body;
+    const provider = decodeAccountFilterValue(providerPart);
+    return {
+      ...emptyCriteria,
+      accounts: normalizeAccountFilterValues([decodeAccountFilterValue(accountPart)]),
+      provider: readString(provider),
     };
   }
 
@@ -357,13 +378,22 @@ export const buildAnalyticsFilters = (
     ) {
       const legacyAccount = accountCriteria.accounts[0] || account;
       const normalizedAccount = normalizeFilterText(legacyAccount);
+      const normalizedCriteriaProvider = normalizeFilterText(accountCriteria.provider);
       const accountAuthIndices = Array.from(authMetaMap.entries())
-        .filter(([, meta]) => normalizeFilterText(meta.account) === normalizedAccount)
+        .filter(
+          ([, meta]) =>
+            normalizeFilterText(meta.account) === normalizedAccount &&
+            (!normalizedCriteriaProvider ||
+              normalizeFilterText(meta.provider) === normalizedCriteriaProvider)
+        )
         .map(([authIndex]) => authIndex);
       authIndices = addAuthIndexConstraint(authIndices, accountAuthIndices);
       if (accountAuthIndices.length === 0) {
         filters.accounts =
           accountCriteria.accounts.length > 0 ? accountCriteria.accounts : [account];
+        if (normalizedCriteriaProvider) {
+          filters.providers = [normalizedCriteriaProvider];
+        }
       }
     }
   }
@@ -663,6 +693,7 @@ export const buildAccountRowsFromAnalytics = (
         filterValue:
           buildMonitoringAccountFilterValue({
             account,
+            provider,
             authIndices: row.auth_indices,
             sourceHashes: row.source_hashes,
           }) || account,

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -33,6 +33,7 @@ import {
   readString,
 } from './base';
 import { sanitizeApiKeyDisplayText, type ApiKeyDisplayInfo } from './apiKeys';
+import { buildMonitoringAccountRowId, normalizeMonitoringProvider } from './accountIdentity';
 import { buildDayLabel, buildHourLabel, buildLocalDayKey, padNumber } from './range';
 import { buildMonitoringSourceDisplay } from './sourceDisplay';
 import type {
@@ -609,6 +610,9 @@ export const buildAccountRowsFromAnalytics = (
         { authMetaMap, authFileMap, sourceInfoMap, channelByAuthIndex }
       );
       const account = firstReadableValue(display.account, row.account_snapshot, row.id);
+      const provider = normalizeMonitoringProvider(
+        firstReadableValue(row.auth_provider_snapshot, display.provider)
+      );
       const displayAccount = firstReadableValue(display.primary, account);
       const authLabels = uniqueReadableValues([
         ...authMetas.map((meta) => meta.label),
@@ -624,8 +628,18 @@ export const buildAccountRowsFromAnalytics = (
       );
 
       return {
-        id: account || row.id,
+        id:
+          firstReadableValue(row.id) ||
+          buildMonitoringAccountRowId({
+            provider,
+            account: row.account_snapshot,
+            authLabel: row.auth_label_snapshot,
+            source: row.sources?.[0],
+            authIndex,
+            sourceHash: row.source_hashes?.[0],
+          }),
         account,
+        provider,
         displayAccount,
         accountMasked: display.accountMasked || maskEmailLike(account),
         authLabels,
@@ -780,6 +794,7 @@ export const buildFilterOptionsFromAnalytics = (
       (account): MonitoringAccountRow => ({
         id: `selector:${normalizeFilterText(account)}`,
         account,
+        provider: '',
         filterValue: buildMonitoringAccountFilterValue({ account }) || account,
         displayAccount: account,
         accountMasked: maskEmailLike(account),
@@ -987,10 +1002,12 @@ export const buildUsageDetailsFromAnalyticsEvents = (
 ): UsageDetailWithEndpoint[] =>
   items.map((item) => {
     const requestedModel = readString(item.requested_model) || item.model;
-    const analyticsModel = readString(item.analytics_model) || normalizeAnalyticsModel(requestedModel);
+    const analyticsModel =
+      readString(item.analytics_model) || normalizeAnalyticsModel(requestedModel);
     return {
       timestamp: new Date(item.timestamp_ms).toISOString(),
       source: readString(item.source),
+      source_hash: readString(item.source_hash),
       auth_index: item.auth_index || null,
       api_key_hash: readString(item.api_key_hash),
       account_snapshot: readString(item.account_snapshot),

--- a/apps/web/src/features/monitoring/model/eventRows.test.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.test.ts
@@ -39,6 +39,22 @@ const buildRows = (
   );
 
 describe('buildEventRows', () => {
+  it('preserves persisted account identity fields before display enrichment', () => {
+    const [row] = buildRows({
+      account_snapshot: '',
+      auth_label_snapshot: 'Shared Label',
+      auth_provider_snapshot: '',
+      provider: 'antigravity',
+    });
+
+    expect(row.accountIdentity).toBe('');
+    expect(row.authLabelIdentity).toBe('Shared Label');
+    expect(row.authIndexIdentity).toBe('auth-1');
+    expect(row.sourceIdentity).toBe('alice@example.com');
+    expect(row.providerIdentity).toBe('antigravity');
+    expect(row.provider).toBe('antigravity');
+  });
+
   it('calculates tokens per second from total latency', () => {
     const [row] = buildRows();
 

--- a/apps/web/src/features/monitoring/model/eventRows.test.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildRealtimeSourceDisplay } from '@/features/monitoring/realtimeSourceDisplay';
+import type { MonitoringAuthMeta } from './types';
 import type { ModelPrice, UsageDetailWithEndpoint } from '@/utils/usage';
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { buildEventRows } from './eventRows';
@@ -53,6 +54,67 @@ describe('buildEventRows', () => {
     expect(row.sourceIdentity).toBe('alice@example.com');
     expect(row.providerIdentity).toBe('antigravity');
     expect(row.provider).toBe('antigravity');
+  });
+
+  it('keeps providerIdentity empty when only display metadata has a provider', () => {
+    const authMetaMap = new Map<string, MonitoringAuthMeta>([
+      [
+        'auth-1',
+        {
+          authIndex: 'auth-1',
+          label: 'Codex Label',
+          account: 'codex@example.com',
+          provider: 'codex',
+          status: 'active',
+          disabled: false,
+          unavailable: false,
+          runtimeOnly: false,
+          planType: '',
+          updatedAt: '',
+        },
+      ],
+    ]);
+
+    const [row] = buildEventRows(
+      [
+        {
+          timestamp: '2026-05-19T10:00:00Z',
+          source: 'alice@example.com',
+          auth_index: 'auth-1',
+          latency_ms: 1500,
+          ttft_ms: 500,
+          tokens: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+          failed: false,
+          __modelName: 'gpt-5.4',
+          __endpoint: 'POST /v1/chat/completions',
+          __endpointMethod: 'POST',
+          __endpointPath: '/v1/chat/completions',
+          __timestampMs: Date.parse('2026-05-19T10:00:00Z'),
+          account_snapshot: '',
+          auth_provider_snapshot: '',
+          provider: '',
+        },
+      ],
+      authMetaMap,
+      new Map(),
+      { byAuthIndex: new Map(), bySource: new Map(), byIdentityKey: new Map() },
+      new Map(),
+      {},
+      new Map()
+    );
+
+    expect(row.providerIdentity).toBe('');
+    expect(row.provider).toBe('codex');
+  });
+
+  it('uses event provider for providerIdentity when snapshot is empty', () => {
+    const [row] = buildRows({
+      account_snapshot: '',
+      auth_provider_snapshot: '',
+      provider: 'antigravity',
+    });
+
+    expect(row.providerIdentity).toBe('antigravity');
   });
 
   it('calculates tokens per second from total latency', () => {

--- a/apps/web/src/features/monitoring/model/eventRows.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.ts
@@ -46,7 +46,10 @@ export const buildEventRows = (
         return null;
       }
 
-      const authIndex = normalizeAuthIndex(detail.auth_index) ?? '-';
+      const authIndexIdentity = normalizeAuthIndex(detail.auth_index) ?? '';
+      const authIndex = authIndexIdentity || '-';
+      const sourceIdentity = readString(detail.source);
+      const sourceHashIdentity = readString(detail.source_hash ?? detail.sourceHash);
       const authMeta = authMetaMap.get(authIndex);
       const sourceMeta = resolveSourceDisplay(
         detail.source,
@@ -64,6 +67,9 @@ export const buildEventRows = (
       const snapshotProvider = readString(
         detail.auth_provider_snapshot ?? detail.authProviderSnapshot
       );
+      const eventProvider = readString(detail.provider);
+      const effectiveProvider =
+        snapshotProvider || eventProvider || authMeta?.provider || sourceMeta.type || '-';
       const snapshotDisplay = snapshotAccount || snapshotLabel;
       const channelMeta =
         channelByAuthIndex.get(authIndex) ||
@@ -204,17 +210,23 @@ export const buildEventRows = (
         userAgent,
         sourceKey,
         source: sourceLabel,
+        sourceIdentity,
+        sourceHashIdentity,
         sourceMasked,
         account,
+        accountIdentity: snapshotAccount,
         accountMasked,
         authIndex,
+        authIndexIdentity,
         authIndexMasked: maskAuthIndex(authIndex),
         authLabel: authMeta?.label || snapshotLabel || sourceMasked,
+        authLabelIdentity: snapshotLabel,
         projectId,
         apiKeyHash,
         apiKeyLabel,
         apiKeyMasked,
-        provider: authMeta?.provider || snapshotProvider || sourceMeta.type || '-',
+        provider: authMeta?.provider || snapshotProvider || eventProvider || sourceMeta.type || '-',
+        providerIdentity: effectiveProvider,
         planType: authMeta?.planType || '-',
         channel: channelLabel,
         channelHost: channelMeta?.host || '-',

--- a/apps/web/src/features/monitoring/model/eventRows.ts
+++ b/apps/web/src/features/monitoring/model/eventRows.ts
@@ -68,8 +68,7 @@ export const buildEventRows = (
         detail.auth_provider_snapshot ?? detail.authProviderSnapshot
       );
       const eventProvider = readString(detail.provider);
-      const effectiveProvider =
-        snapshotProvider || eventProvider || authMeta?.provider || sourceMeta.type || '-';
+      const effectiveProvider = snapshotProvider || eventProvider;
       const snapshotDisplay = snapshotAccount || snapshotLabel;
       const channelMeta =
         channelByAuthIndex.get(authIndex) ||

--- a/apps/web/src/features/monitoring/model/monitoringAnalyticsModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringAnalyticsModel.test.ts
@@ -164,4 +164,21 @@ describe('mergeMonitoringAccountOptionRows', () => {
     ]);
     expect(rows[0]?.totalCalls).toBe(2);
   });
+
+  it('keeps same-email provider account options when their selectors are distinct', () => {
+    const rows = mergeMonitoringAccountOptionRows([
+      accountOptionRow({
+        id: 'codex-row',
+        account: 'same@example.com',
+        filterValue: 'auth:codex-auth',
+      }),
+      accountOptionRow({
+        id: 'antigravity-row',
+        account: 'same@example.com',
+        filterValue: 'auth:antigravity-auth',
+      }),
+    ]);
+
+    expect(rows.map((row) => row.id)).toEqual(['codex-row', 'antigravity-row']);
+  });
 });

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -10,7 +10,10 @@ import {
 import zhCN from '@/i18n/locales/zh-CN.json';
 import zhTW from '@/i18n/locales/zh-TW.json';
 import type { MonitoringAccountQuotaTarget } from '@/features/monitoring/accountOverviewQuotaTargets';
-import type { AccountQuotaEntry } from '@/features/monitoring/components/accountOverviewPresentation';
+import type {
+  AccountQuotaEntry,
+  AccountQuotaState,
+} from '@/features/monitoring/components/accountOverviewPresentation';
 import type {
   MonitoringAccountRow,
   MonitoringApiKeyRow,
@@ -29,6 +32,7 @@ import {
   mergeObservedAccountQuotaEntry,
   mergeObservedAccountQuotaState,
   requestAccountQuota,
+  updateMonitoringAccountQuotaStateByRowId,
 } from './monitoringCenterPageModel';
 import { getDefaultMonitoringCenterUiState } from '@/features/monitoring/monitoringCenterUiState';
 
@@ -291,6 +295,34 @@ describe('monitoringCenterPageModel filter options', () => {
       ).map((item) => item.value)
     ).toEqual(['all', 'auth:openai-auth']);
   });
+
+  it('renders same-email provider account options as distinct selectable scopes', () => {
+    const options = buildAccountOptions(
+      [
+        createAccountRow('same@example.com', {
+          id: 'codex-row',
+          provider: 'codex',
+          channels: ['Codex'],
+          filterValue: 'auth:codex-auth',
+        }),
+        createAccountRow('same@example.com', {
+          id: 'antigravity-row',
+          provider: 'antigravity',
+          channels: ['Antigravity'],
+          filterValue: 'auth:antigravity-auth',
+        }),
+      ],
+      'all',
+      t,
+      'full'
+    );
+
+    expect(options).toMatchObject([
+      { value: 'all' },
+      { value: 'auth:antigravity-auth', label: 'same@example.com / Antigravity' },
+      { value: 'auth:codex-auth', label: 'same@example.com / Codex' },
+    ]);
+  });
 });
 
 describe('monitoringCenterPageModel account quota', () => {
@@ -299,6 +331,44 @@ describe('monitoringCenterPageModel account quota', () => {
     vi.mocked(fetchClaudeQuota).mockReset();
     vi.mocked(fetchCodexQuota).mockReset();
     vi.mocked(fetchXaiQuota).mockReset();
+  });
+
+  it('updates quota refresh state only for the selected provider-scoped row id', () => {
+    const antigravityState: AccountQuotaState = {
+      status: 'error',
+      targetKey: 'antigravity-target',
+      entries: [],
+      error: 'antigravity-error',
+      failedAtMs: 100,
+      lastRefreshedAt: 90,
+    };
+    const states: Record<string, AccountQuotaState> = {
+      'codex-row': {
+        status: 'success',
+        targetKey: 'codex-target',
+        entries: [],
+        error: '',
+        lastRefreshedAt: 80,
+      },
+      'antigravity-row': antigravityState,
+    };
+    const codexLoadingState: AccountQuotaState = {
+      status: 'loading',
+      targetKey: 'codex-target',
+      entries: [],
+      error: '',
+    };
+
+    const next = updateMonitoringAccountQuotaStateByRowId(states, 'codex-row', codexLoadingState);
+
+    expect(next['codex-row']).toBe(codexLoadingState);
+    expect(next['antigravity-row']).toBe(antigravityState);
+    expect(next['antigravity-row']).toMatchObject({
+      status: 'error',
+      error: 'antigravity-error',
+      failedAtMs: 100,
+      lastRefreshedAt: 90,
+    });
   });
 
   it('maps Claude usage windows into account quota entries', async () => {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -893,10 +893,7 @@ const mergeAccountQuotaWindows = (
     };
   });
 
-  return [
-    ...mergedWindows,
-    ...observedWindows.filter((_, index) => !usedObserved.has(index)),
-  ];
+  return [...mergedWindows, ...observedWindows.filter((_, index) => !usedObserved.has(index))];
 };
 
 const mergeAccountQuotaMetaLabels = (
@@ -1068,6 +1065,12 @@ export const mergeObservedAccountQuotaState = (
     failedAtMs: firstError ? state.failedAtMs : undefined,
   };
 };
+
+export const updateMonitoringAccountQuotaStateByRowId = (
+  states: Record<string, AccountQuotaState>,
+  rowId: string,
+  state: AccountQuotaState
+) => ({ ...states, [rowId]: state });
 
 const buildClaudeAccountQuotaWindows = (
   windows: ClaudeQuotaWindow[],

--- a/apps/web/src/features/monitoring/model/rowBuilders.providerScoped.test.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.providerScoped.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAccountRows,
+  buildScopeFilteredRows,
+} from './rowBuilders';
+import type { MonitoringEventRow } from './types';
+
+const eventRow = (overrides: Partial<MonitoringEventRow> = {}): MonitoringEventRow =>
+  ({
+    id: 'event-1',
+    timestamp: '2026-08-24T00:00:00.000Z',
+    timestampMs: Date.parse('2026-08-24T00:00:00.000Z'),
+    dayKey: '2026-08-24',
+    hourLabel: '00:00',
+    model: 'model-x',
+    endpoint: 'POST /v1/responses',
+    endpointMethod: 'POST',
+    endpointPath: '/v1/responses',
+    sourceKey: 'source:key',
+    source: 'source.json',
+    sourceIdentity: 'source.json',
+    sourceMasked: 'source.json',
+    account: 'same@example.com',
+    accountIdentity: 'same@example.com',
+    accountMasked: 'sam***@example.com',
+    authIndex: '-',
+    authIndexIdentity: '',
+    authIndexMasked: '-',
+    authLabel: 'Same Account',
+    authLabelIdentity: 'Same Account',
+    projectId: '-',
+    apiKeyHash: '',
+    apiKeyLabel: '-',
+    apiKeyMasked: '-',
+    provider: 'codex',
+    providerIdentity: 'codex',
+    planType: '-',
+    channel: 'codex',
+    channelHost: '-',
+    channelDisabled: false,
+    failed: false,
+    statsIncluded: true,
+    latencyMs: 100,
+    ttftMs: null,
+    tokensPerSecond: null,
+    inputTokens: 1,
+    outputTokens: 1,
+    reasoningTokens: 0,
+    cachedTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    totalTokens: 2,
+    totalCost: 0,
+    taskKey: 'task-1',
+    searchText: 'same@example.com',
+    ...overrides,
+  }) as MonitoringEventRow;
+
+describe('provider-scoped monitoring account fallback filters', () => {
+  it('keeps account-provider local filtering isolated by persisted provider identity', () => {
+    const codex = eventRow({
+      id: 'codex-event',
+      provider: 'codex',
+      providerIdentity: 'codex',
+    });
+    const antigravity = eventRow({
+      id: 'antigravity-event',
+      provider: 'antigravity',
+      providerIdentity: 'antigravity',
+      channel: 'antigravity',
+    });
+
+    const filtered = buildScopeFilteredRows([codex, antigravity], {
+      account: 'account-provider:codex|same%40example.com',
+    });
+
+    expect(filtered.map((row) => row.id)).toEqual(['codex-event']);
+  });
+
+  it('uses persisted label identity for fallback filterValue instead of enriched display account', () => {
+    const [row] = buildAccountRows([
+      eventRow({
+        account: 'metadata@example.com',
+        accountIdentity: '',
+        authLabel: 'Shared Label',
+        authLabelIdentity: 'Shared Label',
+        source: '-',
+        sourceIdentity: '',
+        authIndex: '-',
+        authIndexIdentity: '',
+        apiKeyHash: '',
+        provider: 'codex',
+        providerIdentity: 'codex',
+      }),
+    ]);
+
+    expect(row.filterValue).toBe('account-provider:codex|Shared%20Label');
+
+    const filtered = buildScopeFilteredRows(
+      [
+        eventRow({
+          id: 'persisted-label-event',
+          account: 'metadata@example.com',
+          accountIdentity: '',
+          authLabel: 'Shared Label',
+          authLabelIdentity: 'Shared Label',
+          source: '-',
+          sourceIdentity: '',
+          authIndex: '-',
+          authIndexIdentity: '',
+          apiKeyHash: '',
+          provider: 'codex',
+          providerIdentity: 'codex',
+        }),
+      ],
+      { account: row.filterValue }
+    );
+
+    expect(filtered.map((item) => item.id)).toEqual(['persisted-label-event']);
+  });
+});

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -471,6 +471,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
         filterValue:
           buildMonitoringAccountFilterValue({
             account: item.filterAccount,
+            provider: item.provider,
             authIndices,
             sourceHashes,
             apiKeyHashes,

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -109,6 +109,7 @@ export const buildScopeFilteredRows = (
   const accountAuthIndices = new Set(accountCriteria.authIndices.map(normalizeScopeValue));
   const accountApiKeyHashes = new Set(accountCriteria.apiKeyHashes.map(normalizeScopeValue));
   const hasAccountSourceHashFilter = accountCriteria.sourceHashes.length > 0;
+  const accountProvider = normalizeScopeValue(accountCriteria.provider);
   const provider = normalizeScopeValue(scopeFilters.provider);
   const authFile = normalizeScopeValue(scopeFilters.authFile);
   const projectId = normalizeScopeValue(scopeFilters.projectId);
@@ -134,12 +135,22 @@ export const buildScopeFilteredRows = (
         // source_hash is only available in analytics payloads, so avoid dropping rows after
         // the backend has already applied the exact source_hash filter.
       } else {
+        if (
+          accountProvider &&
+          normalizeScopeValue(row.providerIdentity ?? row.provider) !== accountProvider
+        ) {
+          return false;
+        }
         const rowAccountValues = [
+          row.accountIdentity,
+          row.authLabelIdentity,
+          row.sourceIdentity,
           row.account,
           row.accountMasked,
           row.authLabel,
           row.source,
           row.sourceMasked,
+          row.authIndexIdentity,
           row.authIndex,
         ].map(normalizeScopeValue);
         if (!rowAccountValues.includes(account)) return false;
@@ -363,6 +374,10 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
 
   rows.forEach((row) => {
     const provider = normalizeMonitoringProvider(row.providerIdentity ?? row.provider);
+    const filterAccount =
+      [row.accountIdentity, row.authLabelIdentity, row.sourceIdentity, row.account].find(
+        (value) => Boolean(value && isEffectiveLabel(value))
+      ) || '';
     const accountKey = buildMonitoringAccountRowId({
       provider,
       account: row.accountIdentity ?? row.account,
@@ -374,7 +389,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     const existing = grouped.get(accountKey) ?? {
       id: accountKey,
       account: row.account,
-      filterAccount: row.accountIdentity ?? row.account,
+      filterAccount,
       provider,
       accountMasked: row.accountMasked,
       authLabels: new Set<string>(),

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -9,6 +9,7 @@ import {
   buildMonitoringAccountFilterValue,
   parseMonitoringAccountFilterValue,
 } from './analyticsAdapters';
+import { buildMonitoringAccountRowId, normalizeMonitoringProvider } from './accountIdentity';
 import { getRangeBounds } from './range';
 import type {
   MonitoringAccountRow,
@@ -317,10 +318,13 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     {
       id: string;
       account: string;
+      filterAccount: string;
+      provider: string;
       accountMasked: string;
       authLabels: Set<string>;
       authIndices: Set<string>;
       sourceKeys: Set<string>;
+      sourceHashes: Set<string>;
       apiKeyHashes: Set<string>;
       channels: Set<string>;
       modelMap: Map<
@@ -358,14 +362,25 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
   >();
 
   rows.forEach((row) => {
-    const accountKey = row.account || row.authLabel || row.source;
+    const provider = normalizeMonitoringProvider(row.providerIdentity ?? row.provider);
+    const accountKey = buildMonitoringAccountRowId({
+      provider,
+      account: row.accountIdentity ?? row.account,
+      authLabel: row.authLabelIdentity ?? row.authLabel,
+      source: row.sourceIdentity ?? row.source,
+      authIndex: row.authIndexIdentity ?? row.authIndex,
+      sourceHash: row.sourceHashIdentity,
+    });
     const existing = grouped.get(accountKey) ?? {
       id: accountKey,
       account: row.account,
+      filterAccount: row.accountIdentity ?? row.account,
+      provider,
       accountMasked: row.accountMasked,
       authLabels: new Set<string>(),
       authIndices: new Set<string>(),
       sourceKeys: new Set<string>(),
+      sourceHashes: new Set<string>(),
       apiKeyHashes: new Set<string>(),
       channels: new Set<string>(),
       modelMap: new Map(),
@@ -387,10 +402,11 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
 
     existing.rows.push(row);
     existing.authLabels.add(row.authLabel);
-    existing.authIndices.add(row.authIndex);
+    existing.authIndices.add(row.authIndexIdentity ?? row.authIndex);
     if (row.sourceKey) {
       existing.sourceKeys.add(row.sourceKey);
     }
+    existing.sourceHashes.add(row.sourceHashIdentity ?? '');
     existing.apiKeyHashes.add(row.apiKeyHash);
     existing.channels.add(row.channel);
     existing.totalCalls += 1;
@@ -446,14 +462,17 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       const channels = Array.from(item.channels).sort();
       const authIndices = Array.from(item.authIndices).sort();
       const sourceKeys = Array.from(item.sourceKeys).sort();
+      const sourceHashes = Array.from(item.sourceHashes).sort();
       const apiKeyHashes = Array.from(item.apiKeyHashes).sort();
       return {
         id: item.id,
         account: item.account,
+        provider: item.provider,
         filterValue:
           buildMonitoringAccountFilterValue({
-            account: item.account,
+            account: item.filterAccount,
             authIndices,
+            sourceHashes,
             apiKeyHashes,
           }) || item.account,
         displayAccount: resolveAccountDisplayName(item.account, channels),

--- a/apps/web/src/features/monitoring/model/sourceDisplay.test.ts
+++ b/apps/web/src/features/monitoring/model/sourceDisplay.test.ts
@@ -20,6 +20,7 @@ describe('isGenericMonitoringProviderLabel', () => {
     expect(isGenericMonitoringProviderLabel('XAI')).toBe(true);
     expect(isGenericMonitoringProviderLabel('x-ai')).toBe(true);
     expect(isGenericMonitoringProviderLabel('grok')).toBe(true);
+    expect(isGenericMonitoringProviderLabel('antigravity')).toBe(true);
     expect(isGenericMonitoringProviderLabel('anyrouter.top #1')).toBe(false);
   });
 });

--- a/apps/web/src/features/monitoring/model/sourceDisplay.ts
+++ b/apps/web/src/features/monitoring/model/sourceDisplay.ts
@@ -6,6 +6,7 @@ import type { MonitoringAuthMeta, MonitoringChannelMeta } from './types';
 
 const GENERIC_PROVIDER_LABELS = new Set([
   'codex',
+  'antigravity',
   'openai',
   'openai-compatibility',
   'gemini',
@@ -171,8 +172,7 @@ export const buildMonitoringSourceDisplay = (
   const sourceMasked = maskEmailLike(sourceLabel || sourceMeta.displayName);
   const accountMasked = maskEmailLike(account || sourceLabel);
   const fallbackId = shortHash(input.sourceHash || input.apiKeyHash || authIndex);
-  const nonGenericChannel =
-    channel && !isGenericMonitoringProviderLabel(channel) ? channel : '';
+  const nonGenericChannel = channel && !isGenericMonitoringProviderLabel(channel) ? channel : '';
   const nonGenericSource =
     sourceMasked && !isGenericMonitoringProviderLabel(sourceMasked) ? sourceMasked : '';
   const keyDisambiguatedSource =

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -158,17 +158,23 @@ export type MonitoringEventRow = {
   userAgent?: string;
   sourceKey: string;
   source: string;
+  sourceIdentity?: string;
+  sourceHashIdentity?: string;
   sourceMasked: string;
   account: string;
+  accountIdentity?: string;
   accountMasked: string;
   authIndex: string;
+  authIndexIdentity?: string;
   authIndexMasked: string;
   authLabel: string;
+  authLabelIdentity?: string;
   projectId: string;
   apiKeyHash: string;
   apiKeyLabel: string;
   apiKeyMasked: string;
   provider: string;
+  providerIdentity?: string;
   planType: string;
   channel: string;
   channelHost: string;
@@ -249,6 +255,7 @@ export type MonitoringAccountModelSpendRow = {
 export type MonitoringAccountRow = {
   id: string;
   account: string;
+  provider?: string;
   filterValue?: string;
   displayAccount: string;
   accountMasked: string;

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -177,6 +177,8 @@ export interface UsageResponseHeaderMetadata {
 export interface UsageDetail {
   timestamp: string;
   source: string;
+  source_hash?: string;
+  sourceHash?: string;
   auth_index: string | number | null;
   api_key_hash?: string;
   apiKeyHash?: string;


### PR DESCRIPTION
## Summary

Fix Request Monitoring Account Overview so logical accounts are namespaced by canonical provider identity.

This prevents Codex and Antigravity accounts with the same email from being merged while preserving one logical row for multiple credentials belonging to the same provider and account.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add canonical provider-scoped logical account grouping to Manager Server AccountStats and account filter selectors.
- Preserve same-provider, same-account aggregation across multiple auth indices and retain precise credential-backed filter scopes.
- Preserve backend account row IDs in analytics adapters and use the same provider-scoped semantics in fallback event aggregation.
- Use account row IDs for focus, expanded/auth/status state, quota targets, request queues, loading/error state, and observed quota state.
- Show provider metadata so equal display accounts remain visually distinguishable.
- Add backend and frontend regression coverage for aggregation, selectors, filtering, state isolation, and quota refresh behavior.

## User Impact

Users with the same account name or email under different providers now see separate Account Overview rows with isolated calls, tokens, costs, filters, focus state, expansion state, authentication state, and quota state.

Multiple credentials for the same provider and logical account continue to appear as one aggregated account row.

## Compatibility / Runtime Notes

- CPA panel mode: Uses the provider-scoped row identity and retains credential-scoped filter values; no configuration change is required.
- Manager Server mode: AccountStats and selector row IDs are now opaque provider-scoped identities. The account field remains the display value.
- Full Docker / native packages: The bundled frontend and Manager Server use the same identity contract; no runtime or packaging change is required.

## Data / Security Notes

No database migration is required. The authoritative usage_events table and historical events are not deleted, rewritten, or rebuilt.

Account History and credential identity formats are unchanged. Existing precise auth index, source hash, and API key hash filters remain in place.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert commit `a07373d96bec30201108a99c2e8083b23b7d775d`. No data restoration or migration rollback is required. Reverting restores the previous account-first aggregation behavior.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run manager-server:test
go test -race ./internal/service/monitoring ./internal/usageidentity ./internal/repository/usageevent ./internal/repository/usagemonitoring
npm run test
# 199 test files, 2483 tests passed
npm run type-check
npm run lint
# 0 errors; one pre-existing warning in unmodified AccountHealthBadge.tsx:73
npm run build
# vite-plugin-singlefile produced dist/index.html
git diff --check origin/dev...HEAD
```

## Screenshots / Recordings

Not captured. This is a targeted identity and state-correctness fix rather than a panel redesign; provider-separated rendering and interactions are covered by regression tests.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: No documentation update is needed because this restores the intended existing Account Overview behavior and does not introduce a new workflow or configuration surface.

## Related

N/A