### PR TITLE
feat(manager-server): support SQLite database URLs

### DIFF
--- a/Dockerfile.manager-server
+++ b/Dockerfile.manager-server
@@ -24,6 +24,5 @@ WORKDIR /app
 COPY --from=service-build /out/cpa-manager-plus /usr/local/bin/cpa-manager-plus
 ENV HTTP_ADDR=0.0.0.0:18317
 ENV USAGE_DATA_DIR=/data
-ENV USAGE_DB_PATH=/data/usage.sqlite
 EXPOSE 18317
 ENTRYPOINT ["cpa-manager-plus"]

--- a/apps/docs/deployment/docker.md
+++ b/apps/docs/deployment/docker.md
@@ -85,6 +85,8 @@ services:
     environment:
       HTTP_ADDR: '0.0.0.0:18317'
       USAGE_DB_PATH: '/data/usage.sqlite'
+      # 高级替代：删除上一行后启用完整 SQLite URL：
+      # USAGE_DB_URL: 'file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)'
       CPA_MANAGER_DATA_KEY_PATH: '/data/data.key'
       # 托管部署建议显式设置：
       # CPA_MANAGER_ADMIN_KEY: "replace-with-a-long-random-admin-key"
@@ -189,7 +191,8 @@ http://host.docker.internal:8317
 | ---------------------------- | --------------------------------- | --------------------------------------- |
 | `HTTP_ADDR`                  | `0.0.0.0:18317`                   | Manager Server 监听地址。               |
 | `USAGE_DATA_DIR`             | `/data`                           | 数据目录。                              |
-| `USAGE_DB_PATH`              | `/data/usage.sqlite`              | SQLite 数据库路径。                     |
+| `USAGE_DB_URL`               | 空                                | 高级 SQLite `file:` URL；与 path 互斥。 |
+| `USAGE_DB_PATH`              | `/data/usage.sqlite`              | SQLite 数据库路径；URL 模式时移除。     |
 | `CPA_MANAGER_DATA_KEY_PATH`  | `/data/data.key`                  | 数据密钥路径。                          |
 | `CPA_MANAGER_ADMIN_KEY`      | 空                                | 显式设置 Manager Server 管理员密钥。    |
 | `CPA_MANAGER_ADMIN_KEY_FILE` | `/run/secrets/cpa_admin_key`      | 从文件读取管理员密钥。                  |
@@ -203,6 +206,8 @@ http://host.docker.internal:8317
 | `USAGE_POLL_INTERVAL_MS`     | `500`                             | 空闲轮询间隔。                          |
 | `USAGE_QUERY_LIMIT`          | `50000`                           | 最近用量事件返回上限。                  |
 
+普通部署保留 `USAGE_DB_PATH` 即可。使用 `USAGE_DB_URL` 时必须从 Compose 中删除 `USAGE_DB_PATH`，不能同时保留两个非空值。URL 中的 `&` 位于 YAML 单引号内，不需要额外转义。完整约束见 [Manager Server 指南](../operations/manager-server.md#高级-sqlite-database-url)。
+
 更多运行时配置见 [Manager Server 指南](../operations/manager-server.md)。
 
 :::
@@ -213,12 +218,12 @@ http://host.docker.internal:8317
 
 ```text
 /data/usage.sqlite
-/data/usage.sqlite-wal
-/data/usage.sqlite-shm
 /data/data.key
+/data/usage.sqlite-wal  # WAL 模式且文件存在时
+/data/usage.sqlite-shm  # WAL 模式且文件存在时
 ```
 
-备份必须包含 SQLite 文件和 `data.key`：
+备份必须包含 SQLite 主数据库、`data.key` 和当前实际存在的 sidecar 文件：
 
 ```bash
 docker run --rm \
@@ -291,6 +296,8 @@ docker compose run --rm --no-deps \
 
 docker compose start cpa-manager-plus
 ```
+
+如果 service 使用 `USAGE_DB_URL`，运行中间命令时删除 `--db-path /data/usage.sqlite`，让容器继承完整 URL；显式 path 会选择默认 SQLite 连接设置。
 
 如果 Compose 服务名不是 `cpa-manager-plus`，请替换为实际服务名。不要在 Manager Server 仍运行时执行，也不要从 Web UI 在线触发清理；该命令需要独占 SQLite 进程锁。完成后重新启动，维护状态会从数据库 metadata 自动恢复为 clean，UI Warning 也会自动消失。
 

--- a/apps/docs/deployment/native.md
+++ b/apps/docs/deployment/native.md
@@ -130,13 +130,21 @@ USAGE_DATA_DIR=/var/lib/cpa-manager-plus ./cpa-manager-plus
 USAGE_DB_PATH=/var/lib/cpa-manager-plus/usage.sqlite ./cpa-manager-plus
 ```
 
+需要完整 SQLite driver 参数时，也可以只设置 `USAGE_DB_URL`：
+
+```bash
+USAGE_DB_URL='file:///var/lib/cpa-manager-plus/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)' ./cpa-manager-plus
+```
+
+`USAGE_DB_URL` 与 `USAGE_DB_PATH` 互斥；不要同时设置。完整约束见 [Manager Server 指南](../operations/manager-server.md#高级-sqlite-database-url)。
+
 需要备份：
 
 ```text
 data/usage.sqlite
-data/usage.sqlite-wal
-data/usage.sqlite-shm
 data/data.key
+data/usage.sqlite-wal  # WAL 模式且文件存在时
+data/usage.sqlite-shm  # WAL 模式且文件存在时
 ```
 
 `data.key` 用来解密已保存的 CPA Management Key。丢失后只能重新保存 CPA 连接。
@@ -229,7 +237,7 @@ setup 后：
 1. 停止原生进程。
 2. 备份数据目录，包括 `data.key`。
 3. 解压新包。
-4. 复制 `config.json` 和 `data/`，或继续使用 `USAGE_DATA_DIR` / `USAGE_DB_PATH`。
+4. 复制 `config.json` 和 `data/`，或继续使用 `USAGE_DATA_DIR`、`USAGE_DB_PATH` 或 `USAGE_DB_URL`。URL 与 path 不能同时设置。
 5. 启动新二进制。
 
 systemd 示例：

--- a/apps/docs/en/deployment/docker.md
+++ b/apps/docs/en/deployment/docker.md
@@ -85,6 +85,8 @@ services:
     environment:
       HTTP_ADDR: '0.0.0.0:18317'
       USAGE_DB_PATH: '/data/usage.sqlite'
+      # Advanced alternative: remove the previous line before enabling a complete SQLite URL:
+      # USAGE_DB_URL: 'file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)'
       CPA_MANAGER_DATA_KEY_PATH: '/data/data.key'
       # Recommended for managed deployments:
       # CPA_MANAGER_ADMIN_KEY: "replace-with-a-long-random-admin-key"
@@ -185,23 +187,26 @@ Do not use `127.0.0.1` from inside a container to reach CPA on the host. Inside 
 
 ## Common Environment Variables
 
-| Variable                     | Default                           | Description                                      |
-| ---------------------------- | --------------------------------- | ------------------------------------------------ |
-| `HTTP_ADDR`                  | `0.0.0.0:18317`                   | Manager Server listen address.                   |
-| `USAGE_DATA_DIR`             | `/data`                           | Data directory.                                  |
-| `USAGE_DB_PATH`              | `/data/usage.sqlite`              | SQLite database path.                            |
-| `CPA_MANAGER_DATA_KEY_PATH`  | `/data/data.key`                  | Data key path.                                   |
-| `CPA_MANAGER_ADMIN_KEY`      | empty                             | Explicit Manager Server admin key.               |
-| `CPA_MANAGER_ADMIN_KEY_FILE` | `/run/secrets/cpa_admin_key`      | Read the admin key from a file.                  |
-| `CPA_MANAGER_DATA_KEY`       | empty                             | Explicit data encryption key.                    |
-| `CPA_MANAGER_DATA_KEY_FILE`  | `/run/secrets/cpa_data_key`       | Read the data encryption key from a file.        |
-| `CPA_UPSTREAM_URL`           | empty                             | Optional environment-managed CPA URL.            |
-| `CPA_MANAGEMENT_KEY`         | empty                             | Optional environment-managed CPA Management Key. |
-| `CPA_MANAGEMENT_KEY_FILE`    | `/run/secrets/cpa_management_key` | Read the CPA Management Key from a file.         |
-| `USAGE_COLLECTOR_MODE`       | `auto`                            | `auto`, `subscribe`, `http`, or `resp`.          |
-| `USAGE_BATCH_SIZE`           | `100`                             | Max collected records per batch.                 |
-| `USAGE_POLL_INTERVAL_MS`     | `500`                             | Idle poll interval.                              |
-| `USAGE_QUERY_LIMIT`          | `50000`                           | Max recent usage events returned.                |
+| Variable                     | Default                           | Description                                                    |
+| ---------------------------- | --------------------------------- | -------------------------------------------------------------- |
+| `HTTP_ADDR`                  | `0.0.0.0:18317`                   | Manager Server listen address.                                 |
+| `USAGE_DATA_DIR`             | `/data`                           | Data directory.                                                |
+| `USAGE_DB_URL`               | empty                             | Advanced SQLite `file:` URL; mutually exclusive with the path. |
+| `USAGE_DB_PATH`              | `/data/usage.sqlite`              | SQLite database path; remove it in URL mode.                   |
+| `CPA_MANAGER_DATA_KEY_PATH`  | `/data/data.key`                  | Data key path.                                                 |
+| `CPA_MANAGER_ADMIN_KEY`      | empty                             | Explicit Manager Server admin key.                             |
+| `CPA_MANAGER_ADMIN_KEY_FILE` | `/run/secrets/cpa_admin_key`      | Read the admin key from a file.                                |
+| `CPA_MANAGER_DATA_KEY`       | empty                             | Explicit data encryption key.                                  |
+| `CPA_MANAGER_DATA_KEY_FILE`  | `/run/secrets/cpa_data_key`       | Read the data encryption key from a file.                      |
+| `CPA_UPSTREAM_URL`           | empty                             | Optional environment-managed CPA URL.                          |
+| `CPA_MANAGEMENT_KEY`         | empty                             | Optional environment-managed CPA Management Key.               |
+| `CPA_MANAGEMENT_KEY_FILE`    | `/run/secrets/cpa_management_key` | Read the CPA Management Key from a file.                       |
+| `USAGE_COLLECTOR_MODE`       | `auto`                            | `auto`, `subscribe`, `http`, or `resp`.                        |
+| `USAGE_BATCH_SIZE`           | `100`                             | Max collected records per batch.                               |
+| `USAGE_POLL_INTERVAL_MS`     | `500`                             | Idle poll interval.                                            |
+| `USAGE_QUERY_LIMIT`          | `50000`                           | Max recent usage events returned.                              |
+
+Keep `USAGE_DB_PATH` for normal deployments. When using `USAGE_DB_URL`, remove `USAGE_DB_PATH` from Compose; the two values cannot both be non-empty. The `&` characters are inside a YAML single-quoted scalar and do not need additional escaping. See [Manager Server Guide](../operations/manager-server.md#advanced-sqlite-database-urls) for the complete constraints.
 
 For the full runtime reference, see [Manager Server Guide](../operations/manager-server.md).
 
@@ -213,12 +218,12 @@ Always mount `/data`. Docker defaults:
 
 ```text
 /data/usage.sqlite
-/data/usage.sqlite-wal
-/data/usage.sqlite-shm
 /data/data.key
+/data/usage.sqlite-wal  # when WAL mode is active and the file exists
+/data/usage.sqlite-shm  # when WAL mode is active and the file exists
 ```
 
-Backups must include both SQLite files and `data.key`:
+Backups must include the main SQLite database, `data.key`, and every sidecar file that currently exists:
 
 ```bash
 docker run --rm \
@@ -291,6 +296,8 @@ docker compose run --rm --no-deps \
 
 docker compose start cpa-manager-plus
 ```
+
+If the service uses `USAGE_DB_URL`, remove `--db-path /data/usage.sqlite` from the middle command so the container inherits the complete URL; an explicit path selects the default SQLite connection settings.
 
 Replace `cpa-manager-plus` if your Compose service uses another name. Do not run cleanup while Manager Server is still active, and do not trigger it from the web UI; the command requires the exclusive SQLite process lock. After restart, Manager Server derives the state from database metadata again, so the warning disappears automatically when maintenance is clean.
 

--- a/apps/docs/en/deployment/native.md
+++ b/apps/docs/en/deployment/native.md
@@ -132,13 +132,21 @@ or:
 USAGE_DB_PATH=/var/lib/cpa-manager-plus/usage.sqlite ./cpa-manager-plus
 ```
 
+When complete SQLite driver parameters are required, set only `USAGE_DB_URL` instead:
+
+```bash
+USAGE_DB_URL='file:///var/lib/cpa-manager-plus/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)' ./cpa-manager-plus
+```
+
+`USAGE_DB_URL` and `USAGE_DB_PATH` are mutually exclusive; do not set both. See [Manager Server Guide](../operations/manager-server.md#advanced-sqlite-database-urls) for the complete constraints.
+
 Back up:
 
 ```text
 data/usage.sqlite
-data/usage.sqlite-wal
-data/usage.sqlite-shm
 data/data.key
+data/usage.sqlite-wal  # when WAL mode is active and the file exists
+data/usage.sqlite-shm  # when WAL mode is active and the file exists
 ```
 
 `data.key` decrypts the saved CPA Management Key. If it is lost, save the CPA connection again.
@@ -231,7 +239,7 @@ For production, you can also run the process through systemd, launchd, Windows S
 1. Stop the native process.
 2. Back up the data directory, including `data.key`.
 3. Extract the new package.
-4. Copy over `config.json` and `data/`, or keep using `USAGE_DATA_DIR` / `USAGE_DB_PATH`.
+4. Copy over `config.json` and `data/`, or keep using `USAGE_DATA_DIR`, `USAGE_DB_PATH`, or `USAGE_DB_URL`. The URL and path cannot both be set.
 5. Start the new binary.
 
 systemd example:

--- a/apps/docs/en/migration/from-cpa-manager.md
+++ b/apps/docs/en/migration/from-cpa-manager.md
@@ -19,11 +19,10 @@ If you never used the old `seakee/cpa-manager`, skip this page and use [Quick St
    - Docker volume is commonly `cpa-manager-data`.
    - Host directory mounts usually map to container `/data`.
    - Native packages default to `data/usage.sqlite` under the program directory.
-3. Stop the old container or process so SQLite WAL files stop changing.
+3. Stop the old container or process so the SQLite files stop changing.
 4. Back up the whole old data directory. Keep at least:
    - `usage.sqlite`
-   - `usage.sqlite-wal`
-   - `usage.sqlite-shm`
+   - Any current `usage.sqlite-wal` / `usage.sqlite-shm` files when WAL mode is active
 5. Decide the admin key strategy. During migration, explicitly setting `CPA_MANAGER_ADMIN_KEY` or `CPA_MANAGER_ADMIN_KEY_FILE` is recommended.
 
 ## Docker Volume Migration
@@ -53,6 +52,8 @@ services:
     environment:
       HTTP_ADDR: '0.0.0.0:18317'
       USAGE_DB_PATH: '/data/usage.sqlite'
+      # Advanced alternative: remove the previous line before setting a complete USAGE_DB_URL.
+      # USAGE_DB_URL: 'file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)'
       CPA_MANAGER_DATA_KEY_PATH: '/data/data.key'
       CPA_MANAGER_ADMIN_KEY: 'replace-with-a-long-random-admin-key'
       USAGE_COLLECTOR_MODE: 'auto'
@@ -88,7 +89,7 @@ After startup, open `http://<host>:18317/management.html` and log in with the ad
 1. Stop the old `cpa-manager` process.
 2. Back up the old program directory, especially `data/usage.sqlite*`.
 3. Extract `cpa-manager-plus_<version>_<os>_<arch>`.
-4. Copy the old `data` directory into the new package directory, or set `USAGE_DATA_DIR` / `USAGE_DB_PATH` to the old data directory.
+4. Copy the old `data` directory into the new package directory, or set `USAGE_DATA_DIR`, `USAGE_DB_PATH`, or `USAGE_DB_URL` to the old database. The URL and path cannot both be set.
 5. Set an admin key for the first startup:
 
 ```bash

--- a/apps/docs/en/operations/backup.md
+++ b/apps/docs/en/operations/backup.md
@@ -1,15 +1,17 @@
 # Backup And Restore
 
-CPAMP keeps request history, configuration, and encrypted credentials on the host. The common mistake is backing up only `usage.sqlite` and missing WAL/SHM files, `data.key`, or secret files in the install directory.
+CPAMP keeps request history, configuration, and encrypted credentials on the host. The common mistake is copying only `usage.sqlite` while the process is running, or missing current WAL/SHM files, `data.key`, or secret files in the install directory.
 
 ## Required Backup Files
 
-Back up these files as a set:
+After stopping Manager Server, back up these files as one set:
 
 - `usage.sqlite`
-- `usage.sqlite-wal`
-- `usage.sqlite-shm`
 - `data.key`
+- `usage.sqlite-wal` (when WAL mode is active and the file exists)
+- `usage.sqlite-shm` (when WAL mode is active and the file exists)
+
+`journal_mode=DELETE` normally has no WAL/SHM files. Do not manually delete sidecars to make the directory look clean; back up every file that actually exists after shutdown.
 
 If your deployment directory contains custom configuration files, back them up too. With the one-click installer, also back up `secrets/` under the install directory; full installation and env/secret-managed connections store the CPA Management Key in `secrets/cpa-management-key`.
 
@@ -63,10 +65,11 @@ Copy-Item -Recurse .\data .\data.backup
 
 1. Stop CPAMP.
 2. Restore the full data directory.
-3. Confirm that `usage.sqlite` and `data.key` come from the same backup.
-4. If the CPA connection is env/secret-managed, also restore `secrets/` from the install directory.
-5. Start CPAMP.
-6. Log in and check configuration, monitoring data, and collector status.
+3. Confirm that `usage.sqlite`, `data.key`, and any sidecars come from the same backup.
+4. If `USAGE_DB_URL` is used, confirm that the restore target is the URL path and that its declared journal mode matches the restored deployment.
+5. If the CPA connection is env/secret-managed, also restore `secrets/` from the install directory.
+6. Start CPAMP.
+7. Log in and check configuration, monitoring data, and collector status.
 
 If restore produces decryption errors, first check whether `data.key` matches the SQLite database.
 

--- a/apps/docs/en/operations/configuration.md
+++ b/apps/docs/en/operations/configuration.md
@@ -7,8 +7,8 @@ CPAMP stores its core data locally. During deployment, identify three things fir
 | File               | Description                                                                           |
 | ------------------ | ------------------------------------------------------------------------------------- |
 | `usage.sqlite`     | SQLite database for request events, configuration, prices, aliases, and related data. |
-| `usage.sqlite-wal` | SQLite WAL file. Back it up when present.                                             |
-| `usage.sqlite-shm` | SQLite SHM file. Back it up when present.                                             |
+| `usage.sqlite-wal` | May exist in WAL mode. Back it up when present.                                       |
+| `usage.sqlite-shm` | May exist in WAL mode. Back it up when present.                                       |
 | `data.key`         | Data key used to encrypt sensitive configuration written to SQLite.                   |
 
 Docker defaults:
@@ -24,6 +24,23 @@ Native package defaults:
 ./data/usage.sqlite
 ./data/data.key
 ```
+
+## SQLite Database Location
+
+Use `USAGE_DATA_DIR` or `USAGE_DB_PATH` for normal deployments. When complete SQLite driver parameters are required, use the single `USAGE_DB_URL` setting instead; it is mutually exclusive with `USAGE_DB_PATH`. The equivalent `config.json` fields are `dbUrl` and `dbPath`, which are also mutually exclusive.
+
+Database-location precedence:
+
+```text
+environment USAGE_DB_URL / USAGE_DB_PATH
+> environment USAGE_DATA_DIR
+> config.json dbUrl / dbPath
+> default data/usage.sqlite
+```
+
+`USAGE_DB_URL` accepts only an absolute, local, persistent `file:` URI and requires explicit `_txlock=immediate`, foreign-key, journal-mode, synchronous, and positive busy-timeout settings. See [Manager Server Guide](./manager-server.md#advanced-sqlite-database-urls) for the complete syntax, examples, journal-mode transition rules, and network-filesystem limitations.
+
+When a URL is used and `CPA_MANAGER_DATA_KEY_PATH` is not set explicitly, `data.key` defaults to the URL database directory. With every database-location method, back up the database, `data.key`, and every SQLite sidecar file that currently exists as one set.
 
 ## Admin Key
 

--- a/apps/docs/en/operations/manager-server.md
+++ b/apps/docs/en/operations/manager-server.md
@@ -195,7 +195,8 @@ Saving CPAMP configuration does not rewrite the full CPA `config.yaml`.
 | `HTTP_ADDR`                             | `0.0.0.0:18317`                                             | Manager Server listen address.                                                                                                                                                                                                     |
 | `CPA_MANAGER_PPROF_ADDR`                | empty                                                       | Optional Go pprof listen address; only `localhost`, `127.0.0.1`, or `::1` is accepted.                                                                                                                                             |
 | `USAGE_DATA_DIR`                        | Docker: `/data`; native: `./data`                           | Base data directory.                                                                                                                                                                                                               |
-| `USAGE_DB_PATH`                         | Docker: `/data/usage.sqlite`; native: `./data/usage.sqlite` | SQLite database path.                                                                                                                                                                                                              |
+| `USAGE_DB_URL`                          | empty                                                       | Advanced SQLite `file:` URL; mutually exclusive with `USAGE_DB_PATH`, for passing complete connection parameters.                                                                                                                  |
+| `USAGE_DB_PATH`                         | Docker: `/data/usage.sqlite`; native: `./data/usage.sqlite` | SQLite database path; remove it when `USAGE_DB_URL` is set.                                                                                                                                                                        |
 | `CPA_MANAGER_ADMIN_KEY`                 | empty                                                       | Optional admin key.                                                                                                                                                                                                                |
 | `CPA_MANAGER_ADMIN_KEY_FILE`            | `/run/secrets/cpa_admin_key`                                | Optional admin key file.                                                                                                                                                                                                           |
 | `CPA_MANAGER_DATA_KEY`                  | empty                                                       | Optional data encryption key.                                                                                                                                                                                                      |
@@ -223,6 +224,32 @@ Startup precedence:
 ```text
 environment variables > config.json > defaults
 ```
+
+The complete database-location precedence is environment `USAGE_DB_URL` / `USAGE_DB_PATH`, then environment `USAGE_DATA_DIR`, then `dbUrl` / `dbPath` in `config.json`, and finally the default data directory. A URL and path at the same level are mutually exclusive. Manager Server fails startup on a conflict instead of guessing which value to use.
+
+### Advanced SQLite database URLs
+
+Default deployments should keep using `USAGE_DB_PATH`. Their behavior remains WAL, `synchronous=FULL`, `busy_timeout=5000`, four maximum connections, and two idle connections. Use `USAGE_DB_URL` only when SQLite driver parameters must be supplied as a complete URL. It must be an absolute, local, persistent, hierarchical `file:` URI. Hosts, userinfo, fragments, relative paths, `:memory:`, `mode=memory`, `immutable`, `nolock`, and custom VFS selections are rejected.
+
+The URL must explicitly include these safety settings:
+
+```text
+_txlock=immediate
+_pragma=foreign_keys(1)        # or foreign_keys(ON)
+_pragma=journal_mode(WAL)      # or journal_mode(DELETE)
+_pragma=synchronous(FULL)      # or synchronous(EXTRA)
+_pragma=busy_timeout(a positive integer)
+```
+
+For example, to use a rollback journal and disable mmap:
+
+```bash
+USAGE_DB_URL='file:///var/lib/cpa-manager-plus/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)&_pragma=cell_size_check(1)&_pragma=temp_store(FILE)'
+```
+
+SQLite executes `_pragma` values through the driver, so only a trusted deployment administrator may control this URL. At startup, Manager Server reads back and validates the journal mode, foreign keys, synchronous level, and busy timeout; it exits if the configured values did not take effect. The WAL checkpoint worker is not started when the effective mode is `DELETE`.
+
+Before changing journal mode, stop every Manager Server connected to the database, back up the database together with any existing sidecar files, and restart as a single instance. A `file:` URL, rollback journal, and process lock do not make SQLite automatically safe on a network filesystem. SMB/CIFS/NFS remains best-effort and requires strict single-instance operation.
 
 Temporarily enable the loopback-only pprof server when diagnosing CPU, heap, or goroutine behavior:
 
@@ -295,6 +322,8 @@ cpa-manager-plus cleanup-derived
 cpa-manager-plus cleanup-derived --db-path /path/to/usage.sqlite
 ```
 
+Deployments using `USAGE_DB_URL` should omit `--db-path` in the same configured environment so the offline command inherits the complete URL parameters; an explicit `--db-path` selects the default SQLite connection settings. If the Compose service is configured with a URL, also remove `--db-path /data/usage.sqlite` from the example above.
+
 Manager Server holds an operating-system lock at `<absolute-database-path>.manager.lock` for its entire lifetime, and the command refuses to run while that lock is held. The web UI therefore detects, explains, and shows the steps only; it does not offer an online repair button, spawn the cleanup command, or bypass the process lock. The lock file itself is persistent and does not need to be deleted; stop the Manager Server process and retry instead. Symbolic-link aliases resolve to the same lock, while databases with multiple hard links are rejected because SQLite WAL/SHM sidecars cannot safely share those aliases. Back up the SQLite database plus `data.key` before offline maintenance. The command prepares deferred indexes, replaces obsolete derived indexes, completes oversized legacy quota observation groups, and removes obsolete derived FTS/projection generations. It never deletes, rebuilds, or rewrites authoritative `usage_events`.
 
 See the [July 10, 2026 Performance Optimization Report](./performance-optimization-2026-07-10.md) for the causes, delivery stages, and complete 100k benchmark evidence.
@@ -349,10 +378,12 @@ Back up:
 
 ```text
 usage.sqlite
-usage.sqlite-wal
-usage.sqlite-shm
 data.key
+usage.sqlite-wal  # when journal_mode=WAL and the file exists
+usage.sqlite-shm  # when journal_mode=WAL and the file exists
 ```
+
+After stopping the process, back up the database, `data.key`, and every sidecar file that actually exists as one set. Do not copy only the main database while it is running, and do not manually delete WAL/SHM files.
 
 Security notes:
 

--- a/apps/docs/en/operations/reset-admin-key.md
+++ b/apps/docs/en/operations/reset-admin-key.md
@@ -32,11 +32,11 @@ The alias `reset-admin-password` is also available.
 ## Before You Run It
 
 1. Stop Manager Server.
-2. Back up the full data directory, including `usage.sqlite`, `usage.sqlite-wal`, `usage.sqlite-shm`, and `data.key`.
+2. Back up the full data directory: `usage.sqlite`, `data.key`, and any current `usage.sqlite-wal` / `usage.sqlite-shm` files when WAL mode is active.
 3. Confirm the command points to the real Manager Server database:
    - Docker default: `/data/usage.sqlite`
    - Native package default: `data/usage.sqlite` next to the binary
-   - Custom deployment: the value of `USAGE_DB_PATH`
+   - Custom deployment: the `USAGE_DB_PATH` value or the local path in `USAGE_DB_URL`
 
 ## Docker Compose
 
@@ -89,7 +89,7 @@ docker run --rm \
 docker start cpa-manager-plus
 ```
 
-If you use the GitHub Container Registry image, replace `seakee/cpa-manager-plus:latest` with `ghcr.io/seakee/cpa-manager-plus:latest`.
+If you use the GitHub Container Registry image, replace `seakee/cpa-manager-plus:latest` with `ghcr.io/seakee/cpa-manager-plus:latest`. If the original deployment uses `USAGE_DB_URL`, a manual `docker run` must also pass the same value with `-e USAGE_DB_URL='original URL'`; the Compose command is preferred because it inherits the service environment.
 
 ## Provide A Specific Admin Key
 
@@ -120,7 +120,9 @@ Windows PowerShell:
 .\cpa-manager-plus.exe reset-admin-key
 ```
 
-If the SQLite database is not in the default data directory, pass the path explicitly:
+If the deployment uses `USAGE_DB_URL`, run the command in the same configured environment and omit `--db-path` so the command preserves the SQLite URL parameters. Passing `--db-path` explicitly selects the default SQLite settings.
+
+For a custom path-only deployment outside the default data directory, pass the path explicitly:
 
 ```bash
 ./cpa-manager-plus reset-admin-key --db-path /path/to/usage.sqlite
@@ -128,7 +130,7 @@ If the SQLite database is not in the default data directory, pass the path expli
 
 ## Troubleshooting
 
-- `SQLite database not found`: the command is not running against the real configured environment. Pass `--db-path`, or mount the correct Docker volume or host directory.
+- `SQLite database not found`: the command is not running against the real configured environment. For a URL deployment, pass the original `USAGE_DB_URL` and omit `--db-path`; for a path deployment, pass `--db-path`. In Docker, also mount the correct volume or host directory.
 - `is empty` / `does not look like a CPA Manager Plus Manager Server database`: the path points to the wrong file or a newly created empty file.
 - `database is locked`: Manager Server or another process is still using SQLite. Stop related processes and retry.
 - Login still fails after reset: confirm the panel is accessing the same Manager Server.

--- a/apps/docs/en/operations/update.md
+++ b/apps/docs/en/operations/update.md
@@ -8,7 +8,7 @@ This guide explains how to upgrade CPAMP without losing SQLite data, `data.key`,
 2. Record the current image tag or native version, launch command, environment variables, and data directory.
 3. Stop extra instances that could write to the same SQLite database. Only one Manager Server may consume a CPA usage queue.
 4. Back up:
-   - `usage.sqlite`, `usage.sqlite-wal`, and `usage.sqlite-shm`.
+   - `usage.sqlite`, plus any current `usage.sqlite-wal` / `usage.sqlite-shm` files when WAL mode is active.
    - `data.key`.
    - Installer-managed `secrets/`, `.env`, `compose.yaml`, or `config.json`.
    - Custom reverse-proxy, systemd, launchd, or Windows service configuration.
@@ -158,7 +158,7 @@ Do not overwrite the running version directory:
 6. If the generated systemd unit is installed, update `WorkingDirectory` and `ExecStart`, then run `systemctl daemon-reload`.
 7. Start and verify the new version before deciding whether to remove the old runtime.
 
-Do not copy only `usage.sqlite` and omit WAL/SHM. Back up while the process is stopped or use a safe SQLite method from [Backup And Restore](./backup.md).
+Do not copy only `usage.sqlite` while the process is running. After shutdown, include every WAL/SHM file that actually exists, or use a safe SQLite method from [Backup And Restore](./backup.md). Having no WAL/SHM in DELETE mode is normal.
 
 ## Manual Native Packages
 
@@ -167,7 +167,7 @@ Do not copy only `usage.sqlite` and omit WAL/SHM. Back up while the process is s
 1. Run `./cpa-manager-plusctl stop`, or stop your process supervisor.
 2. Back up the data directory and `data.key`.
 3. Extract the new package into a new version directory.
-4. Continue using the external `USAGE_DATA_DIR` / `USAGE_DB_PATH`, or copy `config.json` and `data/` while the process is stopped.
+4. Continue using the external `USAGE_DATA_DIR`, `USAGE_DB_PATH`, or `USAGE_DB_URL`, or copy `config.json` and `data/` while the process is stopped. The URL and path remain mutually exclusive.
 5. Start with the control script from the new directory:
 
 ```bash
@@ -270,5 +270,5 @@ Confirm:
 - Docker: restore the previous image tag and recreate the container while mounting the pre-upgrade data backup.
 - Native: stop the new version and restore the old binary, configuration, and pre-upgrade data backup.
 - Single-file panel: restore the previous `management.html`.
-- Do not assume an older binary can read a database migrated by a newer version. For schema or data-semantics changes, restore the pre-upgrade SQLite, WAL/SHM, and `data.key` together.
+- Do not assume an older binary can read a database migrated by a newer version. For schema or data-semantics changes, restore the pre-upgrade SQLite, `data.key`, every WAL/SHM file that existed in the backup, and the original `USAGE_DB_URL` / journal-mode configuration together.
 - If the cause is unclear, preserve both versions' logs and database copies. Do not repeatedly start different versions against the same live database.

--- a/apps/docs/en/reference/faq.md
+++ b/apps/docs/en/reference/faq.md
@@ -274,14 +274,18 @@ Back up the full data directory:
 
 ```text
 usage.sqlite
-usage.sqlite-wal
-usage.sqlite-shm
 data.key
+usage.sqlite-wal  # when WAL mode is active and the file exists
+usage.sqlite-shm  # when WAL mode is active and the file exists
 ```
 
 CPA connections saved through setup or the panel are encrypted with `data.key` before being written to SQLite. If `data.key` is lost, the encrypted CPA Management Key cannot be recovered and the CPA connection must be saved again.
 
 If the installer manages the connection through env/secrets, the CPA Management Key is usually stored in `secrets/cpa-management-key` under the install directory and is not written to SQLite. Back up `secrets/` together with the data directory.
+
+## Should I Use `USAGE_DB_URL` Or `USAGE_DB_PATH`?
+
+Use `USAGE_DB_PATH` for normal deployments. Use `USAGE_DB_URL` only when complete SQLite driver parameters are required. They are mutually exclusive; setting both fails startup so the database path, process lock, and actual connection cannot point to different targets. See [Manager Server Guide](../operations/manager-server.md#advanced-sqlite-database-urls) for the complete URL syntax and safety constraints.
 
 ## 401 From Manager Server
 

--- a/apps/docs/migration/from-cpa-manager.md
+++ b/apps/docs/migration/from-cpa-manager.md
@@ -19,11 +19,10 @@
    - Docker volume 常见为 `cpa-manager-data`。
    - 宿主机目录挂载通常映射到容器 `/data`。
    - 原生包默认在程序目录下的 `data/usage.sqlite`。
-3. 停止旧容器或旧进程，避免 SQLite WAL 文件继续写入。
+3. 停止旧容器或旧进程，避免 SQLite 文件继续变化。
 4. 备份整个旧数据目录。至少保留：
    - `usage.sqlite`
-   - `usage.sqlite-wal`
-   - `usage.sqlite-shm`
+   - WAL 模式下当前存在的 `usage.sqlite-wal` / `usage.sqlite-shm`
 5. 决定管理员密钥策略。推荐迁移时显式设置 `CPA_MANAGER_ADMIN_KEY` 或 `CPA_MANAGER_ADMIN_KEY_FILE`。
 
 ## Docker Volume 迁移
@@ -53,6 +52,8 @@ services:
     environment:
       HTTP_ADDR: '0.0.0.0:18317'
       USAGE_DB_PATH: '/data/usage.sqlite'
+      # 高级替代：删除上一行后设置完整 USAGE_DB_URL。
+      # USAGE_DB_URL: 'file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)'
       CPA_MANAGER_DATA_KEY_PATH: '/data/data.key'
       CPA_MANAGER_ADMIN_KEY: 'replace-with-a-long-random-admin-key'
       USAGE_COLLECTOR_MODE: 'auto'
@@ -88,7 +89,7 @@ docker run -d \
 1. 停止旧 `cpa-manager` 进程。
 2. 备份旧程序目录，尤其是 `data/usage.sqlite*`。
 3. 解压 `cpa-manager-plus_<version>_<os>_<arch>`。
-4. 将旧 `data` 目录复制到新包目录，或设置 `USAGE_DATA_DIR` / `USAGE_DB_PATH` 指向旧数据目录。
+4. 将旧 `data` 目录复制到新包目录，或设置 `USAGE_DATA_DIR`、`USAGE_DB_PATH` 或 `USAGE_DB_URL` 指向旧数据库。URL 与 path 不能同时设置。
 5. 首次启动时建议设置管理员密钥：
 
 ```bash

--- a/apps/docs/operations/backup.md
+++ b/apps/docs/operations/backup.md
@@ -1,15 +1,17 @@
 # 备份与恢复
 
-CPAMP 的请求历史、配置和加密凭证都在本机。备份时最容易犯的错，是只复制 `usage.sqlite`，漏掉 WAL/SHM、`data.key` 或安装目录里的 secret 文件。
+CPAMP 的请求历史、配置和加密凭证都在本机。备份时最容易犯的错，是在进程运行时只复制 `usage.sqlite`，或漏掉当前存在的 WAL/SHM、`data.key` 和安装目录里的 secret 文件。
 
 ## 必备备份文件
 
-至少把这些文件作为一组备份：
+停止 Manager Server 后，至少把这些文件作为一组备份：
 
 - `usage.sqlite`
-- `usage.sqlite-wal`
-- `usage.sqlite-shm`
 - `data.key`
+- `usage.sqlite-wal`（WAL 模式且文件存在时）
+- `usage.sqlite-shm`（WAL 模式且文件存在时）
+
+`journal_mode=DELETE` 正常情况下没有 WAL/SHM；不要为了得到“整洁”目录而手工删除 sidecar。只备份停止后实际存在的文件。
 
 如果部署目录还有自定义配置文件，也应一起备份。使用一键安装脚本时，至少额外备份安装目录中的 `secrets/`；完整安装和 env/secret 管理模式会把 CPA Management Key 放在 `secrets/cpa-management-key`。
 
@@ -63,10 +65,11 @@ Copy-Item -Recurse .\data .\data.backup
 
 1. 停止 CPAMP。
 2. 恢复完整数据目录。
-3. 确认 `usage.sqlite` 和 `data.key` 来自同一次备份。
-4. 如果使用 env/secret 管理 CPA 连接，同时恢复安装目录里的 `secrets/`。
-5. 启动 CPAMP。
-6. 登录后检查配置、监控数据和采集器状态。
+3. 确认 `usage.sqlite`、`data.key` 和任何 sidecar 来自同一次备份。
+4. 如果使用 `USAGE_DB_URL`，确认恢复路径是 URL 的 path，且恢复后的 journal mode 与 URL 中声明的模式一致。
+5. 如果使用 env/secret 管理 CPA 连接，同时恢复安装目录里的 `secrets/`。
+6. 启动 CPAMP。
+7. 登录后检查配置、监控数据和采集器状态。
 
 如果恢复后出现解密失败，优先检查 `data.key` 是否和 SQLite 匹配。
 

--- a/apps/docs/operations/configuration.md
+++ b/apps/docs/operations/configuration.md
@@ -7,8 +7,8 @@ CPAMP 的核心数据都在本地。部署时先搞清楚三件事：SQLite 放�
 | 文件               | 说明                                                  |
 | ------------------ | ----------------------------------------------------- |
 | `usage.sqlite`     | SQLite 数据库，保存请求事件、配置、价格、别名等数据。 |
-| `usage.sqlite-wal` | SQLite WAL 文件，存在时必须一起备份。                 |
-| `usage.sqlite-shm` | SQLite SHM 文件，存在时必须一起备份。                 |
+| `usage.sqlite-wal` | WAL 模式下可能存在；存在时必须一起备份。              |
+| `usage.sqlite-shm` | WAL 模式下可能存在；存在时必须一起备份。              |
 | `data.key`         | 数据密钥，用于加密写入 SQLite 的敏感配置。            |
 
 Docker 默认路径：
@@ -24,6 +24,23 @@ Docker 默认路径：
 ./data/usage.sqlite
 ./data/data.key
 ```
+
+## SQLite 数据库位置
+
+默认使用 `USAGE_DATA_DIR` 或 `USAGE_DB_PATH`。需要把完整 SQLite 连接参数传给 driver 时，可以改用单一的 `USAGE_DB_URL`；它与 `USAGE_DB_PATH` 互斥。配置文件中的等价字段是 `dbUrl` 和 `dbPath`，同样不能同时设置。
+
+数据库位置优先级：
+
+```text
+环境变量 USAGE_DB_URL / USAGE_DB_PATH
+> 环境变量 USAGE_DATA_DIR
+> config.json dbUrl / dbPath
+> 默认 data/usage.sqlite
+```
+
+`USAGE_DB_URL` 只接受绝对、本地、持久化的 `file:` URI，并要求显式设置 `_txlock=immediate`、foreign keys、journal mode、synchronous 和正数 busy timeout。完整格式、示例、journal mode 切换和网络文件系统限制见 [Manager Server 指南](./manager-server.md#高级-sqlite-database-url)。
+
+使用 URL 且未显式设置 `CPA_MANAGER_DATA_KEY_PATH` 时，`data.key` 默认放在 URL 数据库的同一目录。无论使用哪种数据库位置配置，都应把数据库、`data.key` 和当前存在的 SQLite sidecar 文件作为一组备份。
 
 ## 管理员密钥
 

--- a/apps/docs/operations/manager-server.md
+++ b/apps/docs/operations/manager-server.md
@@ -193,7 +193,8 @@ Manager Server 管理：
 | `HTTP_ADDR`                             | `0.0.0.0:18317`                                             | Manager Server 监听地址。                                                                                                                                  |
 | `CPA_MANAGER_PPROF_ADDR`                | 空                                                          | 可选 Go pprof 监听地址；仅接受 `localhost`、`127.0.0.1` 或 `::1`。                                                                                         |
 | `USAGE_DATA_DIR`                        | Docker: `/data`; native: `./data`                           | 数据目录。                                                                                                                                                 |
-| `USAGE_DB_PATH`                         | Docker: `/data/usage.sqlite`; native: `./data/usage.sqlite` | SQLite 路径。                                                                                                                                              |
+| `USAGE_DB_URL`                          | 空                                                          | 高级 SQLite `file:` URL；与 `USAGE_DB_PATH` 互斥，用于传入完整连接参数。                                                                                   |
+| `USAGE_DB_PATH`                         | Docker: `/data/usage.sqlite`; native: `./data/usage.sqlite` | SQLite 路径；设置 `USAGE_DB_URL` 时必须移除。                                                                                                              |
 | `CPA_MANAGER_ADMIN_KEY`                 | 空                                                          | 可选管理员密钥。                                                                                                                                           |
 | `CPA_MANAGER_ADMIN_KEY_FILE`            | `/run/secrets/cpa_admin_key`                                | 可选管理员密钥文件。                                                                                                                                       |
 | `CPA_MANAGER_DATA_KEY`                  | 空                                                          | 可选数据加密 key。                                                                                                                                         |
@@ -221,6 +222,32 @@ Manager Server 管理：
 ```text
 environment variables > config.json > defaults
 ```
+
+数据库位置的完整优先级是：环境变量 `USAGE_DB_URL` / `USAGE_DB_PATH`，然后是环境变量 `USAGE_DATA_DIR`，再然后是 `config.json` 的 `dbUrl` / `dbPath`，最后才是默认数据目录。同一层的 URL 和 path 不能同时设置；冲突时 Manager Server 会拒绝启动，而不会猜测要使用哪一个。
+
+### 高级 SQLite database URL
+
+默认部署继续使用 `USAGE_DB_PATH`，行为保持为 WAL、`synchronous=FULL`、`busy_timeout=5000`、4 个最大连接和 2 个空闲连接。只有需要向 SQLite driver 传递完整连接参数时才使用 `USAGE_DB_URL`。它必须是绝对、本地、持久化的分层 `file:` URI；不接受 host、userinfo、fragment、相对路径、`:memory:`、`mode=memory`、`immutable`、`nolock` 或自定义 VFS。
+
+URL 必须显式包含以下安全参数：
+
+```text
+_txlock=immediate
+_pragma=foreign_keys(1)        # 或 foreign_keys(ON)
+_pragma=journal_mode(WAL)      # 或 journal_mode(DELETE)
+_pragma=synchronous(FULL)      # 或 synchronous(EXTRA)
+_pragma=busy_timeout(正整数)
+```
+
+例如，使用 rollback journal 并关闭 mmap：
+
+```bash
+USAGE_DB_URL='file:///var/lib/cpa-manager-plus/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)&_pragma=cell_size_check(1)&_pragma=temp_store(FILE)'
+```
+
+`_pragma` 会由 SQLite driver 执行，因此该 URL 只能由受信任的部署管理员控制。Manager Server 会在启动时回读并验证 journal mode、foreign keys、synchronous 和 busy timeout；配置的 journal mode 无法生效时会直接退出。实际模式为 `DELETE` 时不会启动 WAL checkpoint worker。
+
+切换 journal mode 前必须停止所有连接同一数据库的 Manager Server，备份数据库和当前存在的 sidecar 文件，再以单实例启动。`file:` URL、rollback journal 和进程锁都不能让 SQLite 自动变成网络文件系统安全方案；SMB/CIFS/NFS 上仍是 best-effort，且必须严格单实例运行。
 
 需要诊断 CPU、堆或 goroutine 时，可临时启用仅本机可访问的 pprof 服务：
 
@@ -293,6 +320,8 @@ cpa-manager-plus cleanup-derived
 cpa-manager-plus cleanup-derived --db-path /path/to/usage.sqlite
 ```
 
+使用 `USAGE_DB_URL` 的部署应在同一配置环境中省略 `--db-path`，让离线命令继承完整 URL 参数；显式 `--db-path` 会选择默认 SQLite 连接设置。Compose service 已配置 URL 时，也应删除上面示例中的 `--db-path /data/usage.sqlite`。
+
 Manager Server 在整个生命周期内都会持有 `<数据库绝对路径>.manager.lock` 操作系统锁；锁仍被持有时，该命令会直接拒绝执行。因此 Web UI 只检测、解释和展示步骤，不会提供在线修复按钮、启动子进程或绕过进程锁。锁文件会持久保留，无需手工删除，应停止 Manager Server 进程后重试。符号链接别名会解析到同一个锁；具有多个硬链接的数据库会被拒绝，因为 SQLite WAL/SHM 侧车文件无法安全共享这些别名。离线维护前应备份 SQLite 和 `data.key`。该命令会创建延后的索引、替换过期派生索引、完成超大旧 quota observation group 的迁移并删除已过期的 FTS/投影 generation；它不会删除、重建或改写 authoritative `usage_events`。
 
 完整的优化原因、实现阶段和 100k benchmark 数据见 [2026-07-10 性能优化报告](./performance-optimization-2026-07-10.md)。
@@ -347,10 +376,12 @@ Authorization: Bearer <CPAMP_ADMIN_KEY>
 
 ```text
 usage.sqlite
-usage.sqlite-wal
-usage.sqlite-shm
 data.key
+usage.sqlite-wal  # journal_mode=WAL 且文件存在时
+usage.sqlite-shm  # journal_mode=WAL 且文件存在时
 ```
+
+停止进程后把数据库、`data.key` 和当前实际存在的 sidecar 文件作为同一组备份。不要在运行期间只复制主数据库，也不要手工删除 WAL/SHM。
 
 安全边界：
 

--- a/apps/docs/operations/reset-admin-key.md
+++ b/apps/docs/operations/reset-admin-key.md
@@ -32,11 +32,11 @@
 ## 执行前检查
 
 1. 停止 Manager Server。
-2. 备份完整数据目录，包含 `usage.sqlite`、`usage.sqlite-wal`、`usage.sqlite-shm` 和 `data.key`。
+2. 备份完整数据目录：`usage.sqlite`、`data.key`，以及 WAL 模式下当前存在的 `usage.sqlite-wal` / `usage.sqlite-shm`。
 3. 确认命令指向真实的 Manager Server 数据库：
    - Docker 默认：`/data/usage.sqlite`
    - 原生包默认：二进制旁边的 `data/usage.sqlite`
-   - 自定义部署：`USAGE_DB_PATH` 的值
+   - 自定义部署：`USAGE_DB_PATH` 的值，或 `USAGE_DB_URL` 的本地 path
 
 ## Docker Compose
 
@@ -89,7 +89,7 @@ docker run --rm \
 docker start cpa-manager-plus
 ```
 
-如果使用 GitHub Container Registry 镜像，把 `seakee/cpa-manager-plus:latest` 替换为 `ghcr.io/seakee/cpa-manager-plus:latest`。
+如果使用 GitHub Container Registry 镜像，把 `seakee/cpa-manager-plus:latest` 替换为 `ghcr.io/seakee/cpa-manager-plus:latest`。若原部署使用 `USAGE_DB_URL`，手工 `docker run` 时还必须用 `-e USAGE_DB_URL='原 URL'` 传入同一值；更推荐使用会继承 service environment 的 Compose 命令。
 
 ## 指定管理员密钥
 
@@ -120,7 +120,9 @@ Windows PowerShell：
 .\cpa-manager-plus.exe reset-admin-key
 ```
 
-如果 SQLite 数据库不在默认数据目录，显式指定路径：
+如果部署使用 `USAGE_DB_URL`，应在同一配置环境中直接运行命令并省略 `--db-path`，这样命令会保留 URL 中的 SQLite 参数。显式传入 `--db-path` 会改用默认 SQLite 设置。
+
+仅使用自定义 path 且数据库不在默认目录时，可显式指定：
 
 ```bash
 ./cpa-manager-plus reset-admin-key --db-path /path/to/usage.sqlite
@@ -128,7 +130,7 @@ Windows PowerShell：
 
 ## 排障
 
-- `SQLite database not found`：当前命令没有运行在真实配置环境中。请传入 `--db-path`，或挂载正确的 Docker volume / 宿主机目录。
+- `SQLite database not found`：当前命令没有运行在真实配置环境中。URL 部署应传入原来的 `USAGE_DB_URL` 并省略 `--db-path`；path 部署可传入 `--db-path`。Docker 中还要挂载正确的 volume / 宿主机目录。
 - `is empty` / `does not look like a CPA Manager Plus Manager Server database`：路径指向了错误文件或新建的空文件。
 - `database is locked`：Manager Server 或其他进程仍在使用 SQLite。停止相关进程后重试。
 - 重置后仍无法登录：确认面板访问的是同一个 Manager Server。

--- a/apps/docs/operations/update.md
+++ b/apps/docs/operations/update.md
@@ -8,7 +8,7 @@
 2. 记录当前镜像标签、原生包版本、启动命令、环境变量和数据目录。
 3. 停止会修改相同 SQLite 的额外实例。同一个 CPA 用量队列只能由一个 Manager Server 消费。
 4. 备份完整数据和配置：
-   - `usage.sqlite`、`usage.sqlite-wal`、`usage.sqlite-shm`。
+   - `usage.sqlite`，以及 WAL 模式下当前存在的 `usage.sqlite-wal` / `usage.sqlite-shm`。
    - `data.key`。
    - 安装器目录中的 `secrets/`、`.env`、`compose.yaml` 或 `config.json`。
    - 自定义反向代理、systemd、launchd 或 Windows 服务配置。
@@ -158,7 +158,7 @@ cpa-manager-plus.service
 6. 如果使用安装器生成的 systemd 文件，同步更新 `WorkingDirectory` 和 `ExecStart`，然后执行 `systemctl daemon-reload`。
 7. 启动并完成验证后再决定是否清理旧 runtime；保留旧包可以缩短程序回滚时间。
 
-不要只复制 `usage.sqlite` 而遗漏 WAL/SHM；备份应在进程停止后进行，或使用 [备份与恢复](./backup.md) 中的 SQLite 安全方法。
+不要在进程运行时只复制 `usage.sqlite`；停止后应同时保存当前实际存在的 WAL/SHM，或使用 [备份与恢复](./backup.md) 中的 SQLite 安全方法。DELETE 模式没有 WAL/SHM 属于正常情况。
 
 ## 手动原生包
 
@@ -167,7 +167,7 @@ cpa-manager-plus.service
 1. 执行 `./cpa-manager-plusctl stop`，或停止你自己的进程管理器。
 2. 备份数据目录和 `data.key`。
 3. 解压新包到新的版本目录。
-4. 继续使用原来的外部 `USAGE_DATA_DIR` / `USAGE_DB_PATH`，或在停机状态下把 `config.json` 和 `data/` 复制到新目录。
+4. 继续使用原来的外部 `USAGE_DATA_DIR`、`USAGE_DB_PATH` 或 `USAGE_DB_URL`，或在停机状态下把 `config.json` 和 `data/` 复制到新目录。URL 与 path 仍必须互斥。
 5. 使用新目录里的控制脚本启动：
 
 ```bash
@@ -270,5 +270,5 @@ curl -f -H "Authorization: Bearer <CPAMP_ADMIN_KEY>" \
 - Docker：将镜像标签改回旧版本并重建容器，继续挂载更新前的数据备份。
 - 原生包：停止新版本，恢复旧二进制、配置和更新前的数据备份后再启动。
 - 单文件面板：恢复旧 `management.html`。
-- 不要假设旧程序一定能读取新版本迁移后的数据库。涉及 schema 或数据语义变更时，应同时恢复更新前的 SQLite、WAL/SHM 和 `data.key`。
+- 不要假设旧程序一定能读取新版本迁移后的数据库。涉及 schema 或数据语义变更时，应同时恢复更新前的 SQLite、`data.key` 和备份时实际存在的 WAL/SHM，并恢复原来的 `USAGE_DB_URL` / journal mode 配置。
 - 如果失败原因不明确，保留新旧日志和数据库副本，不要反复启动多个版本写入同一数据库。

--- a/apps/docs/reference/faq.md
+++ b/apps/docs/reference/faq.md
@@ -274,14 +274,18 @@ Plus 示例 volume:   cpa-manager-plus-data
 
 ```text
 usage.sqlite
-usage.sqlite-wal
-usage.sqlite-shm
 data.key
+usage.sqlite-wal  # WAL 模式且文件存在时
+usage.sqlite-shm  # WAL 模式且文件存在时
 ```
 
 通过 setup 或面板保存的 CPA 连接会把 CPA Management Key 用 `data.key` 加密后写入 SQLite。丢失 `data.key` 后，已加密的 CPA Management Key 无法恢复，只能重新保存 CPA 连接。
 
 如果使用安装器 env/secret 管理连接，CPA Management Key 通常在安装目录的 `secrets/cpa-management-key`，不写入 SQLite。备份时要把安装目录里的 `secrets/` 和数据目录一起保存。
+
+## `USAGE_DB_URL` 和 `USAGE_DB_PATH` 应该用哪个？
+
+普通部署使用 `USAGE_DB_PATH`。只有需要传入完整 SQLite driver 参数时才使用 `USAGE_DB_URL`。两者互斥；同时设置会拒绝启动，避免数据库 path、进程锁和实际连接指向不同目标。URL 的完整格式和安全约束见 [Manager Server 指南](../operations/manager-server.md#高级-sqlite-database-url)。
 
 ## Manager Server 返回 401
 

--- a/apps/manager-server/cmd/cpa-manager-plus/main.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main.go
@@ -10,6 +10,7 @@ import (
 	httppprof "net/http/pprof"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -74,7 +75,13 @@ func runServer() {
 	if err != nil {
 		log.Fatalf("initialize secret protector: %v", err)
 	}
-	db, err := store.Open(cfg.DBPath, protector)
+	db, err := store.OpenWithOptions(sqliterepo.Options{
+		Path:                cfg.DBPath,
+		DataSourceName:      cfg.DBURL,
+		ExpectedJournalMode: cfg.DBJournalMode,
+		ExpectedSynchronous: cfg.DBSynchronous,
+		ExpectedBusyTimeout: cfg.DBBusyTimeout,
+	}, protector)
 	if err != nil {
 		log.Fatalf("open sqlite: %v", err)
 	}
@@ -83,6 +90,17 @@ func runServer() {
 			log.Printf("close sqlite: %v", err)
 		}
 	}()
+	journalMode, err := db.SQLiteJournalMode(context.Background())
+	if err != nil {
+		log.Fatalf("read SQLite journal mode: %v", err)
+	}
+	if cfg.DBURL != "" {
+		log.Printf(
+			"[startup] custom SQLite database URL enabled: database=%s journal_mode=%s",
+			filepath.Base(cfg.DBPath),
+			journalMode,
+		)
+	}
 
 	bootstrapResult, err := bootstrapservice.Run(context.Background(), cfg, db, dataKeyCreated)
 	if err != nil {
@@ -105,16 +123,21 @@ func runServer() {
 	collectorWorker := worker.NewCollectorWorker(cfg, db, collectorService)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	walMaintenance, err := sqliterepo.NewWALMaintenance(cfg.DBPath)
-	if err != nil {
-		log.Printf("configure SQLite WAL maintenance: %v", err)
+	var walMaintenance *sqliterepo.WALMaintenance
+	if journalMode == "wal" {
+		walMaintenance, err = sqliterepo.NewWALMaintenance(cfg.DBPath)
+		if err != nil {
+			log.Printf("configure SQLite WAL maintenance: %v", err)
+		} else {
+			walMaintenance.Start(ctx)
+			defer func() {
+				if err := walMaintenance.Close(); err != nil {
+					log.Printf("close SQLite WAL maintenance: %v", err)
+				}
+			}()
+		}
 	} else {
-		walMaintenance.Start(ctx)
-		defer func() {
-			if err := walMaintenance.Close(); err != nil {
-				log.Printf("close SQLite WAL maintenance: %v", err)
-			}
-		}()
+		log.Printf("[startup] SQLite WAL maintenance disabled: journal_mode=%s", journalMode)
 	}
 
 	serverApp := httpapi.New(cfg, db, manager)

--- a/apps/manager-server/cmd/cpa-manager-plus/main_test.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/main_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -149,11 +150,61 @@ func TestManagerDatabaseProcessLockPrecedesStoreOpen(t *testing.T) {
 	}
 	source := string(content)
 	lockAt := strings.Index(source, "processlock.Acquire(cfg.DBPath)")
-	storeOpenAt := strings.Index(source, "store.Open(cfg.DBPath, protector)")
+	storeOpenAt := strings.Index(source, "store.OpenWithOptions(sqliterepo.Options{")
 	lockCloseAt := strings.Index(source, "databaseLock.Close()")
 	if lockAt < 0 || storeOpenAt < lockAt || lockCloseAt < lockAt {
 		t.Fatalf("database lock ordering invalid: lock=%d open=%d close=%d", lockAt, storeOpenAt, lockCloseAt)
 	}
+}
+
+func TestWALMaintenanceStartsOnlyForEffectiveWALMode(t *testing.T) {
+	content, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	source := string(content)
+	readAt := strings.Index(source, "db.SQLiteJournalMode(context.Background())")
+	gateAt := strings.Index(source, `if journalMode == "wal"`)
+	workerAt := strings.Index(source, "sqliterepo.NewWALMaintenance(cfg.DBPath)")
+	disabledAt := strings.Index(source, "SQLite WAL maintenance disabled")
+	if readAt < 0 || gateAt < readAt || workerAt < gateAt || disabledAt < workerAt {
+		t.Fatalf("WAL maintenance gating invalid: read=%d gate=%d worker=%d disabled=%d", readAt, gateAt, workerAt, disabledAt)
+	}
+}
+
+func TestManagerServerCustomDatabaseURLDisablesWALMaintenanceAndRestarts(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "usage.sqlite")
+	dbURL := managerServerDatabaseURL(dbPath)
+	first := startManagerServerProcessWithEnvironment(t, managerServerURLTestEnvironment(dataDir, dbPath, dbURL))
+	firstStopped := false
+	t.Cleanup(func() {
+		if !firstStopped {
+			first.stop(t)
+		}
+	})
+	assertManagerEndpoint(t, first.addr, "/management.html")
+	assertManagerEndpoint(t, first.addr, "/usage-service/info")
+	if logs := first.logs.String(); !strings.Contains(logs, "custom SQLite database URL enabled") ||
+		!strings.Contains(logs, "SQLite WAL maintenance disabled: journal_mode=delete") {
+		t.Fatalf("custom database startup logs missing:\n%s", logs)
+	}
+	first.stop(t)
+	firstStopped = true
+	assertManagerDatabaseModeAndSchema(t, dbPath, "delete")
+
+	second := startManagerServerProcessWithEnvironment(t, managerServerURLTestEnvironment(dataDir, dbPath, dbURL))
+	secondStopped := false
+	t.Cleanup(func() {
+		if !secondStopped {
+			second.stop(t)
+		}
+	})
+	assertManagerEndpoint(t, second.addr, "/management.html")
+	assertManagerEndpoint(t, second.addr, "/usage-service/info")
+	second.stop(t)
+	secondStopped = true
+	assertManagerDatabaseModeAndSchema(t, dbPath, "delete")
 }
 
 func TestCleanupDerivedCommandUsesSignalContext(t *testing.T) {
@@ -312,8 +363,13 @@ func (l *synchronizedLog) String() string {
 
 func startManagerServerProcess(t testing.TB, dataDir, dbPath string) *managerServerProcess {
 	t.Helper()
+	return startManagerServerProcessWithEnvironment(t, managerServerTestEnvironment(dataDir, dbPath))
+}
+
+func startManagerServerProcessWithEnvironment(t testing.TB, environment []string) *managerServerProcess {
+	t.Helper()
 	cmd := exec.Command(os.Args[0], "-test.run=^TestManagerServerHelperProcess$")
-	cmd.Env = managerServerTestEnvironment(dataDir, dbPath)
+	cmd.Env = environment
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		t.Fatalf("open manager server stderr: %v", err)
@@ -369,6 +425,7 @@ func managerServerTestEnvironment(dataDir, dbPath string) []string {
 		"HTTP_ADDR":                             "127.0.0.1:0",
 		"USAGE_DATA_DIR":                        dataDir,
 		"USAGE_DB_PATH":                         dbPath,
+		"USAGE_DB_URL":                          "",
 		"USAGE_COLLECTOR_MODE":                  "http",
 		"USAGE_POLL_INTERVAL_MS":                "1000",
 		"USAGE_DASHBOARD_HOURLY_ROLLUP_ENABLED": "false",
@@ -384,6 +441,70 @@ func managerServerTestEnvironment(dataDir, dbPath string) []string {
 		environment = append(environment, key+"="+value)
 	}
 	return environment
+}
+
+func managerServerURLTestEnvironment(dataDir, dbPath, dbURL string) []string {
+	environment := managerServerTestEnvironment(dataDir, dbPath)
+	for index, entry := range environment {
+		key, _, _ := strings.Cut(entry, "=")
+		switch key {
+		case "USAGE_DB_PATH":
+			environment[index] = "USAGE_DB_PATH="
+		case "USAGE_DB_URL":
+			environment[index] = "USAGE_DB_URL=" + dbURL
+		}
+	}
+	return environment
+}
+
+func managerServerDatabaseURL(dbPath string) string {
+	uriPath := filepath.ToSlash(dbPath)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn := url.URL{Scheme: "file", Path: uriPath}
+	query := url.Values{}
+	query.Add("_txlock", "immediate")
+	query.Add("_pragma", "journal_mode(DELETE)")
+	query.Add("_pragma", "synchronous(EXTRA)")
+	query.Add("_pragma", "busy_timeout(15000)")
+	query.Add("_pragma", "foreign_keys(1)")
+	query.Add("_pragma", "mmap_size(0)")
+	query.Add("_pragma", "cell_size_check(1)")
+	query.Add("_pragma", "temp_store(FILE)")
+	dsn.RawQuery = query.Encode()
+	return dsn.String()
+}
+
+func assertManagerDatabaseModeAndSchema(t testing.TB, dbPath, wantMode string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open manager database: %v", err)
+	}
+	defer db.Close()
+	var mode string
+	if err := db.QueryRow(`pragma journal_mode`).Scan(&mode); err != nil {
+		t.Fatalf("read manager journal mode: %v", err)
+	}
+	if !strings.EqualFold(mode, wantMode) {
+		t.Fatalf("manager journal mode = %q, want %q", mode, wantMode)
+	}
+	var tables int
+	if err := db.QueryRow(`select count(*) from sqlite_schema where type = 'table'
+		and name in ('settings', 'usage_events')`).Scan(&tables); err != nil {
+		t.Fatalf("read manager schema: %v", err)
+	}
+	if tables != 2 {
+		t.Fatalf("manager schema table count = %d, want 2", tables)
+	}
+	var integrity string
+	if err := db.QueryRow(`pragma integrity_check`).Scan(&integrity); err != nil {
+		t.Fatalf("run manager integrity check: %v", err)
+	}
+	if integrity != "ok" {
+		t.Fatalf("manager integrity check = %q, want ok", integrity)
+	}
 }
 
 func (p *managerServerProcess) stop(t testing.TB) {

--- a/apps/manager-server/internal/app/app.go
+++ b/apps/manager-server/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
 	bootstrapsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/bootstrap"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
@@ -34,7 +35,13 @@ func New(ctx context.Context, cfg config.Config, options Options) (*Context, err
 	if err != nil {
 		return nil, err
 	}
-	st, err := store.Open(cfg.DBPath, protector)
+	st, err := store.OpenWithOptions(sqliterepo.Options{
+		Path:                cfg.DBPath,
+		DataSourceName:      cfg.DBURL,
+		ExpectedJournalMode: cfg.DBJournalMode,
+		ExpectedSynchronous: cfg.DBSynchronous,
+		ExpectedBusyTimeout: cfg.DBBusyTimeout,
+	}, protector)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/manager-server/internal/command/adminreset/command.go
+++ b/apps/manager-server/internal/command/adminreset/command.go
@@ -2,7 +2,6 @@ package adminreset
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -12,9 +11,9 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/processlock"
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	adminauthsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/adminauth"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
-	_ "modernc.org/sqlite"
 )
 
 func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
@@ -30,26 +29,26 @@ func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	if err != nil {
 		return err
 	}
-	dbPath, err := resolveDBPath(opts.DBPath)
+	databaseOptions, err := resolveDatabaseOptions(opts.DBPath)
 	if err != nil {
 		return err
 	}
-	if err := validateDatabaseFile(dbPath); err != nil {
+	if err := validateDatabaseFile(databaseOptions.Path); err != nil {
 		return err
 	}
-	databaseLock, err := processlock.Acquire(dbPath)
+	databaseLock, err := processlock.Acquire(databaseOptions.Path)
 	if err != nil {
 		return fmt.Errorf("acquire admin reset lock; stop Manager Server and retry: %w", err)
 	}
 	defer func() { _ = databaseLock.Close() }()
-	dbPath = databaseLock.DatabasePath()
-	if err := ensureManagerDB(ctx, dbPath); err != nil {
+	databaseOptions.Path = databaseLock.DatabasePath()
+	if err := ensureManagerDB(ctx, databaseOptions.Path); err != nil {
 		return err
 	}
 
-	st, err := store.Open(dbPath)
+	st, err := store.OpenWithOptions(databaseOptions)
 	if err != nil {
-		return fmt.Errorf("open sqlite %s: %w", dbPath, err)
+		return fmt.Errorf("open sqlite %s: %w", databaseOptions.Path, err)
 	}
 	defer st.Close()
 
@@ -112,18 +111,24 @@ func resolveAdminKey(opts options) (string, error) {
 	return adminKey, nil
 }
 
-func resolveDBPath(override string) (string, error) {
+func resolveDatabaseOptions(override string) (sqliterepo.Options, error) {
 	if strings.TrimSpace(override) != "" {
-		return strings.TrimSpace(override), nil
+		return sqliterepo.Options{Path: strings.TrimSpace(override)}, nil
 	}
 	cfg, err := config.LoadWithoutCreatingDefault()
 	if err != nil {
-		return "", fmt.Errorf("load config: %w", err)
+		return sqliterepo.Options{}, fmt.Errorf("load config: %w", err)
 	}
 	if strings.TrimSpace(cfg.DBPath) == "" {
-		return "", errors.New("SQLite database path is empty; pass --db-path")
+		return sqliterepo.Options{}, errors.New("SQLite database path is empty; pass --db-path")
 	}
-	return cfg.DBPath, nil
+	return sqliterepo.Options{
+		Path:                cfg.DBPath,
+		DataSourceName:      cfg.DBURL,
+		ExpectedJournalMode: cfg.DBJournalMode,
+		ExpectedSynchronous: cfg.DBSynchronous,
+		ExpectedBusyTimeout: cfg.DBBusyTimeout,
+	}, nil
 }
 
 func validateDatabaseFile(dbPath string) error {
@@ -147,8 +152,11 @@ func ensureManagerDB(ctx context.Context, dbPath string) error {
 	if err := validateDatabaseFile(dbPath); err != nil {
 		return err
 	}
-
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := sqliterepo.OpenUnmigratedWithOptions(sqliterepo.Options{
+		Path:         dbPath,
+		MaxOpenConns: 1,
+		MaxIdleConns: 1,
+	})
 	if err != nil {
 		return fmt.Errorf("open sqlite %s for validation: %w", dbPath, err)
 	}

--- a/apps/manager-server/internal/command/adminreset/command_test.go
+++ b/apps/manager-server/internal/command/adminreset/command_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/processlock"
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/security"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
@@ -51,6 +53,34 @@ func TestRunUsesProvidedAdminKeyWithoutEchoingIt(t *testing.T) {
 		t.Fatalf("stdout leaked provided admin key: %s", stdout.String())
 	}
 	requireAdminKeyVerifies(t, dbPath, adminKey)
+}
+
+func TestRunUsesConfiguredDatabaseURLWithoutChangingJournalMode(t *testing.T) {
+	dbPath := newCommandTestDB(t)
+	databaseOptions := commandDatabaseOptions(dbPath)
+	st, err := store.OpenWithOptions(databaseOptions)
+	if err != nil {
+		t.Fatalf("switch command fixture to DELETE mode: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close DELETE fixture: %v", err)
+	}
+	for key, value := range map[string]string{
+		"CPA_MANAGER_CONFIG": "",
+		"USAGE_DATA_DIR":     "",
+		"USAGE_DB_PATH":      "",
+		"USAGE_DB_URL":       databaseOptions.DataSourceName,
+	} {
+		t.Setenv(key, value)
+	}
+	const adminKey = "cpamp_from_database_url"
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := Run(context.Background(), []string{"--admin-key", adminKey}, &stdout, &stderr); err != nil {
+		t.Fatalf("run reset command with configured URL: %v stderr=%s", err, stderr.String())
+	}
+	requireAdminKeyVerifiesWithOptions(t, databaseOptions, adminKey)
+	requireJournalMode(t, dbPath, "delete")
 }
 
 func TestRunRejectsMissingDB(t *testing.T) {
@@ -96,6 +126,54 @@ func TestRunRejectsUnrelatedSQLiteDBWithoutMigratingIt(t *testing.T) {
 	err = Run(context.Background(), []string{"--db-path", dbPath}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "does not look like a CPA Manager Plus") {
 		t.Fatalf("err = %v", err)
+	}
+	requireNoManagerTables(t, dbPath)
+}
+
+func TestRunValidatesConfiguredDatabaseURLBeforeApplyingPragmas(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "unrelated.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open unrelated sqlite: %v", err)
+	}
+	if _, err := db.Exec(`create table unrelated(id integer primary key); pragma user_version = 7`); err != nil {
+		t.Fatalf("create unrelated fixture: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close unrelated fixture: %v", err)
+	}
+	databaseOptions := commandDatabaseOptions(dbPath)
+	dsn, err := url.Parse(databaseOptions.DataSourceName)
+	if err != nil {
+		t.Fatalf("parse test database URL: %v", err)
+	}
+	query := dsn.Query()
+	query.Add("_pragma", "user_version(123)")
+	dsn.RawQuery = query.Encode()
+	for key, value := range map[string]string{
+		"CPA_MANAGER_CONFIG": "",
+		"USAGE_DATA_DIR":     "",
+		"USAGE_DB_PATH":      "",
+		"USAGE_DB_URL":       dsn.String(),
+	} {
+		t.Setenv(key, value)
+	}
+	var stdout, stderr bytes.Buffer
+	err = Run(context.Background(), nil, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "does not look like a CPA Manager Plus") {
+		t.Fatalf("Run() error = %v", err)
+	}
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen unrelated sqlite: %v", err)
+	}
+	defer db.Close()
+	var userVersion int
+	if err := db.QueryRow(`pragma user_version`).Scan(&userVersion); err != nil {
+		t.Fatalf("read unrelated user_version: %v", err)
+	}
+	if userVersion != 7 {
+		t.Fatalf("unrelated user_version = %d, want 7", userVersion)
 	}
 	requireNoManagerTables(t, dbPath)
 }
@@ -150,6 +228,60 @@ func newCommandTestDB(t testing.TB) string {
 		t.Fatalf("close store: %v", err)
 	}
 	return dbPath
+}
+
+func commandDatabaseOptions(dbPath string) sqliterepo.Options {
+	uriPath := filepath.ToSlash(dbPath)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn := url.URL{Scheme: "file", Path: uriPath}
+	query := url.Values{}
+	query.Add("_txlock", "immediate")
+	query.Add("_pragma", "journal_mode(DELETE)")
+	query.Add("_pragma", "synchronous(EXTRA)")
+	query.Add("_pragma", "busy_timeout(15000)")
+	query.Add("_pragma", "foreign_keys(1)")
+	dsn.RawQuery = query.Encode()
+	return sqliterepo.Options{
+		Path:                dbPath,
+		DataSourceName:      dsn.String(),
+		ExpectedJournalMode: "delete",
+		ExpectedSynchronous: 3,
+		ExpectedBusyTimeout: 15000,
+	}
+}
+
+func requireAdminKeyVerifiesWithOptions(t testing.TB, options sqliterepo.Options, adminKey string) {
+	t.Helper()
+	st, err := store.OpenWithOptions(options)
+	if err != nil {
+		t.Fatalf("open custom store: %v", err)
+	}
+	defer st.Close()
+	credential, ok, err := st.LoadAdminCredential(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("load credential ok=%v err=%v", ok, err)
+	}
+	if !security.VerifyAdminKey(credential, adminKey) {
+		t.Fatalf("admin key %q does not verify", adminKey)
+	}
+}
+
+func requireJournalMode(t testing.TB, dbPath string, want string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite journal check: %v", err)
+	}
+	defer db.Close()
+	var got string
+	if err := db.QueryRow(`pragma journal_mode`).Scan(&got); err != nil {
+		t.Fatalf("read journal mode: %v", err)
+	}
+	if !strings.EqualFold(got, want) {
+		t.Fatalf("journal mode = %q, want %q", got, want)
+	}
 }
 
 func requireNoManagerTables(t testing.TB, dbPath string) {

--- a/apps/manager-server/internal/command/derivedmaintenance/command.go
+++ b/apps/manager-server/internal/command/derivedmaintenance/command.go
@@ -2,7 +2,6 @@ package derivedmaintenance
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -13,7 +12,6 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/config"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/processlock"
 	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
-	_ "modernc.org/sqlite"
 )
 
 func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
@@ -24,28 +22,29 @@ func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		}
 		return err
 	}
-	dbPath, err := resolveDBPath(opts.DBPath)
+	databaseOptions, err := resolveDatabaseOptions(opts.DBPath)
 	if err != nil {
 		return err
 	}
-	if err := validateDatabaseFile(dbPath); err != nil {
+	if err := validateDatabaseFile(databaseOptions.Path); err != nil {
 		return err
 	}
-	databaseLock, err := processlock.Acquire(dbPath)
+	databaseLock, err := processlock.Acquire(databaseOptions.Path)
 	if err != nil {
 		return fmt.Errorf("acquire offline cleanup lock; stop Manager Server and retry: %w", err)
 	}
 	defer func() { _ = databaseLock.Close() }()
-	dbPath = databaseLock.DatabasePath()
-	if err := validateManagerDB(ctx, dbPath); err != nil {
+	databaseOptions.Path = databaseLock.DatabasePath()
+	if err := validateManagerDB(ctx, databaseOptions.Path); err != nil {
 		return err
 	}
-	db, err := sql.Open("sqlite", dbPath)
+	databaseOptions.MaxOpenConns = 1
+	databaseOptions.MaxIdleConns = 1
+	db, err := sqliterepo.OpenUnmigratedWithOptions(databaseOptions)
 	if err != nil {
-		return fmt.Errorf("open sqlite %s: %w", dbPath, err)
+		return fmt.Errorf("open sqlite %s: %w", databaseOptions.Path, err)
 	}
 	defer db.Close()
-	db.SetMaxOpenConns(1)
 	result, err := sqliterepo.CleanupDerivedOffline(ctx, db)
 	if err != nil {
 		return fmt.Errorf("cleanup derived data: %w", err)
@@ -81,18 +80,24 @@ func parseArgs(args []string, stderr io.Writer) (options, error) {
 	return opts, nil
 }
 
-func resolveDBPath(override string) (string, error) {
+func resolveDatabaseOptions(override string) (sqliterepo.Options, error) {
 	if strings.TrimSpace(override) != "" {
-		return strings.TrimSpace(override), nil
+		return sqliterepo.Options{Path: strings.TrimSpace(override)}, nil
 	}
 	cfg, err := config.LoadWithoutCreatingDefault()
 	if err != nil {
-		return "", fmt.Errorf("load config: %w", err)
+		return sqliterepo.Options{}, fmt.Errorf("load config: %w", err)
 	}
 	if strings.TrimSpace(cfg.DBPath) == "" {
-		return "", errors.New("SQLite database path is empty; pass --db-path")
+		return sqliterepo.Options{}, errors.New("SQLite database path is empty; pass --db-path")
 	}
-	return cfg.DBPath, nil
+	return sqliterepo.Options{
+		Path:                cfg.DBPath,
+		DataSourceName:      cfg.DBURL,
+		ExpectedJournalMode: cfg.DBJournalMode,
+		ExpectedSynchronous: cfg.DBSynchronous,
+		ExpectedBusyTimeout: cfg.DBBusyTimeout,
+	}, nil
 }
 
 func validateDatabaseFile(dbPath string) error {
@@ -110,9 +115,13 @@ func validateDatabaseFile(dbPath string) error {
 }
 
 func validateManagerDB(ctx context.Context, dbPath string) error {
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := sqliterepo.OpenUnmigratedWithOptions(sqliterepo.Options{
+		Path:         dbPath,
+		MaxOpenConns: 1,
+		MaxIdleConns: 1,
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("open sqlite %s for validation: %w", dbPath, err)
 	}
 	defer db.Close()
 	var count int

--- a/apps/manager-server/internal/command/derivedmaintenance/command_test.go
+++ b/apps/manager-server/internal/command/derivedmaintenance/command_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/processlock"
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 )
 
@@ -88,6 +90,100 @@ func TestRunFinalizesPairedAndOrphanMonitoringFTSJobs(t *testing.T) {
 	}
 }
 
+func TestRunUsesConfiguredDatabaseURL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	databaseOptions := cleanupDatabaseOptions(dbPath)
+	st, err := store.OpenWithOptions(databaseOptions)
+	if err != nil {
+		t.Fatalf("open DELETE cleanup fixture: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close DELETE cleanup fixture: %v", err)
+	}
+	for key, value := range map[string]string{
+		"CPA_MANAGER_CONFIG": "",
+		"USAGE_DATA_DIR":     "",
+		"USAGE_DB_PATH":      "",
+		"USAGE_DB_URL":       databaseOptions.DataSourceName,
+	} {
+		t.Setenv(key, value)
+	}
+	resolved, err := resolveDatabaseOptions("")
+	if err != nil {
+		t.Fatalf("resolve configured database URL: %v", err)
+	}
+	if resolved.DataSourceName != databaseOptions.DataSourceName ||
+		resolved.ExpectedJournalMode != "delete" ||
+		resolved.ExpectedSynchronous != 3 ||
+		resolved.ExpectedBusyTimeout != 15000 {
+		t.Fatalf("resolved database options = %+v", resolved)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), nil, &stdout, &stderr); err != nil {
+		t.Fatalf("run cleanup with configured URL: %v stderr=%s", err, stderr.String())
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen configured cleanup database: %v", err)
+	}
+	defer db.Close()
+	var journalMode string
+	if err := db.QueryRow(`pragma journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatalf("read cleanup journal mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "delete") {
+		t.Fatalf("cleanup journal mode = %q, want delete", journalMode)
+	}
+}
+
+func TestRunValidatesConfiguredDatabaseURLBeforeApplyingPragmas(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "unrelated.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open unrelated sqlite: %v", err)
+	}
+	if _, err := db.Exec(`create table unrelated(id integer primary key); pragma user_version = 7`); err != nil {
+		t.Fatalf("create unrelated fixture: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close unrelated fixture: %v", err)
+	}
+	databaseOptions := cleanupDatabaseOptions(dbPath)
+	dsn, err := url.Parse(databaseOptions.DataSourceName)
+	if err != nil {
+		t.Fatalf("parse test database URL: %v", err)
+	}
+	query := dsn.Query()
+	query.Add("_pragma", "user_version(123)")
+	dsn.RawQuery = query.Encode()
+	for key, value := range map[string]string{
+		"CPA_MANAGER_CONFIG": "",
+		"USAGE_DATA_DIR":     "",
+		"USAGE_DB_PATH":      "",
+		"USAGE_DB_URL":       dsn.String(),
+	} {
+		t.Setenv(key, value)
+	}
+	var stdout, stderr bytes.Buffer
+	err = Run(context.Background(), nil, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "does not look like a CPA Manager Plus") {
+		t.Fatalf("Run() error = %v", err)
+	}
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen unrelated sqlite: %v", err)
+	}
+	defer db.Close()
+	var userVersion int
+	if err := db.QueryRow(`pragma user_version`).Scan(&userVersion); err != nil {
+		t.Fatalf("read unrelated user_version: %v", err)
+	}
+	if userVersion != 7 {
+		t.Fatalf("unrelated user_version = %d, want 7", userVersion)
+	}
+}
+
 func TestRunRejectsMissingDatabase(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := Run(context.Background(), []string{"--db-path", filepath.Join(t.TempDir(), "missing.sqlite")}, &stdout, &stderr)
@@ -133,6 +229,28 @@ func TestRunIsIdempotentAndLeavesMaintenanceStatusClean(t *testing.T) {
 	}
 	if status.Required || status.PerformanceDegraded || status.DeferredIndexes != 0 || status.OfflineJobs != 0 {
 		t.Fatalf("maintenance status after repeated cleanup = %+v", status)
+	}
+}
+
+func cleanupDatabaseOptions(dbPath string) sqliterepo.Options {
+	uriPath := filepath.ToSlash(dbPath)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn := url.URL{Scheme: "file", Path: uriPath}
+	query := url.Values{}
+	query.Add("_txlock", "immediate")
+	query.Add("_pragma", "journal_mode(DELETE)")
+	query.Add("_pragma", "synchronous(EXTRA)")
+	query.Add("_pragma", "busy_timeout(15000)")
+	query.Add("_pragma", "foreign_keys(1)")
+	dsn.RawQuery = query.Encode()
+	return sqliterepo.Options{
+		Path:                dbPath,
+		DataSourceName:      dsn.String(),
+		ExpectedJournalMode: "delete",
+		ExpectedSynchronous: 3,
+		ExpectedBusyTimeout: 15000,
 	}
 }
 

--- a/apps/manager-server/internal/config/config.go
+++ b/apps/manager-server/internal/config/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	HTTPAddr                     string
 	DataDir                      string
 	DBPath                       string
+	DBURL                        string
+	DBJournalMode                string
+	DBSynchronous                int
+	DBBusyTimeout                int
 	CPAUpstreamURL               string
 	ManagementKey                string
 	AdminKey                     string
@@ -65,6 +69,7 @@ type fileConfig struct {
 	HTTPAddr                  string   `json:"httpAddr,omitempty"`
 	DataDir                   string   `json:"dataDir,omitempty"`
 	DBPath                    string   `json:"dbPath,omitempty"`
+	DBURL                     string   `json:"dbUrl,omitempty"`
 	CPAUpstreamURL            string   `json:"cpaUpstreamUrl,omitempty"`
 	ManagementKeyFile         string   `json:"managementKeyFile,omitempty"`
 	AdminKeyFile              string   `json:"adminKeyFile,omitempty"`
@@ -111,9 +116,9 @@ func LoadWithOptions(options LoadOptions) (Config, error) {
 	}
 	dataDir := env("USAGE_DATA_DIR", dataDirFallback)
 
-	dbPathFallback := filepath.Join(dataDir, "usage.sqlite")
-	if !hasEnv("USAGE_DATA_DIR") && cfgFile.DBPath != "" {
-		dbPathFallback = resolveConfigPath(cfgFile.DBPath, cfgDir)
+	database, err := resolveDatabaseConfig(cfgFile, cfgDir, dataDir)
+	if err != nil {
+		return Config{}, err
 	}
 
 	managementKeyFile := defaultSecretFile
@@ -132,13 +137,21 @@ func LoadWithOptions(options LoadOptions) (Config, error) {
 	}
 	dataKeyPath := resolveConfigPath(cfgFile.DataKeyPath, cfgDir)
 	if dataKeyPath == "" {
-		dataKeyPath = filepath.Join(dataDir, "data.key")
+		dataKeyDir := dataDir
+		if database.dataSourceName != "" {
+			dataKeyDir = filepath.Dir(database.path)
+		}
+		dataKeyPath = filepath.Join(dataKeyDir, "data.key")
 	}
 
 	return Config{
 		HTTPAddr:                     env("HTTP_ADDR", stringFallback(cfgFile.HTTPAddr, "0.0.0.0:18317")),
 		DataDir:                      dataDir,
-		DBPath:                       env("USAGE_DB_PATH", dbPathFallback),
+		DBPath:                       database.path,
+		DBURL:                        database.dataSourceName,
+		DBJournalMode:                database.journalMode,
+		DBSynchronous:                database.synchronous,
+		DBBusyTimeout:                database.busyTimeout,
 		CPAUpstreamURL:               env("CPA_UPSTREAM_URL", cfgFile.CPAUpstreamURL),
 		ManagementKey:                readSecret("CPA_MANAGEMENT_KEY", "CPA_MANAGEMENT_KEY_FILE", managementKeyFile),
 		AdminKey:                     readSecret("CPA_MANAGER_ADMIN_KEY", "CPA_MANAGER_ADMIN_KEY_FILE", adminKeyFile),
@@ -200,7 +213,7 @@ func loadFileConfig(options LoadOptions) (fileConfig, string, error) {
 	if err != nil || ok {
 		return cfg, cfgDir, err
 	}
-	if hasEnv("USAGE_DATA_DIR") || hasEnv("USAGE_DB_PATH") {
+	if hasEnv("USAGE_DATA_DIR") || hasEnv(usageDBPathEnvKey) || hasEnv(usageDBURLEnvKey) {
 		return fileConfig{}, "", nil
 	}
 	if !options.CreateDefaultConfig {

--- a/apps/manager-server/internal/config/config_test.go
+++ b/apps/manager-server/internal/config/config_test.go
@@ -225,6 +225,7 @@ func clearConfigEnv(t *testing.T) {
 		"HTTP_ADDR",
 		"USAGE_DATA_DIR",
 		"USAGE_DB_PATH",
+		"USAGE_DB_URL",
 		"CPA_UPSTREAM_URL",
 		"CPA_MANAGEMENT_KEY",
 		"CPA_MANAGEMENT_KEY_FILE",

--- a/apps/manager-server/internal/config/database_url.go
+++ b/apps/manager-server/internal/config/database_url.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const usageDBURLEnvKey = "USAGE_DB_URL"
+const usageDBPathEnvKey = "USAGE_DB_PATH"
+
+type databaseURL struct {
+	dataSourceName string
+	path           string
+	journalMode    string
+	synchronous    int
+	busyTimeout    int
+}
+
+type databasePragmas struct {
+	journalMode string
+	synchronous int
+	busyTimeout int
+}
+
+func resolveDatabaseConfig(cfgFile fileConfig, cfgDir string, dataDir string) (databaseURL, error) {
+	envURL := strings.TrimSpace(os.Getenv(usageDBURLEnvKey))
+	envPath := strings.TrimSpace(os.Getenv(usageDBPathEnvKey))
+	if envURL != "" && envPath != "" {
+		return databaseURL{}, fmt.Errorf("%s and %s cannot both be set", usageDBURLEnvKey, usageDBPathEnvKey)
+	}
+	if envURL != "" {
+		return parseDatabaseURL(envURL)
+	}
+	if envPath != "" {
+		return databaseURL{path: envPath}, nil
+	}
+
+	fallbackPath := filepath.Join(dataDir, "usage.sqlite")
+	if hasEnv("USAGE_DATA_DIR") {
+		return databaseURL{path: fallbackPath}, nil
+	}
+
+	fileURL := strings.TrimSpace(cfgFile.DBURL)
+	filePath := strings.TrimSpace(cfgFile.DBPath)
+	if fileURL != "" && filePath != "" {
+		return databaseURL{}, fmt.Errorf("config fields dbUrl and dbPath cannot both be set")
+	}
+	if fileURL != "" {
+		return parseDatabaseURL(fileURL)
+	}
+	if filePath != "" {
+		return databaseURL{path: resolveConfigPath(filePath, cfgDir)}, nil
+	}
+	return databaseURL{path: fallbackPath}, nil
+}
+
+func parseDatabaseURL(value string) (databaseURL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return databaseURL{}, fmt.Errorf("parse SQLite database URL: %w", sanitizedURLParseError(err))
+	}
+	if !strings.EqualFold(parsed.Scheme, "file") {
+		return databaseURL{}, fmt.Errorf("SQLite database URL scheme must be file")
+	}
+	if parsed.Opaque != "" {
+		return databaseURL{}, fmt.Errorf("SQLite database URL must use hierarchical file URI syntax")
+	}
+	if parsed.User != nil {
+		return databaseURL{}, fmt.Errorf("SQLite database URL must not contain user information")
+	}
+	if parsed.Host != "" {
+		return databaseURL{}, fmt.Errorf("SQLite database URL must not contain a host")
+	}
+	if parsed.Fragment != "" {
+		return databaseURL{}, fmt.Errorf("SQLite database URL must not contain a fragment")
+	}
+	path, err := databaseURLPath(parsed)
+	if err != nil {
+		return databaseURL{}, err
+	}
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return databaseURL{}, fmt.Errorf("parse SQLite database URL query: %w", sanitizedURLParseError(err))
+	}
+	if err := validateDatabaseURIOptions(query); err != nil {
+		return databaseURL{}, err
+	}
+	pragmas, err := validateDatabaseURLQuery(query)
+	if err != nil {
+		return databaseURL{}, err
+	}
+	return databaseURL{
+		dataSourceName: strings.TrimSpace(value),
+		path:           path,
+		journalMode:    pragmas.journalMode,
+		synchronous:    pragmas.synchronous,
+		busyTimeout:    pragmas.busyTimeout,
+	}, nil
+}
+
+func databaseURLPath(parsed *url.URL) (string, error) {
+	uriPath := parsed.Path
+	if uriPath == "" || strings.EqualFold(uriPath, ":memory:") || strings.EqualFold(uriPath, "/:memory:") {
+		return "", fmt.Errorf("SQLite database URL must reference a persistent file")
+	}
+	if strings.HasPrefix(uriPath, "//") {
+		return "", fmt.Errorf("SQLite database URL must not reference a network path")
+	}
+	path := filepath.FromSlash(uriPath)
+	if runtime.GOOS == "windows" && len(path) >= 3 && (path[0] == '\\' || path[0] == '/') && path[2] == ':' {
+		path = path[1:]
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("SQLite database URL path must be absolute")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve SQLite database URL path: %w", err)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func validateDatabaseURIOptions(query url.Values) error {
+	for _, value := range queryValuesFold(query, "mode") {
+		if strings.EqualFold(strings.TrimSpace(value), "memory") {
+			return fmt.Errorf("SQLite database URL mode must reference a persistent file")
+		}
+	}
+	for _, key := range []string{"immutable", "nolock"} {
+		for _, value := range queryValuesFold(query, key) {
+			if !isExplicitFalse(value) {
+				return fmt.Errorf("SQLite database URL must not enable %s", key)
+			}
+		}
+	}
+	if len(queryValuesFold(query, "vfs")) > 0 {
+		return fmt.Errorf("SQLite database URL must not select a custom VFS")
+	}
+	return nil
+}
+
+func validateDatabaseURLQuery(query url.Values) (databasePragmas, error) {
+	txLocks := query["_txlock"]
+	if len(txLocks) != 1 || !strings.EqualFold(strings.TrimSpace(txLocks[0]), "immediate") {
+		return databasePragmas{}, fmt.Errorf("SQLite database URL must set _txlock=immediate")
+	}
+
+	required := map[string]string{}
+	for index, raw := range query["_pragma"] {
+		name, value, ok := splitPragma(raw)
+		if !ok {
+			return databasePragmas{}, fmt.Errorf("SQLite database URL contains invalid _pragma at position %d", index+1)
+		}
+		name = pragmaBaseName(name)
+		switch name {
+		case "foreign_keys", "journal_mode", "synchronous", "busy_timeout":
+			if _, exists := required[name]; exists {
+				return databasePragmas{}, fmt.Errorf("SQLite database URL contains duplicate %s pragma", name)
+			}
+			required[name] = value
+		}
+	}
+
+	if value := strings.ToLower(required["foreign_keys"]); value != "1" && value != "on" {
+		return databasePragmas{}, fmt.Errorf("SQLite database URL must set foreign_keys(1) or foreign_keys(ON)")
+	}
+	journalMode := strings.ToLower(required["journal_mode"])
+	if journalMode != "wal" && journalMode != "delete" {
+		return databasePragmas{}, fmt.Errorf("SQLite database URL journal_mode must be WAL or DELETE")
+	}
+	synchronous := 0
+	switch strings.ToLower(required["synchronous"]) {
+	case "full":
+		synchronous = 2
+	case "extra":
+		synchronous = 3
+	default:
+		return databasePragmas{}, fmt.Errorf("SQLite database URL synchronous must be FULL or EXTRA")
+	}
+	busyTimeout, err := strconv.Atoi(strings.TrimSpace(required["busy_timeout"]))
+	if err != nil || busyTimeout <= 0 {
+		return databasePragmas{}, fmt.Errorf("SQLite database URL busy_timeout must be a positive integer")
+	}
+	return databasePragmas{
+		journalMode: journalMode,
+		synchronous: synchronous,
+		busyTimeout: busyTimeout,
+	}, nil
+}
+
+func splitPragma(raw string) (string, string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, ";\r\n\x00") {
+		return "", "", false
+	}
+	var name string
+	var value string
+	if open := strings.IndexByte(raw, '('); open > 0 && strings.HasSuffix(raw, ")") {
+		name = strings.TrimSpace(raw[:open])
+		value = strings.TrimSpace(raw[open+1 : len(raw)-1])
+	} else if equals := strings.IndexByte(raw, '='); equals > 0 {
+		name = strings.TrimSpace(raw[:equals])
+		value = strings.TrimSpace(raw[equals+1:])
+	} else {
+		return "", "", false
+	}
+	if !validPragmaName(name) || value == "" {
+		return "", "", false
+	}
+	return strings.ToLower(name), value, true
+}
+
+func validPragmaName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, character := range name {
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '_' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func pragmaBaseName(name string) string {
+	if separator := strings.LastIndexByte(name, '.'); separator >= 0 {
+		return name[separator+1:]
+	}
+	return name
+}
+
+func queryValuesFold(query url.Values, key string) []string {
+	var values []string
+	for candidate, candidateValues := range query {
+		if strings.EqualFold(candidate, key) {
+			values = append(values, candidateValues...)
+		}
+	}
+	return values
+}
+
+func sanitizedURLParseError(err error) error {
+	var urlError *url.Error
+	if errors.As(err, &urlError) && urlError.Err != nil {
+		return urlError.Err
+	}
+	return err
+}
+
+func isExplicitFalse(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/manager-server/internal/config/database_url_test.go
+++ b/apps/manager-server/internal/config/database_url_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestLoadUsesSQLiteDatabaseURL(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	dbPath := filepath.Join(dir, "custom data", "usage ? #.sqlite")
+	dbURL := testDatabaseURL(dbPath, "DELETE", "EXTRA", 15000,
+		"mmap_size(0)",
+		"cell_size_check(1)",
+		"temp_store(FILE)",
+	)
+	t.Setenv(configEnvKey, configPath)
+	t.Setenv(usageDBURLEnvKey, dbURL)
+
+	cfg, err := LoadWithoutCreatingDefault()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.DBURL != dbURL {
+		t.Fatalf("DBURL = %q, want original URL", cfg.DBURL)
+	}
+	if cfg.DBPath != filepath.Clean(dbPath) {
+		t.Fatalf("DBPath = %q, want %q", cfg.DBPath, filepath.Clean(dbPath))
+	}
+	if cfg.DBJournalMode != "delete" || cfg.DBSynchronous != 3 || cfg.DBBusyTimeout != 15000 {
+		t.Fatalf("database expectations = mode:%q synchronous:%d busy:%d", cfg.DBJournalMode, cfg.DBSynchronous, cfg.DBBusyTimeout)
+	}
+	if want := filepath.Join(filepath.Dir(dbPath), "data.key"); cfg.DataKeyPath != want {
+		t.Fatalf("DataKeyPath = %q, want %q", cfg.DataKeyPath, want)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("config file exists or stat failed: %v", err)
+	}
+}
+
+func TestLoadDatabaseURLPrecedenceAndConflicts(t *testing.T) {
+	t.Run("environment URL overrides file path and data directory", func(t *testing.T) {
+		clearConfigEnv(t)
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.json")
+		if err := os.WriteFile(configPath, []byte(`{"dbPath":"file-data/usage.sqlite"}`), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		dbPath := filepath.Join(dir, "env-data", "usage.sqlite")
+		t.Setenv(configEnvKey, configPath)
+		t.Setenv("USAGE_DATA_DIR", filepath.Join(dir, "ignored-data"))
+		t.Setenv(usageDBURLEnvKey, testDatabaseURL(dbPath, "WAL", "FULL", 7000))
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.DBPath != filepath.Clean(dbPath) || cfg.DBJournalMode != "wal" {
+			t.Fatalf("database config = path:%q mode:%q", cfg.DBPath, cfg.DBJournalMode)
+		}
+	})
+
+	t.Run("environment URL conflicts with environment path", func(t *testing.T) {
+		clearConfigEnv(t)
+		dir := t.TempDir()
+		t.Setenv(usageDBURLEnvKey, testDatabaseURL(filepath.Join(dir, "usage.sqlite"), "DELETE", "EXTRA", 5000))
+		t.Setenv(usageDBPathEnvKey, filepath.Join(dir, "other.sqlite"))
+		if _, err := Load(); err == nil || !strings.Contains(err.Error(), "cannot both be set") {
+			t.Fatalf("Load() error = %v", err)
+		}
+	})
+
+	t.Run("file URL conflicts with file path", func(t *testing.T) {
+		clearConfigEnv(t)
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.json")
+		content, err := json.Marshal(fileConfig{
+			DBPath: "usage.sqlite",
+			DBURL:  testDatabaseURL(filepath.Join(dir, "url.sqlite"), "DELETE", "EXTRA", 5000),
+		})
+		if err != nil {
+			t.Fatalf("marshal config: %v", err)
+		}
+		if err := os.WriteFile(configPath, content, 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		t.Setenv(configEnvKey, configPath)
+		if _, err := Load(); err == nil || !strings.Contains(err.Error(), "dbUrl and dbPath cannot both be set") {
+			t.Fatalf("Load() error = %v", err)
+		}
+	})
+}
+
+func TestParseDatabaseURLRejectsUnsafeOrIncompleteURLs(t *testing.T) {
+	validQuery := func() string {
+		values := url.Values{}
+		values.Add("_txlock", "immediate")
+		values.Add("_pragma", "journal_mode(DELETE)")
+		values.Add("_pragma", "synchronous(EXTRA)")
+		values.Add("_pragma", "busy_timeout(15000)")
+		values.Add("_pragma", "foreign_keys(1)")
+		return values.Encode()
+	}
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{name: "scheme", url: "https://localhost/tmp/usage.sqlite?" + validQuery(), want: "scheme must be file"},
+		{name: "host", url: "file://server/share/usage.sqlite?" + validQuery(), want: "must not contain a host"},
+		{name: "opaque relative path", url: "file:usage.sqlite?" + validQuery(), want: "hierarchical"},
+		{name: "memory path", url: "file:///:memory:?" + validQuery(), want: "persistent file"},
+		{name: "network path", url: "file:////server/share/usage.sqlite?" + validQuery(), want: "network path"},
+		{name: "memory mode", url: "file:///tmp/usage.sqlite?mode=memory&" + validQuery(), want: "persistent file"},
+		{name: "immutable", url: "file:///tmp/usage.sqlite?immutable=1&" + validQuery(), want: "must not enable immutable"},
+		{name: "no locking", url: "file:///tmp/usage.sqlite?nolock=on&" + validQuery(), want: "must not enable nolock"},
+		{name: "custom VFS", url: "file:///tmp/usage.sqlite?vfs=unix-none&" + validQuery(), want: "custom VFS"},
+		{name: "missing transaction lock", url: "file:///tmp/usage.sqlite?_pragma=journal_mode%28DELETE%29", want: "_txlock=immediate"},
+		{name: "duplicate journal mode using equals syntax", url: "file:///tmp/usage.sqlite?" + validQuery() + "&_pragma=journal_mode%3DOFF", want: "duplicate journal_mode"},
+		{name: "duplicate foreign keys using equals syntax", url: "file:///tmp/usage.sqlite?" + validQuery() + "&_pragma=foreign_keys%3DOFF", want: "duplicate foreign_keys"},
+		{name: "invalid pragma syntax", url: "file:///tmp/usage.sqlite?" + validQuery() + "&_pragma=cache_size%281%29%3Bjournal_mode%28OFF%29", want: "invalid _pragma"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseDatabaseURL(test.url); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("parseDatabaseURL() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDatabaseURLErrorsDoNotExposeRawURL(t *testing.T) {
+	const secret = "sqlite-url-secret-sentinel"
+	for _, rawURL := range []string{
+		"file:///tmp/%zz?token=" + secret,
+		"file:///tmp/usage.sqlite?_txlock=immediate&_pragma=journal_mode%28DELETE%29&_pragma=synchronous%28EXTRA%29&_pragma=busy_timeout%2815000%29&_pragma=foreign_keys%281%29&_pragma=" + url.QueryEscape("cache_size(1);"+secret),
+	} {
+		_, err := parseDatabaseURL(rawURL)
+		if err == nil {
+			t.Fatalf("parseDatabaseURL(%q) error = nil", rawURL)
+		}
+		if strings.Contains(err.Error(), secret) || strings.Contains(err.Error(), rawURL) {
+			t.Fatalf("database URL error leaked raw input: %v", err)
+		}
+	}
+}
+
+func TestSplitPragmaAcceptsDriverSyntaxes(t *testing.T) {
+	for _, test := range []struct {
+		raw       string
+		wantName  string
+		wantValue string
+	}{
+		{raw: "journal_mode(DELETE)", wantName: "journal_mode", wantValue: "DELETE"},
+		{raw: "synchronous=EXTRA", wantName: "synchronous", wantValue: "EXTRA"},
+		{raw: "main.cache_size(-2000)", wantName: "main.cache_size", wantValue: "-2000"},
+	} {
+		name, value, ok := splitPragma(test.raw)
+		if !ok || name != test.wantName || value != test.wantValue {
+			t.Fatalf("splitPragma(%q) = %q, %q, %v", test.raw, name, value, ok)
+		}
+	}
+}
+
+func testDatabaseURL(path string, journalMode string, synchronous string, busyTimeout int, extraPragmas ...string) string {
+	uriPath := filepath.ToSlash(path)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn := url.URL{Scheme: "file", Path: uriPath}
+	query := url.Values{}
+	query.Add("_txlock", "immediate")
+	query.Add("_pragma", "journal_mode("+journalMode+")")
+	query.Add("_pragma", "synchronous("+synchronous+")")
+	query.Add("_pragma", "busy_timeout("+strconv.Itoa(busyTimeout)+")")
+	query.Add("_pragma", "foreign_keys(1)")
+	for _, pragma := range extraPragmas {
+		query.Add("_pragma", pragma)
+	}
+	dsn.RawQuery = query.Encode()
+	return dsn.String()
+}

--- a/apps/manager-server/internal/repository/sqlite/db.go
+++ b/apps/manager-server/internal/repository/sqlite/db.go
@@ -1,7 +1,10 @@
 package sqlite
 
 import (
+	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,16 +25,45 @@ func OpenWithOptions(options Options) (*sql.DB, error) {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite", dataSourceName(dbPath))
+	options.Path = dbPath
+	db, err := OpenUnmigratedWithOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	if err := MigrateWithOptions(db, options); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func OpenUnmigratedWithOptions(options Options) (*sql.DB, error) {
+	if err := options.validate(); err != nil {
+		return nil, err
+	}
+	dbPath, err := filepath.Abs(options.Path)
+	if err != nil {
+		return nil, err
+	}
+	dsn := dataSourceName(dbPath)
+	if options.hasCustomDataSourceName() {
+		dsn, err = customDataSourceName(options.DataSourceName, dbPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}
 	db.SetMaxOpenConns(options.maxOpenConns())
 	db.SetMaxIdleConns(options.maxIdleConns())
 	db.SetConnMaxIdleTime(options.connMaxIdleTime())
-	if err := Migrate(db); err != nil {
-		_ = db.Close()
-		return nil, err
+	if options.hasCustomDataSourceName() {
+		if err := validateCustomConnectionPragmas(context.Background(), db, options); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
 	}
 	return db, nil
 }
@@ -52,4 +84,125 @@ func dataSourceName(path string) string {
 	query.Add("_pragma", "synchronous(FULL)")
 	dsn.RawQuery = query.Encode()
 	return dsn.String()
+}
+
+func customDataSourceName(rawURL string, path string) (string, error) {
+	dsn, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("parse SQLite data source name: %w", sanitizedURLParseError(err))
+	}
+	if !strings.EqualFold(dsn.Scheme, "file") || dsn.Opaque != "" || dsn.Host != "" || dsn.User != nil || dsn.Fragment != "" {
+		return "", fmt.Errorf("custom SQLite data source must be a local hierarchical file URL")
+	}
+	query, err := url.ParseQuery(dsn.RawQuery)
+	if err != nil {
+		return "", fmt.Errorf("parse SQLite data source query: %w", sanitizedURLParseError(err))
+	}
+	if err := validateCustomTransactionLock(query); err != nil {
+		return "", err
+	}
+	if err := validatePersistentDataSourceOptions(query); err != nil {
+		return "", err
+	}
+	uriPath := filepath.ToSlash(path)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn.Path = uriPath
+	dsn.RawPath = ""
+	return dsn.String(), nil
+}
+
+func validateCustomTransactionLock(query url.Values) error {
+	values := query["_txlock"]
+	if len(values) != 1 || !strings.EqualFold(strings.TrimSpace(values[0]), "immediate") {
+		return fmt.Errorf("custom SQLite data source must set _txlock=immediate")
+	}
+	return nil
+}
+
+func validatePersistentDataSourceOptions(query url.Values) error {
+	for key, values := range query {
+		switch strings.ToLower(key) {
+		case "mode":
+			for _, value := range values {
+				if strings.EqualFold(strings.TrimSpace(value), "memory") {
+					return fmt.Errorf("custom SQLite data source must reference a persistent file")
+				}
+			}
+		case "immutable", "nolock":
+			for _, value := range values {
+				if !explicitFalse(value) {
+					return fmt.Errorf("custom SQLite data source must not enable %s", strings.ToLower(key))
+				}
+			}
+		case "vfs":
+			return fmt.Errorf("custom SQLite data source must not select a custom VFS")
+		}
+	}
+	return nil
+}
+
+func sanitizedURLParseError(err error) error {
+	var urlError *url.Error
+	if errors.As(err, &urlError) && urlError.Err != nil {
+		return urlError.Err
+	}
+	return err
+}
+
+func explicitFalse(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateCustomConnectionPragmas(ctx context.Context, db *sql.DB, options Options) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("open SQLite connection for URL validation: %w", err)
+	}
+	defer conn.Close()
+
+	var journalMode string
+	if err := conn.QueryRowContext(ctx, `pragma journal_mode`).Scan(&journalMode); err != nil {
+		return fmt.Errorf("read SQLite journal mode: %w", err)
+	}
+	journalMode = strings.ToLower(strings.TrimSpace(journalMode))
+	if expected := strings.ToLower(strings.TrimSpace(options.ExpectedJournalMode)); journalMode != expected {
+		return fmt.Errorf("SQLite database URL applied journal mode %q, want %q", journalMode, expected)
+	}
+
+	for _, check := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{name: "foreign_keys", query: `pragma foreign_keys`, want: 1},
+		{name: "synchronous", query: `pragma synchronous`, want: options.ExpectedSynchronous},
+		{name: "busy_timeout", query: `pragma busy_timeout`, want: options.ExpectedBusyTimeout},
+	} {
+		var got int
+		if err := conn.QueryRowContext(ctx, check.query).Scan(&got); err != nil {
+			return fmt.Errorf("read SQLite %s pragma: %w", check.name, err)
+		}
+		if got != check.want {
+			return fmt.Errorf("SQLite database URL applied %s=%d, want %d", check.name, got, check.want)
+		}
+	}
+	return nil
+}
+
+func JournalMode(ctx context.Context, db *sql.DB) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("read SQLite journal mode: database is nil")
+	}
+	var mode string
+	if err := db.QueryRowContext(ctx, `pragma journal_mode`).Scan(&mode); err != nil {
+		return "", fmt.Errorf("read SQLite journal mode: %w", err)
+	}
+	return strings.ToLower(strings.TrimSpace(mode)), nil
 }

--- a/apps/manager-server/internal/repository/sqlite/db_test.go
+++ b/apps/manager-server/internal/repository/sqlite/db_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -141,6 +143,248 @@ func TestOpenWithOptionsBeginsWriteTransactionsImmediately(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("competing write did not resume after transaction release")
+	}
+}
+
+func TestOpenWithOptionsAppliesCustomDatabaseURLToEveryConnection(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "custom data", "usage ? #.sqlite")
+	options := customDatabaseOptions(dbPath, "DELETE", "EXTRA", 15000)
+	db, err := OpenWithOptions(options)
+	if err != nil {
+		t.Fatalf("open custom SQLite URL: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	connections := make([]*sql.Conn, 0, defaultMaxOpenConns)
+	for i := 0; i < defaultMaxOpenConns; i++ {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Fatalf("open custom connection %d: %v", i, err)
+		}
+		connections = append(connections, conn)
+		assertCustomConnectionPragmas(t, conn)
+	}
+	var schemaCount int
+	if err := connections[0].QueryRowContext(context.Background(), `select count(*) from sqlite_schema
+		where type = 'table' and name = 'usage_events'`).Scan(&schemaCount); err != nil {
+		t.Fatalf("read migrated schema: %v", err)
+	}
+	if schemaCount != 1 {
+		t.Fatalf("usage_events table count = %d, want 1", schemaCount)
+	}
+	stats := db.Stats()
+	if stats.MaxOpenConnections != defaultMaxOpenConns || stats.OpenConnections != defaultMaxOpenConns {
+		t.Fatalf("custom pool stats = %+v", stats)
+	}
+	for _, conn := range connections {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("close custom connection: %v", err)
+		}
+	}
+}
+
+func TestOpenWithOptionsRejectsUnsafeOrMismatchedCustomDatabaseURL(t *testing.T) {
+	t.Run("missing transaction lock", func(t *testing.T) {
+		options := customDatabaseOptions(filepath.Join(t.TempDir(), "usage.sqlite"), "DELETE", "EXTRA", 15000)
+		dsn, err := url.Parse(options.DataSourceName)
+		if err != nil {
+			t.Fatalf("parse test data source: %v", err)
+		}
+		query := dsn.Query()
+		query.Del("_txlock")
+		dsn.RawQuery = query.Encode()
+		options.DataSourceName = dsn.String()
+		if _, err := OpenWithOptions(options); err == nil || !strings.Contains(err.Error(), "_txlock=immediate") {
+			t.Fatalf("OpenWithOptions() error = %v", err)
+		}
+	})
+
+	t.Run("malformed URL is sanitized", func(t *testing.T) {
+		const secret = "sqlite-repository-secret-sentinel"
+		options := customDatabaseOptions(filepath.Join(t.TempDir(), "usage.sqlite"), "DELETE", "EXTRA", 15000)
+		options.DataSourceName = "file:///tmp/%zz?token=" + secret
+		if _, err := OpenWithOptions(options); err == nil || strings.Contains(err.Error(), secret) || strings.Contains(err.Error(), options.DataSourceName) {
+			t.Fatalf("OpenWithOptions() error = %v", err)
+		}
+	})
+
+	t.Run("missing expected settings", func(t *testing.T) {
+		options := customDatabaseOptions(filepath.Join(t.TempDir(), "usage.sqlite"), "DELETE", "EXTRA", 15000)
+		options.ExpectedBusyTimeout = 0
+		if _, err := OpenWithOptions(options); err == nil || !strings.Contains(err.Error(), "positive expected busy timeout") {
+			t.Fatalf("OpenWithOptions() error = %v", err)
+		}
+	})
+
+	t.Run("effective synchronous mismatch", func(t *testing.T) {
+		options := customDatabaseOptions(filepath.Join(t.TempDir(), "usage.sqlite"), "DELETE", "FULL", 15000)
+		options.ExpectedSynchronous = 3
+		if _, err := OpenWithOptions(options); err == nil || !strings.Contains(err.Error(), "synchronous=2, want 3") {
+			t.Fatalf("OpenWithOptions() error = %v", err)
+		}
+	})
+
+	t.Run("effective required pragma override", func(t *testing.T) {
+		options := customDatabaseOptions(filepath.Join(t.TempDir(), "usage.sqlite"), "DELETE", "EXTRA", 15000)
+		options.DataSourceName += "&_pragma=foreign_keys%3DOFF"
+		if _, err := OpenWithOptions(options); err == nil || !strings.Contains(err.Error(), "foreign_keys=0, want 1") {
+			t.Fatalf("OpenWithOptions() error = %v", err)
+		}
+	})
+
+	t.Run("memory mode", func(t *testing.T) {
+		options := customDatabaseOptions(filepath.Join(t.TempDir(), "usage.sqlite"), "DELETE", "EXTRA", 15000)
+		options.DataSourceName += "&mode=memory"
+		if _, err := OpenWithOptions(options); err == nil || !strings.Contains(err.Error(), "persistent file") {
+			t.Fatalf("OpenWithOptions() error = %v", err)
+		}
+	})
+}
+
+func TestCustomDatabaseURLJournalTransitionsPreserveData(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open default WAL database: %v", err)
+	}
+	if _, err := db.Exec(`create table db_url_transition (
+		id integer primary key,
+		payload text not null
+	)`); err != nil {
+		t.Fatalf("create transition fixture: %v", err)
+	}
+	if _, err := db.Exec(`insert into db_url_transition values (1, 'alpha'), (2, 'beta')`); err != nil {
+		t.Fatalf("insert transition fixture: %v", err)
+	}
+	assertJournalMode(t, db, "wal")
+	if err := db.Close(); err != nil {
+		t.Fatalf("close WAL database: %v", err)
+	}
+
+	deleteOptions := customDatabaseOptions(dbPath, "DELETE", "EXTRA", 15000)
+	db, err = OpenWithOptions(deleteOptions)
+	if err != nil {
+		t.Fatalf("open DELETE database: %v", err)
+	}
+	assertJournalMode(t, db, "delete")
+	assertTransitionData(t, db, "1:alpha|2:beta")
+	if _, err := db.Exec(`insert into db_url_transition values (3, 'gamma')`); err != nil {
+		t.Fatalf("insert DELETE-mode row: %v", err)
+	}
+	assertSQLiteIntegrity(t, db)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close DELETE database: %v", err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(dbPath + suffix); !os.IsNotExist(err) {
+			t.Fatalf("SQLite sidecar %s still exists or stat failed: %v", suffix, err)
+		}
+	}
+
+	db, err = Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen WAL database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	assertJournalMode(t, db, "wal")
+	assertTransitionData(t, db, "1:alpha|2:beta|3:gamma")
+	assertSQLiteIntegrity(t, db)
+}
+
+func customDatabaseOptions(path string, journalMode string, synchronous string, busyTimeout int) Options {
+	uriPath := filepath.ToSlash(path)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn := url.URL{Scheme: "file", Path: uriPath}
+	query := url.Values{}
+	query.Add("_txlock", "immediate")
+	query.Add("_pragma", "journal_mode("+journalMode+")")
+	query.Add("_pragma", "synchronous("+synchronous+")")
+	query.Add("_pragma", "busy_timeout("+strconv.Itoa(busyTimeout)+")")
+	query.Add("_pragma", "foreign_keys(1)")
+	query.Add("_pragma", "mmap_size(0)")
+	query.Add("_pragma", "cell_size_check(1)")
+	query.Add("_pragma", "temp_store(FILE)")
+	dsn.RawQuery = query.Encode()
+	expectedSynchronous := 2
+	if strings.EqualFold(synchronous, "EXTRA") {
+		expectedSynchronous = 3
+	}
+	return Options{
+		Path:                path,
+		DataSourceName:      dsn.String(),
+		ExpectedJournalMode: strings.ToLower(journalMode),
+		ExpectedSynchronous: expectedSynchronous,
+		ExpectedBusyTimeout: busyTimeout,
+	}
+}
+
+func assertCustomConnectionPragmas(t *testing.T, conn *sql.Conn) {
+	t.Helper()
+	for _, test := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{name: "foreign keys", query: "pragma foreign_keys", want: 1},
+		{name: "synchronous", query: "pragma synchronous", want: 3},
+		{name: "busy timeout", query: "pragma busy_timeout", want: 15000},
+		{name: "mmap size", query: "pragma mmap_size", want: 0},
+		{name: "cell size check", query: "pragma cell_size_check", want: 1},
+		{name: "temp store", query: "pragma temp_store", want: 1},
+	} {
+		var got int
+		if err := conn.QueryRowContext(context.Background(), test.query).Scan(&got); err != nil {
+			t.Fatalf("read custom %s: %v", test.name, err)
+		}
+		if got != test.want {
+			t.Fatalf("custom %s = %d, want %d", test.name, got, test.want)
+		}
+	}
+	var journalMode string
+	if err := conn.QueryRowContext(context.Background(), `pragma journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatalf("read custom journal mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "delete") {
+		t.Fatalf("custom journal mode = %q, want delete", journalMode)
+	}
+}
+
+func assertJournalMode(t *testing.T, db *sql.DB, want string) {
+	t.Helper()
+	got, err := JournalMode(context.Background(), db)
+	if err != nil {
+		t.Fatalf("read journal mode: %v", err)
+	}
+	if got != want {
+		t.Fatalf("journal mode = %q, want %q", got, want)
+	}
+}
+
+func assertTransitionData(t *testing.T, db *sql.DB, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRow(`select group_concat(id || ':' || payload, '|') from (
+		select id, payload from db_url_transition order by id
+	)`).Scan(&got); err != nil {
+		t.Fatalf("read transition data: %v", err)
+	}
+	if got != want {
+		t.Fatalf("transition data = %q, want %q", got, want)
+	}
+}
+
+func assertSQLiteIntegrity(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, pragma := range []string{"quick_check", "integrity_check"} {
+		var result string
+		if err := db.QueryRow("pragma " + pragma).Scan(&result); err != nil {
+			t.Fatalf("run %s: %v", pragma, err)
+		}
+		if result != "ok" {
+			t.Fatalf("%s = %q, want ok", pragma, result)
+		}
 	}
 }
 

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
@@ -188,6 +189,19 @@ const (
 )
 
 func Migrate(db *sql.DB) error {
+	return MigrateWithOptions(db, Options{})
+}
+
+func MigrateWithOptions(db *sql.DB, options Options) error {
+	if err := options.validate(); err != nil {
+		return err
+	}
+	if options.hasCustomDataSourceName() {
+		if err := validateCustomConnectionPragmas(context.Background(), db, options); err != nil {
+			return err
+		}
+	}
+
 	monitoringSnapshot, err := inspectUsageMonitoringMigrationSnapshot(db)
 	if err != nil {
 		return err
@@ -212,11 +226,21 @@ func Migrate(db *sql.DB) error {
 		return err
 	}
 
-	statements := []string{
+	defaultPragmaStatements := []string{
 		`pragma journal_mode = WAL`,
 		`pragma synchronous = FULL`,
 		`pragma busy_timeout = 5000`,
 		`pragma foreign_keys = ON`,
+	}
+	if !options.hasCustomDataSourceName() {
+		for _, statement := range defaultPragmaStatements {
+			if _, err := db.Exec(statement); err != nil {
+				return err
+			}
+		}
+	}
+
+	schemaStatements := []string{
 		`create table if not exists usage_events (
 			id integer primary key autoincrement,
 			request_id text,
@@ -905,7 +929,7 @@ func Migrate(db *sql.DB) error {
 			created_at_ms integer not null
 		)`,
 	}
-	for _, statement := range statements {
+	for _, statement := range schemaStatements {
 		if _, err := db.Exec(statement); err != nil {
 			return err
 		}

--- a/apps/manager-server/internal/repository/sqlite/options.go
+++ b/apps/manager-server/internal/repository/sqlite/options.go
@@ -1,6 +1,10 @@
 package sqlite
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 const (
 	defaultMaxOpenConns    = 4
@@ -9,10 +13,14 @@ const (
 )
 
 type Options struct {
-	Path            string
-	MaxOpenConns    int
-	MaxIdleConns    int
-	ConnMaxIdleTime time.Duration
+	Path                string
+	DataSourceName      string
+	ExpectedJournalMode string
+	ExpectedSynchronous int
+	ExpectedBusyTimeout int
+	MaxOpenConns        int
+	MaxIdleConns        int
+	ConnMaxIdleTime     time.Duration
 }
 
 func (o Options) maxOpenConns() int {
@@ -34,4 +42,25 @@ func (o Options) connMaxIdleTime() time.Duration {
 		return o.ConnMaxIdleTime
 	}
 	return defaultConnMaxIdleTime
+}
+
+func (o Options) hasCustomDataSourceName() bool {
+	return strings.TrimSpace(o.DataSourceName) != ""
+}
+
+func (o Options) validate() error {
+	if !o.hasCustomDataSourceName() {
+		return nil
+	}
+	mode := strings.ToLower(strings.TrimSpace(o.ExpectedJournalMode))
+	if mode != "wal" && mode != "delete" {
+		return fmt.Errorf("custom SQLite data source must declare expected journal mode WAL or DELETE")
+	}
+	if o.ExpectedSynchronous != 2 && o.ExpectedSynchronous != 3 {
+		return fmt.Errorf("custom SQLite data source must declare expected synchronous mode FULL or EXTRA")
+	}
+	if o.ExpectedBusyTimeout <= 0 {
+		return fmt.Errorf("custom SQLite data source must declare a positive expected busy timeout")
+	}
+	return nil
 }

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"sync"
 	"time"
@@ -144,7 +145,11 @@ type Store struct {
 }
 
 func Open(path string, protector ...*security.Protector) (*Store, error) {
-	db, err := sqliterepo.Open(path)
+	return OpenWithOptions(sqliterepo.Options{Path: path}, protector...)
+}
+
+func OpenWithOptions(options sqliterepo.Options, protector ...*security.Protector) (*Store, error) {
+	db, err := sqliterepo.OpenWithOptions(options)
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +181,13 @@ func (s *Store) Close() error {
 		return nil
 	}
 	return s.db.Close()
+}
+
+func (s *Store) SQLiteJournalMode(ctx context.Context) (string, error) {
+	if s == nil {
+		return "", errors.New("store is nil")
+	}
+	return sqliterepo.JournalMode(ctx, s.db)
 }
 
 func (s *Store) StartDerivedMaintenance(ctx context.Context) {

--- a/docker-compose.manager.yml
+++ b/docker-compose.manager.yml
@@ -10,6 +10,8 @@ services:
     environment:
       HTTP_ADDR: "0.0.0.0:18317"
       USAGE_DB_PATH: "/data/usage.sqlite"
+      # Advanced alternative: remove USAGE_DB_PATH before enabling USAGE_DB_URL.
+      # USAGE_DB_URL: "file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)&_pragma=mmap_size(0)"
       CPA_MANAGER_DATA_KEY_PATH: "/data/data.key"
       # Optional: set CPA_MANAGER_ADMIN_KEY or CPA_MANAGER_ADMIN_KEY_FILE to provide
       # a stable admin key. If omitted, the first startup log prints a generated key once.

--- a/docs/migration-from-cpa-manager.md
+++ b/docs/migration-from-cpa-manager.md
@@ -18,11 +18,10 @@ This guide is for users migrating from the old `seakee/cpa-manager` / CPA-Manage
    - Docker volume is commonly `cpa-manager-data`.
    - Host directory mounts usually map to container `/data`.
    - Native packages default to `data/usage.sqlite` next to the binary.
-3. Stop the old container or process so SQLite WAL files are no longer being written.
+3. Stop the old container or process so the SQLite files stop changing.
 4. Back up the full old data directory, not only a single database file. Keep at least:
    - `usage.sqlite`
-   - `usage.sqlite-wal`
-   - `usage.sqlite-shm`
+   - Any current `usage.sqlite-wal` / `usage.sqlite-shm` files when WAL mode is active
 5. Decide the admin-key strategy. During migration, prefer setting `CPA_MANAGER_ADMIN_KEY` or `CPA_MANAGER_ADMIN_KEY_FILE` explicitly instead of relying on the first startup log.
 
 ## Docker Volume Migration
@@ -48,13 +47,15 @@ services:
     image: seakee/cpa-manager-plus:latest
     restart: unless-stopped
     ports:
-      - "18317:18317"
+      - '18317:18317'
     environment:
-      HTTP_ADDR: "0.0.0.0:18317"
-      USAGE_DB_PATH: "/data/usage.sqlite"
-      CPA_MANAGER_DATA_KEY_PATH: "/data/data.key"
-      CPA_MANAGER_ADMIN_KEY: "replace-with-a-long-random-admin-key"
-      USAGE_COLLECTOR_MODE: "auto"
+      HTTP_ADDR: '0.0.0.0:18317'
+      USAGE_DB_PATH: '/data/usage.sqlite'
+      # Advanced alternative: remove the previous line before setting a complete USAGE_DB_URL.
+      # USAGE_DB_URL: "file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)"
+      CPA_MANAGER_DATA_KEY_PATH: '/data/data.key'
+      CPA_MANAGER_ADMIN_KEY: 'replace-with-a-long-random-admin-key'
+      USAGE_COLLECTOR_MODE: 'auto'
     volumes:
       - cpa-manager-data:/data
 
@@ -99,7 +100,7 @@ Then open `http://<host>:18317/management.html` and log in with the admin key.
 1. Stop the old `cpa-manager` process.
 2. Back up the old program directory, especially `data/usage.sqlite*`.
 3. Extract `cpa-manager-plus_<version>_<os>_<arch>`.
-4. Copy the old `data` directory into the new package directory, or set `USAGE_DATA_DIR` / `USAGE_DB_PATH` to the old data path.
+4. Copy the old `data` directory into the new package directory, or set `USAGE_DATA_DIR`, `USAGE_DB_PATH`, or `USAGE_DB_URL` to the old database. The URL and path cannot both be set.
 5. Prefer setting the admin key on first startup:
 
 ```bash

--- a/docs/migration-from-cpa-manager.zh-CN.md
+++ b/docs/migration-from-cpa-manager.zh-CN.md
@@ -18,11 +18,10 @@
    - Docker volume 常见为 `cpa-manager-data`。
    - 宿主机目录挂载通常映射到容器 `/data`。
    - 原生包默认在程序目录下的 `data/usage.sqlite`。
-3. 停止旧容器或旧进程，避免 SQLite WAL 文件仍在写入。
+3. 停止旧容器或旧进程，避免 SQLite 文件继续变化。
 4. 备份整个旧数据目录，而不是只备份单个数据库文件。至少保留：
    - `usage.sqlite`
-   - `usage.sqlite-wal`
-   - `usage.sqlite-shm`
+   - WAL 模式下当前存在的 `usage.sqlite-wal` / `usage.sqlite-shm`
 5. 决定管理员密钥策略。推荐迁移时显式设置 `CPA_MANAGER_ADMIN_KEY` 或 `CPA_MANAGER_ADMIN_KEY_FILE`，避免依赖首次启动日志。
 
 ## Docker Volume 迁移
@@ -48,13 +47,15 @@ services:
     image: seakee/cpa-manager-plus:latest
     restart: unless-stopped
     ports:
-      - "18317:18317"
+      - '18317:18317'
     environment:
-      HTTP_ADDR: "0.0.0.0:18317"
-      USAGE_DB_PATH: "/data/usage.sqlite"
-      CPA_MANAGER_DATA_KEY_PATH: "/data/data.key"
-      CPA_MANAGER_ADMIN_KEY: "replace-with-a-long-random-admin-key"
-      USAGE_COLLECTOR_MODE: "auto"
+      HTTP_ADDR: '0.0.0.0:18317'
+      USAGE_DB_PATH: '/data/usage.sqlite'
+      # 高级替代：删除上一行后设置完整 USAGE_DB_URL。
+      # USAGE_DB_URL: "file:///data/usage.sqlite?_txlock=immediate&_pragma=journal_mode(DELETE)&_pragma=synchronous(EXTRA)&_pragma=busy_timeout(15000)&_pragma=foreign_keys(1)"
+      CPA_MANAGER_DATA_KEY_PATH: '/data/data.key'
+      CPA_MANAGER_ADMIN_KEY: 'replace-with-a-long-random-admin-key'
+      USAGE_COLLECTOR_MODE: 'auto'
     volumes:
       - cpa-manager-data:/data
 
@@ -99,7 +100,7 @@ docker run -d \
 1. 停止旧 `cpa-manager` 进程。
 2. 备份旧程序目录，尤其是 `data/usage.sqlite*`。
 3. 解压 `cpa-manager-plus_<version>_<os>_<arch>`。
-4. 将旧 `data` 目录复制到新包目录，或设置 `USAGE_DATA_DIR` / `USAGE_DB_PATH` 指向旧数据目录。
+4. 将旧 `data` 目录复制到新包目录，或设置 `USAGE_DATA_DIR`、`USAGE_DB_PATH` 或 `USAGE_DB_URL` 指向旧数据库。URL 与 path 不能同时设置。
 5. 首次启动时建议设置管理员密钥：
 
 ```bash

--- a/docs/reset-admin-key.md
+++ b/docs/reset-admin-key.md
@@ -22,7 +22,7 @@ The alias `reset-admin-password` is also accepted for users who think of the adm
 3. Make sure you are pointing at the real Manager Server database:
    - Docker default: `/data/usage.sqlite`
    - Native default: `data/usage.sqlite` next to the binary
-   - Custom deployments: the value of `USAGE_DB_PATH`
+   - Custom deployments: the `USAGE_DB_PATH` value or the local path in `USAGE_DB_URL`
 
 ## Docker Compose
 
@@ -57,7 +57,7 @@ docker run --rm \
 docker start cpa-manager-plus
 ```
 
-If you use the GitHub Container Registry image, replace `seakee/cpa-manager-plus:latest` with `ghcr.io/seakee/cpa-manager-plus:latest`.
+If you use the GitHub Container Registry image, replace `seakee/cpa-manager-plus:latest` with `ghcr.io/seakee/cpa-manager-plus:latest`. A manual `docker run` for a URL deployment must also pass the original `USAGE_DB_URL`; Compose is preferred because it inherits the service environment.
 
 ## Docker Host Directory Mount
 
@@ -110,7 +110,9 @@ Windows PowerShell:
 .\cpa-manager-plus.exe reset-admin-key
 ```
 
-If your SQLite database is not in the default package data directory, pass it explicitly:
+If the deployment uses `USAGE_DB_URL`, run in the same configured environment and omit `--db-path` so the URL parameters are preserved. Passing `--db-path` selects the default SQLite settings.
+
+If a path-only SQLite database is not in the default package data directory, pass it explicitly:
 
 macOS / Linux:
 
@@ -128,7 +130,7 @@ Then restart the native process and log in with the new admin key.
 
 ## Troubleshooting
 
-- **`SQLite database not found`**: you are not running the command in the same configured environment as Manager Server. Pass `--db-path`, or mount the correct Docker volume/host directory.
+- **`SQLite database not found`**: you are not running the command in the same configured environment as Manager Server. URL deployments should pass the original `USAGE_DB_URL` and omit `--db-path`; path deployments may pass `--db-path`. Also mount the correct Docker volume/host directory.
 - **`is empty` / `does not look like a CPA Manager Plus Manager Server database`**: the path points to the wrong file or to a newly created empty file. Find the real `usage.sqlite` from the Manager Server data directory.
 - **`database is locked`**: Manager Server or another process is still using SQLite. Stop it and rerun the command.
 - **Login still fails**: confirm the panel is using the same Manager Server whose database was reset. For Docker, verify the volume name or host mount path.

--- a/docs/reset-admin-key.zh-CN.md
+++ b/docs/reset-admin-key.zh-CN.md
@@ -22,7 +22,7 @@
 3. 确认命令指向真实的 Manager Server 数据库：
    - Docker 默认：`/data/usage.sqlite`
    - 原生包默认：二进制旁边的 `data/usage.sqlite`
-   - 自定义部署：`USAGE_DB_PATH` 的值
+   - 自定义部署：`USAGE_DB_PATH` 的值，或 `USAGE_DB_URL` 的本地 path
 
 ## Docker Compose
 
@@ -57,7 +57,7 @@ docker run --rm \
 docker start cpa-manager-plus
 ```
 
-如果使用 GitHub Container Registry 镜像，请把 `seakee/cpa-manager-plus:latest` 替换为 `ghcr.io/seakee/cpa-manager-plus:latest`。
+如果使用 GitHub Container Registry 镜像，请把 `seakee/cpa-manager-plus:latest` 替换为 `ghcr.io/seakee/cpa-manager-plus:latest`。URL 部署手工 `docker run` 时还必须传入原来的 `USAGE_DB_URL`；更推荐会继承 service environment 的 Compose 命令。
 
 ## Docker 宿主机目录挂载
 
@@ -110,7 +110,9 @@ Windows PowerShell：
 .\cpa-manager-plus.exe reset-admin-key
 ```
 
-如果 SQLite 数据库不在默认数据目录，显式指定路径：
+如果部署使用 `USAGE_DB_URL`，请在同一配置环境中省略 `--db-path`，以保留 URL 参数。显式传入 `--db-path` 会选择默认 SQLite 设置。
+
+仅使用 path 且 SQLite 数据库不在默认数据目录时，显式指定路径：
 
 macOS / Linux：
 
@@ -128,7 +130,7 @@ Windows PowerShell：
 
 ## 排障
 
-- **`SQLite database not found`**：当前命令没有运行在 Manager Server 的真实配置环境中。请传入 `--db-path`，或挂载正确的 Docker volume / 宿主机目录。
+- **`SQLite database not found`**：当前命令没有运行在 Manager Server 的真实配置环境中。URL 部署应传入原来的 `USAGE_DB_URL` 并省略 `--db-path`；path 部署可传入 `--db-path`。同时确认已挂载正确的 Docker volume / 宿主机目录。
 - **`is empty` / `does not look like a CPA Manager Plus Manager Server database`**：路径指向了错误文件或新建的空文件。请从 Manager Server 数据目录中找到真实的 `usage.sqlite`。
 - **`database is locked`**：Manager Server 或其他进程仍在使用 SQLite。停止相关进程后重试。
 - **重置后仍无法登录**：确认面板访问的是同一个 Manager Server。Docker 场景请检查 volume 名称或宿主机挂载路径。


### PR DESCRIPTION
## Summary

Add a single `USAGE_DB_URL` / `dbUrl` entry point for complete local SQLite `file:` URLs while preserving the existing `USAGE_DB_PATH` defaults. Custom URLs are validated, applied consistently to Manager Server and offline commands, and used to gate WAL maintenance by the effective journal mode.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Accept one mutually exclusive `USAGE_DB_URL` / `dbUrl` setting, derive the canonical database path for locking and `data.key`, and reject non-local, in-memory, unlocked, or incomplete SQLite URLs.
- Preserve URL PRAGMAs through schema migration and offline commands, validate effective durability settings on a real connection, and start WAL maintenance only when the effective mode is WAL.
- Keep default path deployments unchanged; document Docker/native usage, backup semantics, URL-mode admin reset/cleanup, and WAL/DELETE transitions in English and Chinese.

## User Impact

Existing deployments that use `USAGE_DB_PATH` or `USAGE_DATA_DIR` keep the same WAL, `synchronous=FULL`, `busy_timeout=5000`, and connection-pool defaults. Advanced deployments can now provide one complete SQLite URL instead of requiring a custom build.

## Compatibility / Runtime Notes

- CPA panel mode: no behavior change; the lightweight panel does not open Manager Server SQLite.
- Manager Server mode: `USAGE_DB_URL` and `USAGE_DB_PATH` are mutually exclusive. The URL must be an absolute local persistent `file:` URI with `_txlock=immediate`, foreign keys enabled, WAL or DELETE journal mode, FULL or EXTRA synchronous mode, and a positive busy timeout.
- Full Docker / native packages: defaults remain `/data/usage.sqlite` and `./data/usage.sqlite`. The image no longer predefines `USAGE_DB_PATH`; `USAGE_DATA_DIR=/data` resolves to the same default while allowing URL-only configuration without an inherited conflict.

## Data / Security Notes

- URL paths are canonicalized before process locking and the canonical path is written back into the driver URL, so the lock and SQLite connection cannot target different files.
- Hosts, userinfo, fragments, relative paths, memory mode, `immutable`, `nolock`, custom VFS selection, missing immediate transaction locking, duplicate protected PRAGMAs, and unsafe PRAGMA syntax are rejected.
- The effective journal mode, foreign-key setting, synchronous level, and busy timeout are read back before migration. URL parse errors and invalid PRAGMA errors do not echo the raw URL.
- Offline admin-reset and derived-cleanup commands validate the Manager Server schema before applying custom PRAGMAs and inherit the configured URL unless `--db-path` is explicitly supplied.
- DELETE mode does not start the WAL checkpoint worker. This does not claim that SQLite or the process lock is network-filesystem safe; deployments still require one Manager Server per database.

## Risk / Rollback

Risk level: Medium

Rollback notes:

Remove `USAGE_DB_URL`, restore the previous `USAGE_DB_PATH` / `USAGE_DATA_DIR`, and restart with the previous image or binary. Stop all database users and back up the main database plus any existing sidecars before changing journal mode. No business schema or authoritative `usage_events` data is changed by this feature.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [x] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm ci
npm run type-check
npm run lint                         # 0 errors; one pre-existing react-refresh warning
npm run test                         # 200 files, 2493 tests passed
npm run build
VERSION=ci npm --workspace apps/web run build:bundle
VERSION=ci-demo npm --workspace apps/web run build:demo:bundle
npm run check:demo-isolation
npm run docs:build
node node_modules/vitest/vitest.mjs run tests/nativeControlScripts.test.mjs --root .
bash -n bin/release/package-native.sh
docker compose -f docker-compose.manager.yml config
go test ./...
go test -race ./...
Docker build/run smoke             # Go 1.24 image build; URL-only DELETE mode; health/UI/info; stop, integrity check, no WAL/SHM; restart
```

The SQLite tests cover default DSN compatibility, percent-encoded paths, unsafe URI rejection, effective PRAGMA readback on every pooled connection, WAL -> DELETE -> WAL transitions, integrity checks, process lifecycle/restart, offline commands, and URL error redaction.

Fork preview evidence (automation is isolated on the fork `main` branch and is not part of this PR diff):

- Workflow: https://github.com/legendtang/CPA-Manager-Plus/actions/runs/32717602942
- Public multi-arch image: `ghcr.io/legendtang/cpa-manager-plus:sqlite-db-url-upstream-c456c4408aac-patch-4d64fbc6c279`
- Manifest digest: `sha256:c522a35925231596772e3b4077e3ed7d428f50e44e265029edf91d0ffada1cf5`
- Verified `linux/amd64` and `linux/arm64`; an anonymous digest pull and URL-only DELETE-mode container smoke test passed (`/health`, `/management.html`, `/usage-service/info`, WAL worker disabled, stopped-database `integrity_check=ok`, no WAL/SHM, restart healthy).
- The fork workflow periodically replays this patch on `upstream/dev`, but only while PR #609 remains open. It publishes images only and does not deploy production.

## Screenshots / Recordings

N/A — backend, deployment configuration, tests, and documentation only; no visible UI change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [x] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

Updated the existing English and Chinese Manager Server, configuration, Docker, native, backup, update, migration, admin-reset, and FAQ pages plus the checked-in Compose example. README snippets do not expose SQLite location settings, so changing them would add duplicate configuration reference material without improving the quick-start path. No navigation or screenshot change is required because no new page or UI was added.

## Related

N/A

