### PR TITLE
fix(ci): handle Dependabot PRs without template failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     target-branch: dev
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   pr-template:
     name: PR Template
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Prevent Dependabot-generated pull requests from failing the human PR template check, and disable routine Dependabot version-update PRs while retaining the configuration needed for security update handling.

## Scope

- [x] CI / build / tooling

## Changes

- Skip the `PR Template` job when the pull request actor is `dependabot[bot]`.
- Set `open-pull-requests-limit: 0` for the `github-actions` Dependabot version-update configuration.

## User Impact

None. This changes repository maintenance automation only.

## Compatibility / Runtime Notes

No CPAMP or CPA runtime behavior changes.

## Data / Security Notes

Human pull requests remain subject to the full PR template validation. The exemption is limited to GitHub's Dependabot bot actor.

## Risk / Rollback

Low risk. Revert the workflow condition or Dependabot limit if routine automated version PRs are desired again.

## Verification

- Existing Dependabot PR #611 failed only because its generated body did not contain the required human template sections.
- Updating #611 to the required template made the `PR Template` check pass.

## Screenshots / Recordings

Not applicable.

## Docs

No user-facing documentation changes required.

## Related

- #611