### PR TITLE
chore(release): prepare v1.12.4

### DIFF
--- a/docs/release-notes/v1.12.4-en.md
+++ b/docs/release-notes/v1.12.4-en.md
@@ -1,0 +1,38 @@
+# CPA Manager Plus v1.12.4
+
+> 23 commits · 36 files changed · +1789 / -192
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.4/docs/release-notes/v1.12.4-zh.md)
+
+## Overview
+
+v1.12.4 focuses on provider-scoped Request Monitoring account identity, Codex OAuth re-login continuity, and Manager Server SQLite WAL reader recovery. Equal account values are no longer merged across providers while multiple credentials for the same provider remain aggregated; an Accounts refresh no longer sends a successful Codex re-login into a new OAuth session; and WAL maintenance can recover after a canceled SQLite read transaction releases its reader snapshot. This release has no database schema, configuration, or usage_events data migration.
+
+## Highlights
+
+### Fixes
+
+- Request Monitoring Account Overview now uses canonical provider-scoped logical account identity, so the same display account is shown as separate rows across providers while credentials for the same provider remain aggregated and provider-scoped filters are preserved.
+- Request Monitoring uses opaque account row IDs to isolate focus, expansion, authentication, status, and quota-refresh state, preventing equal display accounts from sharing UI state.
+- Codex OAuth re-login keeps its current session while the Accounts parent refreshes during callback-success synchronization, avoiding a second authorization URL and preserving the final synchronization result.
+- Manager Server upgrades modernc.org/sqlite from v1.34.5 to v1.46.1 and covers WAL recovery after a canceled read transaction releases its reader snapshot, preventing reader lifecycle cleanup from blocking WAL maintenance.
+
+### CI / Build
+
+- CI and release workflows use docker/setup-buildx-action v4.3.0.
+- Routine Dependabot version-update PRs are disabled, and bot maintenance PRs no longer run the human-only PR template check.
+
+## Upgrade Notes
+
+- No database schema migration, configuration change, or usage_events backfill is required; upgrade normally.
+- The modernc.org/sqlite update is included in Manager Server, Full Docker, and native release packages; no additional deployment step is required.
+- Monitoring AccountStats and selector account row IDs are now opaque provider-scoped values; external integrations should use row.id for state and filter values, use row.account for display, and avoid grouping by display account alone.
+- Same-provider aggregation across multiple credentials and credential-scoped filter values remain compatible.
+
+## Acknowledgements
+
+- [@HuiCheng](https://github.com/HuiCheng) - Fixed the duplicate OAuth redirect after the Codex callback, keeping the re-login flow continuous.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.3...v1.12.4

--- a/docs/release-notes/v1.12.4-zh.md
+++ b/docs/release-notes/v1.12.4-zh.md
@@ -1,0 +1,38 @@
+# CPA Manager Plus v1.12.4
+
+> 23 commits · 36 files changed · +1789 / -192
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.4/docs/release-notes/v1.12.4-en.md)
+
+## Overview
+
+v1.12.4 聚焦 Request Monitoring 账号身份隔离、Codex OAuth 重新登录连续性和 Manager Server SQLite WAL 读事务恢复。相同账号在不同 Provider 下不再被合并，同一 Provider 的多个凭证仍保持聚合；Accounts 刷新不会让成功的 Codex 重新登录跳转到新的 OAuth 会话；取消中的 SQLite 读事务释放后，WAL 维护可以继续恢复。本版本不包含数据库 schema、配置或 usage_events 数据迁移。
+
+## Highlights
+
+### Fixes
+
+- Request Monitoring Account Overview 使用按 Provider 作用域划分的逻辑账号身份，相同显示账号在不同 Provider 下显示为独立行，同一 Provider 的多个凭证仍聚合为一个账号，并保留 Provider 作用域的筛选。
+- Request Monitoring 使用不透明的账号行标识隔离聚焦、展开、认证、状态和配额刷新状态，避免显示相同的账号共享 UI 状态。
+- Codex OAuth 重新登录在 Accounts 父级刷新和回调成功后的同步过程中保持当前会话，避免再次获取登录地址并保留最终同步结果。
+- Manager Server 将 modernc.org/sqlite 从 v1.34.5 升级到 v1.46.1，并覆盖取消读事务释放读快照后的 WAL 恢复路径，避免读者生命周期阻塞 WAL 维护。
+
+### CI / Build
+
+- CI 与 release workflow 使用 docker/setup-buildx-action v4.3.0。
+- Dependabot 常规版本更新 PR 已停用，机器人维护 PR 不再执行面向人工 PR 的模板检查。
+
+## Upgrade Notes
+
+- 不需要数据库 schema 迁移、配置变更或 usage_events 数据回填；可按常规方式升级。
+- modernc.org/sqlite 更新已包含在 Manager Server、Full Docker 和原生发布包中，不需要额外部署步骤。
+- Monitoring AccountStats 和筛选器的账号行标识现在是按 Provider 作用域划分的不透明值；外部集成应使用 row.id 保存状态和筛选值，并使用 row.account 展示账号，不要仅按显示账号合并。
+- 同一 Provider 下多个凭证的账号聚合和凭证级筛选值保持兼容。
+
+## Acknowledgements
+
+- [@HuiCheng](https://github.com/HuiCheng) - 修复 Codex 回调后的重复 OAuth 跳转，让重新登录流程保持连续。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.3...v1.12.4

--- a/docs/release-posts/v1.12.4-telegram.html
+++ b/docs/release-posts/v1.12.4-telegram.html
@@ -1,0 +1,17 @@
+🚀 <b>8 月 25 日 · v1.12.4</b>
+
+✨ <b>更新内容</b>
+
+• Request Monitoring Account Overview 会按 Provider 拆分相同账号或邮箱，同时继续合并同一 Provider 下的多个凭证。
+• Request Monitoring 的筛选、聚焦、展开、认证状态和配额刷新状态会隔离到正确的账号行。
+• Codex 重新登录在 Accounts 刷新后会保持原 OAuth 会话，回调成功后不再跳转到第二个登录地址。
+• Manager Server 在取消 SQLite 读事务后可以继续完成 WAL 检查点维护。
+
+⚠️ <b>注意事项</b>
+
+• 本版本不需要数据库迁移、数据回填或配置变更，可按常规方式升级。
+• Monitoring 账号行标识已按 Provider 隔离并保持不透明；外部集成应使用 <code>row.id</code> 保存状态、使用 <code>row.account</code> 展示账号，不要仅按显示账号合并。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/HuiCheng">@HuiCheng</a> - 修复 Codex 回调后的重复 OAuth 跳转，让重新登录流程保持连续。


### PR DESCRIPTION
## Summary

Prepare the finalized v1.12.4 release materials on the dedicated release branch.
The notes cover provider-scoped Monitoring account identity, Codex OAuth re-login continuity, SQLite WAL reader recovery, and the related CI maintenance.

> Community and maintenance PRs must target `dev`. Repository automation
> retargets other pull requests to `dev`; this can change the diff and make
> existing review comments outdated. `main` accepts only a promotion PR whose
> source is this repository's `dev` branch.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.4 release notes.
- Add the reviewed v1.12.4 Telegram release post.
- Record upgrade and compatibility guidance for provider-scoped account rows, Codex re-login continuity, and SQLite WAL recovery.

## User Impact

No runtime behavior is introduced by this release-materials PR. It documents the behavior already integrated on `dev` and provides the user-facing upgrade guidance for v1.12.4.

## Compatibility / Runtime Notes

- CPA panel mode: The notes cover provider-scoped Monitoring account identity and the Codex OAuth re-login flow.
- Manager Server mode: The notes cover the SQLite driver update and WAL reader lifecycle recovery.
- Full Docker / native packages: The notes document the bundled Manager Server and panel behavior; no packaging configuration change is introduced by this PR.

## Data / Security Notes

No schema, configuration, credential, authentication, or persisted-data changes are introduced by these release files. The documented runtime changes do not delete, rewrite, or rebuild `usage_events`. No secrets or runtime data are included.

## Risk / Rollback

Risk level: Low

Rollback notes:

Close this PR before merge, or revert its release-materials merge before promotion. No application code or persisted data is changed by this PR.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
Frozen source dev SHA: e0c3297f62d0a3f6bd9a28909326337ddd878604
Release branch head: 7536d2e89c8b14cc68bc5098f12d9d04cc43e7bd
Changed paths: exactly the three v1.12.4 release files
npm run release:validate -- --tag v1.12.4 --content-only: passed
Chinese SHA-256: 99ee227b9f2b8a6669cdfc9b34d6a4e7fdd967089396c06d8393aa1bdc73a2c4
English SHA-256: 6db70e64de03c102eab3e7673bdcc289d8f77e1a76af9aa087cce041b636af40
Telegram SHA-256: b02a9c5523a9d59d02f728ec417526608f0c8a7257c68d8e0e9360dc9b3cbb72
Telegram HTML: 569 characters; allowed HTML subset and reciprocal tag-pinned language links validated.
```

## Screenshots / Recordings

N/A — release documentation and Telegram HTML only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

This is the dedicated v1.12.4 release-materials change. The formal notes and Telegram post cover the reviewed user-visible behavior and upgrade guidance.

## Related

N/A