### PR TITLE
feat(web): optimize realtime monitoring table

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.module.scss
@@ -1319,14 +1319,6 @@
 
 @include summaryTable.styles;
 @include accountOverview.styles;
-.realtimeTable {
-  --realtime-col-source: 16%;
-  --realtime-col-model: 16%;
-  --realtime-col-tps: 8%;
-  --realtime-col-latency: 8%;
-  --realtime-col-time: 8%;
-}
-
 .realtimeTable .logTypeCell .primaryCell > span {
   display: inline-block;
   max-width: 100%;
@@ -1350,10 +1342,17 @@
 }
 
 .realtimeUsageCell {
-  display: grid;
-  gap: 4px;
+  display: inline-grid;
+  grid-template-columns: max-content max-content;
+  justify-content: center;
+  column-gap: 8px;
+  row-gap: 3px;
+  max-width: 100%;
   min-width: 0;
+  color: var(--monitor-ink);
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
+  line-height: 1.25;
   cursor: help;
 
   &:focus-visible {
@@ -1364,23 +1363,30 @@
 }
 
 .realtimeUsageTotal {
+  grid-column: 1 / -1;
+  justify-self: center;
   color: var(--monitor-ink);
-}
-
-.realtimeUsageFlow {
-  display: grid;
-  grid-template-columns: max-content max-content;
-  column-gap: 8px;
-  color: var(--monitor-muted);
-  font-size: 11px;
-  line-height: 1.25;
-  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 700;
 }
 
 .realtimeUsageMetric {
   display: inline-flex;
   align-items: center;
   gap: 3px;
+  min-width: 0;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.realtimeUsageSecondary {
+  color: var(--monitor-muted);
+  font-weight: 500;
+}
+
+.realtimeUsageIcon {
+  display: inline-flex;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif;
 }
 
 .realtimeUsageTooltip {
@@ -1444,14 +1450,19 @@
 
 .realtimeModelCell {
   max-width: 100%;
+  justify-items: center;
+  text-align: center;
 }
 
 .realtimeModelText {
   display: block;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap !important;
+  overflow-wrap: anywhere;
+  white-space: normal !important;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.3;
+  text-align: center;
 }
 
 .realtimeApiKeyLine {
@@ -1504,12 +1515,25 @@
 .realtimeLatencyColumn,
 .realtimeTimeColumn,
 .realtimeTpsColumn,
+.realtimeUsageColumn,
+.realtimeCostColumn,
 .realtimeCenteredColumn {
   text-align: center !important;
 }
 
-.realtimeSettingsColumn {
-  text-align: left !important;
+.realtimeTable thead th {
+  text-align: center;
+}
+
+.realtimeTable tbody td[data-column='usage'] {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.realtimeCostColumn {
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .realtimeCenteredColumn .primaryCell {
@@ -1621,6 +1645,76 @@
 .realtimeMetricText {
   min-width: 0;
   text-align: left;
+}
+
+.realtimeColumnSelectorPanel {
+  --monitor-surface: var(--bg-primary);
+  --monitor-surface-elevated: var(--app-surface-strong);
+  --monitor-surface-hover: var(--bg-hover);
+  --monitor-ink: var(--text-primary);
+  --monitor-muted: var(--text-secondary);
+  --monitor-line: var(--border-color);
+
+  position: fixed;
+  z-index: 2040;
+  box-sizing: border-box;
+  width: 224px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--monitor-line) 86%, transparent);
+  border-radius: 10px;
+  background: var(--monitor-surface-elevated);
+  box-shadow: var(--shadow-lg);
+  color: var(--monitor-ink);
+}
+
+.realtimeColumnSelectorList {
+  display: grid;
+  gap: 2px;
+}
+
+.realtimeColumnSelectorList > label {
+  min-height: 30px;
+  padding: 4px 6px;
+  border-radius: 7px;
+}
+
+.realtimeColumnSelectorList > label:hover {
+  background: var(--monitor-surface-hover);
+}
+
+.realtimeColumnSelectorLabel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.realtimeColumnSelectorLabel small {
+  color: var(--monitor-muted);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.realtimeColumnSelectorReset {
+  width: 100%;
+  margin-top: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--monitor-line);
+  border-radius: 8px;
+  background: var(--monitor-surface);
+  color: var(--monitor-ink);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.realtimeColumnSelectorReset:hover {
+  border-color: color-mix(in srgb, var(--monitor-accent) 35%, var(--monitor-line));
+  background: var(--monitor-surface-hover);
 }
 
 .realtimeMetricText.goodText {
@@ -2210,10 +2304,6 @@
 
   .apiKeySummaryTable {
     min-width: 980px;
-  }
-
-  .realtimeTable {
-    min-width: 1260px;
   }
 }
 

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -366,6 +366,9 @@ export function MonitoringCenterPage() {
   const [realtimePageSize, setRealtimePageSize] = useState(
     initialMonitoringCenterUiState.current.realtimePageSize
   );
+  const [realtimeVisibleColumns, setRealtimeVisibleColumns] = useState(
+    () => initialMonitoringCenterUiState.current.realtimeVisibleColumns
+  );
   const focusSnapshotRef = useRef<FocusSnapshot | null>(null);
   const previousAccountPageResetStateRef = useRef<AccountOverviewPageResetState | null>(null);
   const accountQuotaStatesByRowIdRef = useRef<Record<string, AccountQuotaState>>({});
@@ -809,6 +812,7 @@ export function MonitoringCenterPage() {
       selectedStatus,
       apiKeyPageSize,
       realtimePageSize,
+      realtimeVisibleColumns,
     });
   }, [
     activeDataTab,
@@ -817,6 +821,7 @@ export function MonitoringCenterPage() {
     customEndInput,
     customStartInput,
     realtimePageSize,
+    realtimeVisibleColumns,
     searchInput,
     selectedAccount,
     selectedApiKeyHash,
@@ -1726,9 +1731,11 @@ export function MonitoringCenterPage() {
         scopedFailureCount={scopedFailureCount}
         failedOnlyActive={failedOnlyActive}
         accountDisplayMode={accountDisplayMode}
+        visibleColumns={realtimeVisibleColumns}
         t={t}
         onToggleFailedOnly={toggleFailedOnly}
         onAccountDisplayModeChange={setAccountDisplayMode}
+        onVisibleColumnsChange={setRealtimeVisibleColumns}
       />
     );
   }, [
@@ -1742,6 +1749,7 @@ export function MonitoringCenterPage() {
     handleAccountSortKeyChange,
     overallLoading,
     realtimeLogRows.length,
+    realtimeVisibleColumns,
     refreshAll,
     scopedFailureCount,
     searchInput,
@@ -2202,11 +2210,13 @@ export function MonitoringCenterPage() {
               overallLoading={overallLoading}
               hasPrices={hasPrices}
               accountDisplayMode={accountDisplayMode}
+              visibleColumns={realtimeVisibleColumns}
               locale={i18n.language}
               emptyState={renderMonitoringEmptyState()}
               t={t}
               onToggleFailedOnly={toggleFailedOnly}
               onAccountDisplayModeChange={setAccountDisplayMode}
+              onVisibleColumnsChange={setRealtimeVisibleColumns}
               onPageChange={setRealtimePage}
               onPageSizeChange={handleRealtimePageSizeChange}
               onLoadMoreEvents={loadMoreEvents}

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.test.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next';
 import { describe, expect, it, vi } from 'vitest';
 import type { AccountDisplayMode } from '@/features/monitoring/accountOverviewState';
 import type { MonitoringEventRow } from '@/features/monitoring/hooks/useMonitoringData';
+import type { RealtimeColumnId } from '@/features/monitoring/realtimeColumns';
 import styles from '../MonitoringCenterPage.module.scss';
 import { RealtimeEventsPanel } from './RealtimeEventsPanel';
 
@@ -10,6 +11,7 @@ const t = ((key: string, options?: Record<string, unknown>) => {
   const messages: Record<string, string> = {
     'common.loading': 'Loading',
     'common.copy': 'Copy',
+    'common.reset': 'Reset',
     'common.yes': 'Yes',
     'common.no': 'No',
     'monitoring.account_overview_account_display_masked': 'Masked',
@@ -47,6 +49,8 @@ const t = ((key: string, options?: Record<string, unknown>) => {
     'monitoring.realtime_usage_cached_label': 'Cached',
     'monitoring.realtime_usage_cache_read_label': 'Cache Read',
     'monitoring.realtime_usage_cache_creation_label': 'Cache Creation',
+    'monitoring.realtime_columns': 'Columns',
+    'monitoring.realtime_column_fixed': 'Fixed',
     'monitoring.load_more_events': 'Load more',
     'monitoring.log_rows': 'Rows',
     'monitoring.no_more_events': 'No more events',
@@ -108,6 +112,7 @@ type PanelOverrides = {
   eventsTotalCount?: number;
   eventsLoadedCount?: number;
   hasPrices?: boolean;
+  visibleColumns?: readonly RealtimeColumnId[];
 };
 
 const baseRow = (overrides: Partial<PanelRow> = {}): PanelRow => ({
@@ -191,6 +196,8 @@ const renderPanel = (row: PanelRow, overrides: PanelOverrides = {}) =>
       onPageChange={noop}
       onPageSizeChange={noop}
       onLoadMoreEvents={noop}
+      visibleColumns={overrides.visibleColumns}
+      onVisibleColumnsChange={noop}
     />
   );
 
@@ -224,15 +231,21 @@ describe('RealtimeEventsPanel', () => {
       })
     );
 
-    expect(markup).toContain(
-      `class="${styles.realtimeSettingsColumn}">Reasoning / Tier</th>`
+    expect(markup).toContain('data-column="settings">Reasoning / Tier</th>');
+    expect(markup).toMatch(
+      new RegExp(`data-column="settings" class="[^"]*${styles.realtimeCenteredColumn}[^"]*"`)
     );
     expect(markup).toContain('>TPS</th>');
     expect(markup).toContain(styles.realtimeTpsColumn);
     expect(markup).toContain(styles.realtimeLatencyColumn);
     expect(markup).toContain(styles.realtimeTimeColumn);
-    expect(markup.match(new RegExp(styles.realtimeCenteredColumn, 'g'))).toHaveLength(8);
-    expect(markup.match(new RegExp(styles.realtimeSettingsColumn, 'g'))).toHaveLength(2);
+    expect(markup).toContain('data-column="usage"');
+    expect(markup).toContain('style="width:100%;min-width:1236px"');
+    expect(markup).toContain('data-column="source" style="width:calc((100% - 904px)');
+    expect(markup).toContain('data-column="model" style="width:calc((100% - 904px)');
+    expect(markup).toMatch(
+      new RegExp(`data-column="model" class="[^"]*${styles.realtimeCenteredColumn}[^"]*"`)
+    );
     expect(markup).toContain('>Recent Status</th>');
     expect(markup).toContain('>Success Rate</th>');
     expect(markup).toContain('Source / API Key');
@@ -248,6 +261,11 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('client-gpt');
     expect(markup).toContain('gpt-5.4');
     expect(markup).not.toContain('Resolved');
+    expect(markup).toContain('🧮');
+    expect(markup).toContain('⬆️');
+    expect(markup).toContain('⬇️');
+    expect(markup).toContain('⚡️');
+    expect(markup).toContain('🧠');
     expect(markup).not.toContain('POST /v1/chat/completions');
     expect(markup).toContain('Failed');
     expect(markup).toContain('>Elapsed</th>');
@@ -259,8 +277,8 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).not.toContain('>Gen</span>');
     expect(markup).not.toContain('>E2E</span>');
     expect(markup).toContain(styles.realtimeUsageCell);
-    expect(markup).toContain('>↑</span>10');
-    expect(markup).toContain('>↓</span>20');
+    expect(markup).toContain('>⬇️</span><span>10</span>');
+    expect(markup).toContain('>⬆️</span><span>20</span>');
     expect(markup).toContain('>Total</span>');
     expect(markup).toContain('>Input</span>');
     expect(markup).toContain('>Output</span>');
@@ -354,17 +372,15 @@ describe('RealtimeEventsPanel', () => {
     expect(
       markup.match(new RegExp(`class="[^"]*${styles.realtimeSettingValue}[^"]*">-</span>`, 'g'))
     ).toHaveLength(2);
-    expect(markup).toContain(
-      `class="${styles.realtimeSettingsColumn}">Reasoning / Tier</th>`
-    );
+    expect(markup).toContain('data-column="settings">Reasoning / Tier</th>');
     expect(markup).toContain('>TPS</th>');
     expect(markup).toContain('Success');
     expect(markup).toContain('>Elapsed</th>');
     expect(markup).toContain('>TTFT</span><span class=');
     expect(markup).toContain(expectedDate);
     expect(markup).toContain(expectedTime);
-    expect(markup).toContain('>↑</span>10');
-    expect(markup).toContain('>↓</span>20');
+    expect(markup).toContain('>⬇️</span><span>10</span>');
+    expect(markup).toContain('>⬆️</span><span>20</span>');
     expect(markup).toContain('>Reasoning</span><span class=');
     expect(markup).toContain('>0</span>');
     expect(markup).toContain(styles.realtimeUsageTooltip);
@@ -389,7 +405,7 @@ describe('RealtimeEventsPanel', () => {
       })
     );
 
-    expect(markup).toContain('<th>Source / API Key</th>');
+    expect(markup).toContain('data-column="source">Source / API Key</th>');
     expect(markup).toContain('API Key: Team A');
     expect(markup).not.toContain('#12345678');
     expect(markup).toContain('API Key hash: 1234567890abcdef');
@@ -419,9 +435,7 @@ describe('RealtimeEventsPanel', () => {
       })
     );
 
-    expect(markup).toContain(
-      'title="deepseek-v4-flash(max)\nresolved-deepseek-v4-flash"'
-    );
+    expect(markup).toContain('title="deepseek-v4-flash(max)\nresolved-deepseek-v4-flash"');
     expect(markup.indexOf('>deepseek-v4-flash(max)</span>')).toBeLessThan(
       markup.indexOf('>resolved-deepseek-v4-flash</small>')
     );
@@ -502,9 +516,7 @@ describe('RealtimeEventsPanel', () => {
     expect(fullMarkup).toContain(`<details class="${styles.realtimeRequestMetadata}">`);
     expect(fullMarkup).toContain('<summary>Request metadata</summary>');
     expect(fullMarkup).toContain('Client IP: 192.0.2.10');
-    expect(fullMarkup).toContain(
-      'Forwarded chain (unverified): 203.0.113.5, 198.51.100.8'
-    );
+    expect(fullMarkup).toContain('Forwarded chain (unverified): 203.0.113.5, 198.51.100.8');
     expect(fullMarkup).toContain('User-Agent: test-client/1.0');
   });
 
@@ -568,8 +580,34 @@ describe('RealtimeEventsPanel', () => {
     expect(markup).toContain('>Cache Creation</span><span class=');
     expect(markup).toContain('>151.0K</span>');
     expect(markup).toContain('>1.0K</span>');
-    expect(markup).toContain('aria-label="Total: 33, Input: 152.6K, Output: 20, Reasoning: 3, Cached: 0, Cache Read: 151.0K, Cache Creation: 1.0K"');
+    expect(markup).toContain(
+      'aria-label="Total: 33, Input: 152.6K, Output: 20, Cached: 151.0K, Reasoning: 3"'
+    );
     expect(markup).toContain('tabindex="0"');
+  });
+
+  it('uses a compact dynamic width and restores mandatory columns', () => {
+    const markup = renderPanel(baseRow(), { visibleColumns: ['usage'] });
+
+    expect(markup).toContain('style="width:100%;min-width:676px"');
+    expect(markup).toContain('data-column="source" style="width:calc((100% - 344px)');
+    expect(markup).toContain('data-column="model" style="width:calc((100% - 344px)');
+    expect(markup.match(/<col\b/g)).toHaveLength(5);
+    expect(markup).toContain('data-column="source"');
+    expect(markup).toContain('data-column="model"');
+    expect(markup).toContain('data-column="request-status"');
+    expect(markup).toContain('data-column="time"');
+    expect(markup).toContain('data-column="usage"');
+    expect(markup).not.toContain('data-column="cost"');
+    expect(markup).not.toContain('data-column="settings"');
+  });
+
+  it('prefers cache read tokens and falls back to legacy cached tokens', () => {
+    const cacheReadMarkup = renderPanel(baseRow({ cachedTokens: 7_000, cacheReadTokens: 4_000 }));
+    const legacyMarkup = renderPanel(baseRow({ cachedTokens: 7_000, cacheReadTokens: 0 }));
+
+    expect(cacheReadMarkup).toContain('>⚡️</span><span>4.0K</span>');
+    expect(legacyMarkup).toContain('>⚡️</span><span>7.0K</span>');
   });
 
   it('shows the loaded vs total summary with a load-more action when more pages exist', () => {

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -12,7 +13,14 @@ import {
 import { createPortal } from 'react-dom';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
-import { IconCopy, IconEye, IconEyeOff, IconFilter } from '@/components/ui/icons';
+import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
+import {
+  IconCopy,
+  IconEye,
+  IconEyeOff,
+  IconFilter,
+  IconSlidersHorizontal,
+} from '@/components/ui/icons';
 import {
   PaginationControls,
   RecentPattern,
@@ -22,6 +30,15 @@ import { formatPercent } from '@/features/monitoring/components/accountOverviewP
 import { buildRealtimeSourceDisplay } from '@/features/monitoring/realtimeSourceDisplay';
 import type { MonitoringEventRow } from '@/features/monitoring/hooks/useMonitoringData';
 import type { AccountDisplayMode } from '@/features/monitoring/accountOverviewState';
+import {
+  DEFAULT_REALTIME_VISIBLE_COLUMNS,
+  REALTIME_COLUMN_DEFINITIONS,
+  getRealtimeColumnDefinitions,
+  getRealtimeTableWidth,
+  normalizeRealtimeVisibleColumns,
+  type RealtimeColumnDefinition,
+  type RealtimeColumnId,
+} from '@/features/monitoring/realtimeColumns';
 import { useNotificationStore } from '@/stores';
 import { copyToClipboard } from '@/utils/clipboard';
 import { maskSensitiveText, truncateText } from '@/utils/format';
@@ -67,6 +84,8 @@ type RealtimeEventsPanelProps = {
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onLoadMoreEvents: () => void;
+  visibleColumns?: readonly RealtimeColumnId[];
+  onVisibleColumnsChange?: (columns: RealtimeColumnId[]) => void;
 };
 
 export type RealtimeEventsPanelActionsProps = {
@@ -77,6 +96,8 @@ export type RealtimeEventsPanelActionsProps = {
   t: TFunction;
   onToggleFailedOnly: () => void;
   onAccountDisplayModeChange: (mode: AccountDisplayMode) => void;
+  visibleColumns?: readonly RealtimeColumnId[];
+  onVisibleColumnsChange?: (columns: RealtimeColumnId[]) => void;
 };
 
 const REALTIME_PAGE_SIZE_OPTIONS = [10, 50, 100, 150, 300] as const;
@@ -122,6 +143,169 @@ const shortLabel = (
   const label = t(shortKey, { defaultValue: fallback });
   return label === shortKey ? (fallbackDefault ?? fallback) : label;
 };
+
+const getRealtimeColumnLabel = (columnId: RealtimeColumnId, t: TFunction): string => {
+  switch (columnId) {
+    case 'source':
+      return shortLabel(
+        t,
+        'monitoring.column_source_api_key_short',
+        'monitoring.column_source_api_key'
+      );
+    case 'model':
+      return t('monitoring.column_model');
+    case 'settings':
+      return t('monitoring.reasoning_service_short');
+    case 'recent-status':
+      return shortLabel(t, 'monitoring.recent_status_short', 'monitoring.recent_status');
+    case 'request-status':
+      return shortLabel(t, 'monitoring.request_status_short', 'monitoring.request_status');
+    case 'success-rate':
+      return shortLabel(
+        t,
+        'monitoring.column_success_rate_short',
+        'monitoring.column_success_rate'
+      );
+    case 'calls':
+      return shortLabel(t, 'monitoring.total_calls_short', 'monitoring.total_calls', 'Calls');
+    case 'tps':
+      return t('monitoring.column_output_tps');
+    case 'latency':
+      return t('monitoring.elapsed_short');
+    case 'time':
+      return t('monitoring.column_time');
+    case 'usage':
+      return shortLabel(t, 'monitoring.this_call_usage_short', 'monitoring.this_call_usage');
+    case 'cost':
+      return shortLabel(t, 'monitoring.this_call_cost_short', 'monitoring.this_call_cost');
+  }
+};
+
+type RealtimeColumnSelectorProps = {
+  visibleColumns: readonly RealtimeColumnId[];
+  t: TFunction;
+  onChange: (columns: RealtimeColumnId[]) => void;
+};
+
+function RealtimeColumnSelector({ visibleColumns, t, onChange }: RealtimeColumnSelectorProps) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<CSSProperties | null>(null);
+  const panelId = useId();
+  const normalizedVisibleColumns = normalizeRealtimeVisibleColumns(visibleColumns);
+  const visibleColumnSet = new Set(normalizedVisibleColumns);
+  const label = t('monitoring.realtime_columns');
+
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current || typeof window === 'undefined') return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const panelWidth = panelRef.current?.offsetWidth ?? 224;
+    const viewportPadding = 8;
+    const left = Math.max(
+      viewportPadding,
+      Math.min(rect.right - panelWidth, window.innerWidth - panelWidth - viewportPadding)
+    );
+    setPosition({ top: rect.bottom + 6, left });
+  }, []);
+
+  const close = useCallback((restoreFocus = false) => {
+    setOpen(false);
+    setPosition(null);
+    if (restoreFocus) triggerRef.current?.focus();
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePosition();
+  }, [open, updatePosition]);
+
+  useEffect(() => {
+    if (!open || typeof window === 'undefined') return undefined;
+
+    const handlePointer = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (triggerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      close();
+    };
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      close(true);
+    };
+    const handleViewportChange = () => updatePosition();
+
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+    };
+  }, [close, open, updatePosition]);
+
+  const panel = open ? (
+    <div
+      ref={panelRef}
+      id={panelId}
+      role="dialog"
+      aria-label={label}
+      className={styles.realtimeColumnSelectorPanel}
+      style={position ?? { visibility: 'hidden', top: 0, left: 0 }}
+    >
+      <div className={styles.realtimeColumnSelectorList}>
+        {REALTIME_COLUMN_DEFINITIONS.map((column) => (
+          <SelectionCheckbox
+            key={column.id}
+            checked={visibleColumnSet.has(column.id)}
+            disabled={!column.hideable}
+            label={
+              <span className={styles.realtimeColumnSelectorLabel}>
+                <span>{getRealtimeColumnLabel(column.id, t)}</span>
+                {!column.hideable ? <small>{t('monitoring.realtime_column_fixed')}</small> : null}
+              </span>
+            }
+            onChange={(checked) => {
+              const nextColumns = checked
+                ? [...normalizedVisibleColumns, column.id]
+                : normalizedVisibleColumns.filter((columnId) => columnId !== column.id);
+              onChange(normalizeRealtimeVisibleColumns(nextColumns));
+            }}
+          />
+        ))}
+      </div>
+      <button
+        type="button"
+        className={styles.realtimeColumnSelectorReset}
+        onClick={() => onChange([...DEFAULT_REALTIME_VISIBLE_COLUMNS])}
+      >
+        {t('common.reset')}
+      </button>
+    </div>
+  ) : null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={styles.accountOverviewToolButton}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        title={label}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <IconSlidersHorizontal size={15} aria-hidden="true" />
+        <span>{label}</span>
+      </button>
+      {panel && typeof document !== 'undefined' ? createPortal(panel, document.body) : null}
+    </>
+  );
+}
 
 const formatShortHash = (value: string | null | undefined) => {
   const trimmed = formatReadableText(value);
@@ -730,11 +914,15 @@ type RealtimeTokenUsageDetails = {
   total: string;
   input: string;
   output: string;
+  cache: string;
+  reasoning: string;
   fields: Array<{ label: string; value: string }>;
   ariaLabel: string;
 };
 
 const buildRealtimeTokenUsageDetails = (row: MonitoringEventRow, t: TFunction) => {
+  const displayCacheTokens =
+    row.cacheReadTokens > 0 ? row.cacheReadTokens : Math.max(row.cachedTokens, 0);
   const fields = [
     {
       label: t('monitoring.realtime_usage_total_label'),
@@ -750,7 +938,7 @@ const buildRealtimeTokenUsageDetails = (row: MonitoringEventRow, t: TFunction) =
     },
     {
       label: t('monitoring.realtime_usage_reasoning_label'),
-      value: String(row.reasoningTokens),
+      value: formatCompactNumber(row.reasoningTokens),
     },
     {
       label: t('monitoring.realtime_usage_cached_label'),
@@ -770,8 +958,21 @@ const buildRealtimeTokenUsageDetails = (row: MonitoringEventRow, t: TFunction) =
     total: fields[0].value,
     input: fields[1].value,
     output: fields[2].value,
+    cache: formatCompactNumber(displayCacheTokens),
+    reasoning: fields[3].value,
     fields,
-    ariaLabel: fields.map((field) => `${field.label}: ${field.value}`).join(', '),
+    ariaLabel: [
+      fields[0],
+      fields[1],
+      fields[2],
+      {
+        label: t('monitoring.realtime_usage_cached_label'),
+        value: formatCompactNumber(displayCacheTokens),
+      },
+      fields[3],
+    ]
+      .map((field) => `${field.label}: ${field.value}`)
+      .join(', '),
   } satisfies RealtimeTokenUsageDetails;
 };
 
@@ -916,16 +1117,35 @@ function RealtimeTokenUsage({ details, tooltipId }: RealtimeTokenUsageProps) {
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
     >
-      <span className={styles.realtimeUsageTotal}>{details.total}</span>
-      <span className={styles.realtimeUsageFlow}>
-        <span className={styles.realtimeUsageMetric}>
-          <span aria-hidden="true">↑</span>
-          {details.input}
+      <span className={`${styles.realtimeUsageMetric} ${styles.realtimeUsageTotal}`}>
+        <span className={styles.realtimeUsageIcon} aria-hidden="true">
+          🧮
         </span>
-        <span className={styles.realtimeUsageMetric}>
-          <span aria-hidden="true">↓</span>
-          {details.output}
+        <span>{details.total}</span>
+      </span>
+      <span className={styles.realtimeUsageMetric}>
+        <span className={styles.realtimeUsageIcon} aria-hidden="true">
+          ⬇️
         </span>
+        <span>{details.input}</span>
+      </span>
+      <span className={styles.realtimeUsageMetric}>
+        <span className={styles.realtimeUsageIcon} aria-hidden="true">
+          ⬆️
+        </span>
+        <span>{details.output}</span>
+      </span>
+      <span className={`${styles.realtimeUsageMetric} ${styles.realtimeUsageSecondary}`}>
+        <span className={styles.realtimeUsageIcon} aria-hidden="true">
+          ⚡️
+        </span>
+        <span>{details.cache}</span>
+      </span>
+      <span className={`${styles.realtimeUsageMetric} ${styles.realtimeUsageSecondary}`}>
+        <span className={styles.realtimeUsageIcon} aria-hidden="true">
+          🧠
+        </span>
+        <span>{details.reasoning}</span>
       </span>
       {!isBrowser ? tooltip : null}
       {isBrowser && open ? createPortal(tooltip, document.body) : null}
@@ -938,9 +1158,11 @@ export function RealtimeEventsPanelActions({
   scopedFailureCount,
   failedOnlyActive,
   accountDisplayMode,
+  visibleColumns = DEFAULT_REALTIME_VISIBLE_COLUMNS,
   t,
   onToggleFailedOnly,
   onAccountDisplayModeChange,
+  onVisibleColumnsChange = () => undefined,
 }: RealtimeEventsPanelActionsProps) {
   const nextAccountDisplayMode: AccountDisplayMode =
     accountDisplayMode === 'masked' ? 'full' : 'masked';
@@ -968,6 +1190,11 @@ export function RealtimeEventsPanelActions({
       <span title={t('monitoring.recent_failures')}>
         {`${recentFailuresLabel}: ${scopedFailureCount}`}
       </span>
+      <RealtimeColumnSelector
+        visibleColumns={visibleColumns}
+        t={t}
+        onChange={onVisibleColumnsChange}
+      />
       <button
         type="button"
         className={[
@@ -1027,42 +1254,18 @@ export function RealtimeEventsPanel({
   onPageChange,
   onPageSizeChange,
   onLoadMoreEvents,
+  visibleColumns = DEFAULT_REALTIME_VISIBLE_COLUMNS,
+  onVisibleColumnsChange = () => undefined,
 }: RealtimeEventsPanelProps) {
   const tooltipIdPrefix = useId();
   const showNotification = useNotificationStore((state) => state.showNotification);
-  const sourceApiKeyLabel = shortLabel(
-    t,
-    'monitoring.column_source_api_key_short',
-    'monitoring.column_source_api_key'
-  );
-  const reasoningServiceLabel = t('monitoring.reasoning_service_short');
-  const recentStatusLabel = shortLabel(
-    t,
-    'monitoring.recent_status_short',
-    'monitoring.recent_status'
-  );
-  const requestStatusLabel = shortLabel(
-    t,
-    'monitoring.request_status_short',
-    'monitoring.request_status'
-  );
-  const successRateLabel = shortLabel(
-    t,
-    'monitoring.column_success_rate_short',
-    'monitoring.column_success_rate'
-  );
-  const totalCallsLabel = shortLabel(
-    t,
-    'monitoring.total_calls_short',
-    'monitoring.total_calls',
-    'Calls'
-  );
-  const usageLabel = shortLabel(
-    t,
-    'monitoring.this_call_usage_short',
-    'monitoring.this_call_usage'
-  );
-  const costLabel = shortLabel(t, 'monitoring.this_call_cost_short', 'monitoring.this_call_cost');
+  const normalizedVisibleColumns = normalizeRealtimeVisibleColumns(visibleColumns);
+  const visibleColumnDefinitions = getRealtimeColumnDefinitions(normalizedVisibleColumns);
+  const tableWidth = getRealtimeTableWidth(normalizedVisibleColumns);
+  const flexibleColumnWidth = visibleColumnDefinitions
+    .filter((column) => column.id === 'source' || column.id === 'model')
+    .reduce((total, column) => total + column.width, 0);
+  const fixedColumnWidth = tableWidth - flexibleColumnWidth;
   const handleCopyFailureDetails = async (text: string) => {
     const copied = await copyToClipboard(text);
     showNotification(
@@ -1076,43 +1279,41 @@ export function RealtimeEventsPanel({
       scopedFailureCount={scopedFailureCount}
       failedOnlyActive={failedOnlyActive}
       accountDisplayMode={accountDisplayMode}
+      visibleColumns={normalizedVisibleColumns}
       t={t}
       onToggleFailedOnly={onToggleFailedOnly}
       onAccountDisplayModeChange={onAccountDisplayModeChange}
+      onVisibleColumnsChange={onVisibleColumnsChange}
     />
   );
   const content = (
     <>
       <div className={styles.tableWrapper}>
-        <table className={`${styles.table} ${styles.realtimeTable}`}>
+        <table
+          className={`${styles.table} ${styles.realtimeTable}`}
+          style={{ width: '100%', minWidth: tableWidth }}
+        >
           <colgroup>
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
-            <col />
+            {visibleColumnDefinitions.map((column) => (
+              <col
+                key={column.id}
+                data-column={column.id}
+                style={{
+                  width:
+                    column.id === 'source' || column.id === 'model'
+                      ? `calc((100% - ${fixedColumnWidth}px) * ${column.width / flexibleColumnWidth})`
+                      : column.width,
+                }}
+              />
+            ))}
           </colgroup>
           <thead>
             <tr>
-              <th>{sourceApiKeyLabel}</th>
-              <th>{t('monitoring.column_model')}</th>
-              <th className={styles.realtimeSettingsColumn}>{reasoningServiceLabel}</th>
-              <th className={styles.realtimeCenteredColumn}>{recentStatusLabel}</th>
-              <th className={styles.realtimeCenteredColumn}>{requestStatusLabel}</th>
-              <th className={styles.realtimeCenteredColumn}>{successRateLabel}</th>
-              <th className={styles.realtimeCenteredColumn}>{totalCallsLabel}</th>
-              <th className={styles.realtimeTpsColumn}>{t('monitoring.column_output_tps')}</th>
-              <th className={styles.realtimeLatencyColumn}>{t('monitoring.elapsed_short')}</th>
-              <th className={styles.realtimeTimeColumn}>{t('monitoring.column_time')}</th>
-              <th>{usageLabel}</th>
-              <th>{costLabel}</th>
+              {visibleColumnDefinitions.map((column) => (
+                <th key={column.id} data-column={column.id}>
+                  {getRealtimeColumnLabel(column.id, t)}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -1141,174 +1342,214 @@ export function RealtimeEventsPanel({
               const ttftToneClass = getRealtimeDurationToneClass(row.ttftMs);
               const latencyToneClass = getRealtimeDurationToneClass(row.latencyMs);
               const tokenUsage = buildRealtimeTokenUsageDetails(row, t);
-              return (
-                <tr key={row.id} className={row.failed ? styles.logRowFailed : undefined}>
-                  <td>
-                    <div className={styles.logTypeCell}>
-                      <div className={styles.primaryCell} title={sourceDisplay.title}>
-                        <span>{sourceDisplay.primary}</span>
-                        {sourceDisplay.meta ? <small>{sourceDisplay.meta}</small> : null}
-                        {sourceDisplay.requestMetadataTitle ? (
-                          <details className={styles.realtimeRequestMetadata}>
-                            <summary>{t('monitoring.request_metadata')}</summary>
-                            <small>
-                              {sourceDisplay.requestMetadataTitle.split('\n').map((line) => (
-                                <span key={line}>{line}</span>
-                              ))}
+              const renderCellContent = (columnId: RealtimeColumnId): ReactNode => {
+                switch (columnId) {
+                  case 'source':
+                    return (
+                      <div className={styles.logTypeCell}>
+                        <div className={styles.primaryCell} title={sourceDisplay.title}>
+                          <span>{sourceDisplay.primary}</span>
+                          {sourceDisplay.meta ? <small>{sourceDisplay.meta}</small> : null}
+                          {sourceDisplay.requestMetadataTitle ? (
+                            <details className={styles.realtimeRequestMetadata}>
+                              <summary>{t('monitoring.request_metadata')}</summary>
+                              <small>
+                                {sourceDisplay.requestMetadataTitle.split('\n').map((line) => (
+                                  <span key={line}>{line}</span>
+                                ))}
+                              </small>
+                            </details>
+                          ) : null}
+                          {apiKeyDisplay ? (
+                            <small
+                              className={styles.realtimeApiKeyLine}
+                              title={apiKeyDisplay.title}
+                            >
+                              {`${t('monitoring.realtime_api_key_label')}: ${apiKeyDisplay.display}`}
                             </small>
-                          </details>
-                        ) : null}
-                        {apiKeyDisplay ? (
-                          <small className={styles.realtimeApiKeyLine} title={apiKeyDisplay.title}>
-                            {`${t('monitoring.realtime_api_key_label')}: ${apiKeyDisplay.display}`}
+                          ) : null}
+                        </div>
+                      </div>
+                    );
+                  case 'model':
+                    return (
+                      <div
+                        className={`${styles.primaryCell} ${styles.realtimeModelCell}`}
+                        title={[requestedModel, showResolvedModel ? resolvedModel : '']
+                          .filter(Boolean)
+                          .join('\n')}
+                      >
+                        <span className={`${styles.monoCell} ${styles.realtimeModelText}`}>
+                          {requestedModel}
+                        </span>
+                        {showResolvedModel ? (
+                          <small className={`${styles.monoCell} ${styles.realtimeModelText}`}>
+                            {resolvedModel}
                           </small>
                         ) : null}
                       </div>
-                    </div>
-                  </td>
-                  <td>
-                    <div
-                      className={`${styles.primaryCell} ${styles.realtimeModelCell}`}
-                      title={[requestedModel, showResolvedModel ? resolvedModel : '']
-                        .filter(Boolean)
-                        .join('\n')}
+                    );
+                  case 'settings':
+                    return (
+                      <div className={styles.realtimeSettingsCell}>
+                        <span className={styles.realtimeSettingLine}>
+                          <span className={styles.realtimeSettingLabel}>
+                            {t('monitoring.realtime_reasoning_label')}
+                          </span>
+                          <span
+                            className={`${styles.realtimeSettingValue} ${styles.realtimeReasoningValue}`}
+                          >
+                            {reasoningEffort}
+                          </span>
+                        </span>
+                        <span className={styles.realtimeSettingLine}>
+                          <span className={styles.realtimeSettingLabel}>
+                            {t('monitoring.realtime_service_label')}
+                          </span>
+                          <span
+                            className={`${styles.realtimeSettingValue} ${styles.realtimeServiceValue}`}
+                          >
+                            {effectiveServiceTier}
+                          </span>
+                        </span>
+                      </div>
+                    );
+                  case 'recent-status':
+                    return (
+                      <div className={styles.recentStatusCell}>
+                        <RecentPattern pattern={row.recentPattern} variant="plain" />
+                      </div>
+                    );
+                  case 'request-status':
+                    return (
+                      <div className={styles.primaryCell}>
+                        {requestDiagnosticDetails ? (
+                          <RealtimeRequestDiagnosticStatus
+                            details={requestDiagnosticDetails}
+                            tooltipId={
+                              requestDiagnosticTooltipId ??
+                              `${tooltipIdPrefix}-request-diagnostic-tooltip`
+                            }
+                            t={t}
+                            onCopy={handleCopyFailureDetails}
+                          />
+                        ) : (
+                          <span
+                            className={[
+                              styles.realtimeRequestStatus,
+                              row.failed
+                                ? styles.realtimeRequestStatusBad
+                                : styles.realtimeRequestStatusGood,
+                            ]
+                              .filter(Boolean)
+                              .join(' ')}
+                          >
+                            {row.failed
+                              ? t('monitoring.result_failed')
+                              : t('monitoring.result_success')}
+                          </span>
+                        )}
+                      </div>
+                    );
+                  case 'success-rate':
+                    return formatPercent(row.successRate);
+                  case 'calls':
+                    return formatCompactNumber(row.requestCount);
+                  case 'tps':
+                    return (
+                      <span className={styles.realtimeTpsCell}>
+                        {formatTokensPerSecond(row.tokensPerSecond, locale)}
+                      </span>
+                    );
+                  case 'latency':
+                    return (
+                      <div className={styles.realtimeMetricCell}>
+                        <span className={styles.realtimeMetricLine}>
+                          <span className={styles.realtimeMetricLabel}>
+                            {t('monitoring.ttft_short')}
+                          </span>
+                          <span
+                            className={[styles.realtimeMetricText, ttftToneClass]
+                              .filter(Boolean)
+                              .join(' ')}
+                          >
+                            {hasTtftMs ? formatRealtimeCompactDuration(row.ttftMs, locale) : '--'}
+                          </span>
+                        </span>
+                        <span className={styles.realtimeMetricLine}>
+                          <span className={styles.realtimeMetricLabel}>
+                            {t('monitoring.elapsed_short')}
+                          </span>
+                          <span
+                            className={[styles.realtimeMetricText, latencyToneClass]
+                              .filter(Boolean)
+                              .join(' ')}
+                          >
+                            {formatRealtimeCompactDuration(row.latencyMs, locale)}
+                          </span>
+                        </span>
+                      </div>
+                    );
+                  case 'time':
+                    return (
+                      <div className={styles.realtimeTimeCell}>
+                        <span className={styles.realtimeTimeLine}>{timeParts.date}</span>
+                        <span className={styles.realtimeTimeLine}>{timeParts.time}</span>
+                      </div>
+                    );
+                  case 'usage':
+                    return (
+                      <RealtimeTokenUsage
+                        details={tokenUsage}
+                        tooltipId={`${tooltipIdPrefix}-token-usage-tooltip-${row.id}`}
+                      />
+                    );
+                  case 'cost':
+                    return hasPrices ? formatUsd(row.totalCost, 3) : '--';
+                }
+              };
+
+              const getCellClassName = (column: RealtimeColumnDefinition) => {
+                const classes = [];
+                if (column.align === 'center') {
+                  classes.push(styles.realtimeCenteredColumn);
+                }
+                const columnId = column.id;
+                if (columnId === 'settings') classes.push(styles.realtimeSettingsColumn);
+                if (columnId === 'tps') classes.push(styles.realtimeTpsColumn);
+                if (columnId === 'latency') classes.push(styles.realtimeLatencyColumn);
+                if (columnId === 'time') classes.push(styles.realtimeTimeColumn);
+                if (columnId === 'usage') classes.push(styles.realtimeUsageColumn);
+                if (columnId === 'cost') classes.push(styles.realtimeCostColumn);
+                if (columnId === 'success-rate') {
+                  classes.push(
+                    row.successRate >= 0.95
+                      ? styles.goodText
+                      : row.successRate >= 0.85
+                        ? styles.warnText
+                        : styles.badText
+                  );
+                }
+                return classes.filter(Boolean).join(' ') || undefined;
+              };
+
+              return (
+                <tr key={row.id} className={row.failed ? styles.logRowFailed : undefined}>
+                  {visibleColumnDefinitions.map((column) => (
+                    <td
+                      key={column.id}
+                      data-column={column.id}
+                      className={getCellClassName(column)}
                     >
-                      <span className={`${styles.monoCell} ${styles.realtimeModelText}`}>
-                        {requestedModel}
-                      </span>
-                      {showResolvedModel ? (
-                        <small className={`${styles.monoCell} ${styles.realtimeModelText}`}>
-                          {resolvedModel}
-                        </small>
-                      ) : null}
-                    </div>
-                  </td>
-                  <td className={styles.realtimeSettingsColumn}>
-                    <div className={styles.realtimeSettingsCell}>
-                      <span className={styles.realtimeSettingLine}>
-                        <span className={styles.realtimeSettingLabel}>
-                          {t('monitoring.realtime_reasoning_label')}
-                        </span>
-                        <span
-                          className={`${styles.realtimeSettingValue} ${styles.realtimeReasoningValue}`}
-                        >
-                          {reasoningEffort}
-                        </span>
-                      </span>
-                      <span className={styles.realtimeSettingLine}>
-                        <span className={styles.realtimeSettingLabel}>
-                          {t('monitoring.realtime_service_label')}
-                        </span>
-                        <span
-                          className={`${styles.realtimeSettingValue} ${styles.realtimeServiceValue}`}
-                        >
-                          {effectiveServiceTier}
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td className={styles.realtimeCenteredColumn}>
-                    <div className={styles.recentStatusCell}>
-                      <RecentPattern pattern={row.recentPattern} variant="plain" />
-                    </div>
-                  </td>
-                  <td className={styles.realtimeCenteredColumn}>
-                    <div className={styles.primaryCell}>
-                      {requestDiagnosticDetails ? (
-                        <RealtimeRequestDiagnosticStatus
-                          details={requestDiagnosticDetails}
-                          tooltipId={
-                            requestDiagnosticTooltipId ??
-                            `${tooltipIdPrefix}-request-diagnostic-tooltip`
-                          }
-                          t={t}
-                          onCopy={handleCopyFailureDetails}
-                        />
-                      ) : (
-                        <span
-                          className={[
-                            styles.realtimeRequestStatus,
-                            row.failed
-                              ? styles.realtimeRequestStatusBad
-                              : styles.realtimeRequestStatusGood,
-                          ]
-                            .filter(Boolean)
-                            .join(' ')}
-                        >
-                          {row.failed
-                            ? t('monitoring.result_failed')
-                            : t('monitoring.result_success')}
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td
-                    className={[
-                      styles.realtimeCenteredColumn,
-                      row.successRate >= 0.95
-                        ? styles.goodText
-                        : row.successRate >= 0.85
-                          ? styles.warnText
-                          : styles.badText,
-                    ].join(' ')}
-                  >
-                    {formatPercent(row.successRate)}
-                  </td>
-                  <td className={styles.realtimeCenteredColumn}>
-                    {formatCompactNumber(row.requestCount)}
-                  </td>
-                  <td className={styles.realtimeTpsColumn}>
-                    <span className={styles.realtimeTpsCell}>
-                      {formatTokensPerSecond(row.tokensPerSecond, locale)}
-                    </span>
-                  </td>
-                  <td className={styles.realtimeLatencyColumn}>
-                    <div className={styles.realtimeMetricCell}>
-                      <span className={styles.realtimeMetricLine}>
-                        <span className={styles.realtimeMetricLabel}>
-                          {t('monitoring.ttft_short')}
-                        </span>
-                        <span
-                          className={[styles.realtimeMetricText, ttftToneClass]
-                            .filter(Boolean)
-                            .join(' ')}
-                        >
-                          {hasTtftMs ? formatRealtimeCompactDuration(row.ttftMs, locale) : '--'}
-                        </span>
-                      </span>
-                      <span className={styles.realtimeMetricLine}>
-                        <span className={styles.realtimeMetricLabel}>
-                          {t('monitoring.elapsed_short')}
-                        </span>
-                        <span
-                          className={[styles.realtimeMetricText, latencyToneClass]
-                            .filter(Boolean)
-                            .join(' ')}
-                        >
-                          {formatRealtimeCompactDuration(row.latencyMs, locale)}
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td className={styles.realtimeTimeColumn}>
-                    <div className={styles.realtimeTimeCell}>
-                      <span className={styles.realtimeTimeLine}>{timeParts.date}</span>
-                      <span className={styles.realtimeTimeLine}>{timeParts.time}</span>
-                    </div>
-                  </td>
-                  <td>
-                    <RealtimeTokenUsage
-                      details={tokenUsage}
-                      tooltipId={`${tooltipIdPrefix}-token-usage-tooltip-${row.id}`}
-                    />
-                  </td>
-                  <td>{hasPrices ? formatUsd(row.totalCost, 3) : '--'}</td>
+                      {renderCellContent(column.id)}
+                    </td>
+                  ))}
                 </tr>
               );
             })}
             {rows.length === 0 ? (
               <tr>
-                <td colSpan={12}>{emptyState}</td>
+                <td colSpan={visibleColumnDefinitions.length}>{emptyState}</td>
               </tr>
             ) : null}
           </tbody>

--- a/apps/web/src/features/monitoring/monitoringCenterUiState.test.ts
+++ b/apps/web/src/features/monitoring/monitoringCenterUiState.test.ts
@@ -11,6 +11,11 @@ import {
   readMonitoringCenterUiState,
   writeMonitoringCenterUiState,
 } from './monitoringCenterUiState';
+import {
+  DEFAULT_REALTIME_VISIBLE_COLUMNS,
+  getRealtimeTableWidth,
+  normalizeRealtimeVisibleColumns,
+} from './realtimeColumns';
 
 type StorageLike = {
   getItem: (key: string) => string | null;
@@ -74,6 +79,26 @@ describe('monitoringCenterUiState', () => {
     expect(normalizeMonitoringAutoRefreshMs('123')).toBe('30000');
   });
 
+  it('normalizes realtime columns in canonical order and restores mandatory columns', () => {
+    expect(normalizeRealtimeVisibleColumns(undefined)).toEqual(DEFAULT_REALTIME_VISIBLE_COLUMNS);
+    expect(normalizeRealtimeVisibleColumns(['cost', 'model', 'cost', 'unknown', 'usage'])).toEqual([
+      'source',
+      'model',
+      'request-status',
+      'time',
+      'usage',
+      'cost',
+    ]);
+    expect(normalizeRealtimeVisibleColumns([])).toEqual([
+      'source',
+      'model',
+      'request-status',
+      'time',
+    ]);
+    expect(getRealtimeTableWidth(DEFAULT_REALTIME_VISIBLE_COLUMNS)).toBe(1236);
+    expect(getRealtimeTableWidth([])).toBe(0);
+  });
+
   it('normalizes ui state from arbitrary input', () => {
     expect(normalizeMonitoringCenterUiState(null)).toEqual(getDefaultMonitoringCenterUiState());
     expect(normalizeMonitoringCenterUiState({ activeDataTab: 'realtime' })).toEqual({
@@ -96,6 +121,7 @@ describe('monitoringCenterUiState', () => {
         selectedStatus: 'failed',
         apiKeyPageSize: 50,
         realtimePageSize: 150,
+        realtimeVisibleColumns: ['usage', 'source', 'cost'],
       })
     ).toEqual({
       ...getDefaultMonitoringCenterUiState(),
@@ -113,6 +139,7 @@ describe('monitoringCenterUiState', () => {
       selectedStatus: 'failed',
       apiKeyPageSize: 50,
       realtimePageSize: 150,
+      realtimeVisibleColumns: ['source', 'model', 'request-status', 'time', 'usage', 'cost'],
     });
   });
 
@@ -121,18 +148,21 @@ describe('monitoringCenterUiState', () => {
       activeDataTab: 'apiKeys',
       selectedProvider: 'claude',
       apiKeyPageSize: 20,
+      realtimeVisibleColumns: ['source', 'model', 'request-status', 'time', 'usage'],
     });
     expect(JSON.parse(storage.getItem(MONITORING_CENTER_UI_STATE_STORAGE_KEY) ?? '{}')).toEqual({
       ...getDefaultMonitoringCenterUiState(),
       activeDataTab: 'apiKeys',
       selectedProvider: 'claude',
       apiKeyPageSize: 20,
+      realtimeVisibleColumns: ['source', 'model', 'request-status', 'time', 'usage'],
     });
     expect(readMonitoringCenterUiState()).toEqual({
       ...getDefaultMonitoringCenterUiState(),
       activeDataTab: 'apiKeys',
       selectedProvider: 'claude',
       apiKeyPageSize: 20,
+      realtimeVisibleColumns: ['source', 'model', 'request-status', 'time', 'usage'],
     });
   });
 

--- a/apps/web/src/features/monitoring/monitoringCenterUiState.ts
+++ b/apps/web/src/features/monitoring/monitoringCenterUiState.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_REALTIME_VISIBLE_COLUMNS,
+  normalizeRealtimeVisibleColumns,
+  type RealtimeColumnId,
+} from '@/features/monitoring/realtimeColumns';
+
 export type MonitoringDataTab = 'accounts' | 'apiKeys' | 'realtime';
 export type MonitoringCenterTimeRange = 'today' | '7d' | '14d' | '30d' | 'all' | 'custom';
 export type MonitoringCenterStatusFilter = 'all' | 'success' | 'failed';
@@ -32,6 +38,7 @@ export type MonitoringCenterUiState = {
   selectedStatus: MonitoringCenterStatusFilter;
   apiKeyPageSize: number;
   realtimePageSize: number;
+  realtimeVisibleColumns: RealtimeColumnId[];
 };
 
 const TAB_SET = new Set<MonitoringDataTab>(MONITORING_DATA_TABS);
@@ -103,6 +110,7 @@ export const getDefaultMonitoringCenterUiState = (): MonitoringCenterUiState => 
   selectedStatus: 'all',
   apiKeyPageSize: DEFAULT_MONITORING_TABLE_PAGE_SIZE,
   realtimePageSize: DEFAULT_MONITORING_REALTIME_PAGE_SIZE,
+  realtimeVisibleColumns: [...DEFAULT_REALTIME_VISIBLE_COLUMNS],
 });
 
 export const normalizeMonitoringCenterUiState = (value: unknown): MonitoringCenterUiState => {
@@ -138,6 +146,7 @@ export const normalizeMonitoringCenterUiState = (value: unknown): MonitoringCent
       REALTIME_PAGE_SIZE_OPTIONS,
       defaults.realtimePageSize
     ),
+    realtimeVisibleColumns: normalizeRealtimeVisibleColumns(record.realtimeVisibleColumns),
   };
 };
 

--- a/apps/web/src/features/monitoring/realtimeColumns.ts
+++ b/apps/web/src/features/monitoring/realtimeColumns.ts
@@ -1,0 +1,68 @@
+export const REALTIME_COLUMN_IDS = [
+  'source',
+  'model',
+  'settings',
+  'recent-status',
+  'request-status',
+  'success-rate',
+  'calls',
+  'tps',
+  'latency',
+  'time',
+  'usage',
+  'cost',
+] as const;
+
+export type RealtimeColumnId = (typeof REALTIME_COLUMN_IDS)[number];
+
+export type RealtimeColumnDefinition = {
+  id: RealtimeColumnId;
+  width: number;
+  hideable: boolean;
+  align: 'left' | 'center';
+};
+
+export const REALTIME_COLUMN_DEFINITIONS: readonly RealtimeColumnDefinition[] = [
+  { id: 'source', width: 220, hideable: false, align: 'left' },
+  { id: 'model', width: 112, hideable: false, align: 'center' },
+  { id: 'settings', width: 98, hideable: true, align: 'center' },
+  { id: 'recent-status', width: 78, hideable: true, align: 'center' },
+  { id: 'request-status', width: 86, hideable: false, align: 'center' },
+  { id: 'success-rate', width: 82, hideable: true, align: 'center' },
+  { id: 'calls', width: 58, hideable: true, align: 'center' },
+  { id: 'tps', width: 64, hideable: true, align: 'center' },
+  { id: 'latency', width: 112, hideable: true, align: 'center' },
+  { id: 'time', width: 114, hideable: false, align: 'center' },
+  { id: 'usage', width: 144, hideable: true, align: 'center' },
+  { id: 'cost', width: 68, hideable: true, align: 'center' },
+] as const;
+
+export const DEFAULT_REALTIME_VISIBLE_COLUMNS: readonly RealtimeColumnId[] = REALTIME_COLUMN_IDS;
+
+const REALTIME_COLUMN_ID_SET = new Set<RealtimeColumnId>(REALTIME_COLUMN_IDS);
+const MANDATORY_REALTIME_COLUMN_ID_SET = new Set<RealtimeColumnId>(
+  REALTIME_COLUMN_DEFINITIONS.filter((column) => !column.hideable).map((column) => column.id)
+);
+
+export const normalizeRealtimeVisibleColumns = (value: unknown): RealtimeColumnId[] => {
+  if (!Array.isArray(value)) return [...DEFAULT_REALTIME_VISIBLE_COLUMNS];
+
+  const requested = new Set<RealtimeColumnId>(
+    value.filter(
+      (columnId): columnId is RealtimeColumnId =>
+        typeof columnId === 'string' && REALTIME_COLUMN_ID_SET.has(columnId as RealtimeColumnId)
+    )
+  );
+
+  return REALTIME_COLUMN_IDS.filter(
+    (columnId) => requested.has(columnId) || MANDATORY_REALTIME_COLUMN_ID_SET.has(columnId)
+  );
+};
+
+export const getRealtimeColumnDefinitions = (visibleColumns: readonly RealtimeColumnId[]) => {
+  const visible = new Set(visibleColumns);
+  return REALTIME_COLUMN_DEFINITIONS.filter((column) => visible.has(column.id));
+};
+
+export const getRealtimeTableWidth = (visibleColumns: readonly RealtimeColumnId[]) =>
+  getRealtimeColumnDefinitions(visibleColumns).reduce((total, column) => total + column.width, 0);

--- a/apps/web/src/features/monitoring/styles/_monitoring-summary-table.scss
+++ b/apps/web/src/features/monitoring/styles/_monitoring-summary-table.scss
@@ -709,72 +709,11 @@
   }
 
   .realtimeTable {
-    --realtime-col-source: 21%;
-    --realtime-col-model: 12%;
-    --realtime-col-effort: 7%;
-    --realtime-col-recent: 6%;
-    --realtime-col-status: 7%;
-    --realtime-col-success-rate: 7%;
-    --realtime-col-total-calls: 5%;
-    --realtime-col-tps: 5%;
-    --realtime-col-latency: 10%;
-    --realtime-col-time: 8%;
-    --realtime-col-usage: 7%;
-    --realtime-col-cost: 5%;
-
-    min-width: 1260px;
+    min-width: 0;
     border-collapse: separate;
     border-spacing: 0 8px;
     background: transparent;
     table-layout: fixed;
-  }
-
-  .realtimeTable col:nth-child(1) {
-    width: var(--realtime-col-source);
-  }
-
-  .realtimeTable col:nth-child(2) {
-    width: var(--realtime-col-model);
-  }
-
-  .realtimeTable col:nth-child(3) {
-    width: var(--realtime-col-effort);
-  }
-
-  .realtimeTable col:nth-child(4) {
-    width: var(--realtime-col-recent);
-  }
-
-  .realtimeTable col:nth-child(5) {
-    width: var(--realtime-col-status);
-  }
-
-  .realtimeTable col:nth-child(6) {
-    width: var(--realtime-col-success-rate);
-  }
-
-  .realtimeTable col:nth-child(7) {
-    width: var(--realtime-col-total-calls);
-  }
-
-  .realtimeTable col:nth-child(8) {
-    width: var(--realtime-col-tps);
-  }
-
-  .realtimeTable col:nth-child(9) {
-    width: var(--realtime-col-latency);
-  }
-
-  .realtimeTable col:nth-child(10) {
-    width: var(--realtime-col-time);
-  }
-
-  .realtimeTable col:nth-child(11) {
-    width: var(--realtime-col-usage);
-  }
-
-  .realtimeTable col:nth-child(12) {
-    width: var(--realtime-col-cost);
   }
 
   .table thead th {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2435,6 +2435,8 @@
     "realtime_usage_cached_label": "Cached",
     "realtime_usage_cache_read_label": "Cache Read",
     "realtime_usage_cache_creation_label": "Cache Creation",
+    "realtime_columns": "Columns",
+    "realtime_column_fixed": "Fixed",
     "reasoning_effort": "Reasoning Effort",
     "reasoning_effort_short": "Effort",
     "reasoning_service_short": "Reasoning / Tier",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -2436,6 +2436,8 @@
     "realtime_usage_cached_label": "Кэш",
     "realtime_usage_cache_read_label": "Чтение кэша",
     "realtime_usage_cache_creation_label": "Создание кэша",
+    "realtime_columns": "Столбцы",
+    "realtime_column_fixed": "Закреплено",
     "reasoning_effort": "Уровень рассуждения",
     "reasoning_effort_short": "Уровень",
     "reasoning_service_short": "Мышление / сервис",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -2433,6 +2433,8 @@
     "realtime_usage_cached_label": "缓存",
     "realtime_usage_cache_read_label": "缓存读取",
     "realtime_usage_cache_creation_label": "缓存创建",
+    "realtime_columns": "列",
+    "realtime_column_fixed": "固定",
     "reasoning_effort": "思考强度",
     "reasoning_effort_short": "强度",
     "reasoning_service_short": "推理/服务",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -2433,6 +2433,8 @@
     "realtime_usage_cached_label": "快取",
     "realtime_usage_cache_read_label": "快取讀取",
     "realtime_usage_cache_creation_label": "快取建立",
+    "realtime_columns": "欄位",
+    "realtime_column_fixed": "固定",
     "reasoning_effort": "思考強度",
     "reasoning_effort_short": "強度",
     "reasoning_service_short": "推理/服務",


### PR DESCRIPTION
## Summary

Improve the realtime monitoring table so it stays compact when columns are hidden and uses available space on wider screens. Also make token usage easier to scan.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add persistent column visibility controls with fixed required columns and a reset action.
- Let API Key and Model use remaining table width while visible columns determine the minimum width.
- Show token usage in a centered three-line layout with consistent input, output, cache, total, and reasoning metrics.
- Refine column width, font sizes, weights, alignment, and long-text wrapping across table headers and cells.

## User Impact

Users can hide less useful realtime columns, keep a compact view, and scan token usage more easily.

## Compatibility / Runtime Notes

- CPA panel mode: Frontend-only behavior change; no API changes.
- Manager Server mode: Frontend-only behavior change; no API changes.
- Full Docker / native packages: Included when the updated panel is packaged.

## Data / Security Notes

N/A.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this commit to restore the previous fixed realtime table.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test — 2496 tests passed
npm run build — single-file build passed
```

## Screenshots / Recordings

<img width="2244" height="1430" alt="image" src="https://github.com/user-attachments/assets/d7842f11-d61b-4a5c-ab17-d3419a858a4b" />

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: The change is self-contained in the realtime table UI and localized labels.

## Related

N/A.
