### PR TITLE
fix(manager-server): keep response headers out of fail body

### DIFF
--- a/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
@@ -3,6 +3,7 @@ package usagemonitoring_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -558,6 +559,58 @@ func TestUsageMonitoringSearchIndexTracksProjectionInsertUpdateAndDelete(t *test
 	if got := countSearchEvents("updated-marker"); got != 0 {
 		t.Fatalf("deleted search count = %d, want 0", got)
 	}
+}
+
+func TestSuccessfulResponseHeadersDoNotEnterFailureSearchStorage(t *testing.T) {
+	sqlDB, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	marker := strings.Repeat("unindexed-success-header-marker-", 128)
+	payload, err := json.Marshal(map[string]any{
+		"timestamp": "2026-04-25T00:00:00Z",
+		"failed":    false,
+		"provider":  "openai",
+		"model":     "gpt-5.4",
+		"endpoint":  "POST /v1/chat/completions",
+		"tokens":    map[string]any{"input_tokens": 1, "total_tokens": 1},
+		"response_headers": map[string]any{
+			"Content-Type":                 []any{"application/json"},
+			"X-CPAMP-Unindexed-Diagnostic": []any{marker},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal successful event: %v", err)
+	}
+	event, err := usage.NormalizeRaw(payload)
+	if err != nil {
+		t.Fatalf("normalize successful event: %v", err)
+	}
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert successful event: %v", err)
+	}
+
+	var eventID int64
+	var failBody, failSummary, metadataJSON, rawJSON string
+	if err := sqlDB.QueryRowContext(ctx, `select id, coalesce(fail_body, ''), coalesce(fail_summary, ''),
+		coalesce(response_metadata_json, ''), coalesce(raw_json, '')
+		from usage_events where event_hash = ?`, event.EventHash).Scan(&eventID, &failBody, &failSummary, &metadataJSON, &rawJSON); err != nil {
+		t.Fatalf("read persisted successful event: %v", err)
+	}
+	if failBody != "" || failSummary != "" {
+		t.Fatalf("persisted failure fields = body:%q summary:%q", failBody, failSummary)
+	}
+	if !strings.Contains(metadataJSON, "application/json") || !strings.Contains(rawJSON, marker) {
+		t.Fatalf("persisted metadata/raw json missing: metadata=%q rawHasMarker=%v", metadataJSON, strings.Contains(rawJSON, marker))
+	}
+
+	catchUpMonitoringRepository(t, ctx, db)
+	var searchText string
+	if err := sqlDB.QueryRowContext(ctx, `select search_text from usage_monitoring_event_projection_v1 where event_id = ?`, eventID).Scan(&searchText); err != nil {
+		t.Fatalf("read successful event projection: %v", err)
+	}
+	if strings.Contains(searchText, marker) {
+		t.Fatalf("projection search text contains response header marker")
+	}
+	assertSearchIndexCount(t, ctx, sqlDB, marker, 0)
 }
 
 func TestMigrationBackfillsSearchIndexForExistingProjection(t *testing.T) {

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -810,25 +810,7 @@ func readFailFields(record map[string]any) (int64, string) {
 	if body == "" {
 		body = readString(record, "fail_body", "failBody")
 	}
-	if headers, ok := compactJSON(first(record, "response_headers", "responseHeaders", "headers")); ok && headers != "{}" && headers != "[]" {
-		if body == "" {
-			body = headers
-		} else {
-			body = body + "\n" + headers
-		}
-	}
 	return statusCode, body
-}
-
-func compactJSON(value any) (string, bool) {
-	if value == nil {
-		return "", false
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return "", false
-	}
-	return string(data), true
 }
 
 func readOptionalInt(record map[string]any, keys ...string) *int64 {

--- a/apps/manager-server/internal/usage/import_test.go
+++ b/apps/manager-server/internal/usage/import_test.go
@@ -583,11 +583,16 @@ func TestNormalizeRawReadsCPA7118UsageFields(t *testing.T) {
 	}
 	if !event.Failed || event.FailStatusCode != 429 ||
 		!strings.Contains(event.FailBody, "rate limit exceeded") ||
-		!strings.Contains(event.FailBody, "Retry-After") {
+		strings.Contains(event.FailBody, "Retry-After") {
 		t.Fatalf("event failure = %#v", event)
 	}
-	if !strings.Contains(event.FailSummary, "rate limit exceeded") || !strings.Contains(event.FailSummary, "Retry-After") {
+	if !strings.Contains(event.FailSummary, "rate limit exceeded") || strings.Contains(event.FailSummary, "Retry-After") {
 		t.Fatalf("fail summary = %q", event.FailSummary)
+	}
+	if event.ResponseMetadata == nil || event.ResponseMetadata.Errors == nil ||
+		event.ResponseMetadata.Errors.RetryAfterSeconds == nil ||
+		*event.ResponseMetadata.Errors.RetryAfterSeconds != 30 {
+		t.Fatalf("response metadata = %#v", event.ResponseMetadata)
 	}
 	if event.LatencyMS == nil || *event.LatencyMS != 1500 {
 		t.Fatalf("latency = %#v", event.LatencyMS)
@@ -611,9 +616,48 @@ func TestNormalizeRawReadsCPA7118UsageFields(t *testing.T) {
 		detail.Tokens.CacheCreationTokens != 1 || detail.FailStatusCode != 429 ||
 		detail.Tokens.CachedTokens != 0 || detail.Tokens.CacheTokens != 0 ||
 		!strings.Contains(detail.FailSummary, "rate limit exceeded") ||
-		!strings.Contains(detail.FailSummary, "Retry-After") || detail.TTFTMS == nil ||
+		strings.Contains(detail.FailSummary, "Retry-After") || detail.ResponseMetadata == nil ||
+		detail.ResponseMetadata.Errors == nil || detail.TTFTMS == nil ||
 		*detail.TTFTMS != 450 {
 		t.Fatalf("detail = %#v", detail)
+	}
+}
+
+func TestNormalizeRawKeepsSuccessfulResponseHeadersOutOfFailureFields(t *testing.T) {
+	marker := strings.Repeat("large-success-header-marker-", 256)
+	payload, err := json.Marshal(map[string]any{
+		"timestamp": "2026-04-25T00:00:00Z",
+		"source":    "user@example.com",
+		"tokens": map[string]any{
+			"input_tokens": 1,
+			"total_tokens": 1,
+		},
+		"failed":   false,
+		"provider": "openai",
+		"model":    "gpt-5.4",
+		"endpoint": "POST /v1/chat/completions",
+		"response_headers": map[string]any{
+			"Content-Type":                 []any{"application/json"},
+			"X-CPAMP-Unindexed-Diagnostic": []any{marker},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	event, err := NormalizeRaw(payload)
+	if err != nil {
+		t.Fatalf("normalize successful response: %v", err)
+	}
+	if event.Failed || event.FailBody != "" || event.FailSummary != "" {
+		t.Fatalf("successful failure fields = failed:%v body:%q summary:%q", event.Failed, event.FailBody, event.FailSummary)
+	}
+	if event.ResponseMetadata == nil || event.ResponseMetadata.Response == nil ||
+		event.ResponseMetadata.Response.ContentType != "application/json" || event.ResponseMetadataJSON == "" {
+		t.Fatalf("response metadata = %#v json=%q", event.ResponseMetadata, event.ResponseMetadataJSON)
+	}
+	if !strings.Contains(event.RawJSON, marker) {
+		t.Fatalf("raw json did not preserve response headers")
 	}
 }
 

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -139,6 +139,50 @@ func TestAccountActionCandidateFromEventUsesHeaderErrorCode(t *testing.T) {
 	}
 }
 
+func TestAccountActionCandidateUsesNormalizedHeaderMetadataWithoutFailBodyHeaders(t *testing.T) {
+	payload := `{
+		"timestamp": "2026-04-25T00:00:00Z",
+		"failed": true,
+		"fail": {"status_code": 401, "body": "upstream rejected request"},
+		"provider": "codex",
+		"model": "gpt-5.4",
+		"endpoint": "POST /v1/chat/completions",
+		"auth_file_snapshot": "codex-auth.json",
+		"auth_index": "auth-1",
+		"account_snapshot": "user@example.com",
+		"response_headers": {
+			"X-OpenAI-IDE-Error-Code": ["token_invalidated"]
+		}
+	}`
+	event, err := usage.NormalizeRaw([]byte(payload))
+	if err != nil {
+		t.Fatalf("normalize header-only account action event: %v", err)
+	}
+	if event.FailBody != "upstream rejected request" || strings.Contains(event.FailBody, "token_invalidated") {
+		t.Fatalf("fail body = %q", event.FailBody)
+	}
+	if event.HeaderErrorKind != "auth" || event.HeaderErrorCode != "token_invalidated" {
+		t.Fatalf("header error = kind:%q code:%q metadata:%#v", event.HeaderErrorKind, event.HeaderErrorCode, event.ResponseMetadata)
+	}
+
+	// Ensure classification is supplied by structured metadata, not raw JSON.
+	event.RawJSON = ""
+	candidate, ok := accountActionCandidateFromEvent(event, time.Now())
+	if !ok {
+		t.Fatal("candidate not detected from structured response metadata")
+	}
+	if candidate.ActionType != model.AccountActionTypeReauth || candidate.ReasonCode != credentialpolicy.ReasonTokenRevoked {
+		t.Fatalf("candidate = %#v", candidate)
+	}
+	var evidence map[string]any
+	if err := json.Unmarshal([]byte(candidate.EvidenceJSON), &evidence); err != nil {
+		t.Fatalf("decode evidence: %v", err)
+	}
+	if evidence["errorCode"] != "token_invalidated" {
+		t.Fatalf("evidence = %#v", evidence)
+	}
+}
+
 func TestAccountActionCandidateFromEventClassifiesXAIAuthenticationFailures(t *testing.T) {
 	shouldNotRetry := false
 	tests := []struct {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -941,6 +941,48 @@ func TestQuotaAutoDisableCandidateUsesResponseHeaderReset(t *testing.T) {
 	}
 }
 
+func TestQuotaAutoDisableCandidateUsesNormalizedHeaderMetadataWithoutFailBodyHeaders(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	payload := fmt.Sprintf(`{
+		"timestamp": %q,
+		"failed": true,
+		"fail": {"status_code": 429, "body": "rate limit exceeded"},
+		"provider": "codex",
+		"model": "gpt-5.4",
+		"endpoint": "POST /v1/chat/completions",
+		"auth_file_snapshot": "codex-auth.json",
+		"auth_index": "auth-1",
+		"account_snapshot": "user@example.com",
+		"response_headers": {
+			"x-codex-rate-limit-reached-type": ["primary"],
+			"x-codex-primary-used-percent": ["100"],
+			"x-codex-primary-reset-after-seconds": ["300"],
+			"x-codex-primary-window-minutes": ["300"]
+		}
+	}`, now.UTC().Format(time.RFC3339Nano))
+	event, err := usage.NormalizeRaw([]byte(payload))
+	if err != nil {
+		t.Fatalf("normalize header-only quota event: %v", err)
+	}
+	if event.FailBody != "rate limit exceeded" || strings.Contains(event.FailBody, "x-codex") {
+		t.Fatalf("fail body = %q", event.FailBody)
+	}
+	if event.ResponseMetadata == nil || event.ResponseMetadata.Quota == nil {
+		t.Fatalf("response metadata = %#v", event.ResponseMetadata)
+	}
+
+	// Isolate the structured path: historical raw/failure fallbacks are covered
+	// separately and must not be required for newly normalized events.
+	event.RawJSON = ""
+	candidate, ok := quotaAutoDisableCandidateFromEvent(event, "http://cpa", "key", now)
+	if !ok {
+		t.Fatal("candidate not detected from structured response metadata")
+	}
+	if got := candidate.ResetAt.Unix(); got != now.Add(5*time.Minute).Unix() {
+		t.Fatalf("reset unix = %d", got)
+	}
+}
+
 func TestQuotaAutoDisableCandidateUsesReachedWindowResetWithoutReachedType(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	event := usage.Event{


### PR DESCRIPTION
## Summary

Stop new CPA usage events from copying `response_headers` into `fail_body` and the derived failure/search storage path. Header diagnostics remain available through the existing structured response-metadata fields, while historical fallback parsing remains unchanged.

This is intentionally separate from the archive/retention/compaction work in #579.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Keep `readFailFields` limited to actual nested `fail.body` and top-level `fail_body` values instead of appending response headers.
- Add normalization and persistence regressions proving large successful-response headers do not enter `fail_body`, `fail_summary`, projection `search_text`, or trigram FTS.
- Verify quota cooldown and account-action classification continue to use structured `ResponseMetadata` without requiring headers in `FailBody` or `RawJSON`.
- Preserve the existing `FailBody`, `RawJSON`, and `FailSummary` fallbacks for historical SQLite/JSONL events.

## User Impact

New request-monitoring events no longer duplicate entire response-header maps across failure and search storage. Successful events have empty failure fields, while failed events still retain their actual error body and supported header diagnostics remain available through structured metadata.

Existing database rows are not rewritten and the SQLite file is not compacted by this change.

## Compatibility / Runtime Notes

- CPA panel mode: No behavior change; the fix is in Manager Server usage normalization.
- Manager Server mode: New events stop appending response headers to failure text. Structured header metadata and legacy fallback readers remain intact.
- Full Docker / native packages: No configuration or deployment change.

## Data / Security Notes

- No schema migration, historical update, FTS rebuild, retention change, deletion, or compaction is included.
- `usage_events.raw_json` remains the authoritative local record and is unchanged.
- `fail_body` remains a local sensitive field; this change reduces unnecessary duplication into `fail_summary`, projection search text, and FTS.
- Production diagnostics in #618 contain only aggregate sizes and header names, not header values, tokens, keys, or account details.

## Risk / Rollback

Risk level: Low

The main compatibility risk is behavior that historically parsed concatenated header JSON from `FailBody` (#151). Current workers already prefer structured response metadata; regression tests exercise normalized events through both quota cooldown and account-action classification. Historical fallback readers are not removed.

Rollback notes: Revert this commit. There is no migration or persisted state transition to undo.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run manager-server:test
  PASS: all Manager Server packages

go test ./internal/usage ./internal/worker ./internal/repository/usagemonitoring
  PASS

go test -race ./internal/usage -run 'TestNormalizeRawReadsCPA7118UsageFields|TestNormalizeRawKeepsSuccessfulResponseHeadersOutOfFailureFields|TestNormalizeRawSanitizesFailBodyForSummaryAndRawJSON'
  PASS

go test -race ./internal/repository/usagemonitoring -run TestSuccessfulResponseHeadersDoNotEnterFailureSearchStorage
  PASS

go test -race ./internal/worker -run 'TestQuotaAutoDisableCandidateUsesNormalizedHeaderMetadataWithoutFailBodyHeaders|TestAccountActionCandidateUsesNormalizedHeaderMetadataWithoutFailBodyHeaders' -count=3
  PASS

go test -race ./...
  No race detector findings in the affected paths. The full run is blocked by
  the existing timing-sensitive TestUsagePricingRollupWorkerContinuesPendingBacklog;
  unchanged origin/dev reproduces the same 4/5 progress timeout in three
  consecutive isolated race runs.
```

## Screenshots / Recordings

N/A — backend-only normalization and persistence change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This fixes internal event normalization and storage duplication without adding configuration, UI, API, or deployment behavior.

## Related

Fixes #618

Refs #151, #482, #579
