### PR TITLE
chore(release): prepare v1.12.5

### DIFF
--- a/docs/release-notes/v1.12.5-en.md
+++ b/docs/release-notes/v1.12.5-en.md
@@ -1,0 +1,34 @@
+# CPA Manager Plus v1.12.5
+
+> 37 commits · 81 files changed · +5435 / -1020
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.5/docs/release-notes/v1.12.5-zh.md)
+
+## Overview
+
+v1.12.5 focuses on Codex account identity continuity, OAuth re-login synchronization, and Request Monitoring refresh consistency. Manager Server now uses only explicit Codex account-ID evidence as stable account identity, keeps historical usage_events immutable, and rebuilds derived data from raw events; Accounts re-login no longer loses its result during a parent refresh or delayed credential visibility; and Monitoring preserves current metadata and coverage during credential changes. This release also stops response headers from being recorded as failure bodies.
+
+## Highlights
+
+### Fixes
+
+- Codex account history now uses explicit account-ID snapshots as stable identity instead of generic project IDs or display fields; history remains continuous after re-login, while events without explicit IDs retain the exact file/auth-index compatibility fallback. (`Codex identity / usage history`)
+- Accounts Codex OAuth re-login keeps the original session across parent refresh and callback synchronization and applies bounded credential-visibility retries. (`Accounts / OAuth`)
+- Request Monitoring separates requested and covered credential-mutation revisions and fences metadata commits by connection scope and request generation; a newer change during refresh triggers a follow-up refresh instead of leaving stale state. (`Monitoring`)
+- Re-login reconciliation fails closed for changed, ambiguous, or unconfirmed account identities; unrelated credential timestamp or status changes cannot confirm a generic OAuth marker without a target identity. (`Accounts / security`)
+- Usage event normalization no longer appends response headers to `fail_body` when the failure body is empty. (`Manager Server / usage`)
+
+## Upgrade Notes
+
+- Existing Manager Server databases automatically add `auth_account_id_snapshot` and rebuild affected account-history and Monitoring projections from immutable `usage_events`; raw events are not rewritten or backfilled.
+- Stable Codex identity requires explicit `account_id` or `chatgpt_account_id` evidence. Historical events without an explicit ID retain the exact file/auth-index compatibility logic, and `auth_project_id_snapshot` remains project-only.
+- No manual configuration change is required. Raw-event reads remain available while derived data rebuilds catch up, after which the complete derived read path resumes.
+- Monitoring integrations should continue using opaque `row.id` for state and `row.account` for display; do not merge Codex accounts using project IDs or display values alone.
+
+## Acknowledgements
+
+- [@TheOneAdonis](https://github.com/TheOneAdonis) - Fixed failure event parsing so response headers are not treated as the failure body, keeping usage failure details accurate.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.4...v1.12.5

--- a/docs/release-notes/v1.12.5-zh.md
+++ b/docs/release-notes/v1.12.5-zh.md
@@ -1,0 +1,34 @@
+# CPA Manager Plus v1.12.5
+
+> 37 commits · 81 files changed · +5435 / -1020
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.5/docs/release-notes/v1.12.5-en.md)
+
+## Overview
+
+v1.12.5 聚焦 Codex 账号身份连续性、OAuth 重新登录同步和 Request Monitoring 刷新一致性。Manager Server 现在只使用明确的 Codex account_id 证据作为稳定账号身份，历史 usage_events 保持不可变并从原始事件重建派生数据；Accounts 的重新登录不会因父级刷新或凭证可见性延迟而丢失结果；Monitoring 在凭证变更期间会保留最新元数据与覆盖进度。本版本还修正了失败事件把响应头误记为失败正文的问题。
+
+## Highlights
+
+### Fixes
+
+- Codex 账号历史现在将明确的 account_id 快照作为稳定身份，不再把通用 project_id 或显示字段当作身份；重新登录后历史保持连续，未带明确 ID 的历史事件继续使用精确的文件名/auth_index 兼容回退。 (`Codex identity / usage history`)
+- Accounts 中的 Codex OAuth 重新登录会在父级刷新和回调同步期间保持原会话，并对凭证可见性执行有界重试。 (`Accounts / OAuth`)
+- Request Monitoring 区分凭证变更的 requested 与 covered revision，并按连接作用域和请求代次保护元数据提交；刷新期间出现的新变更会触发后续刷新，避免显示过期状态。 (`Monitoring`)
+- 重新登录校验在账号变更、身份歧义或无法确认时安全失败；无关凭证的时间戳或状态变化不能再确认缺少目标身份的通用 OAuth 标记。 (`Accounts / security`)
+- Usage event 规范化不再在失败正文为空时把响应头追加到 `fail_body`。 (`Manager Server / usage`)
+
+## Upgrade Notes
+
+- 现有 Manager Server 数据库会自动增加 `auth_account_id_snapshot` 字段，并从不可变的 `usage_events` 重建受影响的账号历史与 Monitoring 派生投影；原始事件不会被改写或回填。
+- 稳定的 Codex 身份必须来自明确的 `account_id` 或 `chatgpt_account_id` 证据；历史事件没有明确 ID 时继续使用精确的文件名/auth_index 兼容逻辑，`auth_project_id_snapshot` 仍仅表示项目。
+- 无需手动修改配置。派生数据重建期间保留原始事件读取回退，投影追平后再恢复完整的派生读取路径。
+- 集成 Monitoring 的客户端应继续使用不透明的 `row.id` 保存状态、使用 `row.account` 展示账号，不要仅按 project ID 或显示值合并 Codex 账号。
+
+## Acknowledgements
+
+- [@TheOneAdonis](https://github.com/TheOneAdonis) - 修复失败事件误将响应头作为失败正文的问题，提升 usage 失败详情的准确性。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.4...v1.12.5

--- a/docs/release-posts/v1.12.5-telegram.html
+++ b/docs/release-posts/v1.12.5-telegram.html
@@ -1,0 +1,18 @@
+🚀 <b>8 月 26 日 · v1.12.5</b>
+
+✨ <b>更新内容</b>
+
+• Codex 重新登录在 Accounts 刷新和回调同步期间保持原会话，凭证延迟可见时会自动完成有限重试。
+• Codex 账号历史只使用明确的 account_id 识别身份，重新登录后历史连续且不会误用 project_id。
+• Request Monitoring 会区分凭证变更的请求进度与实际覆盖进度，刷新期间出现的新变更会继续触发后续刷新。
+• OAuth 结果与凭证标记在账号变更、身份歧义或无法确认时会进入需关注状态，避免把无关凭证更新当成成功。
+• Usage 失败详情不再把响应头误记为失败正文。
+
+⚠️ <b>注意事项</b>
+
+• 升级时 Manager Server 会自动增加账号身份快照字段并重建受影响的 Monitoring 与账号历史派生数据；<code>usage_events</code> 不会被改写或回填。
+• 集成 Monitoring 账号数据时，请使用不透明的 <code>row.id</code> 保存状态、使用 <code>row.account</code> 展示账号，不要仅按 project_id 或显示账号合并 Codex 账号。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/TheOneAdonis">@TheOneAdonis</a> - 修复失败事件把响应头误记为失败正文，提升 usage 失败详情的准确性。


### PR DESCRIPTION
## Summary

Prepare the v1.12.5 bilingual release notes and the reviewed Telegram release post for the protected release flow.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English formal release notes for v1.12.5.
- Add the reviewed Telegram HTML release post for v1.12.5.
- Document Codex identity continuity, OAuth re-login synchronization, Request Monitoring refresh fencing, and failure-body parsing fixes.

## User Impact

The release documentation describes more reliable Codex re-login continuity, provider-safe account history, lossless Request Monitoring refreshes, and accurate usage failure details. The Telegram post is consumed by the protected release workflow after publication.

## Compatibility / Runtime Notes

- CPA panel mode: No panel-specific runtime change is introduced by this release-notes PR.
- Manager Server mode: The release notes document the v1.12.5 database identity snapshot and derived-data rebuild behavior.
- Full Docker / native packages: The release notes and Telegram post are included in the protected release artifact and publication flow.

## Data / Security Notes

The release notes document that `usage_events` remain immutable, historical events are not backfilled, and stable Codex identity requires explicit account-ID evidence. No runtime data is changed by this PR.

## Risk / Rollback

Risk level: Low

Rollback notes: Before promotion, close this release PR and remove the release branch if needed. After promotion or tagging, follow the protected release recovery procedure; do not retarget a published tag.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
npm run --silent release:validate -- --tag v1.12.5 --content-only
git diff --check
Release content validator passed: reciprocal tag-pinned language links, valid Telegram HTML, and 659 Telegram characters.
Release files are limited to the two bilingual notes and one Telegram post for v1.12.5.
```

## Screenshots / Recordings

N/A — release-notes-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

This PR supplies the required v1.12.5 release notes and the reviewed Telegram release post.

## Related

N/A
