### PR TITLE
fix(manager-server): restore safe Codex credential history

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -1,0 +1,197 @@
+package usageevent
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
+)
+
+// SQLQueryer is the read-only subset shared by *sql.DB and *sql.Tx. Keeping
+// the identity check on this narrow interface lets account-history and
+// account-window readers evaluate the same evidence inside their own snapshot
+// transaction.
+type SQLQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+type legacyAccountIdentityPredicate struct {
+	sql  string
+	args []any
+}
+
+// ResolveCodexLegacyAccountKey returns the file/index account key only when
+// every matching usage event remains attributable to the requested Codex
+// account. A false result is intentionally non-error: callers must fail
+// closed and continue with the stable key only.
+func ResolveCodexLegacyAccountKey(
+	ctx context.Context,
+	queryer SQLQueryer,
+	fields usageidentity.Fields,
+) (string, bool, error) {
+	legacyKey, targetAccountID, authFile, authIndex, valid := codexLegacyTarget(fields)
+	if !valid {
+		return "", false, nil
+	}
+
+	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
+		rows, err := queryer.QueryContext(ctx, `select
+			coalesce(e.provider, ''),
+			coalesce(e.auth_provider_snapshot, ''),
+			coalesce(e.auth_account_id_snapshot, ''),
+			coalesce(e.auth_project_id_snapshot, '')
+		from usage_events e
+		where `+predicate.sql, predicate.args...)
+		if err != nil {
+			return "", false, err
+		}
+		allowed, err := scanLegacyAccountIdentity(rows, targetAccountID)
+		if err != nil {
+			return "", false, err
+		}
+		if !allowed {
+			return "", false, nil
+		}
+	}
+	return legacyKey, true, nil
+}
+
+// ResolveCodexLegacyAccountKey evaluates the same check through a short
+// read-only transaction for service-layer account-history requests.
+func (r *repository) ResolveCodexLegacyAccountKey(
+	ctx context.Context,
+	fields usageidentity.Fields,
+) (string, bool, error) {
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	key, allowed, err := ResolveCodexLegacyAccountKey(ctx, tx, fields)
+	if err != nil {
+		return "", false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return "", false, err
+	}
+	return key, allowed, nil
+}
+
+func codexLegacyTarget(fields usageidentity.Fields) (string, string, string, string, bool) {
+	provider := normalizeIdentityProvider(fields.AuthProviderSnapshot)
+	targetAccountID := strings.TrimSpace(fields.AuthAccountIDSnapshot)
+	if provider != "codex" || targetAccountID == "" {
+		return "", "", "", "", false
+	}
+
+	authFile := strings.TrimSpace(fields.AuthFileSnapshot)
+	if authFile == "" {
+		source := strings.TrimSpace(fields.Source)
+		account := strings.TrimSpace(fields.AccountSnapshot)
+		label := strings.TrimSpace(fields.AuthLabelSnapshot)
+		if source != "" && !strings.EqualFold(source, account) && !strings.EqualFold(source, label) {
+			authFile = source
+		}
+	}
+	authIndex := strings.TrimSpace(fields.AuthIndex)
+	if authFile == "" || authIndex == "" {
+		return "", "", "", "", false
+	}
+	legacyKey, valid := usageidentity.LegacyAccountKey(fields)
+	if !valid {
+		return "", "", "", "", false
+	}
+	return legacyKey, targetAccountID, authFile, authIndex, true
+}
+
+func legacyAccountIdentityPredicates(authFile, authIndex string) []legacyAccountIdentityPredicate {
+	predicates := make([]legacyAccountIdentityPredicate, 0, 6)
+	appendIndexPredicates := func(base string, baseArgs []any) {
+		if authIndex != "" {
+			predicates = append(predicates, legacyAccountIdentityPredicate{
+				sql:  base + ` and e.auth_index collate nocase = ?`,
+				args: append(append([]any{}, baseArgs...), authIndex),
+			})
+			return
+		}
+		predicates = append(predicates,
+			legacyAccountIdentityPredicate{
+				sql:  base + ` and e.auth_index is null`,
+				args: append([]any{}, baseArgs...),
+			},
+			legacyAccountIdentityPredicate{
+				sql:  base + ` and e.auth_index collate nocase = ''`,
+				args: append([]any{}, baseArgs...),
+			},
+		)
+	}
+
+	appendIndexPredicates(`e.auth_file_snapshot collate nocase = ?`, []any{authFile})
+	legacySourceBase := `e.auth_file_snapshot is null and e.source collate nocase = ?` + legacySourceIdentityGuards()
+	appendIndexPredicates(legacySourceBase, []any{authFile})
+	legacyEmptySourceBase := `e.auth_file_snapshot = '' and e.source collate nocase = ?` + legacySourceIdentityGuards()
+	appendIndexPredicates(legacyEmptySourceBase, []any{authFile})
+	return predicates
+}
+
+func legacySourceIdentityGuards() string {
+	// source is used as a physical file only when it is not merely the display
+	// account or label. Keep the indexed source/auth_index predicates intact and
+	// apply these guards as residual filters.
+	return `
+		and (e.account_snapshot is null or lower(trim(e.source)) <> lower(trim(e.account_snapshot)))
+		and (e.auth_label_snapshot is null or lower(trim(e.source)) <> lower(trim(e.auth_label_snapshot)))`
+}
+
+func scanLegacyAccountIdentity(rows *sql.Rows, targetAccountID string) (bool, error) {
+	defer rows.Close()
+	seenIDs := map[string]struct{}{}
+	for rows.Next() {
+		var provider, authProvider, accountID, projectID string
+		if err := rows.Scan(&provider, &authProvider, &accountID, &projectID); err != nil {
+			return false, err
+		}
+		hasProvider := false
+		for _, value := range []string{provider, authProvider} {
+			normalized := normalizeIdentityProvider(value)
+			if normalized == "" {
+				continue
+			}
+			hasProvider = true
+			if normalized != "codex" {
+				return false, nil
+			}
+		}
+		if !hasProvider {
+			return false, nil
+		}
+
+		for _, value := range []string{
+			strings.TrimSpace(accountID),
+			usageidentity.CodexAccountIDFromSnapshot(projectID),
+		} {
+			if value == "" {
+				continue
+			}
+			if value != targetAccountID {
+				return false, nil
+			}
+			seenIDs[value] = struct{}{}
+			if len(seenIDs) > 1 {
+				return false, nil
+			}
+		}
+	}
+	return rows.Err() == nil, rows.Err()
+}
+
+func normalizeIdentityProvider(value string) string {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	switch normalized {
+	case "x-ai", "grok":
+		return "xai"
+	default:
+		return normalized
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/account_identity_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_test.go
@@ -1,0 +1,168 @@
+package usageevent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
+)
+
+func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutate        func([]usage.Event) []usage.Event
+		wantAllowed   bool
+		wantLegacyKey bool
+	}{
+		{
+			name: "matching stable and legacy events",
+			mutate: func(events []usage.Event) []usage.Event {
+				return events
+			},
+			wantAllowed:   true,
+			wantLegacyKey: true,
+		},
+		{
+			name: "provenance marked project snapshot agrees",
+			mutate: func(events []usage.Event) []usage.Event {
+				events[0].AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
+				return events
+			},
+			wantAllowed:   true,
+			wantLegacyKey: true,
+		},
+		{
+			name: "different account id blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events = append(events, identityTestEvent("different-account", 3, "codex-a.json", "auth-a", "codex", "account-b"))
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "foreign provider blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events = append(events, identityTestEvent("foreign-provider", 3, "codex-a.json", "auth-a", "openai", ""))
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "different file and index do not participate",
+			mutate: func(events []usage.Event) []usage.Event {
+				events = append(events, identityTestEvent("different-credential", 3, "codex-b.json", "auth-b", "codex", "account-b"))
+				return events
+			},
+			wantAllowed:   true,
+			wantLegacyKey: true,
+		},
+		{
+			name: "missing provider blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events = append(events, identityTestEvent("missing-provider", 3, "codex-a.json", "auth-a", "", ""))
+				return events
+			},
+			wantAllowed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			events := []usage.Event{
+				identityTestEvent("legacy-event", 1, "codex-a.json", "auth-a", "codex", ""),
+				identityTestEvent("stable-event", 2, "codex-a.json", "auth-a", "codex", "account-a"),
+			}
+			events = test.mutate(events)
+			if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+				t.Fatalf("insert identity events: %v", err)
+			}
+
+			fields := usageidentity.Fields{
+				AuthFileSnapshot:      "codex-a.json",
+				AuthIndex:             "auth-a",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "account-a",
+				AccountSnapshot:       "same@example.com",
+				Source:                "codex-a.json",
+			}
+			gotKey, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+			if err != nil {
+				t.Fatalf("resolve legacy identity: %v", err)
+			}
+			if allowed != test.wantAllowed {
+				t.Fatalf("allowed = %v, want %v (key=%q)", allowed, test.wantAllowed, gotKey)
+			}
+			wantKey, valid := usageidentity.LegacyAccountKey(fields)
+			if !valid {
+				t.Fatal("target legacy key is invalid")
+			}
+			if (gotKey == wantKey) != test.wantLegacyKey {
+				t.Fatalf("legacy key = %q, want key present=%v (%q)", gotKey, test.wantLegacyKey, wantKey)
+			}
+		})
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyAcceptsLegacySourceFile(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+	event := identityTestEvent("legacy-source", 1, "", "auth-a", "codex", "")
+	event.Source = "codex-a.json"
+	event.AccountSnapshot = "same@example.com"
+	stable := identityTestEvent("stable-source", 2, "codex-a.json", "auth-a", "codex", "account-a")
+	if _, err := repo.InsertBatch(context.Background(), []usage.Event{event, stable}); err != nil {
+		t.Fatalf("insert source identity events: %v", err)
+	}
+
+	fields := usageidentity.Fields{
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "same@example.com",
+		Source:                "codex-a.json",
+	}
+	key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+	if err != nil {
+		t.Fatalf("resolve source identity: %v", err)
+	}
+	want, valid := usageidentity.LegacyAccountKey(fields)
+	if !allowed || !valid || key != want {
+		t.Fatalf("source legacy identity = key:%q allowed:%v, want key:%q allowed:true", key, allowed, want)
+	}
+}
+
+func identityTestEvent(hash string, offset int64, file, authIndex, provider, accountID string) usage.Event {
+	timestampMS := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC).UnixMilli() + offset*1000
+	return usage.Event{
+		EventHash:             hash,
+		TimestampMS:           timestampMS,
+		Timestamp:             time.UnixMilli(timestampMS).UTC().Format(time.RFC3339Nano),
+		Provider:              provider,
+		Model:                 "gpt-test",
+		AuthFileSnapshot:      file,
+		AuthProviderSnapshot:  provider,
+		AuthAccountIDSnapshot: accountID,
+		AuthIndex:             authIndex,
+		Source:                file,
+		AccountSnapshot:       "same@example.com",
+		InputTokens:           1,
+		OutputTokens:          1,
+		TotalTokens:           2,
+		CreatedAtMS:           timestampMS,
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -239,6 +239,12 @@ type AccountWindowUsageQuery struct {
 	AuthProjectIDSnapshot string
 	Source                string
 	AuthIndex             string
+	// LegacyAccountKey is populated only after the shared Codex identity
+	// compatibility check. LegacyAccountKeyChecked distinguishes an explicitly
+	// blocked check from a non-Codex/legacy target that needs no compatibility
+	// lookup.
+	LegacyAccountKey        string
+	LegacyAccountKeyChecked bool
 }
 
 type AccountWindowModelStat struct {
@@ -1596,10 +1602,19 @@ func (r *repository) AccountWindowModelStats(ctx context.Context, windows []Acco
 	if len(windows) == 0 {
 		return []AccountWindowModelStat{}, nil
 	}
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	resolvedWindows, err := ResolveAccountWindowLegacyKeys(ctx, tx, windows)
+	if err != nil {
+		return nil, err
+	}
 
-	values := make([]string, 0, len(windows))
-	args := make([]any, 0, len(windows)*5)
-	for _, window := range windows {
+	values := make([]string, 0, len(resolvedWindows))
+	args := make([]any, 0, len(resolvedWindows)*5)
+	for _, window := range resolvedWindows {
 		accountKey, legacyAccountKey := accountWindowQueryKeys(window)
 		values = append(values, "(?, ?, ?, ?, ?)")
 		args = append(
@@ -1612,7 +1627,7 @@ func (r *repository) AccountWindowModelStats(ctx context.Context, windows []Acco
 		)
 	}
 
-	rows, err := r.db.QueryContext(ctx, pricingBandedUsageEventsCTE+`, window_targets(
+	rows, err := tx.QueryContext(ctx, pricingBandedUsageEventsCTE+`, window_targets(
 	request_index, from_ms, to_ms, account_key, legacy_account_key
 ) as (
 	values `+strings.Join(values, ",")+`
@@ -1649,8 +1664,6 @@ order by w.request_index, max(e.timestamp_ms) desc`, args...)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
 	stats := make([]AccountWindowModelStat, 0)
 	for rows.Next() {
 		var stat AccountWindowModelStat
@@ -1681,7 +1694,111 @@ order by w.request_index, max(e.timestamp_ms) desc`, args...)
 		}
 		stats = append(stats, stat)
 	}
-	return stats, rows.Err()
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
+// ResolveAccountWindowLegacyKeys prepares account-window targets with the
+// same fail-closed Codex legacy compatibility decision used by account
+// history. The returned slice is a copy and can safely be used as a query
+// snapshot-local representation.
+func ResolveAccountWindowLegacyKeys(
+	ctx context.Context,
+	queryer SQLQueryer,
+	windows []AccountWindowUsageQuery,
+) ([]AccountWindowUsageQuery, error) {
+	resolved := append([]AccountWindowUsageQuery(nil), windows...)
+	cache := make(map[string]struct {
+		key     string
+		allowed bool
+	})
+	legacyOwners := make(map[string]string)
+	legacyConflicts := make(map[string]struct{})
+	for index := range resolved {
+		window := &resolved[index]
+		if !codexLegacyWindowTarget(*window) {
+			continue
+		}
+		cacheKey := codexLegacyWindowCacheKey(*window)
+		result, ok := cache[cacheKey]
+		if !ok {
+			key, allowed, err := ResolveCodexLegacyAccountKey(ctx, queryer, accountWindowIdentityFields(*window))
+			if err != nil {
+				return nil, err
+			}
+			result = struct {
+				key     string
+				allowed bool
+			}{key: key, allowed: allowed}
+			cache[cacheKey] = result
+		}
+		window.LegacyAccountKeyChecked = true
+		if !result.allowed || result.key == "" {
+			continue
+		}
+		if _, conflicted := legacyConflicts[result.key]; conflicted {
+			continue
+		}
+		ownerKey := codexLegacyOwnerKey(*window)
+		if owner, ok := legacyOwners[result.key]; ok && owner != ownerKey {
+			legacyConflicts[result.key] = struct{}{}
+			continue
+		}
+		legacyOwners[result.key] = ownerKey
+		window.LegacyAccountKey = result.key
+	}
+	if len(legacyConflicts) > 0 {
+		for index := range resolved {
+			window := &resolved[index]
+			if _, conflicted := legacyConflicts[window.LegacyAccountKey]; conflicted {
+				window.LegacyAccountKey = ""
+			}
+		}
+	}
+	return resolved, nil
+}
+
+func codexLegacyOwnerKey(window AccountWindowUsageQuery) string {
+	return normalizeIdentityProvider(window.AuthProviderSnapshot) + "\x00" + strings.TrimSpace(window.AuthAccountIDSnapshot)
+}
+
+func codexLegacyWindowTarget(window AccountWindowUsageQuery) bool {
+	return strings.TrimSpace(window.AuthAccountIDSnapshot) != "" &&
+		normalizeIdentityProvider(window.AuthProviderSnapshot) == "codex"
+}
+
+func codexLegacyWindowCacheKey(window AccountWindowUsageQuery) string {
+	return strings.Join([]string{
+		normalizeIdentityProvider(window.AuthProviderSnapshot),
+		strings.TrimSpace(window.AuthAccountIDSnapshot),
+		strings.TrimSpace(window.AuthFileSnapshot),
+		strings.TrimSpace(window.AuthIndex),
+		strings.TrimSpace(window.AuthProjectIDSnapshot),
+		strings.TrimSpace(window.Source),
+		strings.TrimSpace(window.AccountSnapshot),
+		strings.TrimSpace(window.AuthLabelSnapshot),
+	}, "\x00")
+}
+
+func accountWindowIdentityFields(window AccountWindowUsageQuery) usageidentity.Fields {
+	return usageidentity.Fields{
+		AuthFileSnapshot:      window.AuthFileSnapshot,
+		AuthIndex:             window.AuthIndex,
+		AuthProviderSnapshot:  window.AuthProviderSnapshot,
+		AuthAccountIDSnapshot: window.AuthAccountIDSnapshot,
+		AuthProjectIDSnapshot: window.AuthProjectIDSnapshot,
+		AccountSnapshot:       window.AccountSnapshot,
+		AuthLabelSnapshot:     window.AuthLabelSnapshot,
+		Source:                window.Source,
+	}
 }
 
 func accountWindowQueryKey(window AccountWindowUsageQuery) string {
@@ -1704,16 +1821,8 @@ func accountWindowQueryKey(window AccountWindowUsageQuery) string {
 func accountWindowQueryKeys(window AccountWindowUsageQuery) (string, string) {
 	accountKey := accountWindowQueryKey(window)
 	legacyAccountKey := accountKey
-	provider := strings.TrimSpace(strings.ToLower(strings.ReplaceAll(window.AuthProviderSnapshot, "_", "-")))
-	if provider == "codex" && (strings.TrimSpace(window.AuthAccountIDSnapshot) != "" || usageidentity.CodexAccountIDFromSnapshot(window.AuthProjectIDSnapshot) != "") {
-		if key, valid := usageidentity.LegacyAccountKey(usageidentity.Fields{
-			AuthFileSnapshot:     window.AuthFileSnapshot,
-			AuthIndex:            window.AuthIndex,
-			AuthProviderSnapshot: window.AuthProviderSnapshot,
-			AccountSnapshot:      window.AccountSnapshot,
-			AuthLabelSnapshot:    window.AuthLabelSnapshot,
-			Source:               window.Source,
-		}); valid {
+	if window.LegacyAccountKeyChecked {
+		if key := strings.TrimSpace(window.LegacyAccountKey); key != "" {
 			legacyAccountKey = key
 		}
 	}

--- a/apps/manager-server/internal/repository/usageevent/analytics_account_window_test.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics_account_window_test.go
@@ -32,6 +32,12 @@ func TestAccountWindowQueryKeysRequireExplicitCodexAccountIDForLegacyFallback(t 
 	if !valid {
 		t.Fatal("explicit Codex legacy identity was rejected")
 	}
+	if accountKey != wantAccountKey || legacyAccountKey != accountKey {
+		t.Fatalf("unresolved explicit Codex keys = account:%q legacy:%q, want account:%q and no legacy fallback", accountKey, legacyAccountKey, wantAccountKey)
+	}
+	window.LegacyAccountKeyChecked = true
+	window.LegacyAccountKey = wantLegacyAccountKey
+	accountKey, legacyAccountKey = accountWindowQueryKeys(window)
 	if accountKey != wantAccountKey || legacyAccountKey != wantLegacyAccountKey || accountKey == legacyAccountKey {
 		t.Fatalf("explicit Codex keys = account:%q legacy:%q, want account:%q legacy:%q", accountKey, legacyAccountKey, wantAccountKey, wantLegacyAccountKey)
 	}
@@ -48,7 +54,15 @@ func TestAccountWindowQueryKeysRequireExplicitCodexAccountIDForLegacyFallback(t 
 	otherCredential.AuthFileSnapshot = "codex-b.json"
 	otherCredential.AuthIndex = "auth-b"
 	otherCredential.Source = "codex-b.json"
+	otherCredential.LegacyAccountKey = ""
+	otherCredential.LegacyAccountKeyChecked = false
 	otherCredentialKey, otherLegacyKey := accountWindowQueryKeys(otherCredential)
+	if accountKey == otherCredentialKey || legacyAccountKey == otherLegacyKey {
+		t.Fatalf("distinct credentials sharing display metadata were merged: account %q/%q legacy %q/%q", accountKey, otherCredentialKey, legacyAccountKey, otherLegacyKey)
+	}
+	otherCredential.LegacyAccountKeyChecked = true
+	otherCredential.LegacyAccountKey, _ = usageidentity.LegacyAccountKey(accountWindowFields(otherCredential))
+	otherCredentialKey, otherLegacyKey = accountWindowQueryKeys(otherCredential)
 	if accountKey == otherCredentialKey || legacyAccountKey == otherLegacyKey {
 		t.Fatalf("distinct credentials sharing display metadata were merged: account %q/%q legacy %q/%q", accountKey, otherCredentialKey, legacyAccountKey, otherLegacyKey)
 	}

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -13,6 +13,7 @@ import (
 
 type Repository interface {
 	InsertBatch(ctx context.Context, events []model.UsageEvent) (model.InsertResult, error)
+	ResolveCodexLegacyAccountKey(ctx context.Context, fields usageidentity.Fields) (string, bool, error)
 	ListRecent(ctx context.Context, limit int) ([]model.UsageEvent, error)
 	ModelUsageSummary(ctx context.Context, limit int) (model.ModelUsageSummary, error)
 	BackfillResponseMetadata(ctx context.Context, batchLimit int) (int, error)

--- a/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageevent"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
@@ -19,6 +20,10 @@ func (r *repository) LoadAccountWindowStats(ctx context.Context, windows []Accou
 		return nil, State{}, false, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	windows, err = usageevent.ResolveAccountWindowLegacyKeys(ctx, tx, windows)
+	if err != nil {
+		return nil, State{}, false, err
+	}
 	state, available, projectionComplete, err := projectionReadState(ctx, tx)
 	if err != nil || !available {
 		return nil, state, available, err
@@ -233,9 +238,8 @@ func accountWindowKey(window AccountWindowUsageQuery) string {
 func accountWindowKeys(window AccountWindowUsageQuery) (string, string) {
 	accountKey := accountWindowKey(window)
 	legacyAccountKey := accountKey
-	provider := strings.TrimSpace(strings.ToLower(strings.ReplaceAll(window.AuthProviderSnapshot, "_", "-")))
-	if provider == "codex" && (strings.TrimSpace(window.AuthAccountIDSnapshot) != "" || usageidentity.CodexAccountIDFromSnapshot(window.AuthProjectIDSnapshot) != "") {
-		if key, valid := usageidentity.LegacyAccountKey(usageidentity.Fields{AuthFileSnapshot: window.AuthFileSnapshot, AuthIndex: window.AuthIndex, AuthProviderSnapshot: window.AuthProviderSnapshot, AccountSnapshot: window.AccountSnapshot, AuthLabelSnapshot: window.AuthLabelSnapshot, Source: window.Source}); valid {
+	if window.LegacyAccountKeyChecked {
+		if key := strings.TrimSpace(window.LegacyAccountKey); key != "" {
 			legacyAccountKey = key
 		}
 	}

--- a/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
@@ -517,6 +517,54 @@ func TestCodexAccountWindowKeepsHistoryAcrossSameAccountReauth(t *testing.T) {
 	assertStats("projection plus raw tail", 3, 75)
 }
 
+func TestCodexAccountWindowRejectsConflictingLegacyFileIndex(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_057_600_000)
+	toMS := fromMS + testDayMS
+	makeEvent := func(hash string, offset, input int64, accountID string) usage.Event {
+		event := monitoringRepositoryEvent(hash, fromMS+offset, "gpt-window", "key-a", "same@example.com", "auth-a", "codex-a.json", false, input, 1, 10)
+		event.AuthFileSnapshot = "codex-a.json"
+		event.AuthProviderSnapshot = "codex"
+		event.AuthAccountIDSnapshot = accountID
+		return event
+	}
+	if _, err := db.InsertEvents(ctx, []usage.Event{
+		makeEvent("window-conflict-stable", 1_000, 10, "account-a"),
+		makeEvent("window-conflict-legacy", 2_000, 20, ""),
+		makeEvent("window-conflict-other", 3_000, 90, "account-b"),
+	}); err != nil {
+		t.Fatalf("insert conflicting account-window events: %v", err)
+	}
+	catchUpMonitoringRepository(t, ctx, db)
+
+	windows := []store.AccountWindowUsageQuery{{
+		RequestIndex:          0,
+		FromMS:                fromMS,
+		ToMS:                  toMS,
+		AccountSnapshot:       "same@example.com",
+		AuthFileSnapshot:      "codex-a.json",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AuthIndex:             "auth-a",
+		Source:                "codex-a.json",
+	}}
+	raw, err := db.AccountWindowModelStats(ctx, windows)
+	if err != nil {
+		t.Fatalf("raw conflicting account-window stats: %v", err)
+	}
+	projected, _, available, err := db.UsageMonitoringAccountWindowStats(ctx, windows)
+	if err != nil || !available {
+		t.Fatalf("projected conflicting account-window stats: available=%v err=%v", available, err)
+	}
+	if !reflect.DeepEqual(projected, raw) {
+		t.Fatalf("conflicting account-window projection/raw mismatch\nprojection=%#v\nraw=%#v", projected, raw)
+	}
+	if len(projected) != 1 || projected[0].Calls != 1 || projected[0].InputTokens != 10 {
+		t.Fatalf("conflicting legacy account-window bucket was merged = %#v, want only stable account event", projected)
+	}
+}
+
 func TestAccountWindowProjectionUsesDailyStatsWithEdgesAndRawTail(t *testing.T) {
 	sqlDB, db := newMonitoringRepositoryStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -1396,7 +1396,10 @@ func (s *Service) accountHistory(ctx context.Context, req AccountHistoryRequest)
 		return AccountHistoryResponse{}, err
 	}
 
-	keys := make([]string, 0, len(req.Accounts))
+	keys := make([]string, 0, len(req.Accounts)*2)
+	stableKeys := make([]string, 0, len(req.Accounts))
+	legacyAliases := make(map[string]string)
+	legacyConflicts := make(map[string]struct{})
 	targetKeys := make([]string, len(req.Accounts))
 	validTargets := make([]bool, len(req.Accounts))
 	latestRequestTargets := make([]store.LatestAccountRequestQuery, 0, len(req.Accounts))
@@ -1406,6 +1409,25 @@ func (s *Service) accountHistory(ctx context.Context, req AccountHistoryRequest)
 		validTargets[index] = valid
 		if valid {
 			keys = append(keys, key)
+			stableKeys = append(stableKeys, key)
+			legacyKey, allowed, err := s.store.UsageEvents.ResolveCodexLegacyAccountKey(ctx, accountHistoryIdentityFields(account))
+			if err != nil {
+				return AccountHistoryResponse{}, err
+			}
+			if allowed && legacyKey != "" && legacyKey != key {
+				keys = append(keys, legacyKey)
+				if _, conflicted := legacyConflicts[legacyKey]; conflicted {
+					continue
+				}
+				if owner, exists := legacyAliases[legacyKey]; exists && owner != key {
+					// A blank-ID legacy bucket cannot be assigned to two stable
+					// accounts in one request. Keep both targets fail-closed.
+					delete(legacyAliases, legacyKey)
+					legacyConflicts[legacyKey] = struct{}{}
+				} else {
+					legacyAliases[legacyKey] = key
+				}
+			}
 		}
 		if latestAccountRequestTargetValid(account) {
 			latestRequestTargets = append(latestRequestTargets, store.LatestAccountRequestQuery{
@@ -1415,20 +1437,44 @@ func (s *Service) accountHistory(ctx context.Context, req AccountHistoryRequest)
 			})
 		}
 	}
-	pricingSnapshot, err := s.store.LoadUsagePricingAccountSnapshot(ctx, keys)
+	keys = uniqueAccountHistoryKeys(keys)
+	stableKeys = uniqueAccountHistoryKeys(stableKeys)
+	loadTotals := func(readKeys []string) (map[string]*accountHistoryTotal, error) {
+		pricingSnapshot, err := s.store.LoadUsagePricingAccountSnapshot(ctx, readKeys)
+		if err != nil {
+			return nil, err
+		}
+		prices := pricingSnapshot.Prices
+		if pricingSnapshot.Available {
+			return buildPricingAccountHistoryTotals(pricingSnapshot.Rows, prices), nil
+		}
+		rows, err := s.store.AccountHistoryRollupRows(ctx, readKeys)
+		if err != nil {
+			return nil, err
+		}
+		return buildAccountHistoryTotals(rows, prices), nil
+	}
+	totals, err := loadTotals(keys)
 	if err != nil {
 		return AccountHistoryResponse{}, err
 	}
-	prices := pricingSnapshot.Prices
-	var totals map[string]*accountHistoryTotal
-	if pricingSnapshot.Available {
-		totals = buildPricingAccountHistoryTotals(pricingSnapshot.Rows, prices)
-	} else {
-		rows, err := s.store.AccountHistoryRollupRows(ctx, keys)
-		if err != nil {
-			return AccountHistoryResponse{}, err
+	mergeAliasedAccountHistoryTotals(totals, legacyAliases)
+	if len(legacyAliases) > 0 {
+		fencedLatestID, fenceErr := s.store.LatestUsageEventID(ctx)
+		if fenceErr != nil {
+			return AccountHistoryResponse{}, fenceErr
 		}
-		totals = buildAccountHistoryTotals(rows, prices)
+		if fencedLatestID != latestID {
+			// A writer raced the identity check. Do not expose a possibly
+			// conflicting legacy bucket from the old snapshot; stable events are
+			// still safe and the next refresh will pick up the new tail.
+			latestID = fencedLatestID
+			legacyAliases = nil
+			totals, err = loadTotals(stableKeys)
+			if err != nil {
+				return AccountHistoryResponse{}, err
+			}
+		}
 	}
 	recentRequests, err := s.store.RecentAccountRequests(
 		ctx,
@@ -3610,6 +3656,36 @@ func accountHistoryTargetKey(target AccountHistoryTarget) (string, bool) {
 	return key, key != ""
 }
 
+func accountHistoryIdentityFields(target AccountHistoryTarget) usageidentity.Fields {
+	return usageidentity.Fields{
+		AuthFileSnapshot:      target.AuthFileSnapshot,
+		AuthIndex:             target.AuthIndex,
+		AuthProviderSnapshot:  target.AuthProviderSnapshot,
+		AuthAccountIDSnapshot: target.AuthAccountIDSnapshot,
+		AuthProjectIDSnapshot: target.AuthProjectIDSnapshot,
+		AccountSnapshot:       target.AccountSnapshot,
+		AuthLabelSnapshot:     target.AuthLabelSnapshot,
+		Source:                target.Source,
+	}
+}
+
+func uniqueAccountHistoryKeys(keys []string) []string {
+	seen := make(map[string]struct{}, len(keys))
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	return result
+}
+
 func latestAccountRequestTargetValid(target AccountHistoryTarget) bool {
 	return accountHistoryAuthFileSnapshot(target) != ""
 }
@@ -3719,6 +3795,33 @@ func buildPricingAccountHistoryTotals(rows []store.UsagePricingAccountRow, price
 		}
 	}
 	return totals
+}
+
+func mergeAliasedAccountHistoryTotals(totals map[string]*accountHistoryTotal, aliases map[string]string) {
+	for legacyKey, primaryKey := range aliases {
+		legacy := totals[legacyKey]
+		if legacy == nil {
+			continue
+		}
+		primary := totals[primaryKey]
+		if primary == nil {
+			totals[primaryKey] = legacy
+			delete(totals, legacyKey)
+			continue
+		}
+		primary.requests += legacy.requests
+		primary.successCalls += legacy.successCalls
+		primary.failureCalls += legacy.failureCalls
+		primary.totalTokens += legacy.totalTokens
+		primary.cost += legacy.cost
+		if primary.firstSeenMS == 0 || (legacy.firstSeenMS > 0 && legacy.firstSeenMS < primary.firstSeenMS) {
+			primary.firstSeenMS = legacy.firstSeenMS
+		}
+		if legacy.lastSeenMS > primary.lastSeenMS {
+			primary.lastSeenMS = legacy.lastSeenMS
+		}
+		delete(totals, legacyKey)
+	}
 }
 
 func accountWindowUsageTargetKey(target AccountWindowUsageTarget) (string, bool) {

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -2278,6 +2278,102 @@ func TestAccountHistorySeparatesSharedAccountAndStructuredIdentityOverridesLegac
 	}
 }
 
+func TestAccountHistoryAutoMergesSafeCodexLegacyFileIndex(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	baseMS := int64(1_700_006_000_000)
+	stable := monitoringEvent("history-codex-stable", baseMS+1_000, "gpt-codex", "auth-a", "codex-a.json", false, 10, 2, 0, 0, 12, nil)
+	stable.AuthFileSnapshot = "codex-a.json"
+	stable.AuthProviderSnapshot = "codex"
+	stable.AuthAccountIDSnapshot = "account-a"
+	stable.AccountSnapshot = "same@example.com"
+	legacy := monitoringEvent("history-codex-legacy", baseMS+2_000, "gpt-codex", "auth-a", "codex-a.json", false, 20, 3, 0, 0, 23, nil)
+	legacy.AuthFileSnapshot = "codex-a.json"
+	legacy.AuthProviderSnapshot = "codex"
+	legacy.AuthAccountIDSnapshot = ""
+	legacy.AccountSnapshot = "same@example.com"
+	if _, err := db.InsertEvents(ctx, []usage.Event{stable, legacy}); err != nil {
+		t.Fatalf("insert Codex history events: %v", err)
+	}
+
+	req := AccountHistoryRequest{Accounts: []AccountHistoryTarget{{
+		RowKey:                "codex-row",
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "same@example.com",
+		Source:                "codex-a.json",
+	}}, CatchUp: true}
+	service := New(db)
+	first, err := service.AccountHistory(ctx, req)
+	if err != nil {
+		t.Fatalf("first account history: %v", err)
+	}
+	if len(first.Items) != 1 || !first.Items[0].Matched {
+		t.Fatalf("first account history = %#v", first.Items)
+	}
+	item := first.Items[0]
+	if item.TotalRequests != 2 || item.SuccessCalls != 2 || item.TotalTokens != 35 {
+		t.Fatalf("safe Codex legacy merge totals = %#v, want requests=2 success=2 tokens=35", item)
+	}
+	if item.FirstSeenMS == nil || *item.FirstSeenMS != baseMS+1_000 || item.LastSeenMS == nil || *item.LastSeenMS != baseMS+2_000 {
+		t.Fatalf("safe Codex legacy merge seen range = %#v/%#v", item.FirstSeenMS, item.LastSeenMS)
+	}
+
+	repeat := req
+	repeat.CatchUp = false
+	second, err := service.AccountHistory(ctx, repeat)
+	if err != nil {
+		t.Fatalf("repeat account history: %v", err)
+	}
+	if len(second.Items) != 1 || second.Items[0].TotalRequests != 2 || second.Items[0].TotalTokens != 35 {
+		t.Fatalf("repeat account history double-counted legacy bucket = %#v", second.Items)
+	}
+}
+
+func TestAccountHistoryRejectsConflictingCodexLegacyFileIndex(t *testing.T) {
+	db := newMonitoringTestStore(t)
+	ctx := context.Background()
+	baseMS := int64(1_700_007_000_000)
+	stable := monitoringEvent("history-codex-conflict-stable", baseMS+1_000, "gpt-codex", "auth-a", "codex-a.json", false, 10, 2, 0, 0, 12, nil)
+	stable.AuthFileSnapshot = "codex-a.json"
+	stable.AuthProviderSnapshot = "codex"
+	stable.AuthAccountIDSnapshot = "account-a"
+	legacy := monitoringEvent("history-codex-conflict-legacy", baseMS+2_000, "gpt-codex", "auth-a", "codex-a.json", false, 20, 3, 0, 0, 23, nil)
+	legacy.AuthFileSnapshot = "codex-a.json"
+	legacy.AuthProviderSnapshot = "codex"
+	conflicting := monitoringEvent("history-codex-conflict-other", baseMS+3_000, "gpt-codex", "auth-a", "codex-a.json", false, 90, 9, 0, 0, 99, nil)
+	conflicting.AuthFileSnapshot = "codex-a.json"
+	conflicting.AuthProviderSnapshot = "codex"
+	conflicting.AuthAccountIDSnapshot = "account-b"
+	if _, err := db.InsertEvents(ctx, []usage.Event{stable, legacy, conflicting}); err != nil {
+		t.Fatalf("insert conflicting Codex history events: %v", err)
+	}
+
+	resp, err := New(db).AccountHistory(ctx, AccountHistoryRequest{
+		Accounts: []AccountHistoryTarget{{
+			RowKey:                "codex-conflict-row",
+			AuthFileSnapshot:      "codex-a.json",
+			AuthIndex:             "auth-a",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "account-a",
+			AccountSnapshot:       "same@example.com",
+			Source:                "codex-a.json",
+		}},
+		CatchUp: true,
+	})
+	if err != nil {
+		t.Fatalf("conflicting account history: %v", err)
+	}
+	if len(resp.Items) != 1 || !resp.Items[0].Matched {
+		t.Fatalf("conflicting account history = %#v", resp.Items)
+	}
+	if resp.Items[0].TotalRequests != 1 || resp.Items[0].TotalTokens != 12 {
+		t.Fatalf("conflicting legacy bucket was merged = %#v, want only stable account event", resp.Items[0])
+	}
+}
+
 func TestAccountHistoryPricesContextTierBands(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Restore historical Codex credential usage after auth-file replacement or quota refresh when the legacy bucket is safely attributable.
The fix links only same-provider, same-file/index events with one explicit account ID and keeps ambiguous identities fail-closed.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add shared Codex legacy identity validation for usageevent raw/account-window query paths; only explicit account ID plus provider/file/index matches permit aliasing.
- Apply the same decision to usage monitoring projections and raw reads so historical windows are restored consistently.
- Merge approved legacy account-history buckets into stable account totals with race fencing and idempotence; add conflict/source regression coverage without rewriting `usage_events`.

## User Impact

Credential Management, request monitoring, and usage analysis can again show historical windows that belong to this single Codex account. Different or ambiguous credentials remain unmerged and cannot be misattributed.

## Compatibility / Runtime Notes

- CPA panel mode: No panel or API contract changes; backend behavior is shared when Manager Server is used.
- Manager Server mode: Account-history and account-window reads apply safe legacy aliases.
- Full Docker / native packages: No configuration, schema, or packaging changes.

## Data / Security Notes

`usage_events` remains immutable; no migration, deletion, or backfill is performed. Legacy aliases are accepted only with explicit Codex account-ID provenance and no provider/file/index conflict; foreign, missing, or conflicting identity evidence fails closed.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the three fix commits in reverse order; raw events and existing stable projections remain intact.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
go test ./...
go test -race ./...
npm run manager-server:test
npm run test (203 files, 2528 tests)
npm run type-check
npm run lint (0 errors; one pre-existing warning at apps/web/src/features/accounts/components/AccountHealthBadge.tsx:73)
npm run build
git diff --check origin/dev...HEAD
git range-diff b1179618..079f8b8f origin/dev..HEAD (three commits preserved)
```

## Screenshots / Recordings

N/A — backend-only change; no visible UI changes.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: Backend-only regression fix; no user-facing API, configuration, or documentation change.

## Related

N/A — no issue number provided.