### PR TITLE
refactor(web): unify plan presentation across providers

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -477,6 +477,7 @@ const { mocks } = vi.hoisted(() => {
         setXaiQuota: vi.fn(),
       },
       t: (key: string, options?: Record<string, unknown>) => {
+        if (key === 'auth_files.codex_plan_filter_unknown') return 'Unknown plan';
         if (!options) return key;
         const parts: string[] = [];
         if (typeof options.name === 'string') parts.push(options.name);
@@ -3520,7 +3521,7 @@ describe('AccountsPage replacement flows', () => {
 
     expect(planSelect.props.options).toContainEqual({
       value: 'unknown',
-      label: 'auth_files.codex_plan_filter_unknown',
+      label: 'Unknown plan',
     });
     await act(async () => {
       planSelect.props.onChange('unknown');

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -81,9 +81,7 @@ import {
   createCodexReauthTargetFromAuthFile,
   type CodexReauthTarget,
 } from '@/features/oauth/codexReauthModel';
-import {
-  runCredentialVisibilityRetry,
-} from '@/features/accounts/model/accountCredentialVisibilityRetry';
+import { runCredentialVisibilityRetry } from '@/features/accounts/model/accountCredentialVisibilityRetry';
 import {
   ACCOUNT_CODEX_STATUS_FILTERS,
   buildAccountInspectionBySelectionKey,
@@ -93,6 +91,8 @@ import {
   findAccountRowForInspectionTarget,
   filterAccountRows,
   getHandledAccountInspectionResultKeys,
+  getPlanOptionLabel,
+  getPlanOptionValue,
   getPlanOptions,
   getProviderOptions,
   isAccountCodexStatusFilter,
@@ -1575,19 +1575,20 @@ export function AccountsPage() {
     async (options: { force?: boolean } = {}) => {
       const force = options.force === true;
       const synchronizationScopeKey = credentialEvidenceScopeKey;
-      const markers = listAccountCredentialMutationMarkers(connectionFingerprint).filter((marker) => {
-        if (consumedCredentialMutationMarkerIdsRef.current.has(marker.id)) return false;
-        if (force) return true;
-        const currentEvidence = JSON.stringify(
-          createAccountCredentialMutationBaseline(files, marker.provider)
-        );
-        const exhaustedEvidence = credentialMutationMarkerExhaustedRef.current.get(marker.id);
-        return exhaustedEvidence !== `${synchronizationScopeKey}\u001e${currentEvidence}`;
-      });
-      if (markers.length === 0) return false;
-      const pendingSynchronization = credentialMutationMarkerSynchronizationsRef.current.get(
-        synchronizationScopeKey
+      const markers = listAccountCredentialMutationMarkers(connectionFingerprint).filter(
+        (marker) => {
+          if (consumedCredentialMutationMarkerIdsRef.current.has(marker.id)) return false;
+          if (force) return true;
+          const currentEvidence = JSON.stringify(
+            createAccountCredentialMutationBaseline(files, marker.provider)
+          );
+          const exhaustedEvidence = credentialMutationMarkerExhaustedRef.current.get(marker.id);
+          return exhaustedEvidence !== `${synchronizationScopeKey}\u001e${currentEvidence}`;
+        }
       );
+      if (markers.length === 0) return false;
+      const pendingSynchronization =
+        credentialMutationMarkerSynchronizationsRef.current.get(synchronizationScopeKey);
       if (pendingSynchronization) return pendingSynchronization;
 
       const synchronization = (async () => {
@@ -2952,11 +2953,12 @@ export function AccountsPage() {
       let firstAttempt = true;
       const retry = await runCredentialVisibilityRetry<AuthFileItem[]>({
         load: async () => {
-          const loadedFiles = firstAttempt && options.reload === false
-            ? files
-            : firstAttempt
-              ? await reloadInspectionCredentialArtifacts({ requireSuccessfulReload: true })
-              : await loadFiles({ throwOnError: true });
+          const loadedFiles =
+            firstAttempt && options.reload === false
+              ? files
+              : firstAttempt
+                ? await reloadInspectionCredentialArtifacts({ requireSuccessfulReload: true })
+                : await loadFiles({ throwOnError: true });
           firstAttempt = false;
           if (!loadedFiles) throw new Error(t('notification.refresh_failed'));
           return loadedFiles;
@@ -2992,13 +2994,7 @@ export function AccountsPage() {
       });
       return result;
     },
-    [
-      credentialEvidenceScopeKey,
-      files,
-      loadFiles,
-      reloadInspectionCredentialArtifacts,
-      t,
-    ]
+    [credentialEvidenceScopeKey, files, loadFiles, reloadInspectionCredentialArtifacts, t]
   );
 
   const synchronizePendingAccountDirectReauths = useCallback(
@@ -3751,7 +3747,11 @@ export function AccountsPage() {
     [actionCandidatesByRowKey, quotaCooldownsByRowKey, requestEvidenceBySelectionKey, rows]
   );
   const providerOptions = useMemo(() => getProviderOptions(rows), [rows]);
-  const planOptions = useMemo(() => getPlanOptions(rows), [rows]);
+  const planOptions = useMemo(() => getPlanOptions(rows, t), [rows, t]);
+  const planFilterValue = useMemo(
+    () => getPlanOptionValue(rows, planFilter, t),
+    [planFilter, rows, t]
+  );
   const recommendations = useMemo(
     () => buildAccountRecommendations(rows, requestEvidenceBySelectionKey),
     [requestEvidenceBySelectionKey, rows]
@@ -5966,11 +5966,7 @@ export function AccountsPage() {
         ? t(`auth_files.codex_status_filter_${statusFilter}`)
         : t(`accounts.status_${statusFilter}`);
   const selectedPlanFilterLabel =
-    planFilter === 'all'
-      ? t('accounts.plan_all')
-      : planFilter === 'unknown'
-        ? t('auth_files.codex_plan_filter_unknown')
-        : planFilter;
+    planFilter === 'all' ? t('accounts.plan_all') : getPlanOptionLabel(rows, planFilter, t);
   const selectedQuotaFilterLabel =
     quotaBandFilter === 'all' ? t('accounts.quota_all') : t(`accounts.quota_${quotaBandFilter}`);
   const selectedOperationalFilterLabel = t(`accounts.operational_${effectiveOperationalFilter}`);
@@ -6270,14 +6266,8 @@ export function AccountsPage() {
       </div>
       <div className={styles.filterField}>
         <Select
-          value={planFilter}
-          options={[
-            { value: 'all', label: t('accounts.plan_all') },
-            ...planOptions.map((plan) => ({
-              value: plan,
-              label: plan === 'unknown' ? t('auth_files.codex_plan_filter_unknown') : plan,
-            })),
-          ]}
+          value={planFilterValue}
+          options={[{ value: 'all', label: t('accounts.plan_all') }, ...planOptions]}
           onChange={setPlanFilter}
           ariaLabel={t('accounts.plan_filter')}
           triggerClassName={styles.toolbarSelectTrigger}
@@ -6828,6 +6818,7 @@ export function AccountsPage() {
             const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
             const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
             const item = buildAccountListItem(row, {
+              t,
               recommendation,
               quotaCooldown,
               codexStatus,
@@ -6915,8 +6906,13 @@ export function AccountsPage() {
                     <span className={styles.providerPill}>
                       {getProviderLabel(item.identity.provider, t)}
                     </span>
-                    {item.identity.planType ? (
-                      <span className={styles.accountMetaPill}>{item.identity.planType}</span>
+                    {item.identity.planPresentation ? (
+                      <span
+                        className={styles.accountMetaPill}
+                        title={item.identity.planPresentation.fullLabel}
+                      >
+                        {item.identity.planPresentation.shortLabel}
+                      </span>
                     ) : null}
                   </div>
                   <div className={styles.accountIdentityCopyLine}>
@@ -7223,6 +7219,7 @@ export function AccountsPage() {
     const rowEventsRecentFailure = hasMatchingDetailEvents ? detailEventsRecentFailure : null;
     const rowEventsTotalCount = hasMatchingDetailEvents ? detailEventsTotalCount : 0;
     const detailView = buildAccountDetailViewModel(selectedRow, {
+      t,
       recommendation: recommendationBySelectionKey.get(selectedRow.selectionKey) ?? null,
       quotaCooldown: selectedQuotaCooldown,
       codexStatus: selectedCodexStatus,
@@ -7422,7 +7419,11 @@ export function AccountsPage() {
                 {getDisplayAccount(selectedRow)}
               </strong>
               <span className={styles.drawerTitleMeta}>
-                {getProviderLabel(selectedRow.provider, t)} · {selectedRow.planType ?? '-'} ·{' '}
+                {getProviderLabel(selectedRow.provider, t)} ·{' '}
+                <span title={detailView.identity.planPresentation?.fullLabel}>
+                  {detailView.identity.planPresentation?.shortLabel ?? '-'}
+                </span>{' '}
+                ·{' '}
                 <button
                   type="button"
                   className={styles.drawerFileNameCopy}

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -3765,7 +3765,7 @@ export function AccountsPage() {
       filterAccountRows(rows, {
         provider: providerFilter,
         status: statusFilter,
-        plan: planFilter,
+        plan: planFilterValue,
         quotaBand: quotaBandFilter,
         search,
         codexStatusBySelectionKey,
@@ -3773,7 +3773,7 @@ export function AccountsPage() {
       }),
     [
       codexStatusBySelectionKey,
-      planFilter,
+      planFilterValue,
       providerFilter,
       quotaBandFilter,
       requestEvidenceBySelectionKey,

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
@@ -175,6 +175,29 @@ const makeMonitoringValue = (
 });
 
 describe('accountDetailViewModel', () => {
+  it('uses the full unified plan label for credential details', () => {
+    const viewModel = buildAccountDetailViewModel(
+      makeRow({
+        provider: 'codex',
+        planType: 'self_serve_business_prolite',
+      })
+    );
+
+    expect(viewModel.identity.planPresentation).toMatchObject({
+      rawPlanType: 'self_serve_business_prolite',
+      canonicalPlanType: 'business_premium_5x',
+      shortLabel: 'Business 5x',
+      fullLabel: 'Business Premium 5x',
+      known: true,
+    });
+    expect(viewModel.overview.credential.fields).toContainEqual(
+      expect.objectContaining({
+        key: 'planType',
+        value: 'Business Premium 5x',
+      })
+    );
+  });
+
   it('keeps credential identity fields focused and hides missing values', () => {
     const populated = buildAccountDetailViewModel(
       makeRow({

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
@@ -198,6 +198,30 @@ describe('accountDetailViewModel', () => {
     );
   });
 
+  it('preserves unknown plan casing in credential details', () => {
+    const viewModel = buildAccountDetailViewModel(
+      makeRow({
+        provider: 'antigravity',
+        planType: 'Antigravity Future',
+        quota: { planType: 'Antigravity Future' },
+      })
+    );
+
+    expect(viewModel.identity.planPresentation).toMatchObject({
+      rawPlanType: 'Antigravity Future',
+      canonicalPlanType: 'unknown:antigravity:antigravity future',
+      shortLabel: 'Antigravity Future',
+      fullLabel: 'Antigravity Future',
+      known: false,
+    });
+    expect(viewModel.overview.credential.fields).toContainEqual(
+      expect.objectContaining({
+        key: 'planType',
+        value: 'Antigravity Future',
+      })
+    );
+  });
+
   it('keeps credential identity fields focused and hides missing values', () => {
     const populated = buildAccountDetailViewModel(
       makeRow({

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next';
 import type { CodexQuotaState, QuotaResetAccuracy, XaiQuotaState } from '@/types';
 import { getSortedCodexResetCreditExpiries } from '@/components/quota/quotaConfigs';
 import type {
@@ -13,7 +14,6 @@ import type {
 import type { AuthFileCodexStatusSummary } from '@/features/authFiles/model/credentialStatus';
 import { normalizePlanType, parseIdTokenPayload } from '@/utils/quota/parsers';
 import { isValidQuotaResetAtMs } from '@/utils/quota/formatters';
-import { resolveCodexPlanType } from '@/utils/quota/resolvers';
 import { isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
 import { parseTimestampMs } from '@/utils/timestamp';
 import { sumRecentRequests, type RecentRequestBucket } from '@/utils/recentRequests';
@@ -44,6 +44,11 @@ import {
   type AccountRecommendationPriority,
 } from './quotaRecommendations';
 import type { UsageValueRow, UsageValueSource } from './usageValueRows';
+import {
+  getPlanPresentation,
+  resolveAuthFilePlanType,
+  type PlanPresentation,
+} from '@/utils/plans';
 import {
   classifyAccountCredentialStatusEvidence,
   getAccountRequestCredentialEvidence,
@@ -287,6 +292,7 @@ export interface AccountDetailViewModel {
     accountLabel: string;
     provider: string;
     planType: string | null;
+    planPresentation: PlanPresentation | null;
     authIndex: string;
     projectId: string;
     priority: number;
@@ -338,6 +344,7 @@ export interface AccountDetailViewModel {
 }
 
 export interface BuildAccountDetailViewModelOptions {
+  t?: TFunction;
   recommendation?: AccountRecommendation | null;
   quotaCooldown?: QuotaCooldownInfo | null;
   codexStatus?: AuthFileCodexStatusSummary | null;
@@ -1135,7 +1142,8 @@ const buildOverviewCapacity = (
 
 const buildOverviewCredential = (
   row: AccountRow,
-  codexQuota: CodexQuotaState | null | undefined
+  codexQuota: CodexQuotaState | null | undefined,
+  t?: TFunction
 ): AccountDetailOverviewCredential => {
   const parseValidSubscriptionUntilMs = (value: unknown): number | null => {
     const numeric =
@@ -1154,10 +1162,17 @@ const buildOverviewCredential = (
     return Number.isNaN(new Date(parsed).getTime()) ? null : parsed;
   };
   const effectivePlanType = normalizePlanType(
-    codexQuota?.planType ?? row.planType ?? resolveCodexPlanType(row.raw)
+    codexQuota?.planType ?? row.planType ?? resolveAuthFilePlanType(row.raw)
   );
+  const planPresentation = getPlanPresentation({
+    provider: row.provider,
+    planType: effectivePlanType,
+    t,
+  });
   const hasPaidCodexSubscription =
-    row.provider === 'codex' && effectivePlanType !== null && effectivePlanType !== 'free';
+    row.provider === 'codex' &&
+    effectivePlanType !== null &&
+    planPresentation?.canonicalPlanType !== 'free';
   const liveSubscriptionUntilMs = hasPaidCodexSubscription
     ? parseValidSubscriptionUntilMs(codexQuota?.subscriptionActiveUntil)
     : null;
@@ -1194,7 +1209,7 @@ const buildOverviewCredential = (
       : 'accounts.detail_local_auth_file',
     fields: compactFields([
       field('provider', 'accounts.col_provider', row.provider),
-      field('planType', 'accounts.col_plan', effectivePlanType),
+      field('planType', 'accounts.col_plan', planPresentation?.fullLabel ?? effectivePlanType),
       field('updatedAtMs', 'accounts.detail_updated_at', row.updatedAtMs, 'timestamp'),
       field('subscriptionUntilMs', subscriptionUntilLabelKey, subscriptionUntilMs, 'quota_reset'),
       field('authIndex', 'accounts.detail_auth_index', presentOverviewText(row.authIndex)),
@@ -1524,6 +1539,7 @@ export const buildAccountDetailViewModel = (
   const accountQuotaWindows =
     row.provider === 'codex' ? quotaWindows.filter(isCodexMainQuotaWindow) : quotaWindows;
   const listItem = buildAccountListItem(row, {
+    t: options.t,
     recommendation,
     quotaCooldown,
     codexStatus: options.codexStatus ?? null,
@@ -1560,7 +1576,7 @@ export const buildAccountDetailViewModel = (
   const overview = {
     decision: overviewDecision,
     capacity: buildOverviewCapacity(row, accountQuotaWindows, listItem),
-    credential: buildOverviewCredential(row, options.codexQuota),
+    credential: buildOverviewCredential(row, options.codexQuota, options.t),
     recentStatus: buildOverviewRecentStatus(
       row,
       overviewDecision,
@@ -1589,6 +1605,12 @@ export const buildAccountDetailViewModel = (
       accountLabel: row.accountLabel,
       provider: row.provider,
       planType: row.planType,
+      planPresentation: getPlanPresentation({
+        provider: row.provider,
+        planType:
+          options.codexQuota?.planType ?? row.planType ?? resolveAuthFilePlanType(row.raw),
+        t: options.t,
+      }),
       authIndex: row.authIndex,
       projectId: row.projectId,
       priority: row.priority ?? 0,

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.ts
@@ -12,7 +12,7 @@ import type {
   QuotaCooldownInfo,
 } from '@/services/api';
 import type { AuthFileCodexStatusSummary } from '@/features/authFiles/model/credentialStatus';
-import { normalizePlanType, parseIdTokenPayload } from '@/utils/quota/parsers';
+import { normalizeStringValue, parseIdTokenPayload } from '@/utils/quota/parsers';
 import { isValidQuotaResetAtMs } from '@/utils/quota/formatters';
 import { isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
 import { parseTimestampMs } from '@/utils/timestamp';
@@ -1161,7 +1161,7 @@ const buildOverviewCredential = (
     if (!Number.isFinite(parsed) || parsed <= 0) return null;
     return Number.isNaN(new Date(parsed).getTime()) ? null : parsed;
   };
-  const effectivePlanType = normalizePlanType(
+  const effectivePlanType = normalizeStringValue(
     codexQuota?.planType ?? row.planType ?? resolveAuthFilePlanType(row.raw)
   );
   const planPresentation = getPlanPresentation({

--- a/apps/web/src/features/accounts/model/accountListPresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.test.ts
@@ -94,6 +94,23 @@ const makeCodexStatus = (
 });
 
 describe('accountListPresentation', () => {
+  it('attaches compact and full plan presentation to account list identity', () => {
+    const item = buildAccountListItem(
+      makeRow({
+        provider: 'codex',
+        planType: 'self_serve_business_prolite',
+      })
+    );
+
+    expect(item.identity.planPresentation).toMatchObject({
+      rawPlanType: 'self_serve_business_prolite',
+      canonicalPlanType: 'business_premium_5x',
+      shortLabel: 'Business 5x',
+      fullLabel: 'Business Premium 5x',
+      known: true,
+    });
+  });
+
   it('prioritizes re-authentication over quota state', () => {
     const row = makeRow({
       quota: {

--- a/apps/web/src/features/accounts/model/accountListPresentation.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next';
 import type { QuotaCooldownInfo } from '@/services/api';
 import type { AuthFileCodexStatusSummary } from '@/features/authFiles/model/credentialStatus';
 import type { AccountRow } from './accountRows';
@@ -15,6 +16,7 @@ import {
 import type { UsageValueSource } from './usageValueRows';
 import { isValidQuotaResetAtMs } from '@/utils/quota/formatters';
 import { isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
+import { getPlanPresentation, type PlanPresentation } from '@/utils/plans';
 import {
   classifyAccountCredentialStatusEvidence,
   classifyAccountObservedDiagnosticEvidence,
@@ -96,6 +98,7 @@ export interface AccountListPresentationItem {
     fileName: string;
     provider: string;
     planType: string | null;
+    planPresentation: PlanPresentation | null;
     priority: number;
     priorityIsNegative: boolean;
   };
@@ -142,6 +145,7 @@ export interface AccountListPresentationItem {
 }
 
 export interface AccountListPresentationOptions {
+  t?: TFunction;
   recommendation?: AccountRecommendation | null;
   quotaCooldown?: QuotaCooldownInfo | null;
   estimatedValuePerRequest?: number;
@@ -1173,6 +1177,11 @@ export const buildAccountListItem = (
     accountQuotaWindows,
     options.requestEvidence
   );
+  const planPresentation = getPlanPresentation({
+    provider: row.provider,
+    planType: row.planType,
+    t: options.t,
+  });
 
   return {
     identity: {
@@ -1181,6 +1190,7 @@ export const buildAccountListItem = (
       fileName: row.fileName,
       provider: row.provider,
       planType: row.planType,
+      planPresentation,
       priority: row.priority ?? 0,
       priorityIsNegative: row.priority !== null && row.priority < 0,
     },

--- a/apps/web/src/features/accounts/model/accountQuotaSummary.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSummary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AuthFileItem, CodexQuotaState } from '@/types';
 import { getAuthFileSelectionKey } from '@/features/authFiles/model/credentialStatus';
 import { CODEX_SPARK_MODEL_ID } from '@/utils/quota/codexQuota';
+import { buildQuotaCredentialIdentity } from '@/utils/quota/credentialScope';
 import { resolveAccountQuota, type AccountQuotaStores } from './accountQuotaSummary';
 
 const emptyStores = (): AccountQuotaStores => ({
@@ -108,5 +109,27 @@ describe('resolveAccountQuota', () => {
       remainingPercent: 64,
     });
     expect(summary.observedQuotaAtMs).toBeUndefined();
+  });
+
+  it('uses Antigravity tier metadata when the stored plan is unknown', () => {
+    const file = {
+      name: 'antigravity.json',
+      type: 'antigravity',
+      authIndex: 'auth-1',
+      planType: 'unknown',
+    } as AuthFileItem;
+    const stores = emptyStores();
+    stores.antigravityQuota[file.name] = {
+      ...buildQuotaCredentialIdentity(file),
+      status: 'success',
+      groups: [],
+      subscription: {
+        plan: 'unknown',
+        tierName: 'Antigravity Future',
+        tierId: 'future-tier',
+      },
+    };
+
+    expect(resolveAccountQuota(file, stores).planType).toBe('antigravity future');
   });
 });

--- a/apps/web/src/features/accounts/model/accountQuotaSummary.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSummary.test.ts
@@ -130,6 +130,6 @@ describe('resolveAccountQuota', () => {
       },
     };
 
-    expect(resolveAccountQuota(file, stores).planType).toBe('antigravity future');
+    expect(resolveAccountQuota(file, stores).planType).toBe('Antigravity Future');
   });
 });

--- a/apps/web/src/features/accounts/model/accountQuotaSummary.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSummary.ts
@@ -950,7 +950,7 @@ export const resolveAccountQuota = (
     const quota = getCredentialScopedQuotaState(stores.antigravityQuota, file);
     if (!quota) return emptyQuota(filePlanType);
     const antigravityPlanType = resolveAntigravityPlanType(quota.subscription, filePlanType);
-    const planType = antigravityPlanType?.toLowerCase() ?? null;
+    const planType = antigravityPlanType;
     if (quota.status === 'loading') return loadingQuota(planType);
     if (quota.status === 'error') {
       return quotaFromError(quota.error, planType, quota.errorStatus, quota.failedAtMs);

--- a/apps/web/src/features/accounts/model/accountQuotaSummary.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaSummary.ts
@@ -23,9 +23,9 @@ import {
   getHeaderSnapshotTraceId,
   hasUsageHeaderDiagnosticSignal,
 } from '@/utils/usageHeaderSnapshots';
-import { resolveCodexPlanType } from '@/utils/quota/resolvers';
 import { getCredentialScopedQuotaState } from '@/utils/quota/credentialScope';
 import { isCodexMainQuotaModelScope, isCodexMainQuotaWindow } from '@/utils/quota/codexQuota';
+import { resolveAuthFilePlanType, resolveAntigravityPlanType } from '@/utils/plans';
 
 export type AccountQuotaStatus =
   | 'unknown'
@@ -250,18 +250,7 @@ export const normalizeAccountProvider = (file: AuthFileItem): string => {
 };
 
 const readPlanType = (file: AuthFileItem): string | null => {
-  if (normalizeAccountProvider(file) === 'codex') {
-    const codexPlanType = resolveCodexPlanType(file);
-    if (codexPlanType) return codexPlanType;
-  }
-  const idToken = file.id_token;
-  const idTokenPlan =
-    idToken && typeof idToken === 'object' && !Array.isArray(idToken)
-      ? readString((idToken as Record<string, unknown>).plan_type)
-      : '';
-  const raw =
-    idTokenPlan || readString(file.planType ?? file.plan_type ?? file.tier ?? file.subscription);
-  return raw ? raw.toLowerCase() : null;
+  return resolveAuthFilePlanType(file);
 };
 
 const getQuotaStatusFromRemaining = (remainingPercent: number | null): AccountQuotaStatus => {
@@ -960,11 +949,8 @@ export const resolveAccountQuota = (
   if (provider === 'antigravity') {
     const quota = getCredentialScopedQuotaState(stores.antigravityQuota, file);
     if (!quota) return emptyQuota(filePlanType);
-    const subscriptionPlan =
-      readString(quota.subscription?.plan) ||
-      readString(quota.subscription?.tierName) ||
-      readString(quota.subscription?.tierId);
-    const planType = filePlanType ?? (subscriptionPlan ? subscriptionPlan.toLowerCase() : null);
+    const antigravityPlanType = resolveAntigravityPlanType(quota.subscription, filePlanType);
+    const planType = antigravityPlanType?.toLowerCase() ?? null;
     if (quota.status === 'loading') return loadingQuota(planType);
     if (quota.status === 'error') {
       return quotaFromError(quota.error, planType, quota.errorStatus, quota.failedAtMs);

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -15,6 +15,7 @@ import {
   filterAccountRows,
   getAccountInspectionResultSnapshotKey,
   getHandledAccountInspectionResultKeys,
+  getPlanOptionLabel,
   getPlanOptions,
   sortAccountRows,
   type AccountInspectionResult,
@@ -2486,13 +2487,13 @@ describe('accountRows', () => {
     plusRow.planType = ' plus ';
 
     expect(getPlanOptions(rows)).toEqual([
-      'enterprise',
-      'free',
-      'plus',
-      'team',
-      'prolite',
-      'pro',
-      'unknown',
+      { value: 'enterprise', label: 'Enterprise' },
+      { value: 'free', label: 'Free' },
+      { value: 'plus', label: 'Plus' },
+      { value: 'pro_5x', label: 'Pro 5x' },
+      { value: 'pro_20x', label: 'Pro 20x' },
+      { value: 'team', label: 'Team' },
+      { value: 'unknown', label: 'Unknown plan' },
     ]);
     expect(
       sortAccountRows(rows, { key: 'plan', direction: 'asc' }).map((row) => row.fileName)
@@ -2525,6 +2526,45 @@ describe('accountRows', () => {
         search: '',
       }).map((row) => row.fileName)
     ).toEqual(['plus.json']);
+  });
+
+  it('reads non-Codex planType values from nested token metadata', () => {
+    const [row] = buildAccountRows(
+      [
+        {
+          name: 'claude.json',
+          type: 'claude',
+          id_token: { planType: 'plan_pro' },
+        },
+      ],
+      emptyStores()
+    );
+
+    expect(row.planType).toBe('plan_pro');
+    expect(row.canonicalPlanType).toBe('pro');
+  });
+
+  it('aggregates Codex plan aliases by canonical identity for filtering', () => {
+    const rows = buildAccountRows(
+      [
+        { name: 'prolite.json', type: 'codex', planType: 'prolite' },
+        { name: 'pro-lite.json', type: 'codex', planType: 'pro-lite' },
+        { name: 'pro_lite.json', type: 'codex', planType: 'pro_lite' },
+      ],
+      emptyStores()
+    );
+
+    expect(getPlanOptions(rows)).toEqual([{ value: 'pro_5x', label: 'Pro 5x' }]);
+    expect(getPlanOptionLabel(rows, 'pro-lite')).toBe('Pro 5x');
+    expect(
+      filterAccountRows(rows, {
+        provider: 'all',
+        status: 'all',
+        plan: 'pro_5x',
+        quotaBand: 'all',
+        search: '',
+      }).map((row) => row.fileName)
+    ).toEqual(['prolite.json', 'pro-lite.json', 'pro_lite.json']);
   });
 
   it('sorts rows by priority, recent requests, and reset label', () => {

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { TFunction } from 'i18next';
 import type { AuthFileItem, CodexQuotaState, CredentialScopedQuotaState } from '@/types';
 import type { UsageHeaderSnapshot } from '@/services/api/usageService';
 import {
@@ -2765,5 +2766,69 @@ describe('accountRows', () => {
       source: 'cache',
       observedAtMs: 1_700_000_000_000,
     });
+  });
+
+  it('keeps cross-provider canonical plan filtering mutually exclusive', () => {
+    const rows = buildAccountRows(
+      [
+        { name: 'codex-pro.json', type: 'codex', planType: 'pro' },
+        { name: 'codex-prolite.json', type: 'codex', planType: 'prolite' },
+        { name: 'claude-pro.json', type: 'claude', id_token: { planType: 'plan_pro' } },
+        { name: 'antigravity-pro.json', type: 'antigravity', planType: 'pro' },
+      ],
+      emptyStores()
+    );
+
+    const planValues = getPlanOptions(rows).map((option) => option.value);
+    expect(planValues).toContain('pro');
+    expect(planValues).toContain('pro_20x');
+    expect(planValues).toContain('pro_5x');
+    expect(getPlanOptions(rows)).toEqual(
+      expect.arrayContaining([
+        { value: 'pro', label: 'Pro' },
+        { value: 'pro_20x', label: 'Pro 20x' },
+        { value: 'pro_5x', label: 'Pro 5x' },
+      ])
+    );
+
+    const baseFilters = {
+      provider: 'all',
+      status: 'all' as const,
+      quotaBand: 'all' as const,
+      search: '',
+    };
+    expect(
+      filterAccountRows(rows, { ...baseFilters, plan: 'pro' }).map((row) => row.fileName)
+    ).toEqual(['claude-pro.json', 'antigravity-pro.json']);
+    expect(
+      filterAccountRows(rows, { ...baseFilters, plan: 'pro_20x' }).map((row) => row.fileName)
+    ).toEqual(['codex-pro.json']);
+    expect(
+      filterAccountRows(rows, { ...baseFilters, plan: 'pro_5x' }).map((row) => row.fileName)
+    ).toEqual(['codex-prolite.json']);
+  });
+
+  it('keeps the unknown plan filter label stable regardless of row order', () => {
+    const zhT = ((key: string, options?: { defaultValue?: string }) =>
+      key === 'auth_files.codex_plan_filter_unknown' ? '未知套餐' : (options?.defaultValue ?? key)) as TFunction;
+
+    const baseFile = { type: 'codex' } as AuthFileItem;
+    const nullPlanRow = buildAccountRows(
+      [{ ...baseFile, name: 'missing-plan.json' }],
+      emptyStores()
+    )[0]!;
+    const explicitUnknownRow = buildAccountRows(
+      [{ ...baseFile, name: 'explicit-unknown.json', planType: 'unknown' }],
+      emptyStores()
+    )[0]!;
+
+    for (const ordered of [
+      [nullPlanRow, explicitUnknownRow],
+      [explicitUnknownRow, nullPlanRow],
+    ]) {
+      const options = getPlanOptions(ordered, zhT);
+      expect(options).toHaveLength(1);
+      expect(options[0]).toEqual({ value: 'unknown', label: '未知套餐' });
+    }
   });
 });

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -17,9 +17,11 @@ import {
   getAccountInspectionResultSnapshotKey,
   getHandledAccountInspectionResultKeys,
   getPlanOptionLabel,
+  getPlanOptionValue,
   getPlanOptions,
   sortAccountRows,
   type AccountInspectionResult,
+  type AccountRow,
   type AccountQuotaStores,
 } from './accountRows';
 import {
@@ -2806,6 +2808,85 @@ describe('accountRows', () => {
     expect(
       filterAccountRows(rows, { ...baseFilters, plan: 'pro_5x' }).map((row) => row.fileName)
     ).toEqual(['codex-prolite.json']);
+  });
+
+  it('uses a canonical filter label independent of provider row order', () => {
+    const rows = buildAccountRows(
+      [
+        { name: 'claude-pro.json', type: 'claude', id_token: { planType: 'plan_pro' } },
+        { name: 'antigravity-pro.json', type: 'antigravity', planType: 'pro' },
+      ],
+      emptyStores()
+    );
+    const zhT = ((key: string, options?: { defaultValue?: string }) => {
+      if (key === 'plans.claude.pro') return '专业版';
+      if (key === 'plans.antigravity.pro') return 'Pro';
+      return options?.defaultValue ?? key;
+    }) as TFunction;
+
+    expect(getPlanOptions(rows, zhT)).toEqual([{ value: 'pro', label: 'Pro' }]);
+    expect(getPlanOptions([...rows].reverse(), zhT)).toEqual([
+      { value: 'pro', label: 'Pro' },
+    ]);
+  });
+
+  it('keeps a selected canonical pro filter stable when rows change', () => {
+    const initialRows = buildAccountRows(
+      [
+        { name: 'claude-pro.json', type: 'claude', id_token: { planType: 'plan_pro' } },
+        { name: 'codex-pro.json', type: 'codex', planType: 'pro' },
+      ],
+      emptyStores()
+    );
+    const updatedRows = initialRows.filter((row) => row.provider === 'codex');
+
+    expect(getPlanOptionValue(initialRows, 'pro')).toBe('pro');
+    expect(getPlanOptionValue(updatedRows, 'pro')).toBe('pro');
+    expect(getPlanOptionLabel(updatedRows, 'pro')).toBe('Pro');
+    expect(
+      filterAccountRows(updatedRows, {
+        provider: 'all',
+        status: 'all',
+        plan: 'pro',
+        quotaBand: 'all',
+        search: '',
+      })
+    ).toEqual([]);
+    expect(
+      filterAccountRows(updatedRows, {
+        provider: 'all',
+        status: 'all',
+        plan: 'pro_20x',
+        quotaBand: 'all',
+        search: '',
+      }).map((row) => row.fileName)
+    ).toEqual(['codex-pro.json']);
+  });
+
+  it('normalizes legacy raw plan filter aliases without using current rows', () => {
+    const rows: AccountRow[] = [];
+    expect(getPlanOptionValue(rows, 'prolite')).toBe('pro_5x');
+    expect(getPlanOptionValue(rows, 'pro-lite')).toBe('pro_5x');
+    expect(getPlanOptionValue(rows, 'pro_lite')).toBe('pro_5x');
+    expect(getPlanOptionValue(rows, 'self_serve_business_prolite')).toBe(
+      'business_premium_5x'
+    );
+    expect(getPlanOptionValue(rows, 'enterprise_cbp_automation')).toBe('enterprise_automation');
+  });
+
+  it('scopes same-named unknown plans to their providers', () => {
+    const rows = buildAccountRows(
+      [
+        { name: 'antigravity-future.json', type: 'antigravity', planType: 'future_plan_x' },
+        { name: 'kimi-future.json', type: 'kimi', planType: 'future_plan_x' },
+      ],
+      emptyStores()
+    );
+
+    expect(getPlanOptions(rows)).toEqual([
+      { value: 'unknown:antigravity:future_plan_x', label: 'future_plan_x' },
+      { value: 'unknown:kimi:future_plan_x', label: 'future_plan_x' },
+    ]);
   });
 
   it('keeps the unknown plan filter label stable regardless of row order', () => {

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -1,5 +1,6 @@
 import type { AuthFileItem } from '@/types';
 import type { CodexInspectionResult } from '@/services/api/usageService';
+import type { TFunction } from 'i18next';
 import {
   normalizeRecentRequestBuckets,
   sumRecentRequests,
@@ -15,7 +16,6 @@ import {
   hasActiveCodexInspectionAuthenticationFailure,
   type AuthFileCodexStatusSummary,
 } from '@/features/authFiles/model/credentialStatus';
-import { resolveCodexPlanType } from '@/utils/quota/resolvers';
 import {
   compareQuotaResetLabels,
   compareQuotaResets,
@@ -49,6 +49,7 @@ import {
   type AccountInspectionSummary,
 } from '@/features/accounts/model/accountCredentialEvidence';
 import { getCredentialScopedQuotaState } from '@/utils/quota/credentialScope';
+import { getCanonicalPlanType, getPlanPresentation, resolveAuthFilePlanType } from '@/utils/plans';
 
 export {
   compareQuotaResetLabels,
@@ -172,6 +173,8 @@ export interface AccountRow {
   accountLabel: string;
   provider: string;
   planType: string | null;
+  /** Canonical plan identity used by filtering/grouping; planType remains raw data. */
+  canonicalPlanType?: string | null;
   disabled: boolean;
   runtimeOnly: boolean;
   statusMessage: string;
@@ -222,13 +225,17 @@ export interface AccountRowFilters {
   requestEvidenceBySelectionKey?: AccountRequestEvidenceBySelectionKey;
 }
 
+export interface AccountPlanOption {
+  value: string;
+  label: string;
+}
+
 const QUOTA_LOW_THRESHOLD = 20;
 const QUOTA_OK_THRESHOLD = 50;
 const UNKNOWN_ACCOUNT_PLAN = 'unknown';
 const ACCOUNT_CODEX_STATUS_FILTER_SET = new Set<AccountCodexStatusFilter>(
   ACCOUNT_CODEX_STATUS_FILTERS
 );
-const PREMIUM_CODEX_PLAN_TYPES = new Set(['prolite', 'pro-lite', 'pro_lite']);
 
 export const isAccountCodexStatusFilter = (
   status: AccountStatusFilter
@@ -250,8 +257,8 @@ const readNumber = (value: unknown): number | null => {
   return null;
 };
 
-const getAccountPlanFilterValue = (planType: string | null): string =>
-  planType?.trim() || UNKNOWN_ACCOUNT_PLAN;
+const getAccountPlanFilterValue = (provider: string, planType: string | null): string =>
+  getCanonicalPlanType(provider, planType) || UNKNOWN_ACCOUNT_PLAN;
 
 const readAuthIndex = (file: AuthFileItem): string =>
   readString(file.authIndex ?? file['auth_index']);
@@ -262,18 +269,7 @@ const readProjectId = (file: AuthFileItem): string =>
   );
 
 const readPlanType = (file: AuthFileItem): string | null => {
-  if (normalizeAccountProvider(file) === 'codex') {
-    const codexPlanType = resolveCodexPlanType(file);
-    if (codexPlanType) return codexPlanType;
-  }
-  const idToken = file.id_token;
-  const idTokenPlan =
-    idToken && typeof idToken === 'object' && !Array.isArray(idToken)
-      ? readString((idToken as Record<string, unknown>).plan_type)
-      : '';
-  const raw =
-    idTokenPlan || readString(file.planType ?? file.plan_type ?? file.tier ?? file.subscription);
-  return raw ? raw.toLowerCase() : null;
+  return resolveAuthFilePlanType(file);
 };
 
 const resolveAccountLabel = (file: AuthFileItem): string =>
@@ -453,6 +449,7 @@ export const buildAccountRows = (
       accountLabel: resolveAccountLabel(file),
       provider,
       planType: quota.planType ?? readPlanType(file),
+      canonicalPlanType: getCanonicalPlanType(provider, quota.planType ?? readPlanType(file)),
       disabled: effectiveFile.disabled === true,
       runtimeOnly:
         file.runtimeOnly === true || file.runtimeOnly === 'true' || file.runtime_only === true,
@@ -651,7 +648,12 @@ export const filterAccountRows = (rows: AccountRow[], filters: AccountRowFilters
     : null;
   return rows.filter((row) => {
     if (filters.provider !== 'all' && row.provider !== filters.provider) return false;
-    if (filters.plan !== 'all' && getAccountPlanFilterValue(row.planType) !== filters.plan) {
+    const rowPlan = getAccountPlanFilterValue(row.provider, row.planType);
+    const selectedPlan =
+      filters.plan === 'unknown'
+        ? UNKNOWN_ACCOUNT_PLAN
+        : (getCanonicalPlanType(row.provider, filters.plan) ?? filters.plan);
+    if (filters.plan !== 'all' && rowPlan !== selectedPlan) {
       return false;
     }
     if (
@@ -671,6 +673,7 @@ export const filterAccountRows = (rows: AccountRow[], filters: AccountRowFilters
       row.fileName,
       row.provider,
       row.planType,
+      row.canonicalPlanType,
       row.authIndex,
       row.projectId,
       row.note,
@@ -718,25 +721,81 @@ export const sortAccountRows = (
 export const getProviderOptions = (rows: AccountRow[]) =>
   Array.from(new Set(rows.map((row) => row.provider))).sort();
 
-export const getPlanOptions = (rows: AccountRow[]) => {
-  const plans = new Set<string>();
-  let hasUnknownPlan = false;
+const getUnknownPlanLabel = (t?: TFunction): string =>
+  t?.('auth_files.codex_plan_filter_unknown', { defaultValue: 'Unknown plan' }) ?? 'Unknown plan';
+
+export const getPlanOptions = (rows: AccountRow[], t?: TFunction): AccountPlanOption[] => {
+  const plans = new Map<string, AccountPlanOption>();
   rows.forEach((row) => {
-    const plan = getAccountPlanFilterValue(row.planType);
-    if (plan === UNKNOWN_ACCOUNT_PLAN) {
-      hasUnknownPlan = true;
-      return;
-    }
-    plans.add(plan);
+    const plan = getAccountPlanFilterValue(row.provider, row.planType);
+    const presentation = getPlanPresentation({ provider: row.provider, planType: row.planType, t });
+    const option = {
+      value: plan,
+      label: presentation?.shortLabel ?? getUnknownPlanLabel(t),
+    };
+    if (!plans.has(plan)) plans.set(plan, option);
   });
-  const sortedPlans = Array.from(plans).sort((left, right) =>
-    compareAccountPlanTypes(left, right, 'asc')
+  return Array.from(plans.values()).sort((left, right) => {
+    if (left.value === UNKNOWN_ACCOUNT_PLAN) return 1;
+    if (right.value === UNKNOWN_ACCOUNT_PLAN) return -1;
+    return left.label.localeCompare(right.label, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    });
+  });
+};
+
+export const getPlanOptionLabel = (rows: AccountRow[], value: string, t?: TFunction): string => {
+  if (value === UNKNOWN_ACCOUNT_PLAN) return getUnknownPlanLabel(t);
+  const directOption = getPlanOptions(rows, t).find((option) => option.value === value);
+  if (directOption) return directOption.label;
+
+  const normalizedValue = value.trim().toLowerCase();
+  if (!normalizedValue) return value;
+  const matchingPresentation = rows
+    .map((row) => {
+      const presentation = getPlanPresentation({
+        provider: row.provider,
+        planType: normalizedValue,
+        t,
+      });
+      return presentation &&
+        getAccountPlanFilterValue(row.provider, row.planType) === presentation.canonicalPlanType
+        ? presentation
+        : null;
+    })
+    .find(
+      (presentation): presentation is NonNullable<typeof presentation> => presentation !== null
+    );
+  return (
+    matchingPresentation?.shortLabel ??
+    normalizedValue
   );
-  if (hasUnknownPlan) {
-    const withoutUnknown = sortedPlans.filter((plan) => plan !== UNKNOWN_ACCOUNT_PLAN);
-    return [...withoutUnknown, UNKNOWN_ACCOUNT_PLAN];
+};
+
+export const getPlanOptionValue = (rows: AccountRow[], value: string, t?: TFunction): string => {
+  const normalizedValue = value.trim().toLowerCase();
+  if (!normalizedValue || normalizedValue === 'all' || normalizedValue === UNKNOWN_ACCOUNT_PLAN) {
+    return normalizedValue || value;
   }
-  return sortedPlans;
+  const directOption = getPlanOptions(rows, t).find((option) => option.value === normalizedValue);
+  if (directOption) return directOption.value;
+
+  return (
+    rows
+      .map((row) => {
+        const presentation = getPlanPresentation({
+          provider: row.provider,
+          planType: normalizedValue,
+          t,
+        });
+        return presentation &&
+          getAccountPlanFilterValue(row.provider, row.planType) === presentation.canonicalPlanType
+          ? presentation.canonicalPlanType
+          : null;
+      })
+      .find((canonical): canonical is string => canonical !== null) ?? normalizedValue
+  );
 };
 
 const matchesStatusFilter = (
@@ -835,11 +894,12 @@ const compareDefaultAccountRows = (
   });
 };
 
-const getAccountPlanSortRank = (planType: string | null): number | null => {
-  const normalized = planType?.trim().toLowerCase();
-  if (!normalized) return null;
-  if (normalized === 'pro') return 50;
-  if (PREMIUM_CODEX_PLAN_TYPES.has(normalized)) return 40;
+const getAccountPlanSortRank = (provider: string, planType: string | null): number | null => {
+  const presentation = getPlanPresentation({ provider, planType });
+  if (!presentation?.known || !presentation.canonicalPlanType) return null;
+  const normalized = presentation.canonicalPlanType;
+  if (normalized === 'pro_20x') return 50;
+  if (normalized === 'pro_5x') return 40;
   if (normalized === 'team') return 30;
   if (normalized === 'plus') return 20;
   if (normalized === 'free') return 10;
@@ -847,19 +907,23 @@ const getAccountPlanSortRank = (planType: string | null): number | null => {
 };
 
 const compareAccountPlanTypes = (
+  leftProvider: string,
   left: string | null,
+  rightProvider: string,
   right: string | null,
   direction: AccountRowSortDirection
 ) => {
-  const leftRank = getAccountPlanSortRank(left);
-  const rightRank = getAccountPlanSortRank(right);
+  const leftCanonical = getCanonicalPlanType(leftProvider, left);
+  const rightCanonical = getCanonicalPlanType(rightProvider, right);
+  const leftRank = getAccountPlanSortRank(leftProvider, left);
+  const rightRank = getAccountPlanSortRank(rightProvider, right);
   const leftKnown = leftRank !== null;
   const rightKnown = rightRank !== null;
   if (!leftKnown && !rightKnown) return 0;
   if (!leftKnown) return 1;
   if (!rightKnown) return -1;
   const rankComparison = compareNumbers(leftRank, rightRank, direction);
-  return rankComparison || compareText(left ?? '', right ?? '', direction);
+  return rankComparison || compareText(leftCanonical ?? '', rightCanonical ?? '', direction);
 };
 
 const compareAccountRowsBySort = (left: AccountRow, right: AccountRow, sort: AccountRowSort) => {
@@ -868,7 +932,13 @@ const compareAccountRowsBySort = (left: AccountRow, right: AccountRow, sort: Acc
     return accountComparison || compareText(left.fileName, right.fileName, sort.direction);
   }
   if (sort.key === 'plan') {
-    return compareAccountPlanTypes(left.planType, right.planType, sort.direction);
+    return compareAccountPlanTypes(
+      left.provider,
+      left.planType,
+      right.provider,
+      right.planType,
+      sort.direction
+    );
   }
   if (sort.key === 'note') {
     return compareText(left.note ?? '', right.note ?? '', sort.direction, true);

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -649,11 +649,11 @@ export const filterAccountRows = (rows: AccountRow[], filters: AccountRowFilters
   return rows.filter((row) => {
     if (filters.provider !== 'all' && row.provider !== filters.provider) return false;
     const rowPlan = getAccountPlanFilterValue(row.provider, row.planType);
-    const selectedPlan =
-      filters.plan === 'unknown'
-        ? UNKNOWN_ACCOUNT_PLAN
-        : (getCanonicalPlanType(row.provider, filters.plan) ?? filters.plan);
-    if (filters.plan !== 'all' && rowPlan !== selectedPlan) {
+    // `filters.plan` is already a canonical filter identity (see getPlanOptionValue),
+    // so it must be compared directly against the row's canonical value. Re-canonicalizing
+    // it per row provider would re-introduce cross-provider collisions (e.g. Codex `pro`
+    // mapping to `pro_20x` while Claude/Antigravity `pro` stays `pro`).
+    if (filters.plan !== 'all' && rowPlan !== filters.plan) {
       return false;
     }
     if (
@@ -728,11 +728,15 @@ export const getPlanOptions = (rows: AccountRow[], t?: TFunction): AccountPlanOp
   const plans = new Map<string, AccountPlanOption>();
   rows.forEach((row) => {
     const plan = getAccountPlanFilterValue(row.provider, row.planType);
-    const presentation = getPlanPresentation({ provider: row.provider, planType: row.planType, t });
-    const option = {
-      value: plan,
-      label: presentation?.shortLabel ?? getUnknownPlanLabel(t),
-    };
+    // The reserved `unknown` bucket aggregates both missing plan types and explicit
+    // `unknown` raw values; its label must always be the localized "Unknown plan"
+    // regardless of which row the Map encounters first.
+    const label =
+      plan === UNKNOWN_ACCOUNT_PLAN
+        ? getUnknownPlanLabel(t)
+        : getPlanPresentation({ provider: row.provider, planType: row.planType, t })?.shortLabel ??
+          getUnknownPlanLabel(t);
+    const option = { value: plan, label };
     if (!plans.has(plan)) plans.set(plan, option);
   });
   return Array.from(plans.values()).sort((left, right) => {

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -49,7 +49,12 @@ import {
   type AccountInspectionSummary,
 } from '@/features/accounts/model/accountCredentialEvidence';
 import { getCredentialScopedQuotaState } from '@/utils/quota/credentialScope';
-import { getCanonicalPlanType, getPlanPresentation, resolveAuthFilePlanType } from '@/utils/plans';
+import {
+  getCanonicalPlanFilterLabel,
+  getCanonicalPlanType,
+  getPlanPresentation,
+  resolveAuthFilePlanType,
+} from '@/utils/plans';
 
 export {
   compareQuotaResetLabels,
@@ -724,82 +729,82 @@ export const getProviderOptions = (rows: AccountRow[]) =>
 const getUnknownPlanLabel = (t?: TFunction): string =>
   t?.('auth_files.codex_plan_filter_unknown', { defaultValue: 'Unknown plan' }) ?? 'Unknown plan';
 
+/** Explicit compatibility aliases for values persisted before canonical filters. */
+const LEGACY_PLAN_FILTER_ALIASES: Readonly<Record<string, string>> = {
+  prolite: 'pro_5x',
+  'pro-lite': 'pro_5x',
+  pro_lite: 'pro_5x',
+  plan_free: 'free',
+  plan_pro: 'pro',
+  plan_max: 'max',
+  plan_max5: 'max_5x',
+  plan_max20: 'max_20x',
+  plan_team: 'team',
+  max5: 'max_5x',
+  max20: 'max_20x',
+  self_serve_business_prolite: 'business_premium_5x',
+  self_serve_business_usage_based: 'business_usage_based',
+  ent26: 'enterprise',
+  hc: 'enterprise',
+  enterprise_cbp_automation: 'enterprise_automation',
+  enterprise_cbp_usage_based: 'enterprise_usage_based',
+  education: 'edu',
+  ultra_lite: 'ultra-lite',
+};
+
+const normalizePlanFilterValue = (value: string): string => {
+  const normalized = value.trim().toLowerCase();
+  return LEGACY_PLAN_FILTER_ALIASES[normalized] ?? normalized;
+};
+
+const comparePlanOptions = (left: AccountPlanOption, right: AccountPlanOption): number => {
+  if (left.value === UNKNOWN_ACCOUNT_PLAN) return 1;
+  if (right.value === UNKNOWN_ACCOUNT_PLAN) return -1;
+  const byLabel = left.label.localeCompare(right.label, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+  return byLabel || left.value.localeCompare(right.value, undefined, { numeric: true });
+};
+
 export const getPlanOptions = (rows: AccountRow[], t?: TFunction): AccountPlanOption[] => {
-  const plans = new Map<string, AccountPlanOption>();
+  const labels = new Map<string, string>();
   rows.forEach((row) => {
     const plan = getAccountPlanFilterValue(row.provider, row.planType);
     // The reserved `unknown` bucket aggregates both missing plan types and explicit
     // `unknown` raw values; its label must always be the localized "Unknown plan"
     // regardless of which row the Map encounters first.
-    const label =
-      plan === UNKNOWN_ACCOUNT_PLAN
-        ? getUnknownPlanLabel(t)
-        : getPlanPresentation({ provider: row.provider, planType: row.planType, t })?.shortLabel ??
-          getUnknownPlanLabel(t);
-    const option = { value: plan, label };
-    if (!plans.has(plan)) plans.set(plan, option);
+    if (plan === UNKNOWN_ACCOUNT_PLAN) {
+      labels.set(plan, getUnknownPlanLabel(t));
+      return;
+    }
+    const presentation = getPlanPresentation({ provider: row.provider, planType: row.planType, t });
+    const label = getCanonicalPlanFilterLabel(
+      plan,
+      t,
+      presentation?.shortLabel ?? plan
+    );
+    const previousLabel = labels.get(plan);
+    if (!previousLabel || label < previousLabel) labels.set(plan, label);
   });
-  return Array.from(plans.values()).sort((left, right) => {
-    if (left.value === UNKNOWN_ACCOUNT_PLAN) return 1;
-    if (right.value === UNKNOWN_ACCOUNT_PLAN) return -1;
-    return left.label.localeCompare(right.label, undefined, {
-      numeric: true,
-      sensitivity: 'base',
-    });
-  });
+  return Array.from(labels, ([value, label]) => ({ value, label })).sort(comparePlanOptions);
 };
 
 export const getPlanOptionLabel = (rows: AccountRow[], value: string, t?: TFunction): string => {
-  if (value === UNKNOWN_ACCOUNT_PLAN) return getUnknownPlanLabel(t);
-  const directOption = getPlanOptions(rows, t).find((option) => option.value === value);
-  if (directOption) return directOption.label;
-
-  const normalizedValue = value.trim().toLowerCase();
+  const normalizedValue = normalizePlanFilterValue(value);
   if (!normalizedValue) return value;
-  const matchingPresentation = rows
-    .map((row) => {
-      const presentation = getPlanPresentation({
-        provider: row.provider,
-        planType: normalizedValue,
-        t,
-      });
-      return presentation &&
-        getAccountPlanFilterValue(row.provider, row.planType) === presentation.canonicalPlanType
-        ? presentation
-        : null;
-    })
-    .find(
-      (presentation): presentation is NonNullable<typeof presentation> => presentation !== null
-    );
-  return (
-    matchingPresentation?.shortLabel ??
-    normalizedValue
-  );
+  if (normalizedValue === UNKNOWN_ACCOUNT_PLAN) return getUnknownPlanLabel(t);
+  const directOption = getPlanOptions(rows, t).find((option) => option.value === normalizedValue);
+  if (directOption) return directOption.label;
+  return getCanonicalPlanFilterLabel(normalizedValue, t, normalizedValue);
 };
 
-export const getPlanOptionValue = (rows: AccountRow[], value: string, t?: TFunction): string => {
-  const normalizedValue = value.trim().toLowerCase();
+export const getPlanOptionValue = (_rows: AccountRow[], value: string, _t?: TFunction): string => {
+  const normalizedValue = normalizePlanFilterValue(value);
   if (!normalizedValue || normalizedValue === 'all' || normalizedValue === UNKNOWN_ACCOUNT_PLAN) {
     return normalizedValue || value;
   }
-  const directOption = getPlanOptions(rows, t).find((option) => option.value === normalizedValue);
-  if (directOption) return directOption.value;
-
-  return (
-    rows
-      .map((row) => {
-        const presentation = getPlanPresentation({
-          provider: row.provider,
-          planType: normalizedValue,
-          t,
-        });
-        return presentation &&
-          getAccountPlanFilterValue(row.provider, row.planType) === presentation.canonicalPlanType
-          ? presentation.canonicalPlanType
-          : null;
-      })
-      .find((canonical): canonical is string => canonical !== null) ?? normalizedValue
-  );
+  return normalizedValue;
 };
 
 const matchesStatusFilter = (

--- a/apps/web/src/features/dashboard/components/HealthAlertsCard.tsx
+++ b/apps/web/src/features/dashboard/components/HealthAlertsCard.tsx
@@ -10,6 +10,7 @@ import {
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
 import { maskSensitiveText, truncateText } from '@/utils/format';
 import { formatDurationMs } from '@/utils/usage';
+import { getPlanPresentation } from '@/utils/plans';
 import styles from './HealthAlertsCard.module.scss';
 
 interface HealthAlertsCardProps {
@@ -92,9 +93,14 @@ export function HealthAlertsCard({
       sourceDisplayContext
     );
 
-  const buildFailureTooltip = (failure: DashboardRecentFailure) => {
+  const buildFailureTooltip = (failure: DashboardRecentFailure, provider: string) => {
     const statusCode = failure.fail_status_code;
     const summary = maskSensitiveText(failure.fail_summary || '');
+    const quotaPlanLabel = getPlanPresentation({
+      provider,
+      planType: failure.header_quota_plan_type,
+      t,
+    })?.fullLabel;
     const diagnostics = [
       failure.header_error_code || failure.header_error_kind
         ? `${t('monitoring.header_error')}: ${[failure.header_error_kind, failure.header_error_code]
@@ -104,7 +110,7 @@ export function HealthAlertsCard({
       failure.header_trace_id ? `${t('monitoring.header_trace')}: ${failure.header_trace_id}` : '',
       failure.header_quota_plan_type || typeof failure.header_quota_used_percent === 'number'
         ? `${t('monitoring.header_quota')}: ${[
-            failure.header_quota_plan_type,
+            quotaPlanLabel,
             typeof failure.header_quota_used_percent === 'number'
               ? `${failure.header_quota_used_percent.toFixed(0)}%`
               : '',
@@ -198,7 +204,7 @@ export function HealthAlertsCard({
         <div className={styles.list}>
           {recentFailures.slice(0, 3).map((failure) => {
             const display = buildRecentFailureDisplay(failure);
-            const tooltip = buildFailureTooltip(failure);
+            const tooltip = buildFailureTooltip(failure, display.provider);
             return (
               <div
                 key={`${failure.timestamp_ms}-${failure.source_hash}-${failure.model}`}

--- a/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.test.tsx
@@ -490,11 +490,13 @@ describe('MonitoringCenterPage account card', () => {
     const row = {
       id: 'very-long-account-name@example.com',
       account: 'very-long-account-name@example.com',
+      provider: 'codex',
       displayAccount: 'very-long-account-name@example.com',
       accountMasked: 'ver***@example.com',
       authLabels: ['alpha'],
       authIndices: ['1'],
       channels: ['default'],
+      planTypes: ['self_serve_business_prolite', 'business_premium_5x'],
       totalCalls: 1,
       successCalls: 1,
       failureCalls: 0,
@@ -536,8 +538,12 @@ describe('MonitoringCenterPage account card', () => {
         />
       );
 
-    expect(renderCard('masked')).toContain('>ver***@example.com</span>');
-    expect(renderCard('masked')).toContain('very-long-account-name@example.com');
+    const maskedCard = renderCard('masked');
+    expect(maskedCard).toContain('>ver***@example.com</span>');
+    expect(maskedCard).toContain('very-long-account-name@example.com');
+    expect(maskedCard).toContain('Business 5x');
+    expect(maskedCard).toContain('title="Business Premium 5x"');
+    expect(maskedCard).not.toContain('self_serve_business_prolite');
     expect(renderCard('full')).toContain('>very-long-account-name@example.com</span>');
   });
 

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.lifecycle.test.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.lifecycle.test.tsx
@@ -8,6 +8,7 @@ import type {
   CodexInspectionRun,
   CodexInspectionRunDetail,
   ManagerConfig,
+  UsageHeaderSnapshot,
 } from '@/services/api/usageService';
 import { CodexInspectionStopButton } from '@/features/monitoring/components/CodexInspectionStopButton';
 import {
@@ -222,7 +223,16 @@ describe('ServerCodexInspectionPage quota mapping', () => {
       ],
     };
 
-    const mapped = toServerResultItem(item, t, undefined, 'en');
+    const mapped = toServerResultItem(
+      item,
+      t,
+      {
+        event_hash: 'header-event',
+        timestamp_ms: resetAtMs,
+        header_quota_plan_type: 'self_serve_business_prolite',
+      } satisfies UsageHeaderSnapshot,
+      'en'
+    );
 
     expect(mapped.quotaWindows).toEqual([
       expect.objectContaining({
@@ -231,6 +241,10 @@ describe('ServerCodexInspectionPage quota mapping', () => {
         resetAccuracy: 'exact',
       }),
     ]);
+    expect(mapped.observedHeaderEvidence?.join(' · ')).toContain('Business Premium 5x');
+    expect(mapped.observedHeaderEvidence?.join(' · ')).not.toContain(
+      'self_serve_business_prolite'
+    );
   });
 });
 

--- a/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
+++ b/apps/web/src/features/monitoring/ServerCodexInspectionPage.tsx
@@ -100,6 +100,7 @@ import {
   getHeaderSnapshotUsedPercent,
   getUsageHeaderSnapshotMatchForIdentity,
 } from '@/utils/usageHeaderSnapshots';
+import { getPlanPresentation } from '@/utils/plans';
 import styles from './CodexInspectionPage.module.scss';
 
 type ServerCodexInspectionDraft = {
@@ -545,6 +546,7 @@ function formatObservedHeaderRecoverAt(value: number | null, locale: string) {
 
 function buildObservedHeaderEvidence(
   snapshot: UsageHeaderSnapshot | undefined,
+  provider: string,
   locale: string,
   t: ReturnType<typeof useTranslation>['t']
 ) {
@@ -558,8 +560,13 @@ function buildObservedHeaderEvidence(
       })
     );
   }
+  const planLabel = getPlanPresentation({
+    provider,
+    planType: getHeaderSnapshotPlanType(snapshot),
+    t,
+  })?.fullLabel;
   const quotaParts = [
-    getHeaderSnapshotPlanType(snapshot),
+    planLabel,
     (() => {
       const usedPercent = getHeaderSnapshotUsedPercent(snapshot);
       return typeof usedPercent === 'number' && Number.isFinite(usedPercent)
@@ -603,7 +610,7 @@ export function toServerResultItem(
   const actionReason = item.actionReason?.startsWith('monitoring.')
     ? t(item.actionReason)
     : item.actionReason;
-  const observedHeaderEvidence = buildObservedHeaderEvidence(snapshot, locale, t);
+  const observedHeaderEvidence = buildObservedHeaderEvidence(snapshot, item.provider, locale, t);
   return {
     key: `server-${item.id || item.accountKey}`,
     runtimeId: item.runtimeId ?? null,

--- a/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewCard.tsx
@@ -25,6 +25,7 @@ import type {
 } from '@/features/monitoring/hooks/useMonitoringData';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import type { StatusBarData } from '@/utils/recentRequests';
+import { getPlanPresentation } from '@/utils/plans';
 import { MonitoringHealthStatusBar } from './MonitoringHealthStatusBar';
 import {
   buildAccountSecondaryText,
@@ -82,6 +83,7 @@ export function AccountSummaryPrimary({
   expanded,
   onToggle,
   accountDisplayMode,
+  t,
   statusTone = 'enabled',
   showSecondary = true,
 }: {
@@ -89,12 +91,38 @@ export function AccountSummaryPrimary({
   expanded: boolean;
   onToggle: () => void;
   accountDisplayMode: AccountDisplayMode;
+  t: TFunction;
   statusTone?: string;
   showSecondary?: boolean;
 }) {
   const accountDisplay = resolveAccountDisplayText(row, accountDisplayMode);
   const secondaryText = buildAccountSecondaryText(row);
   const accountSecondaryText = accountDisplay.secondary || secondaryText;
+  const planPresentations = Array.from(
+    new Map(
+      (row.planTypes ?? [])
+        .map((planType) =>
+          getPlanPresentation({
+            provider: row.provider,
+            planType,
+            t,
+          })
+        )
+        .filter(
+          (presentation): presentation is NonNullable<typeof presentation> => presentation !== null
+        )
+        .map((presentation) => [
+          presentation.canonicalPlanType ?? presentation.rawPlanType,
+          presentation,
+        ])
+    ).values()
+  );
+  const planShortLabels = planPresentations.map((presentation) => presentation.shortLabel);
+  const planShortLabel =
+    planShortLabels.length <= 2
+      ? planShortLabels.join(', ')
+      : `${planShortLabels.slice(0, 2).join(', ')} +${planShortLabels.length - 2}`;
+  const planFullLabel = planPresentations.map((presentation) => presentation.fullLabel).join(', ');
 
   return (
     <button
@@ -123,6 +151,11 @@ export function AccountSummaryPrimary({
         <span className={styles.accountButtonLabel}>{accountDisplay.primary}</span>
       </span>
       {showSecondary && accountSecondaryText ? <small>{accountSecondaryText}</small> : null}
+      {planShortLabel ? (
+        <small title={planFullLabel}>
+          {t('accounts.col_plan')}: {planShortLabel}
+        </small>
+      ) : null}
     </button>
   );
 }
@@ -145,6 +178,13 @@ function AccountQuotaPanel({
       ? quotaState.lastRefreshedAt
       : undefined;
   const singleQuotaEntry = quotaEntries.length === 1 ? quotaEntries[0] : null;
+  const singlePlanPresentation = singleQuotaEntry
+    ? getPlanPresentation({
+        provider: singleQuotaEntry.provider,
+        planType: singleQuotaEntry.planType,
+        t,
+      })
+    : null;
 
   const buildQuotaInfoRows = (entry: AccountQuotaEntry) => {
     const fromUsageHeaders = entry.observedFromUsageHeaders === true;
@@ -181,12 +221,7 @@ function AccountQuotaPanel({
         tabIndex={0}
         aria-label={t('codex_quota.tooltip_label', { label: windowLabel })}
       >
-        <IconInfo
-          size={14}
-          className={styles.quotaInfoIcon}
-          aria-hidden="true"
-          focusable={false}
-        />
+        <IconInfo size={14} className={styles.quotaInfoIcon} aria-hidden="true" focusable={false} />
         <span className={styles.quotaInfoTooltip} role="tooltip">
           {rows.map((row) => (
             <span key={row.key} className={styles.quotaInfoTooltipRow}>
@@ -272,6 +307,11 @@ function AccountQuotaPanel({
       <div className={styles.quotaSectionHeader}>
         <div className={styles.quotaSectionTitleGroup}>
           <strong>{t('monitoring.account_quota_title')}</strong>
+          {singlePlanPresentation ? (
+            <small title={singlePlanPresentation.fullLabel}>
+              {t('accounts.col_plan')}: {singlePlanPresentation.shortLabel}
+            </small>
+          ) : null}
         </div>
         {renderRefreshButton()}
       </div>
@@ -322,13 +362,26 @@ function AccountQuotaPanel({
       ) : quotaEntries.length > 0 ? (
         <div className={styles.quotaEntryGrid}>
           {quotaEntries.map((entry) => {
-            const entryMetaText = `${entry.providerLabel} · ${entry.fileName}`;
+            const entryPlanPresentation = getPlanPresentation({
+              provider: entry.provider,
+              planType: entry.planType,
+              t,
+            });
+            const entryMetaText = [
+              entry.providerLabel,
+              entry.fileName,
+              entryPlanPresentation
+                ? `${t('accounts.col_plan')}: ${entryPlanPresentation.shortLabel}`
+                : '',
+            ]
+              .filter(Boolean)
+              .join(' · ');
             return (
               <div key={entry.key} className={styles.quotaEntryCard}>
                 <div className={styles.quotaEntryHeader}>
                   <div className={styles.quotaEntryMain}>
                     <strong>{entry.authLabel}</strong>
-                    <small>{entryMetaText}</small>
+                    <small title={entryPlanPresentation?.fullLabel}>{entryMetaText}</small>
                   </div>
                 </div>
 
@@ -890,6 +943,7 @@ export function AccountOverviewCard({
             expanded={isExpanded}
             onToggle={onToggle}
             accountDisplayMode={accountDisplayMode}
+            t={t}
             statusTone={statusTone}
             showSecondary={false}
           />

--- a/apps/web/src/features/monitoring/components/AccountOverviewPanel.tsx
+++ b/apps/web/src/features/monitoring/components/AccountOverviewPanel.tsx
@@ -388,6 +388,7 @@ export function AccountOverviewPanel({
                           expanded={isExpanded}
                           onToggle={() => onToggleExpanded(row.id)}
                           accountDisplayMode={accountDisplayMode}
+                          t={t}
                           statusTone={statusTone}
                         />
                       </td>

--- a/apps/web/src/features/monitoring/components/CodexInspectionResultsPanel.test.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionResultsPanel.test.tsx
@@ -131,9 +131,7 @@ describe('CodexInspectionResultsPanel', () => {
     const renderer = renderPanel(item, { onOpenCredential });
     const openButton = renderer.root
       .findAllByType(Button)
-      .find(
-        (node) => node.props.children === 'monitoring.codex_inspection_view_credential'
-      );
+      .find((node) => node.props.children === 'monitoring.codex_inspection_view_credential');
 
     expect(openButton).toBeDefined();
 
@@ -195,7 +193,9 @@ describe('CodexInspectionResultsPanel', () => {
   });
 
   it('keeps all action filters visible and renders the plan without a label prefix', () => {
-    const renderer = renderPanel(createItem({ planType: 'free' }));
+    const renderer = renderPanel(
+      createItem({ planType: 'self_serve_business_prolite', provider: 'codex' })
+    );
     const text = collectText(renderer);
 
     expect(text).toEqual(
@@ -208,7 +208,8 @@ describe('CodexInspectionResultsPanel', () => {
     ).toHaveLength(1);
     expect(text).not.toContain('monitoring.codex_inspection_action_filter_label');
     expect(text).not.toEqual(expect.arrayContaining(['pending', 'no_action']));
-    expect(text).toContain('codex_quota.plan_free');
+    expect(text).toContain('Business 5x');
+    expect(text).not.toContain('self_serve_business_prolite');
     expect(text).not.toContain('codex_quota.plan_label');
   });
 

--- a/apps/web/src/features/monitoring/components/CodexInspectionResultsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/CodexInspectionResultsPanel.tsx
@@ -23,11 +23,11 @@ import {
   type InspectionProbeSource,
   type InspectionProbeState,
 } from '@/features/monitoring/model/codexInspectionPresentation';
-import { getCodexPlanLabel } from '@/features/monitoring/components/accountOverviewPresentation';
 import { CodexInspectionQuotaWindows } from '@/features/monitoring/components/CodexInspectionQuotaWindows';
 import { Panel } from '@/features/monitoring/components/CodexInspectionPanels';
 import { useNotificationStore } from '@/stores';
 import { copyToClipboard } from '@/utils/clipboard';
+import { getPlanPresentation } from '@/utils/plans';
 import styles from '../CodexInspectionPage.module.scss';
 
 type CodexInspectionResultsPanelProps = {
@@ -230,7 +230,11 @@ export function CodexInspectionResultsPanel({
             {filteredResults.length > 0 ? (
               filteredResults.map((item) => {
                 const isXai = item.provider.trim().toLowerCase() === 'xai';
-                const planLabel = isXai ? null : getCodexPlanLabel(item.planType, t);
+                const planLabel = getPlanPresentation({
+                  provider: item.provider,
+                  planType: item.planType,
+                  t,
+                })?.shortLabel;
                 const quotaWindows = item.quotaWindows ?? [];
                 const errorText = item.errorDetail || item.error;
                 const errorSummary = summarizeInspectionError(item, t, {

--- a/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
+++ b/apps/web/src/features/monitoring/components/RealtimeEventsPanel.tsx
@@ -25,6 +25,7 @@ import type { AccountDisplayMode } from '@/features/monitoring/accountOverviewSt
 import { useNotificationStore } from '@/stores';
 import { copyToClipboard } from '@/utils/clipboard';
 import { maskSensitiveText, truncateText } from '@/utils/format';
+import { getPlanLabel, getPlanPresentation, type PlanDisplayMode } from '@/utils/plans';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import styles from '../MonitoringCenterPage.module.scss';
 
@@ -334,7 +335,8 @@ const formatHeaderRecoverAt = (value: number | null | undefined, locale: string)
 const buildHeaderDiagnosticParts = (
   row: MonitoringEventRow,
   t: TFunction,
-  locale: string
+  locale: string,
+  planDisplayMode: PlanDisplayMode = 'compact'
 ): string[] => {
   const parts: string[] = [];
   const formatCount = (value: number): string =>
@@ -412,7 +414,13 @@ const buildHeaderDiagnosticParts = (
     row.responseMetadata?.quota?.plan_type ||
     row.responseMetadata?.quota?.active_limit ||
     '';
-  if (planType) quotaParts.push(planType);
+  const planPresentation = getPlanPresentation({
+    provider: row.provider,
+    planType,
+    t,
+  });
+  const planLabel = getPlanLabel(planPresentation, planDisplayMode);
+  if (planLabel) quotaParts.push(planLabel);
   const usedPercent =
     row.headerQuotaUsedPercent ?? row.responseMetadata?.quota?.used_percent ?? null;
   if (typeof usedPercent === 'number' && Number.isFinite(usedPercent)) {
@@ -515,7 +523,7 @@ const buildRequestDiagnosticDetails = (row: MonitoringEventRow, t: TFunction, lo
   if (!row.failed) return null;
 
   const summary = maskSensitiveText(row.failSummary || '');
-  const diagnostics = buildHeaderDiagnosticParts(row, t, locale);
+  const diagnostics = buildHeaderDiagnosticParts(row, t, locale, 'full');
   if (!row.failStatusCode && !summary && diagnostics.length === 0) return null;
   const statusText = row.failStatusCode
     ? `${shortLabel(t, 'monitoring.fail_status_code_short', 'monitoring.fail_status_code')} ${row.failStatusCode}`
@@ -728,14 +736,26 @@ type RealtimeTokenUsageDetails = {
 
 const buildRealtimeTokenUsageDetails = (row: MonitoringEventRow, t: TFunction) => {
   const fields = [
-    { label: t('monitoring.realtime_usage_total_label'), value: formatCompactNumber(row.totalTokens) },
-    { label: t('monitoring.realtime_usage_input_label'), value: formatCompactNumber(row.inputTokens) },
-    { label: t('monitoring.realtime_usage_output_label'), value: formatCompactNumber(row.outputTokens) },
+    {
+      label: t('monitoring.realtime_usage_total_label'),
+      value: formatCompactNumber(row.totalTokens),
+    },
+    {
+      label: t('monitoring.realtime_usage_input_label'),
+      value: formatCompactNumber(row.inputTokens),
+    },
+    {
+      label: t('monitoring.realtime_usage_output_label'),
+      value: formatCompactNumber(row.outputTokens),
+    },
     {
       label: t('monitoring.realtime_usage_reasoning_label'),
       value: String(row.reasoningTokens),
     },
-    { label: t('monitoring.realtime_usage_cached_label'), value: formatCompactNumber(row.cachedTokens) },
+    {
+      label: t('monitoring.realtime_usage_cached_label'),
+      value: formatCompactNumber(row.cachedTokens),
+    },
     {
       label: t('monitoring.realtime_usage_cache_read_label'),
       value: formatCompactNumber(row.cacheReadTokens),
@@ -1101,9 +1121,7 @@ export function RealtimeEventsPanel({
               const apiKeyDisplay = buildRealtimeApiKeyDisplay(row, t);
               const requestedModel = row.requestedModel?.trim() || row.model;
               const resolvedModel = row.resolvedModel?.trim() || '';
-              const showResolvedModel = Boolean(
-                resolvedModel && resolvedModel !== requestedModel
-              );
+              const showResolvedModel = Boolean(resolvedModel && resolvedModel !== requestedModel);
               const reasoningEffort = formatOptionalText(row.reasoningEffort);
               const serviceTier = formatOptionalText(row.serviceTier);
               const requestServiceTier = formatOptionalText(row.requestServiceTier);

--- a/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
+++ b/apps/web/src/features/monitoring/components/accountOverviewPresentation.ts
@@ -3,15 +3,9 @@ import type { MonitoringAccountAuthState } from '@/features/monitoring/accountOv
 import type { MonitoringAccountQuotaProvider } from '@/features/monitoring/accountOverviewQuotaTargets';
 import type { MonitoringAccountRow } from '@/features/monitoring/hooks/useMonitoringData';
 import type { QuotaModelScope, QuotaResetAccuracy } from '@/types';
-import { normalizePlanType } from '@/utils/quota';
-import {
-  formatQuotaResetTime,
-  type QuotaResetTimeFormatOptions,
-} from '@/utils/quota/formatters';
+import { formatQuotaResetTime, type QuotaResetTimeFormatOptions } from '@/utils/quota/formatters';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import styles from '../MonitoringCenterPage.module.scss';
-
-const PREMIUM_CODEX_PLAN_TYPES = new Set(['pro', 'prolite', 'pro-lite', 'pro_lite']);
 
 export type AccountQuotaWindow = {
   id: string;
@@ -145,22 +139,6 @@ const buildAccountCacheSummaryMetric = (
     fullLabel: cacheMetric.fullLabel,
     value: cacheMetric.value,
   };
-};
-
-export const getCodexPlanLabel = (
-  planType: string | null | undefined,
-  t: TFunction
-): string | null => {
-  const normalized = normalizePlanType(planType);
-  if (!normalized) return null;
-  if (normalized === 'pro') return t('codex_quota.plan_pro');
-  if (PREMIUM_CODEX_PLAN_TYPES.has(normalized) && normalized !== 'pro') {
-    return t('codex_quota.plan_prolite');
-  }
-  if (normalized === 'plus') return t('codex_quota.plan_plus');
-  if (normalized === 'team') return t('codex_quota.plan_team');
-  if (normalized === 'free') return t('codex_quota.plan_free');
-  return planType || normalized;
 };
 
 const isRedundantAccountSecondaryLabel = (candidate: string, primaryText: string) => {

--- a/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
+++ b/apps/web/src/features/monitoring/hooks/useMonitoringData.test.ts
@@ -498,6 +498,26 @@ describe('buildMonitoringAuthMetaMap', () => {
     expect(map.get('current-auth-index')?.account).toBe('alice@example.com');
     expect(map.get('6bf749cb7db0e15c')?.account).toBe('alice@example.com');
   });
+
+  it('resolves plan metadata from outer and camel-case token fields', () => {
+    const map = buildMonitoringAuthMetaMap([
+      {
+        name: 'codex.json',
+        provider: 'codex',
+        authIndex: 'codex-auth-index',
+        plan_type: 'pro',
+      },
+      {
+        name: 'claude.json',
+        provider: 'claude',
+        authIndex: 'claude-auth-index',
+        id_token: { planType: 'plan_max' },
+      },
+    ]);
+
+    expect(map.get('codex-auth-index')?.planType).toBe('pro');
+    expect(map.get('claude-auth-index')?.planType).toBe('plan_max');
+  });
 });
 
 describe('buildApiKeyDisplayMap', () => {

--- a/apps/web/src/features/monitoring/model/analyticsAdapters.ts
+++ b/apps/web/src/features/monitoring/model/analyticsAdapters.ts
@@ -683,6 +683,7 @@ export const buildAccountRowsFromAnalytics = (
         authIndices: uniqueReadableValues(row.auth_indices),
         sourceKeys,
         channels,
+        planTypes: uniqueReadableValues(authMetas.map((meta) => meta.planType)),
         totalCalls: row.calls,
         successCalls: row.success_calls,
         failureCalls: row.failure_calls,

--- a/apps/web/src/features/monitoring/model/authMeta.ts
+++ b/apps/web/src/features/monitoring/model/authMeta.ts
@@ -1,5 +1,6 @@
 import type { AuthFileItem } from '@/types/authFile';
 import { normalizeAuthIndex } from '@/utils/usage';
+import { resolveAuthFilePlanType } from '@/utils/plans';
 import { buildLegacyAuthIndexAliases } from '../legacyAuthIndexAliases';
 import { extractHost, isRecord, parseBoolean, readString } from './base';
 import type { MonitoringAuthMeta, MonitoringChannelMeta } from './types';
@@ -68,9 +69,7 @@ const normalizeAuthMeta = (entry: AuthFileItem): MonitoringAuthMeta | null => {
     readString(entry.account) ||
     authIndex;
 
-  const planType = readString(
-    isRecord(entry.id_token) ? entry.id_token.plan_type : entry['plan_type']
-  );
+  const planType = resolveAuthFilePlanType(entry);
 
   return {
     authIndex,

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.test.ts
@@ -52,15 +52,14 @@ const t = ((key: string, options?: Record<string, unknown>) => {
   const copy: Record<string, string> = {
     'antigravity_quota.title': 'Antigravity Quota',
     'claude_quota.title': 'Claude Quota',
-    'claude_quota.plan_label': 'Plan',
-    'claude_quota.plan_pro': 'Pro',
+    'plans.label': 'Plan',
+    'plans.claude.pro': 'Pro',
     'claude_quota.extra_usage_label': 'Extra Usage',
     'claude_quota.empty_windows': 'No Claude quota data',
     'claude_quota.five_hour': '5-hour limit',
     'codex_quota.title': 'Codex Quota',
     'codex_quota.empty_windows': 'No Codex quota data',
-    'codex_quota.plan_label': 'Plan',
-    'codex_quota.plan_free': 'Free',
+    'plans.codex.free': 'Free',
     'codex_quota.monthly_window': 'Monthly limit',
     'codex_quota.window_usage_duration': '{{used}} / {{total}} used',
     'kimi_quota.title': 'Kimi Quota',
@@ -1266,6 +1265,11 @@ describe('monitoringCenterPageModel account quota', () => {
     vi.mocked(fetchAntigravityQuota).mockResolvedValue({
       quotaInventoryObserved: true,
       serverTimeOffsetMs: null,
+      subscription: {
+        plan: 'pro',
+        tierName: 'Antigravity Pro',
+        tierId: 'g1-pro-tier',
+      },
       groups: [
         {
           id: 'agent',
@@ -1299,6 +1303,7 @@ describe('monitoringCenterPageModel account quota', () => {
       t
     );
 
+    expect(entry.planType).toBe('pro');
     expect(entry.metaLabels).toEqual(['Antigravity Quota']);
     expect(entry.windows).toMatchObject([
       {
@@ -1316,6 +1321,30 @@ describe('monitoringCenterPageModel account quota', () => {
         usageLabel: null,
       },
     ]);
+  });
+
+  it('falls back to Antigravity tier metadata when the normalized plan is unknown', async () => {
+    vi.mocked(fetchAntigravityQuota).mockResolvedValue({
+      quotaInventoryObserved: true,
+      serverTimeOffsetMs: null,
+      subscription: {
+        plan: 'unknown',
+        tierName: 'Antigravity Future',
+        tierId: 'future-tier',
+      },
+      groups: [],
+    });
+
+    const entry = await requestAccountQuota(
+      createTarget({
+        provider: 'antigravity',
+        authIndex: '2',
+        fileName: 'antigravity.json',
+      }),
+      t
+    );
+
+    expect(entry.planType).toBe('Antigravity Future');
   });
 
   it('maps Kimi quota rows without amount labels in account quota entries', async () => {

--- a/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
+++ b/apps/web/src/features/monitoring/model/monitoringCenterPageModel.ts
@@ -25,10 +25,8 @@ import type {
   AccountQuotaState,
   AccountQuotaWindow,
 } from '@/features/monitoring/components/accountOverviewPresentation';
-import {
-  formatPercent,
-  getCodexPlanLabel,
-} from '@/features/monitoring/components/accountOverviewPresentation';
+import { formatPercent } from '@/features/monitoring/components/accountOverviewPresentation';
+import { getPlanPresentation, resolveAntigravityPlanType } from '@/utils/plans';
 import type { SummaryCardProps } from '@/features/monitoring/components/MonitoringShared';
 import type {
   MonitoringAccountQuotaProvider,
@@ -1308,7 +1306,7 @@ export const buildObservedCodexAccountQuotaEntry = (
       requestedModel: snapshot?.requested_model,
       resolvedModel: snapshot?.resolved_model,
     });
-  const planLabel = getCodexPlanLabel(planType, t);
+  const planLabel = getPlanPresentation({ provider: target.provider, planType, t })?.shortLabel;
   const observedAtMs = readFiniteTimestamp(snapshot?.timestamp_ms) ?? undefined;
   const observedAt = observedAtMs ? new Date(observedAtMs).toLocaleString() : '';
   const usedPercent = getHeaderSnapshotUsedPercent(snapshot);
@@ -1317,7 +1315,7 @@ export const buildObservedCodexAccountQuotaEntry = (
   const errorCode = getHeaderSnapshotErrorCode(snapshot);
   const traceID = getHeaderSnapshotTraceId(snapshot);
   const metaLabels = [
-    planLabel ? `${t('codex_quota.plan_label')}: ${planLabel}` : '',
+    planLabel ? `${t('plans.label')}: ${planLabel}` : '',
     observedAt
       ? t('monitoring.observed_from_usage_headers_at', {
           time: observedAt,
@@ -1402,17 +1400,21 @@ export const requestAccountQuota = async (
 ): Promise<AccountQuotaEntry> => {
   switch (target.provider) {
     case 'antigravity': {
-      const { groups } = await fetchAntigravityQuota(target.file, t);
+      const { groups, subscription } = await fetchAntigravityQuota(target.file, t);
+      const planType = resolveAntigravityPlanType(subscription, target.planType);
       return stampAccountQuotaFetchTime({
-        ...buildBaseAccountQuotaEntry(target, t),
+        ...buildBaseAccountQuotaEntry({ ...target, planType }, t),
+        planType,
         windows: buildAntigravityAccountQuotaWindows(groups),
       });
     }
     case 'claude': {
       const quota = await fetchClaudeQuota(target.file, t);
       const metaLabels: string[] = [];
-      if (quota.planType) {
-        metaLabels.push(`${t('claude_quota.plan_label')}: ${t(`claude_quota.${quota.planType}`)}`);
+      const planType = quota.planType ?? target.planType;
+      const planLabel = getPlanPresentation({ provider: target.provider, planType, t })?.shortLabel;
+      if (planLabel) {
+        metaLabels.push(`${t('plans.label')}: ${planLabel}`);
       }
       if (quota.extraUsage?.is_enabled) {
         metaLabels.push(
@@ -1421,7 +1423,7 @@ export const requestAccountQuota = async (
       }
       return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(target, t, metaLabels),
-        planType: quota.planType ?? target.planType,
+        planType,
         windows: buildClaudeAccountQuotaWindows(quota.windows, t),
       });
     }
@@ -1457,17 +1459,18 @@ export const requestAccountQuota = async (
     case 'codex':
     default: {
       const quota = await fetchCodexQuota(target.file, t);
-      const planLabel = getCodexPlanLabel(quota.planType ?? target.planType, t);
+      const planType = quota.planType ?? target.planType;
+      const planLabel = getPlanPresentation({ provider: target.provider, planType, t })?.shortLabel;
       return stampAccountQuotaFetchTime({
         ...buildBaseAccountQuotaEntry(
           {
             ...target,
-            planType: quota.planType ?? target.planType,
+            planType,
           },
           t,
-          planLabel ? [`${t('codex_quota.plan_label')}: ${planLabel}`] : []
+          planLabel ? [`${t('plans.label')}: ${planLabel}`] : []
         ),
-        planType: quota.planType ?? target.planType,
+        planType,
         windows: buildCodexAccountQuotaWindows(quota.windows, t),
       });
     }

--- a/apps/web/src/features/monitoring/model/rowBuilders.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.ts
@@ -338,6 +338,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       sourceHashes: Set<string>;
       apiKeyHashes: Set<string>;
       channels: Set<string>;
+      planTypes: Set<string>;
       modelMap: Map<
         string,
         {
@@ -375,8 +376,8 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
   rows.forEach((row) => {
     const provider = normalizeMonitoringProvider(row.providerIdentity ?? row.provider);
     const filterAccount =
-      [row.accountIdentity, row.authLabelIdentity, row.sourceIdentity, row.account].find(
-        (value) => Boolean(value && isEffectiveLabel(value))
+      [row.accountIdentity, row.authLabelIdentity, row.sourceIdentity, row.account].find((value) =>
+        Boolean(value && isEffectiveLabel(value))
       ) || '';
     const accountKey = buildMonitoringAccountRowId({
       provider,
@@ -398,6 +399,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
       sourceHashes: new Set<string>(),
       apiKeyHashes: new Set<string>(),
       channels: new Set<string>(),
+      planTypes: new Set<string>(),
       modelMap: new Map(),
       rows: [] as MonitoringEventRow[],
       totalCalls: 0,
@@ -424,6 +426,9 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
     existing.sourceHashes.add(row.sourceHashIdentity ?? '');
     existing.apiKeyHashes.add(row.apiKeyHash);
     existing.channels.add(row.channel);
+    if (row.planType && row.planType !== '-') {
+      existing.planTypes.add(row.planType);
+    }
     existing.totalCalls += 1;
     existing.successCalls += row.failed ? 0 : 1;
     existing.failureCalls += row.failed ? 1 : 0;
@@ -497,6 +502,7 @@ export const buildAccountRows = (rows: MonitoringEventRow[]): MonitoringAccountR
         authIndices,
         sourceKeys,
         channels,
+        planTypes: Array.from(item.planTypes).sort(),
         totalCalls: item.totalCalls,
         successCalls: item.successCalls,
         failureCalls: item.failureCalls,

--- a/apps/web/src/features/monitoring/model/types.ts
+++ b/apps/web/src/features/monitoring/model/types.ts
@@ -264,6 +264,8 @@ export type MonitoringAccountRow = {
   authIndices: string[];
   sourceKeys?: string[];
   channels: string[];
+  /** Raw provider plan values; presentation is resolved at the UI boundary. */
+  planTypes?: string[];
   totalCalls: number;
   successCalls: number;
   failureCalls: number;

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import {
   USAGE_ANALYTICS_DEFAULT_FILTERS,
+  type UsageDrilldownEvent,
   type UsageRankRow,
   type UsageTimelinePoint,
 } from './usageAnalyticsModel';
@@ -117,6 +118,35 @@ const createRankRow = (overrides: Partial<UsageRankRow> = {}): UsageRankRow => (
   estimatedCost: 1.25,
   averageLatencyMs: null,
   share: 1,
+  ...overrides,
+});
+
+const createDrilldownEvent = (
+  overrides: Partial<UsageDrilldownEvent> = {}
+): UsageDrilldownEvent => ({
+  requestId: 'request-1',
+  eventHash: 'event-1',
+  timestampMs: 1_780_000_000_000,
+  model: 'gpt-4o',
+  apiKeyHash: 'abcdef1234567890',
+  apiKeyLabel: 'sk-****7890',
+  source: 'codex',
+  authIndex: 'auth-1',
+  provider: 'codex',
+  endpoint: 'POST /v1/chat/completions',
+  totalTokens: 100,
+  estimatedCost: 0,
+  latencyMs: 250,
+  ttftMs: 80,
+  failed: false,
+  failStatusCode: null,
+  failSummary: '',
+  headerErrorKind: '',
+  headerErrorCode: '',
+  headerTraceId: '',
+  headerQuotaPlanType: 'pro',
+  headerQuotaUsedPercent: 25,
+  headerQuotaRecoverAtMs: null,
   ...overrides,
 });
 
@@ -519,6 +549,17 @@ describe('UsageAnalyticsPage', () => {
     expect(text).not.toContain('usage_analytics.favorite_views_title');
     expect(text).not.toContain('usage_analytics.recent_views_title');
     expect(text).not.toContain('usage_analytics.model_rank_title');
+  });
+
+  it('uses the unified full plan label in drilldown diagnostics', () => {
+    mocks.usageState = createUsageState({
+      drilldownPreview: [createDrilldownEvent()],
+    });
+    const renderer = renderPage();
+    const text = getText(renderer.root);
+
+    expect(text).toContain('Pro 20x');
+    expect(text).not.toContain('self_serve_business_prolite');
   });
 
   it('renders trends as a focused time-series workspace', () => {

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/icons';
 import { useNotificationStore, useThemeStore } from '@/stores';
 import { copyToClipboard } from '@/utils/clipboard';
+import { getPlanPresentation } from '@/utils/plans';
 import {
   buildUsageHeatmapChartData,
   buildModelKeyDistribution,
@@ -310,8 +311,13 @@ const formatDrilldownDiagnostics = (row: UsageDrilldownEvent, locale: string, t:
   if (row.headerTraceId) {
     parts.push(`${t('monitoring.header_trace')}: ${row.headerTraceId}`);
   }
+  const planLabel = getPlanPresentation({
+    provider: row.provider,
+    planType: row.headerQuotaPlanType,
+    t,
+  })?.fullLabel;
   const quotaParts = [
-    row.headerQuotaPlanType,
+    planLabel,
     typeof row.headerQuotaUsedPercent === 'number'
       ? formatPercent(row.headerQuotaUsedPercent / 100)
       : '',

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -427,6 +427,7 @@ export type UsageDrilldownEvent = {
   apiKeyLabel: string;
   source: string;
   authIndex: string;
+  provider: string;
   endpoint: string;
   totalTokens: number;
   estimatedCost: number;
@@ -2360,6 +2361,7 @@ export const buildDrilldownPreview = (
       apiKeyLabel: resolveUsageApiKeyLabel(row.api_key_hash || '', apiKeyDisplayMap),
       source: row.source || '',
       authIndex: row.auth_index || '',
+      provider: row.auth_provider_snapshot || row.source || '',
       endpoint: row.endpoint || row.path || '',
       totalTokens,
       estimatedCost: totalTokens * costPerToken,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1629,7 +1629,6 @@
     "load_failed": "Failed to load quota: {{message}}",
     "missing_auth_index": "Auth file missing auth_index",
     "empty_models": "No quota data available",
-    "plan_label": "Plan",
     "group_gemini_models": "Gemini models",
     "group_claude_gpt_models": "Claude models",
     "group_models_description": "Models in this group: {{models}}",
@@ -1656,13 +1655,7 @@
     "error_badge": "Plan unavailable",
     "load_failed": "Subscription failed: {{message}}",
     "missing_auth_index": "Auth file missing auth_index",
-    "empty_data": "No subscription data",
-    "plan_badge": "{{plan}}",
-    "plan_free": "Free",
-    "plan_pro": "Pro",
-    "plan_ultra": "Ultra",
-    "plan_ultra_lite": "Ultra Lite",
-    "plan_unknown": "Unknown"
+    "empty_data": "No subscription data"
   },
   "claude_quota": {
     "title": "Claude Quota",
@@ -1684,15 +1677,7 @@
     "iguana_necktie": "Iguana Necktie",
     "weekly_scoped_model": "Weekly {{model}}",
     "limit_index": "Limit #{{index}}",
-    "extra_usage_label": "Extra Usage",
-    "plan_label": "Plan",
-    "plan_unknown": "Unknown",
-    "plan_free": "Free",
-    "plan_pro": "Pro",
-    "plan_max": "Max",
-    "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x",
-    "plan_team": "Team"
+    "extra_usage_label": "Extra Usage"
   },
   "codex_quota": {
     "title": "Codex Quota",
@@ -1704,7 +1689,7 @@
     "missing_auth_index": "Auth file missing auth_index",
     "missing_account_id": "Codex credential missing ChatGPT account ID",
     "empty_windows": "No quota data available",
-    "no_access": "This credential has no Codex access (plan: free).",
+    "no_access": "This credential has no Codex access.",
     "refresh_button": "Refresh Quota",
     "retry_button": "Retry",
     "fetch_all": "Fetch All",
@@ -1766,13 +1751,7 @@
     "additional_monthly_window": "{{name}} monthly limit",
     "additional_generic_window": "{{name}} {{duration}} limit",
     "window_usage": "{{used}} / {{total}} hours used",
-    "window_usage_duration": "{{used}} / {{total}} used",
-    "plan_label": "Plan",
-    "plan_plus": "Plus",
-    "plan_team": "Team",
-    "plan_free": "Free",
-    "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "window_usage_duration": "{{used}} / {{total}} used"
   },
   "kimi_quota": {
     "title": "Kimi Quota",
@@ -1834,9 +1813,6 @@
     "used_percent": "Used {{percent}}",
     "reset_at": "Resets {{time}}",
     "product_usage": "{{product}} usage",
-    "plan_label": "Plan",
-    "plan_supergrok": "SuperGrok",
-    "plan_supergrok_heavy": "SuperGrok Heavy",
     "official_api_plan": "Official API",
     "official_api_health": "Official xAI API identity is reachable. Billing and remaining quota are unavailable for this OAuth credential.",
     "pay_as_you_go_label": "Pay-as-you-go",
@@ -4522,5 +4498,60 @@
     "env_locked_hint": "This switch is locked by the service startup environment. Update the environment variable and restart to change it.",
     "env_locked_reason": "Locked by the {{envKey}} environment variable. Update it and restart the service to change this switch.",
     "gating_note": "Disabling a switch only affects new problems found later. Tasks already queued or in progress will continue to finish."
+  },
+  "plans": {
+    "label": "Plan",
+    "codex": {
+      "free": "Free",
+      "go": "Go",
+      "plus": "Plus",
+      "pro_5x": "Pro 5x",
+      "pro_20x": "Pro 20x",
+      "team": "Team",
+      "business": "Business",
+      "business_premium_5x": {
+        "short": "Business 5x",
+        "full": "Business Premium 5x"
+      },
+      "business_usage_based": {
+        "short": "Business PAYG",
+        "full": "Business Usage-based"
+      },
+      "enterprise": "Enterprise",
+      "enterprise_automation": {
+        "short": "Ent. Auto",
+        "full": "Enterprise Automation"
+      },
+      "enterprise_usage_based": {
+        "short": "Ent. PAYG",
+        "full": "Enterprise Usage-based"
+      },
+      "edu": {
+        "short": "Edu",
+        "full": "Education"
+      },
+      "edu_plus": {
+        "short": "Edu Plus",
+        "full": "Education Plus"
+      },
+      "edu_pro": {
+        "short": "Edu Pro",
+        "full": "Education Pro"
+      }
+    },
+    "claude": {
+      "free": "Free",
+      "pro": "Pro",
+      "max": "Max",
+      "max_5x": "Max 5x",
+      "max_20x": "Max 20x",
+      "team": "Team"
+    },
+    "antigravity": {
+      "free": "Free",
+      "pro": "Pro",
+      "ultra": "Ultra",
+      "ultra_lite": "Ultra Lite"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -1633,7 +1633,6 @@
     "load_failed": "Не удалось загрузить квоту: {{message}}",
     "missing_auth_index": "В файле авторизации отсутствует auth_index",
     "empty_models": "Данные по квоте отсутствуют",
-    "plan_label": "План",
     "group_gemini_models": "Модели Gemini",
     "group_claude_gpt_models": "Модели Claude",
     "group_models_description": "Модели в этой группе: {{models}}",
@@ -1660,13 +1659,7 @@
     "error_badge": "План недоступен",
     "load_failed": "Не удалось получить подписку: {{message}}",
     "missing_auth_index": "В файле авторизации отсутствует auth_index",
-    "empty_data": "Данные подписки отсутствуют",
-    "plan_badge": "{{plan}}",
-    "plan_free": "Free",
-    "plan_pro": "Pro",
-    "plan_ultra": "Ultra",
-    "plan_ultra_lite": "Ultra Lite",
-    "plan_unknown": "Unknown"
+    "empty_data": "Данные подписки отсутствуют"
   },
   "claude_quota": {
     "title": "Квота Claude",
@@ -1688,15 +1681,7 @@
     "iguana_necktie": "Iguana Necktie",
     "weekly_scoped_model": "Недельный {{model}}",
     "limit_index": "Лимит #{{index}}",
-    "extra_usage_label": "Дополнительное использование",
-    "plan_label": "План",
-    "plan_unknown": "Неизвестно",
-    "plan_free": "Free",
-    "plan_pro": "Pro",
-    "plan_max": "Max",
-    "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x",
-    "plan_team": "Team"
+    "extra_usage_label": "Дополнительное использование"
   },
   "codex_quota": {
     "title": "Квота Codex",
@@ -1708,7 +1693,7 @@
     "missing_auth_index": "В файле авторизации отсутствует auth_index",
     "missing_account_id": "В учётных данных Codex отсутствует идентификатор аккаунта ChatGPT",
     "empty_windows": "Данные по квоте отсутствуют",
-    "no_access": "У этих учётных данных нет доступа Codex (план: free).",
+    "no_access": "У этих учётных данных нет доступа Codex.",
     "refresh_button": "Обновить квоту",
     "retry_button": "Повторить",
     "fetch_all": "Получить все",
@@ -1767,13 +1752,7 @@
     "additional_generic_window": "{{name}}: лимит {{duration}}",
     "window_usage": "Использовано {{used}} / {{total}} ч",
     "window_usage_duration": "Использовано {{used}} / {{total}}",
-    "observed_window": "Последний ответ сервиса",
-    "plan_label": "Тариф",
-    "plan_plus": "Plus",
-    "plan_team": "Team",
-    "plan_free": "Free",
-    "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "observed_window": "Последний ответ сервиса"
   },
   "kimi_quota": {
     "title": "Квота Kimi",
@@ -1835,9 +1814,6 @@
     "used_percent": "Использовано {{percent}}",
     "reset_at": "Сброс {{time}}",
     "product_usage": "Использование {{product}}",
-    "plan_label": "План",
-    "plan_supergrok": "SuperGrok",
-    "plan_supergrok_heavy": "SuperGrok Heavy",
     "official_api_plan": "Официальный API",
     "official_api_health": "Идентификация через официальный API xAI доступна. Для этих учетных данных OAuth сведения о биллинге и остатке квоты недоступны.",
     "pay_as_you_go_label": "Pay-as-you-go",
@@ -4523,5 +4499,60 @@
     "env_locked_hint": "Этот переключатель зафиксирован переменной окружения. Измените переменную окружения сервиса и перезапустите его, чтобы изменить значение.",
     "env_locked_reason": "Зафиксировано переменной окружения {{envKey}}. Измените её и перезапустите сервис, чтобы изменить этот переключатель.",
     "gating_note": "Отключение переключателя влияет только на новые проблемы, найденные мониторингом. Уже поставленные или выполняющиеся задачи продолжат работу."
+  },
+  "plans": {
+    "label": "План",
+    "codex": {
+      "free": "Free",
+      "go": "Go",
+      "plus": "Plus",
+      "pro_5x": "Pro 5x",
+      "pro_20x": "Pro 20x",
+      "team": "Team",
+      "business": "Business",
+      "business_premium_5x": {
+        "short": "Business 5x",
+        "full": "Business Premium 5x"
+      },
+      "business_usage_based": {
+        "short": "Business PAYG",
+        "full": "Business Usage-based"
+      },
+      "enterprise": "Enterprise",
+      "enterprise_automation": {
+        "short": "Ent. Auto",
+        "full": "Enterprise Automation"
+      },
+      "enterprise_usage_based": {
+        "short": "Ent. PAYG",
+        "full": "Enterprise Usage-based"
+      },
+      "edu": {
+        "short": "Edu",
+        "full": "Education"
+      },
+      "edu_plus": {
+        "short": "Edu Plus",
+        "full": "Education Plus"
+      },
+      "edu_pro": {
+        "short": "Edu Pro",
+        "full": "Education Pro"
+      }
+    },
+    "claude": {
+      "free": "Free",
+      "pro": "Pro",
+      "max": "Max",
+      "max_5x": "Max 5x",
+      "max_20x": "Max 20x",
+      "team": "Team"
+    },
+    "antigravity": {
+      "free": "Free",
+      "pro": "Pro",
+      "ultra": "Ultra",
+      "ultra_lite": "Ultra Lite"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -1627,7 +1627,6 @@
     "load_failed": "额度获取失败：{{message}}",
     "missing_auth_index": "认证文件缺少 auth_index",
     "empty_models": "暂无额度数据",
-    "plan_label": "套餐",
     "group_gemini_models": "Gemini 模型",
     "group_claude_gpt_models": "Claude 模型",
     "group_models_description": "此分组包含：{{models}}",
@@ -1654,13 +1653,7 @@
     "error_badge": "套餐不可用",
     "load_failed": "订阅获取失败：{{message}}",
     "missing_auth_index": "认证文件缺少 auth_index",
-    "empty_data": "暂无订阅数据",
-    "plan_badge": "{{plan}}",
-    "plan_free": "免费版",
-    "plan_pro": "Pro",
-    "plan_ultra": "Ultra",
-    "plan_ultra_lite": "Ultra Lite",
-    "plan_unknown": "未知"
+    "empty_data": "暂无订阅数据"
   },
   "claude_quota": {
     "title": "Claude 额度",
@@ -1682,15 +1675,7 @@
     "iguana_necktie": "Iguana Necktie",
     "weekly_scoped_model": "{{model}} 周限额",
     "limit_index": "限额 #{{index}}",
-    "extra_usage_label": "额外用量",
-    "plan_label": "套餐",
-    "plan_unknown": "未知",
-    "plan_free": "免费版",
-    "plan_pro": "专业版",
-    "plan_max": "Max",
-    "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x",
-    "plan_team": "团队版"
+    "extra_usage_label": "额外用量"
   },
   "codex_quota": {
     "title": "Codex 额度",
@@ -1702,7 +1687,7 @@
     "missing_auth_index": "认证文件缺少 auth_index",
     "missing_account_id": "Codex 凭证缺少 ChatGPT 账号 ID",
     "empty_windows": "暂无额度数据",
-    "no_access": "该凭证已无 Codex 访问权限（free）。",
+    "no_access": "该凭证已无 Codex 访问权限。",
     "refresh_button": "刷新额度",
     "retry_button": "重试",
     "fetch_all": "获取全部",
@@ -1764,13 +1749,7 @@
     "additional_monthly_window": "{{name}} 月限额",
     "additional_generic_window": "{{name}} {{duration}} 限额",
     "window_usage": "已用 {{used}} / {{total}} 小时",
-    "window_usage_duration": "已用 {{used}} / {{total}}",
-    "plan_label": "套餐",
-    "plan_plus": "Plus",
-    "plan_team": "Team",
-    "plan_free": "Free",
-    "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "window_usage_duration": "已用 {{used}} / {{total}}"
   },
   "kimi_quota": {
     "title": "Kimi 额度",
@@ -1832,9 +1811,6 @@
     "used_percent": "已用 {{percent}}",
     "reset_at": "重置 {{time}}",
     "product_usage": "{{product}} 使用",
-    "plan_label": "套餐",
-    "plan_supergrok": "SuperGrok",
-    "plan_supergrok_heavy": "SuperGrok Heavy",
     "official_api_plan": "官方 API",
     "official_api_health": "xAI 官方 API 身份可访问；此 OAuth 凭证无法通过该接口获取账单和剩余额度。",
     "pay_as_you_go_label": "按量付费",
@@ -4520,5 +4496,60 @@
     "env_locked_hint": "该开关由服务启动环境锁定，请修改环境变量并重启。",
     "env_locked_reason": "由环境变量 {{envKey}} 锁定。修改该变量并重启服务后才能更改此开关。",
     "gating_note": "关闭某项策略只会影响之后发现的新问题；已经排队或正在处理的任务会继续完成。"
+  },
+  "plans": {
+    "label": "套餐",
+    "codex": {
+      "free": "Free",
+      "go": "Go",
+      "plus": "Plus",
+      "pro_5x": "Pro 5x",
+      "pro_20x": "Pro 20x",
+      "team": "Team",
+      "business": "Business",
+      "business_premium_5x": {
+        "short": "Business 5x",
+        "full": "Business Premium 5x"
+      },
+      "business_usage_based": {
+        "short": "Business PAYG",
+        "full": "Business Usage-based"
+      },
+      "enterprise": "Enterprise",
+      "enterprise_automation": {
+        "short": "Ent. Auto",
+        "full": "Enterprise Automation"
+      },
+      "enterprise_usage_based": {
+        "short": "Ent. PAYG",
+        "full": "Enterprise Usage-based"
+      },
+      "edu": {
+        "short": "Edu",
+        "full": "Education"
+      },
+      "edu_plus": {
+        "short": "Edu Plus",
+        "full": "Education Plus"
+      },
+      "edu_pro": {
+        "short": "Edu Pro",
+        "full": "Education Pro"
+      }
+    },
+    "claude": {
+      "free": "免费版",
+      "pro": "专业版",
+      "max": "Max",
+      "max_5x": "Max 5x",
+      "max_20x": "Max 20x",
+      "team": "团队版"
+    },
+    "antigravity": {
+      "free": "免费版",
+      "pro": "Pro",
+      "ultra": "Ultra",
+      "ultra_lite": "Ultra Lite"
+    }
   }
 }

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -1627,7 +1627,6 @@
     "load_failed": "配額取得失敗：{{message}}",
     "missing_auth_index": "驗證檔案缺少 auth_index",
     "empty_models": "暫無配額資料",
-    "plan_label": "方案",
     "group_gemini_models": "Gemini 模型",
     "group_claude_gpt_models": "Claude 模型",
     "group_models_description": "此群組包含：{{models}}",
@@ -1654,13 +1653,7 @@
     "error_badge": "方案不可用",
     "load_failed": "訂閱取得失敗：{{message}}",
     "missing_auth_index": "驗證檔案缺少 auth_index",
-    "empty_data": "暫無訂閱資料",
-    "plan_badge": "{{plan}}",
-    "plan_free": "免費版",
-    "plan_pro": "Pro",
-    "plan_ultra": "Ultra",
-    "plan_ultra_lite": "Ultra Lite",
-    "plan_unknown": "未知"
+    "empty_data": "暫無訂閱資料"
   },
   "claude_quota": {
     "title": "Claude 配額",
@@ -1682,15 +1675,7 @@
     "iguana_necktie": "Iguana Necktie",
     "weekly_scoped_model": "{{model}} 週限額",
     "limit_index": "限額 #{{index}}",
-    "extra_usage_label": "額外用量",
-    "plan_label": "方案",
-    "plan_unknown": "未知",
-    "plan_free": "免費版",
-    "plan_pro": "專業版",
-    "plan_max": "Max",
-    "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x",
-    "plan_team": "團隊版"
+    "extra_usage_label": "額外用量"
   },
   "codex_quota": {
     "title": "Codex 額度",
@@ -1702,7 +1687,7 @@
     "missing_auth_index": "驗證檔案缺少 auth_index",
     "missing_account_id": "Codex 憑證缺少 ChatGPT 帳號 ID",
     "empty_windows": "暫無配額資料",
-    "no_access": "該憑證已無 Codex 存取權限（free）。",
+    "no_access": "該憑證已無 Codex 存取權限。",
     "refresh_button": "重新整理配額",
     "retry_button": "重試",
     "fetch_all": "取得全部",
@@ -1764,13 +1749,7 @@
     "additional_generic_window": "{{name}} {{duration}} 限額",
     "window_usage": "已用 {{used}} / {{total}} 小時",
     "window_usage_duration": "已用 {{used}} / {{total}}",
-    "observed_window": "最近用量 Header",
-    "plan_label": "方案",
-    "plan_plus": "Plus",
-    "plan_team": "Team",
-    "plan_free": "Free",
-    "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "observed_window": "最近用量 Header"
   },
   "kimi_quota": {
     "title": "Kimi 配額",
@@ -1832,9 +1811,6 @@
     "used_percent": "已用 {{percent}}",
     "reset_at": "重置 {{time}}",
     "product_usage": "{{product}} 使用",
-    "plan_label": "方案",
-    "plan_supergrok": "SuperGrok",
-    "plan_supergrok_heavy": "SuperGrok Heavy",
     "official_api_plan": "官方 API",
     "official_api_health": "xAI 官方 API 身分可存取；此 OAuth 憑證無法透過該介面取得帳單和剩餘額度。",
     "pay_as_you_go_label": "按量付費",
@@ -4520,5 +4496,60 @@
     "env_locked_hint": "此開關由服務啟動環境鎖定，請修改環境變數並重新啟動。",
     "env_locked_reason": "由環境變數 {{envKey}} 鎖定。修改該變數並重新啟動服務後才能變更此開關。",
     "gating_note": "關閉某項策略只會影響之後發現的新問題；已經排隊或正在處理的任務會繼續完成。"
+  },
+  "plans": {
+    "label": "方案",
+    "codex": {
+      "free": "Free",
+      "go": "Go",
+      "plus": "Plus",
+      "pro_5x": "Pro 5x",
+      "pro_20x": "Pro 20x",
+      "team": "Team",
+      "business": "Business",
+      "business_premium_5x": {
+        "short": "Business 5x",
+        "full": "Business Premium 5x"
+      },
+      "business_usage_based": {
+        "short": "Business PAYG",
+        "full": "Business Usage-based"
+      },
+      "enterprise": "Enterprise",
+      "enterprise_automation": {
+        "short": "Ent. Auto",
+        "full": "Enterprise Automation"
+      },
+      "enterprise_usage_based": {
+        "short": "Ent. PAYG",
+        "full": "Enterprise Usage-based"
+      },
+      "edu": {
+        "short": "Edu",
+        "full": "Education"
+      },
+      "edu_plus": {
+        "short": "Edu Plus",
+        "full": "Education Plus"
+      },
+      "edu_pro": {
+        "short": "Edu Pro",
+        "full": "Education Pro"
+      }
+    },
+    "claude": {
+      "free": "免費版",
+      "pro": "專業版",
+      "max": "Max",
+      "max_5x": "Max 5x",
+      "max_20x": "Max 20x",
+      "team": "團隊版"
+    },
+    "antigravity": {
+      "free": "免費版",
+      "pro": "Pro",
+      "ultra": "Ultra",
+      "ultra_lite": "Ultra Lite"
+    }
   }
 }

--- a/apps/web/src/utils/plans/index.ts
+++ b/apps/web/src/utils/plans/index.ts
@@ -1,6 +1,11 @@
-export { normalizePlanProvider, normalizeRawPlanType } from './normalize';
+export { normalizePlanProvider, normalizeRawPlanType, readRawPlanType } from './normalize';
 export { resolveAuthFilePlanType } from './source';
-export { getCanonicalPlanType, getPlanLabel, getPlanPresentation } from './presentation';
+export {
+  getCanonicalPlanFilterLabel,
+  getCanonicalPlanType,
+  getPlanLabel,
+  getPlanPresentation,
+} from './presentation';
 export type {
   GetPlanPresentationInput,
   PlanDisplayMode,

--- a/apps/web/src/utils/plans/index.ts
+++ b/apps/web/src/utils/plans/index.ts
@@ -1,0 +1,15 @@
+export { normalizePlanProvider, normalizeRawPlanType } from './normalize';
+export { resolveAuthFilePlanType } from './source';
+export { getCanonicalPlanType, getPlanLabel, getPlanPresentation } from './presentation';
+export type {
+  GetPlanPresentationInput,
+  PlanDisplayMode,
+  PlanPresentation,
+  PlanProvider,
+} from './types';
+export {
+  ANTIGRAVITY_PLAN_DESCRIPTORS,
+  resolveAntigravityPlanType,
+  CLAUDE_PLAN_DESCRIPTORS,
+  CODEX_PLAN_DESCRIPTORS,
+} from './providers';

--- a/apps/web/src/utils/plans/normalize.ts
+++ b/apps/web/src/utils/plans/normalize.ts
@@ -3,11 +3,18 @@ export const normalizePlanProvider = (value: unknown): string => {
   return value.trim().toLowerCase().replace(/_/g, '-');
 };
 
-export const normalizeRawPlanType = (value: unknown): string | null => {
+/** Returns a trimmed source value without changing its display casing. */
+export const readRawPlanType = (value: unknown): string | null => {
   if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    return normalized || null;
+    const trimmed = value.trim();
+    return trimmed || null;
   }
   if (typeof value === 'number' && Number.isFinite(value)) return String(value);
   return null;
+};
+
+/** Returns the case-insensitive lookup key for a source plan value. */
+export const normalizeRawPlanType = (value: unknown): string | null => {
+  const raw = readRawPlanType(value);
+  return raw?.toLowerCase() ?? null;
 };

--- a/apps/web/src/utils/plans/normalize.ts
+++ b/apps/web/src/utils/plans/normalize.ts
@@ -1,0 +1,13 @@
+export const normalizePlanProvider = (value: unknown): string => {
+  if (typeof value !== 'string') return '';
+  return value.trim().toLowerCase().replace(/_/g, '-');
+};
+
+export const normalizeRawPlanType = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized || null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+};

--- a/apps/web/src/utils/plans/presentation.test.ts
+++ b/apps/web/src/utils/plans/presentation.test.ts
@@ -1,11 +1,43 @@
 import { describe, expect, it } from 'vitest';
 import type { TFunction } from 'i18next';
+import enResource from '@/i18n/locales/en.json';
 import { getCanonicalPlanType, getPlanLabel, getPlanPresentation } from './presentation';
+import {
+  ANTIGRAVITY_PLAN_DESCRIPTORS,
+  CLAUDE_PLAN_DESCRIPTORS,
+  CODEX_PLAN_DESCRIPTORS,
+} from './providers';
 import { resolveAntigravityPlanType } from './providers/antigravity';
 import { resolveAuthFilePlanType } from './source';
 
 const t = ((key: string, options?: { defaultValue?: string }) =>
   options?.defaultValue ?? key) as TFunction;
+
+/**
+ * Strict translator backed by the real English locale resource: it resolves a
+ * dotted key path only when it points at a string leaf, and otherwise throws so
+ * malformed descriptor label keys (e.g. pointing at a nested object) surface as
+ * test failures instead of silently falling back to the default value.
+ */
+const resolveResourceKey = (key: string): string => {
+  const segments = key.split('.');
+  let node: unknown = enResource;
+  for (const segment of segments) {
+    if (typeof node !== 'object' || node === null || Array.isArray(node)) {
+      throw new Error(`i18n key "${key}" is not a string leaf in the locale resource`);
+    }
+    node = (node as Record<string, unknown>)[segment];
+    if (node === undefined) {
+      throw new Error(`i18n key "${key}" is missing from the locale resource`);
+    }
+  }
+  if (typeof node !== 'string') {
+    throw new Error(`i18n key "${key}" resolves to a non-string node in the locale resource`);
+  }
+  return node;
+};
+
+const strictT = ((key: string) => resolveResourceKey(key)) as TFunction;
 
 describe('Plan Presentation', () => {
   it.each([
@@ -158,5 +190,35 @@ describe('Plan Presentation', () => {
         },
       })
     ).toBe('pro');
+  });
+
+  it('points every descriptor label key at a real locale string leaf', () => {
+    const descriptors = [
+      ...Object.values(CODEX_PLAN_DESCRIPTORS),
+      ...Object.values(CLAUDE_PLAN_DESCRIPTORS),
+      ...Object.values(ANTIGRAVITY_PLAN_DESCRIPTORS),
+    ];
+    const seen = new Set<string>();
+    descriptors.forEach((descriptor) => {
+      [descriptor.shortLabelKey, descriptor.fullLabelKey ?? descriptor.shortLabelKey].forEach(
+        (key) => {
+          if (seen.has(key)) return;
+          seen.add(key);
+          expect(() => resolveResourceKey(key)).not.toThrow();
+        }
+      );
+    });
+  });
+
+  it('resolves Codex education plans through nested short/full locale tokens', () => {
+    for (const raw of ['edu', 'education']) {
+      const presentation = getPlanPresentation({ provider: 'codex', planType: raw, t: strictT });
+      expect(presentation).toMatchObject({
+        canonicalPlanType: 'edu',
+        shortLabel: 'Edu',
+        fullLabel: 'Education',
+        known: true,
+      });
+    }
   });
 });

--- a/apps/web/src/utils/plans/presentation.test.ts
+++ b/apps/web/src/utils/plans/presentation.test.ts
@@ -117,7 +117,7 @@ describe('Plan Presentation', () => {
     expect(presentation).toEqual({
       provider,
       rawPlanType: raw,
-      canonicalPlanType: raw,
+      canonicalPlanType: `unknown:${provider}:${raw}`,
       shortLabel: raw,
       fullLabel: raw,
       known: false,
@@ -137,6 +137,39 @@ describe('Plan Presentation', () => {
     });
     expect(getPlanLabel(presentation, 'compact')).toBe('Business 5x');
     expect(getPlanLabel(presentation, 'full')).toBe('Business Premium 5x');
+  });
+
+  it('preserves unknown plan display casing while using normalized lookup values', () => {
+    expect(
+      getPlanPresentation({
+        provider: 'antigravity',
+        planType: 'Antigravity Future',
+        t,
+      })
+    ).toEqual({
+      provider: 'antigravity',
+      rawPlanType: 'Antigravity Future',
+      canonicalPlanType: 'unknown:antigravity:antigravity future',
+      shortLabel: 'Antigravity Future',
+      fullLabel: 'Antigravity Future',
+      known: false,
+    });
+  });
+
+  it('matches known descriptors case-insensitively without losing canonical mapping', () => {
+    expect(
+      getPlanPresentation({
+        provider: 'codex',
+        planType: ' PRO ',
+        t,
+      })
+    ).toMatchObject({
+      rawPlanType: 'PRO',
+      canonicalPlanType: 'pro_20x',
+      shortLabel: 'Pro 20x',
+      fullLabel: 'Pro 20x',
+      known: true,
+    });
   });
 
   it('resolves non-Codex plan aliases from nested token fields', () => {
@@ -161,7 +194,7 @@ describe('Plan Presentation', () => {
           tierId: 'future-tier',
         },
       })
-    ).toBe('antigravity future');
+    ).toBe('Antigravity Future');
   });
 
   it('keeps a known Antigravity credential plan ahead of unknown tier metadata', () => {

--- a/apps/web/src/utils/plans/presentation.test.ts
+++ b/apps/web/src/utils/plans/presentation.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import type { TFunction } from 'i18next';
+import { getCanonicalPlanType, getPlanLabel, getPlanPresentation } from './presentation';
+import { resolveAntigravityPlanType } from './providers/antigravity';
+import { resolveAuthFilePlanType } from './source';
+
+const t = ((key: string, options?: { defaultValue?: string }) =>
+  options?.defaultValue ?? key) as TFunction;
+
+describe('Plan Presentation', () => {
+  it.each([
+    ['free', 'free', 'Free', 'Free'],
+    ['go', 'go', 'Go', 'Go'],
+    ['plus', 'plus', 'Plus', 'Plus'],
+    ['prolite', 'pro_5x', 'Pro 5x', 'Pro 5x'],
+    ['pro-lite', 'pro_5x', 'Pro 5x', 'Pro 5x'],
+    ['pro_lite', 'pro_5x', 'Pro 5x', 'Pro 5x'],
+    ['pro', 'pro_20x', 'Pro 20x', 'Pro 20x'],
+    ['self_serve_business_prolite', 'business_premium_5x', 'Business 5x', 'Business Premium 5x'],
+    [
+      'self_serve_business_usage_based',
+      'business_usage_based',
+      'Business PAYG',
+      'Business Usage-based',
+    ],
+    ['ent26', 'enterprise', 'Enterprise', 'Enterprise'],
+    ['enterprise', 'enterprise', 'Enterprise', 'Enterprise'],
+    ['hc', 'enterprise', 'Enterprise', 'Enterprise'],
+    ['enterprise_cbp_automation', 'enterprise_automation', 'Ent. Auto', 'Enterprise Automation'],
+    ['enterprise_cbp_usage_based', 'enterprise_usage_based', 'Ent. PAYG', 'Enterprise Usage-based'],
+    ['edu', 'edu', 'Edu', 'Education'],
+    ['education', 'edu', 'Edu', 'Education'],
+    ['edu_plus', 'edu_plus', 'Edu Plus', 'Education Plus'],
+    ['edu_pro', 'edu_pro', 'Edu Pro', 'Education Pro'],
+  ])('resolves Codex %s', (raw, canonical, shortLabel, fullLabel) => {
+    const presentation = getPlanPresentation({ provider: 'codex', planType: raw, t });
+    expect(presentation).toMatchObject({
+      rawPlanType: raw,
+      canonicalPlanType: canonical,
+      shortLabel,
+      fullLabel,
+      known: true,
+    });
+  });
+
+  it.each([
+    ['plan_free', 'free', 'Free'],
+    ['plan_pro', 'pro', 'Pro'],
+    ['plan_max', 'max', 'Max'],
+    ['plan_team', 'team', 'Team'],
+  ])('resolves Claude %s', (raw, canonical, label) => {
+    expect(getPlanPresentation({ provider: 'claude', planType: raw, t })).toMatchObject({
+      rawPlanType: raw,
+      canonicalPlanType: canonical,
+      shortLabel: label,
+      fullLabel: label,
+      known: true,
+    });
+  });
+
+  it.each([
+    ['free', 'free', 'Free'],
+    ['pro', 'pro', 'Pro'],
+    ['ultra', 'ultra', 'Ultra'],
+    ['ultra-lite', 'ultra-lite', 'Ultra Lite'],
+    ['ultra_lite', 'ultra-lite', 'Ultra Lite'],
+  ])('resolves Antigravity %s', (raw, canonical, label) => {
+    expect(getPlanPresentation({ provider: 'antigravity', planType: raw, t })).toMatchObject({
+      rawPlanType: raw,
+      canonicalPlanType: canonical,
+      shortLabel: label,
+      fullLabel: label,
+      known: true,
+    });
+  });
+
+  it.each([
+    ['codex', 'future_plan_x'],
+    ['claude', 'future_plan_x'],
+    ['antigravity', 'future_plan_x'],
+    ['kimi', 'future_plan_x'],
+    ['xai', 'future_plan_x'],
+  ])('keeps unknown %s plans visible without a translation key', (provider, raw) => {
+    const presentation = getPlanPresentation({ provider, planType: raw, t });
+    expect(presentation).toEqual({
+      provider,
+      rawPlanType: raw,
+      canonicalPlanType: raw,
+      shortLabel: raw,
+      fullLabel: raw,
+      known: false,
+    });
+  });
+
+  it('returns null for an empty plan', () => {
+    expect(getPlanPresentation({ provider: 'codex', planType: '  ', t })).toBeNull();
+  });
+
+  it('uses canonical values for filtering and display mode selection', () => {
+    expect(getCanonicalPlanType('codex', 'pro-lite')).toBe('pro_5x');
+    const presentation = getPlanPresentation({
+      provider: 'codex',
+      planType: 'self_serve_business_prolite',
+      t,
+    });
+    expect(getPlanLabel(presentation, 'compact')).toBe('Business 5x');
+    expect(getPlanLabel(presentation, 'full')).toBe('Business Premium 5x');
+  });
+
+  it('resolves non-Codex plan aliases from nested token fields', () => {
+    expect(
+      resolveAuthFilePlanType({
+        name: 'claude.json',
+        type: 'claude',
+        id_token: { planType: 'plan_pro' },
+      })
+    ).toBe('plan_pro');
+  });
+
+  it('falls through an unknown Antigravity plan to tier metadata', () => {
+    expect(
+      resolveAuthFilePlanType({
+        name: 'antigravity.json',
+        type: 'antigravity',
+        planType: 'unknown',
+        subscription: {
+          plan: 'unknown',
+          tierName: 'Antigravity Future',
+          tierId: 'future-tier',
+        },
+      })
+    ).toBe('antigravity future');
+  });
+
+  it('keeps a known Antigravity credential plan ahead of unknown tier metadata', () => {
+    expect(
+      resolveAntigravityPlanType(
+        {
+          plan: 'unknown',
+          tierName: 'Antigravity Future',
+          tierId: 'future-tier',
+        },
+        'pro'
+      )
+    ).toBe('pro');
+  });
+
+  it('falls through an unknown Codex plan to later subscription metadata', () => {
+    expect(
+      resolveAuthFilePlanType({
+        name: 'codex.json',
+        type: 'codex',
+        planType: 'unknown',
+        metadata: {
+          subscription: {
+            plan: 'pro',
+          },
+        },
+      })
+    ).toBe('pro');
+  });
+});

--- a/apps/web/src/utils/plans/presentation.ts
+++ b/apps/web/src/utils/plans/presentation.ts
@@ -1,5 +1,9 @@
 import type { TFunction } from 'i18next';
-import { normalizePlanProvider, normalizeRawPlanType } from './normalize';
+import {
+  normalizePlanProvider,
+  normalizeRawPlanType,
+  readRawPlanType,
+} from './normalize';
 import {
   resolveAntigravityPlanDescriptor,
   resolveClaudePlanDescriptor,
@@ -16,6 +20,52 @@ const PLAN_RESOLVERS: Readonly<Record<string, PlanResolver>> = {
   antigravity: resolveAntigravityPlanDescriptor,
 };
 
+const RESERVED_UNKNOWN_PLAN = 'unknown';
+const UNKNOWN_PLAN_PREFIX = 'unknown:';
+
+/**
+ * Filter labels are keyed by canonical identity, not by the provider that
+ * happened to produce the first matching row. Existing provider locale keys
+ * are reused with one fixed key per canonical identity.
+ */
+const CANONICAL_PLAN_FILTER_LABELS: Readonly<
+  Record<string, { key: string; fallback: string }>
+> = {
+  free: { key: 'plans.codex.free', fallback: 'Free' },
+  go: { key: 'plans.codex.go', fallback: 'Go' },
+  plus: { key: 'plans.codex.plus', fallback: 'Plus' },
+  pro: { key: 'plans.antigravity.pro', fallback: 'Pro' },
+  pro_5x: { key: 'plans.codex.pro_5x', fallback: 'Pro 5x' },
+  pro_20x: { key: 'plans.codex.pro_20x', fallback: 'Pro 20x' },
+  team: { key: 'plans.codex.team', fallback: 'Team' },
+  business: { key: 'plans.codex.business', fallback: 'Business' },
+  business_premium_5x: {
+    key: 'plans.codex.business_premium_5x.short',
+    fallback: 'Business 5x',
+  },
+  business_usage_based: {
+    key: 'plans.codex.business_usage_based.short',
+    fallback: 'Business PAYG',
+  },
+  enterprise: { key: 'plans.codex.enterprise', fallback: 'Enterprise' },
+  enterprise_automation: {
+    key: 'plans.codex.enterprise_automation.short',
+    fallback: 'Ent. Auto',
+  },
+  enterprise_usage_based: {
+    key: 'plans.codex.enterprise_usage_based.short',
+    fallback: 'Ent. PAYG',
+  },
+  edu: { key: 'plans.codex.edu.short', fallback: 'Edu' },
+  edu_plus: { key: 'plans.codex.edu_plus.short', fallback: 'Edu Plus' },
+  edu_pro: { key: 'plans.codex.edu_pro.short', fallback: 'Edu Pro' },
+  max: { key: 'plans.claude.max', fallback: 'Max' },
+  max_5x: { key: 'plans.claude.max_5x', fallback: 'Max 5x' },
+  max_20x: { key: 'plans.claude.max_20x', fallback: 'Max 20x' },
+  ultra: { key: 'plans.antigravity.ultra', fallback: 'Ultra' },
+  'ultra-lite': { key: 'plans.antigravity.ultra_lite', fallback: 'Ultra Lite' },
+};
+
 const translate = (t: TFunction | undefined, key: string, fallback: string): string => {
   if (!t) return fallback;
   const value = t(key, { defaultValue: fallback });
@@ -25,12 +75,33 @@ const translate = (t: TFunction | undefined, key: string, fallback: string): str
 const resolveDescriptor = (provider: string, planType: unknown) =>
   PLAN_RESOLVERS[provider]?.(planType) ?? null;
 
+const getUnknownPlanIdentity = (provider: string, normalizedPlanType: string): string =>
+  normalizedPlanType === RESERVED_UNKNOWN_PLAN
+    ? RESERVED_UNKNOWN_PLAN
+    : `${UNKNOWN_PLAN_PREFIX}${provider || 'unknown'}:${normalizedPlanType}`;
+
 export const getCanonicalPlanType = (provider: unknown, planType: unknown): string | null => {
+  const normalizedProvider = normalizePlanProvider(provider) || 'unknown';
   const normalized = normalizeRawPlanType(planType);
   if (!normalized) return null;
   return (
-    resolveDescriptor(normalizePlanProvider(provider), normalized)?.canonicalPlanType ?? normalized
+    resolveDescriptor(normalizedProvider, normalized)?.canonicalPlanType ??
+    getUnknownPlanIdentity(normalizedProvider, normalized)
   );
+};
+
+export const getCanonicalPlanFilterLabel = (
+  canonicalPlanType: string | null | undefined,
+  t?: TFunction,
+  fallback?: string
+): string => {
+  const normalized = normalizeRawPlanType(canonicalPlanType);
+  if (!normalized) return fallback ?? '';
+  if (normalized === RESERVED_UNKNOWN_PLAN) {
+    return translate(t, 'auth_files.codex_plan_filter_unknown', 'Unknown plan');
+  }
+  const label = CANONICAL_PLAN_FILTER_LABELS[normalized];
+  return label ? translate(t, label.key, label.fallback) : (fallback ?? normalized);
 };
 
 export const getPlanPresentation = ({
@@ -39,15 +110,17 @@ export const getPlanPresentation = ({
   t,
 }: GetPlanPresentationInput): PlanPresentation | null => {
   const normalizedProvider = normalizePlanProvider(provider) || 'unknown';
-  const rawPlanType = normalizeRawPlanType(planType);
+  const rawPlanType = readRawPlanType(planType);
   if (!rawPlanType) return null;
 
-  const resolved = resolveDescriptor(normalizedProvider, rawPlanType);
+  const normalizedPlanType = normalizeRawPlanType(rawPlanType);
+  if (!normalizedPlanType) return null;
+  const resolved = resolveDescriptor(normalizedProvider, normalizedPlanType);
   if (!resolved) {
     return {
       provider: normalizedProvider,
       rawPlanType,
-      canonicalPlanType: rawPlanType,
+      canonicalPlanType: getUnknownPlanIdentity(normalizedProvider, normalizedPlanType),
       shortLabel: rawPlanType,
       fullLabel: rawPlanType,
       known: false,

--- a/apps/web/src/utils/plans/presentation.ts
+++ b/apps/web/src/utils/plans/presentation.ts
@@ -1,0 +1,79 @@
+import type { TFunction } from 'i18next';
+import { normalizePlanProvider, normalizeRawPlanType } from './normalize';
+import {
+  resolveAntigravityPlanDescriptor,
+  resolveClaudePlanDescriptor,
+  resolveCodexPlanDescriptor,
+} from './providers';
+import type { PlanResolverDescriptor } from './providers/types';
+import type { GetPlanPresentationInput, PlanDisplayMode, PlanPresentation } from './types';
+
+type PlanResolver = (planType: unknown) => PlanResolverDescriptor | null;
+
+const PLAN_RESOLVERS: Readonly<Record<string, PlanResolver>> = {
+  codex: resolveCodexPlanDescriptor,
+  claude: resolveClaudePlanDescriptor,
+  antigravity: resolveAntigravityPlanDescriptor,
+};
+
+const translate = (t: TFunction | undefined, key: string, fallback: string): string => {
+  if (!t) return fallback;
+  const value = t(key, { defaultValue: fallback });
+  return value === key ? fallback : value;
+};
+
+const resolveDescriptor = (provider: string, planType: unknown) =>
+  PLAN_RESOLVERS[provider]?.(planType) ?? null;
+
+export const getCanonicalPlanType = (provider: unknown, planType: unknown): string | null => {
+  const normalized = normalizeRawPlanType(planType);
+  if (!normalized) return null;
+  return (
+    resolveDescriptor(normalizePlanProvider(provider), normalized)?.canonicalPlanType ?? normalized
+  );
+};
+
+export const getPlanPresentation = ({
+  provider,
+  planType,
+  t,
+}: GetPlanPresentationInput): PlanPresentation | null => {
+  const normalizedProvider = normalizePlanProvider(provider) || 'unknown';
+  const rawPlanType = normalizeRawPlanType(planType);
+  if (!rawPlanType) return null;
+
+  const resolved = resolveDescriptor(normalizedProvider, rawPlanType);
+  if (!resolved) {
+    return {
+      provider: normalizedProvider,
+      rawPlanType,
+      canonicalPlanType: rawPlanType,
+      shortLabel: rawPlanType,
+      fullLabel: rawPlanType,
+      known: false,
+    };
+  }
+
+  const shortLabel = translate(t, resolved.shortLabelKey, resolved.shortDefault);
+  const fullLabel = translate(
+    t,
+    resolved.fullLabelKey ?? resolved.shortLabelKey,
+    resolved.fullDefault ?? resolved.shortDefault
+  );
+  return {
+    provider: normalizedProvider,
+    rawPlanType,
+    canonicalPlanType: resolved.canonicalPlanType,
+    shortLabel,
+    fullLabel,
+    known: true,
+  };
+};
+
+export const getPlanLabel = (
+  presentation: PlanPresentation | null | undefined,
+  mode: PlanDisplayMode = 'compact'
+): string | null => {
+  if (!presentation) return null;
+  return mode === 'full' ? presentation.fullLabel : presentation.shortLabel;
+};

--- a/apps/web/src/utils/plans/providers/antigravity.ts
+++ b/apps/web/src/utils/plans/providers/antigravity.ts
@@ -1,0 +1,65 @@
+import { normalizeRawPlanType } from '../normalize';
+import type { PlanResolverDescriptor } from './types';
+
+const descriptor = (canonicalPlanType: string, labelKey: string, labelDefault: string) =>
+  ({
+    canonicalPlanType,
+    shortLabelKey: labelKey,
+    shortDefault: labelDefault,
+  }) satisfies PlanResolverDescriptor;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readTrimmed = (value: unknown): string | null => {
+  if (typeof value === 'string') return value.trim() || null;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+};
+
+/** Resolves Antigravity's plan field and falls back to provider tier metadata. */
+export const resolveAntigravityPlanType = (
+  subscription: unknown,
+  fallback?: unknown
+): string | null => {
+  const record = isRecord(subscription) ? subscription : null;
+  const toValue = (value: unknown) => {
+    const raw = readTrimmed(value);
+    if (!raw) return null;
+    const normalized = normalizeRawPlanType(raw);
+    return normalized ? { raw, normalized } : null;
+  };
+  const directValue = toValue(record?.plan ?? (record ? undefined : subscription));
+  const fallbackValue = toValue(fallback);
+  const tierValues = [toValue(record?.tierName), toValue(record?.tierId)].filter(
+    (value): value is { raw: string; normalized: string } => value !== null
+  );
+
+  if (directValue && directValue.normalized !== 'unknown') return directValue.raw;
+  if (fallbackValue && fallbackValue.normalized !== 'unknown') return fallbackValue.raw;
+  return (
+    [directValue, ...tierValues, fallbackValue].find(
+      (value): value is { raw: string; normalized: string } =>
+        value !== null && value.normalized !== 'unknown'
+    )?.raw ??
+    directValue?.raw ??
+    tierValues[0]?.raw ??
+    fallbackValue?.raw ??
+    null
+  );
+};
+
+export const ANTIGRAVITY_PLAN_DESCRIPTORS: Readonly<Record<string, PlanResolverDescriptor>> = {
+  free: descriptor('free', 'plans.antigravity.free', 'Free'),
+  pro: descriptor('pro', 'plans.antigravity.pro', 'Pro'),
+  ultra: descriptor('ultra', 'plans.antigravity.ultra', 'Ultra'),
+  'ultra-lite': descriptor('ultra-lite', 'plans.antigravity.ultra_lite', 'Ultra Lite'),
+  ultra_lite: descriptor('ultra-lite', 'plans.antigravity.ultra_lite', 'Ultra Lite'),
+};
+
+export const resolveAntigravityPlanDescriptor = (
+  planType: unknown
+): PlanResolverDescriptor | null => {
+  const normalized = normalizeRawPlanType(planType);
+  return normalized ? (ANTIGRAVITY_PLAN_DESCRIPTORS[normalized] ?? null) : null;
+};

--- a/apps/web/src/utils/plans/providers/claude.ts
+++ b/apps/web/src/utils/plans/providers/claude.ts
@@ -1,0 +1,34 @@
+import { normalizeRawPlanType } from '../normalize';
+import type { PlanResolverDescriptor } from './types';
+
+const descriptor = (canonicalPlanType: string, labelKey: string, labelDefault: string) =>
+  ({
+    canonicalPlanType,
+    shortLabelKey: labelKey,
+    shortDefault: labelDefault,
+  }) satisfies PlanResolverDescriptor;
+
+/**
+ * Claude quota resolution currently emits the `plan_*` values below. Plain
+ * names are accepted as credential compatibility aliases without changing the
+ * raw value retained by quota state.
+ */
+export const CLAUDE_PLAN_DESCRIPTORS: Readonly<Record<string, PlanResolverDescriptor>> = {
+  plan_free: descriptor('free', 'plans.claude.free', 'Free'),
+  free: descriptor('free', 'plans.claude.free', 'Free'),
+  plan_pro: descriptor('pro', 'plans.claude.pro', 'Pro'),
+  pro: descriptor('pro', 'plans.claude.pro', 'Pro'),
+  plan_max: descriptor('max', 'plans.claude.max', 'Max'),
+  max: descriptor('max', 'plans.claude.max', 'Max'),
+  plan_max5: descriptor('max_5x', 'plans.claude.max_5x', 'Max 5x'),
+  max_5x: descriptor('max_5x', 'plans.claude.max_5x', 'Max 5x'),
+  plan_max20: descriptor('max_20x', 'plans.claude.max_20x', 'Max 20x'),
+  max_20x: descriptor('max_20x', 'plans.claude.max_20x', 'Max 20x'),
+  plan_team: descriptor('team', 'plans.claude.team', 'Team'),
+  team: descriptor('team', 'plans.claude.team', 'Team'),
+};
+
+export const resolveClaudePlanDescriptor = (planType: unknown): PlanResolverDescriptor | null => {
+  const normalized = normalizeRawPlanType(planType);
+  return normalized ? (CLAUDE_PLAN_DESCRIPTORS[normalized] ?? null) : null;
+};

--- a/apps/web/src/utils/plans/providers/codex.ts
+++ b/apps/web/src/utils/plans/providers/codex.ts
@@ -1,0 +1,111 @@
+import { normalizeRawPlanType } from '../normalize';
+import type { PlanResolverDescriptor } from './types';
+
+const descriptor = (
+  canonicalPlanType: string,
+  shortLabelKey: string,
+  shortDefault: string,
+  fullLabelKey?: string,
+  fullDefault?: string
+): PlanResolverDescriptor => ({
+  canonicalPlanType,
+  shortLabelKey,
+  shortDefault,
+  ...(fullLabelKey ? { fullLabelKey } : {}),
+  ...(fullDefault ? { fullDefault } : {}),
+});
+
+/** Codex raw plan aliases mapped to one stable internal plan identity. */
+export const CODEX_PLAN_DESCRIPTORS: Readonly<Record<string, PlanResolverDescriptor>> = {
+  free: descriptor('free', 'plans.codex.free', 'Free'),
+  go: descriptor('go', 'plans.codex.go', 'Go'),
+  plus: descriptor('plus', 'plans.codex.plus', 'Plus'),
+  prolite: descriptor('pro_5x', 'plans.codex.pro_5x', 'Pro 5x'),
+  'pro-lite': descriptor('pro_5x', 'plans.codex.pro_5x', 'Pro 5x'),
+  pro_lite: descriptor('pro_5x', 'plans.codex.pro_5x', 'Pro 5x'),
+  pro_5x: descriptor('pro_5x', 'plans.codex.pro_5x', 'Pro 5x'),
+  pro: descriptor('pro_20x', 'plans.codex.pro_20x', 'Pro 20x'),
+  pro_20x: descriptor('pro_20x', 'plans.codex.pro_20x', 'Pro 20x'),
+  team: descriptor('team', 'plans.codex.team', 'Team'),
+  self_serve_business_prolite: descriptor(
+    'business_premium_5x',
+    'plans.codex.business_premium_5x.short',
+    'Business 5x',
+    'plans.codex.business_premium_5x.full',
+    'Business Premium 5x'
+  ),
+  self_serve_business_usage_based: descriptor(
+    'business_usage_based',
+    'plans.codex.business_usage_based.short',
+    'Business PAYG',
+    'plans.codex.business_usage_based.full',
+    'Business Usage-based'
+  ),
+  business_premium_5x: descriptor(
+    'business_premium_5x',
+    'plans.codex.business_premium_5x.short',
+    'Business 5x',
+    'plans.codex.business_premium_5x.full',
+    'Business Premium 5x'
+  ),
+  business_usage_based: descriptor(
+    'business_usage_based',
+    'plans.codex.business_usage_based.short',
+    'Business PAYG',
+    'plans.codex.business_usage_based.full',
+    'Business Usage-based'
+  ),
+  business: descriptor('business', 'plans.codex.business', 'Business'),
+  ent26: descriptor('enterprise', 'plans.codex.enterprise', 'Enterprise'),
+  enterprise: descriptor('enterprise', 'plans.codex.enterprise', 'Enterprise'),
+  hc: descriptor('enterprise', 'plans.codex.enterprise', 'Enterprise'),
+  enterprise_cbp_automation: descriptor(
+    'enterprise_automation',
+    'plans.codex.enterprise_automation.short',
+    'Ent. Auto',
+    'plans.codex.enterprise_automation.full',
+    'Enterprise Automation'
+  ),
+  enterprise_automation: descriptor(
+    'enterprise_automation',
+    'plans.codex.enterprise_automation.short',
+    'Ent. Auto',
+    'plans.codex.enterprise_automation.full',
+    'Enterprise Automation'
+  ),
+  enterprise_cbp_usage_based: descriptor(
+    'enterprise_usage_based',
+    'plans.codex.enterprise_usage_based.short',
+    'Ent. PAYG',
+    'plans.codex.enterprise_usage_based.full',
+    'Enterprise Usage-based'
+  ),
+  enterprise_usage_based: descriptor(
+    'enterprise_usage_based',
+    'plans.codex.enterprise_usage_based.short',
+    'Ent. PAYG',
+    'plans.codex.enterprise_usage_based.full',
+    'Enterprise Usage-based'
+  ),
+  edu: descriptor('edu', 'plans.codex.edu', 'Edu', 'plans.codex.edu.full', 'Education'),
+  education: descriptor('edu', 'plans.codex.edu', 'Edu', 'plans.codex.edu.full', 'Education'),
+  edu_plus: descriptor(
+    'edu_plus',
+    'plans.codex.edu_plus.short',
+    'Edu Plus',
+    'plans.codex.edu_plus.full',
+    'Education Plus'
+  ),
+  edu_pro: descriptor(
+    'edu_pro',
+    'plans.codex.edu_pro.short',
+    'Edu Pro',
+    'plans.codex.edu_pro.full',
+    'Education Pro'
+  ),
+};
+
+export const resolveCodexPlanDescriptor = (planType: unknown): PlanResolverDescriptor | null => {
+  const normalized = normalizeRawPlanType(planType);
+  return normalized ? (CODEX_PLAN_DESCRIPTORS[normalized] ?? null) : null;
+};

--- a/apps/web/src/utils/plans/providers/codex.ts
+++ b/apps/web/src/utils/plans/providers/codex.ts
@@ -87,8 +87,14 @@ export const CODEX_PLAN_DESCRIPTORS: Readonly<Record<string, PlanResolverDescrip
     'plans.codex.enterprise_usage_based.full',
     'Enterprise Usage-based'
   ),
-  edu: descriptor('edu', 'plans.codex.edu', 'Edu', 'plans.codex.edu.full', 'Education'),
-  education: descriptor('edu', 'plans.codex.edu', 'Edu', 'plans.codex.edu.full', 'Education'),
+  edu: descriptor('edu', 'plans.codex.edu.short', 'Edu', 'plans.codex.edu.full', 'Education'),
+  education: descriptor(
+    'edu',
+    'plans.codex.edu.short',
+    'Edu',
+    'plans.codex.edu.full',
+    'Education'
+  ),
   edu_plus: descriptor(
     'edu_plus',
     'plans.codex.edu_plus.short',

--- a/apps/web/src/utils/plans/providers/index.ts
+++ b/apps/web/src/utils/plans/providers/index.ts
@@ -1,0 +1,8 @@
+export {
+  ANTIGRAVITY_PLAN_DESCRIPTORS,
+  resolveAntigravityPlanDescriptor,
+  resolveAntigravityPlanType,
+} from './antigravity';
+export { CLAUDE_PLAN_DESCRIPTORS, resolveClaudePlanDescriptor } from './claude';
+export { CODEX_PLAN_DESCRIPTORS, resolveCodexPlanDescriptor } from './codex';
+export type { PlanResolverDescriptor } from './types';

--- a/apps/web/src/utils/plans/providers/types.ts
+++ b/apps/web/src/utils/plans/providers/types.ts
@@ -1,0 +1,7 @@
+export interface PlanResolverDescriptor {
+  canonicalPlanType: string;
+  shortLabelKey: string;
+  shortDefault: string;
+  fullLabelKey?: string;
+  fullDefault?: string;
+}

--- a/apps/web/src/utils/plans/source.ts
+++ b/apps/web/src/utils/plans/source.ts
@@ -1,7 +1,7 @@
 import type { AuthFileItem } from '@/types/authFile';
 import { parseIdTokenPayload } from '@/utils/quota/parsers';
 import { resolveCodexPlanType } from '@/utils/quota/resolvers';
-import { normalizePlanProvider, normalizeRawPlanType } from './normalize';
+import { normalizePlanProvider, normalizeRawPlanType, readRawPlanType } from './normalize';
 import { resolveAntigravityPlanType } from './providers/antigravity';
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
@@ -9,11 +9,13 @@ const asRecord = (value: unknown): Record<string, unknown> | null =>
     ? (value as Record<string, unknown>)
     : null;
 
+const isUnknownPlan = (value: string): boolean => normalizeRawPlanType(value) === 'unknown';
+
 const firstMeaningfulPlan = (values: unknown[]): string | null => {
-  const normalized = values
-    .map(normalizeRawPlanType)
+  const rawValues = values
+    .map(readRawPlanType)
     .filter((value): value is string => value !== null);
-  return normalized.find((value) => value !== 'unknown') ?? normalized[0] ?? null;
+  return rawValues.find((value) => !isUnknownPlan(value)) ?? rawValues[0] ?? null;
 };
 
 const readTokenPlanType = (value: unknown): string | null => {
@@ -24,7 +26,7 @@ const readTokenPlanType = (value: unknown): string | null => {
 
 const readNestedSubscriptionPlanType = (value: unknown): string | null => {
   const record = asRecord(value);
-  if (!record) return normalizeRawPlanType(value);
+  if (!record) return readRawPlanType(value);
   return firstMeaningfulPlan([record.plan, record.tierName, record.tierId]);
 };
 
@@ -32,13 +34,13 @@ const readNestedSubscriptionPlanType = (value: unknown): string | null => {
 export const resolveAuthFilePlanType = (file: AuthFileItem): string | null => {
   const provider = normalizePlanProvider(file.provider ?? file.type);
   const codexPlanType = provider === 'codex' ? resolveCodexPlanType(file) : null;
-  if (codexPlanType && codexPlanType !== 'unknown') return codexPlanType;
+  if (codexPlanType && !isUnknownPlan(codexPlanType)) return codexPlanType;
 
   const metadata = asRecord(file.metadata);
   const attributes = asRecord(file.attributes);
   const tokenCandidates = [file.id_token, metadata?.id_token, attributes?.id_token];
   const tokenPlanType = firstMeaningfulPlan(tokenCandidates.map(readTokenPlanType));
-  if (tokenPlanType && tokenPlanType !== 'unknown') return tokenPlanType;
+  if (tokenPlanType && !isUnknownPlan(tokenPlanType)) return tokenPlanType;
 
   const directPlanType = firstMeaningfulPlan([
     file.plan_type,
@@ -53,7 +55,7 @@ export const resolveAuthFilePlanType = (file: AuthFileItem): string | null => {
     file.subscriptionType,
     file.accountType,
   ]);
-  if (directPlanType && directPlanType !== 'unknown') return directPlanType;
+  if (directPlanType && !isUnknownPlan(directPlanType)) return directPlanType;
 
   const subscriptionPlanType = firstMeaningfulPlan([
     provider === 'antigravity'

--- a/apps/web/src/utils/plans/source.ts
+++ b/apps/web/src/utils/plans/source.ts
@@ -1,0 +1,66 @@
+import type { AuthFileItem } from '@/types/authFile';
+import { parseIdTokenPayload } from '@/utils/quota/parsers';
+import { resolveCodexPlanType } from '@/utils/quota/resolvers';
+import { normalizePlanProvider, normalizeRawPlanType } from './normalize';
+import { resolveAntigravityPlanType } from './providers/antigravity';
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+const firstMeaningfulPlan = (values: unknown[]): string | null => {
+  const normalized = values
+    .map(normalizeRawPlanType)
+    .filter((value): value is string => value !== null);
+  return normalized.find((value) => value !== 'unknown') ?? normalized[0] ?? null;
+};
+
+const readTokenPlanType = (value: unknown): string | null => {
+  const payload = parseIdTokenPayload(value);
+  if (!payload) return null;
+  return firstMeaningfulPlan([payload.plan_type, payload.planType]);
+};
+
+const readNestedSubscriptionPlanType = (value: unknown): string | null => {
+  const record = asRecord(value);
+  if (!record) return normalizeRawPlanType(value);
+  return firstMeaningfulPlan([record.plan, record.tierName, record.tierId]);
+};
+
+/** Resolves a raw provider plan identity without changing the raw quota/API contract. */
+export const resolveAuthFilePlanType = (file: AuthFileItem): string | null => {
+  const provider = normalizePlanProvider(file.provider ?? file.type);
+  const codexPlanType = provider === 'codex' ? resolveCodexPlanType(file) : null;
+  if (codexPlanType && codexPlanType !== 'unknown') return codexPlanType;
+
+  const metadata = asRecord(file.metadata);
+  const attributes = asRecord(file.attributes);
+  const tokenCandidates = [file.id_token, metadata?.id_token, attributes?.id_token];
+  const tokenPlanType = firstMeaningfulPlan(tokenCandidates.map(readTokenPlanType));
+  if (tokenPlanType && tokenPlanType !== 'unknown') return tokenPlanType;
+
+  const directPlanType = firstMeaningfulPlan([
+    file.plan_type,
+    file.planType,
+    metadata?.plan_type,
+    metadata?.planType,
+    attributes?.plan_type,
+    attributes?.planType,
+    file.tier,
+    file.tierName,
+    file.tierId,
+    file.subscriptionType,
+    file.accountType,
+  ]);
+  if (directPlanType && directPlanType !== 'unknown') return directPlanType;
+
+  const subscriptionPlanType = firstMeaningfulPlan([
+    provider === 'antigravity'
+      ? resolveAntigravityPlanType(file.subscription)
+      : readNestedSubscriptionPlanType(file.subscription),
+    readNestedSubscriptionPlanType(metadata?.subscription),
+    readNestedSubscriptionPlanType(attributes?.subscription),
+  ]);
+  return subscriptionPlanType ?? tokenPlanType ?? directPlanType ?? codexPlanType;
+};

--- a/apps/web/src/utils/plans/types.ts
+++ b/apps/web/src/utils/plans/types.ts
@@ -1,0 +1,21 @@
+import type { TFunction } from 'i18next';
+
+/** Providers with a known subscription/plan identity are resolved explicitly. */
+export type PlanProvider = string;
+
+export type PlanDisplayMode = 'compact' | 'full';
+
+export interface PlanPresentation {
+  provider: PlanProvider;
+  rawPlanType: string | null;
+  canonicalPlanType: string | null;
+  shortLabel: string;
+  fullLabel: string;
+  known: boolean;
+}
+
+export interface GetPlanPresentationInput {
+  provider: unknown;
+  planType: unknown;
+  t?: TFunction;
+}


### PR DESCRIPTION
## Summary

Unify plan normalization, resolution, and presentation across the accounts, monitoring, dashboard, and usage-analytics surfaces through the shared `apps/web/src/utils/plans` contract. This update also fixes cross-provider canonical plan-filter collisions and makes the localized unknown-plan option deterministic.

> Community and maintenance PRs must target `dev`. Repository automation
> retargets other pull requests to `dev`; this can change the diff and make
> existing review comments outdated. `main` accepts only a promotion PR whose
> source is this repository's `dev` branch.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the shared `utils/plans` module with provider descriptors, canonical plan resolution, auth-file source resolution, and i18n-backed short/full labels with safe fallbacks.
- Route account, monitoring, dashboard, and usage-analytics plan presentation and filtering through the shared contract while preserving raw `planType` values.
- Compare the selected canonical plan identity directly with each account row so provider-specific mappings cannot collide.
- Keep the reserved unknown-plan option localized regardless of row encounter order, with regression coverage for cross-provider collisions and missing/explicit unknown values.
- Consolidate plan labels under the shared `plans.*` i18n namespace and remove obsolete per-quota label keys.

## User Impact

Plan labels are consistent and translated across the affected surfaces. Account filters now keep Codex `pro`, Codex `pro-lite`, and other providers' `pro` values distinct, while unknown and future values retain a stable localized fallback.

## Compatibility / Runtime Notes

- CPA panel mode: N/A — frontend-only presentation and filtering change.
- Manager Server mode: N/A — no API or quota contract changes; raw plan values remain unchanged.
- Full Docker / native packages: N/A.

## Data / Security Notes

N/A — no SQLite, admin key, CPA Management Key, auth file, log, or raw usage data changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the plan-presentation commits on this branch. No data migration or API rollback is required.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/features/accounts/model/accountRows.test.ts
  1 file passed, 65 tests passed

npm run type-check
  passed

npm run lint
  passed with 0 errors and 1 pre-existing Fast Refresh warning

npm run test
  204 test files passed, 2578 tests passed

npm run build
  passed; single-file web bundle generated

npm run check:demo-isolation
  passed; default bundle contains no demo fixture markers

git diff --check
  passed
```

## Screenshots / Recordings

N/A — no manual browser recording was produced; automated regression coverage verifies the changed filter behavior.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: No documentation changes are needed for this presentation consistency and filtering correction.

## Related

N/A