### PR TITLE
fix(quota): preserve previous cycles across observation gaps

### DIFF
--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -13,11 +14,12 @@ import (
 )
 
 const (
-	quotaBoundaryJitterMS         = int64(60 * 1000)
-	quotaProvisionalStartJitterMS = int64(60 * 1000)
-	quotaResetNearZeroPercent     = 1.0
-	quotaResetMinimumPriorPercent = 5.0
-	quotaResetLargeDropPercent    = 20.0
+	quotaBoundaryJitterMS             = int64(60 * 1000)
+	quotaProvisionalStartJitterMS     = int64(60 * 1000)
+	quotaPreviousCycleOverlapJitterMS = int64(60 * 1000)
+	quotaResetNearZeroPercent         = 1.0
+	quotaResetMinimumPriorPercent     = 5.0
+	quotaResetLargeDropPercent        = 20.0
 )
 
 type logicalWindowRow struct {
@@ -1928,7 +1930,10 @@ func latestActivationID(ctx context.Context, db *sql.DB, windowID int64, generat
 	return id, err
 }
 
-func previousCycle(ctx context.Context, db *sql.DB, activationID, currentStartMS int64) (model.AccountQuotaCycle, error) {
+// adjacentPreviousCycle returns the cycle immediately preceding currentStartMS.
+// The jitter bound is intentional: this helper is used only while normalizing
+// early-reset fragments, where time adjacency is part of the collapse proof.
+func adjacentPreviousCycle(ctx context.Context, db *sql.DB, activationID, currentStartMS int64) (model.AccountQuotaCycle, error) {
 	return scanCycle(db.QueryRowContext(ctx, `select
 		id, activation_id, provider_cycle_key, state, scheduled_start_ms, scheduled_end_ms,
 		actual_start_ms, actual_end_ms, duration_seconds, boundary_accuracy,
@@ -1939,6 +1944,42 @@ func previousCycle(ctx context.Context, db *sql.DB, activationID, currentStartMS
 			and actual_start_ms < ? and abs(actual_end_ms - ?) <= ?
 		order by actual_end_ms desc, id desc limit 1`,
 		activationID, currentStartMS, currentStartMS, quotaBoundaryJitterMS))
+}
+
+// latestClosedCycleBefore returns the most recent completed quota cycle in the
+// same activation before cutoffMS. Unlike adjacentPreviousCycle, it intentionally
+// permits observation gaps; activation identity provides the lifecycle fence.
+// A mode change is an explicit boundary between fixed/calendar cycle histories,
+// so candidates before that boundary are not exposed as a previous quota cycle.
+func latestClosedCycleBefore(ctx context.Context, db *sql.DB, activationID, cutoffMS int64) (model.AccountQuotaCycle, error) {
+	overlapCutoffMS := cutoffMS
+	if overlapCutoffMS > math.MaxInt64-quotaPreviousCycleOverlapJitterMS {
+		overlapCutoffMS = math.MaxInt64
+	} else {
+		overlapCutoffMS += quotaPreviousCycleOverlapJitterMS
+	}
+	return scanCycle(db.QueryRowContext(ctx, `select
+		candidate.id, candidate.activation_id, candidate.provider_cycle_key, candidate.state,
+		candidate.scheduled_start_ms, candidate.scheduled_end_ms, candidate.actual_start_ms,
+		candidate.actual_end_ms, candidate.duration_seconds, candidate.boundary_accuracy,
+		coalesce(candidate.end_reason, ''), candidate.first_observation_id,
+		candidate.last_observation_id, candidate.parent_cycle_id,
+		candidate.created_at_ms, candidate.updated_at_ms
+		from account_quota_cycles candidate
+		where candidate.activation_id = ? and candidate.actual_end_ms is not null
+			and coalesce(candidate.end_reason, '') <> 'mode_changed'
+			and candidate.actual_start_ms < ?
+			and candidate.actual_end_ms <= ?
+			and not exists (
+				select 1 from account_quota_cycles barrier
+				where barrier.activation_id = candidate.activation_id
+					and barrier.end_reason = 'mode_changed'
+					and barrier.actual_end_ms is not null
+					and barrier.actual_end_ms >= candidate.actual_start_ms
+					and barrier.actual_end_ms <= ?
+			)
+		order by candidate.actual_end_ms desc, candidate.id desc limit 1`,
+		activationID, cutoffMS, overlapCutoffMS, cutoffMS))
 }
 
 type quotaCycleEvidence struct {
@@ -1971,7 +2012,7 @@ func normalizeCycleView(
 	collapsedCycleIDs := []int64{current.ID}
 	var previousResult *model.AccountQuotaCycle
 	for {
-		previous, previousErr := previousCycle(ctx, db, activationID, lookupStartMS)
+		previous, previousErr := adjacentPreviousCycle(ctx, db, activationID, lookupStartMS)
 		if errors.Is(previousErr, sql.ErrNoRows) {
 			break
 		}
@@ -2036,6 +2077,18 @@ func normalizeCycleView(
 	if collapsed && previousResult != nil && previousResult.ActualEndMS != nil {
 		actualEndMS := current.ActualStartMS
 		previousResult.ActualEndMS = &actualEndMS
+	}
+	if previousResult != nil && previousResult.EndReason == "mode_changed" {
+		previousResult = nil
+	}
+	if previousResult == nil {
+		fallback, fallbackErr := latestClosedCycleBefore(ctx, db, activationID, lookupStartMS)
+		if fallbackErr != nil && !errors.Is(fallbackErr, sql.ErrNoRows) {
+			return model.AccountQuotaCycle{}, nil, nil, fallbackErr
+		}
+		if fallbackErr == nil {
+			previousResult = &fallback
+		}
 	}
 	aliases := make(map[int64]int64)
 	if collapsed {

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -2324,6 +2324,42 @@ func TestQuotaLifecycleClosesFixedCycleWhenProviderChangesWindowMode(t *testing.
 	}
 }
 
+func TestQuotaLifecycleDoesNotCrossModeChangeWhenFindingHistoricalPrevious(t *testing.T) {
+	const durationSeconds = int64(24 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	secondStartMS := firstEndMS + 8*60*1000
+	thirdStartMS := secondStartMS + 3*quotaLifecycleHourMS
+	service := newQuotaSnapshotTestService(t, thirdStartMS+quotaLifecycleHourMS)
+
+	first := quotaLifecycleFixedWindow("weekly", "weekly", firstStartMS, durationSeconds, 70)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+	second := quotaLifecycleFixedWindow("weekly", "weekly", secondStartMS, durationSeconds, 50)
+	writeQuotaLifecycleObservation(t, service, "complete", secondStartMS+quotaLifecycleHourMS, []WindowInput{second})
+
+	duration := durationSeconds
+	used := 45.0
+	rolling := WindowInput{
+		ProviderWindowID: "weekly",
+		WindowKind:       "weekly",
+		WindowMode:       "rolling",
+		ModelScopeKind:   "all",
+		Source:           "inspection",
+		BoundaryAccuracy: "estimated",
+		DurationSeconds:  &duration,
+		UsedPercent:      &used,
+	}
+	writeQuotaLifecycleObservation(t, service, "complete", secondStartMS+2*quotaLifecycleHourMS, []WindowInput{rolling})
+
+	third := quotaLifecycleFixedWindow("weekly", "weekly", thirdStartMS, durationSeconds, 1)
+	writeQuotaLifecycleObservation(t, service, "complete", thirdStartMS+1_000, []WindowInput{third})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != thirdStartMS || window.PreviousCycle != nil {
+		t.Fatalf("mode-change barrier leaked historical previous = %#v", window)
+	}
+}
+
 func TestQuotaLifecycleRestoresClosedProviderCycleWithoutDuplicateInsert(t *testing.T) {
 	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+2*quotaLifecycleDayMS)
 	original := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, 7*24*60*60, 40)
@@ -2421,18 +2457,108 @@ func TestQuotaLifecycleExactEvidenceReplacesDerivedCycleBoundary(t *testing.T) {
 	}
 }
 
-func TestQuotaLifecycleDoesNotExposeNonAdjacentHistoricalCycleAsPrevious(t *testing.T) {
+func TestQuotaLifecycleExposesSameActivationHistoricalCycleAsPreviousAfterGap(t *testing.T) {
 	service := newQuotaSnapshotTestService(t, quotaLifecycleBaseMS+4*quotaLifecycleDayMS)
 	first := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, 24*60*60, 70)
 	writeQuotaLifecycleObservation(t, service, "complete", quotaLifecycleBaseMS+quotaLifecycleHourMS, []WindowInput{first})
 
-	secondStartMS := quotaLifecycleBaseMS + 2*quotaLifecycleDayMS
+	firstEndMS := quotaLifecycleBaseMS + 24*60*60*1000
+	secondStartMS := firstEndMS + 477*1000
 	second := quotaLifecycleFixedWindow("weekly", "weekly", secondStartMS, 24*60*60, 10)
 	writeQuotaLifecycleObservation(t, service, "complete", secondStartMS+quotaLifecycleHourMS, []WindowInput{second})
 
 	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
-	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != secondStartMS || window.PreviousCycle != nil {
-		t.Fatalf("non-adjacent previous lifecycle = %#v", window)
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != secondStartMS ||
+		window.PreviousCycle == nil || window.PreviousCycle.ActualStartMS != quotaLifecycleBaseMS ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != firstEndMS ||
+		window.PreviousCycle.EndReason != "scheduled" ||
+		window.PreviousCycle.ActivationID != window.CurrentCycle.ActivationID {
+		t.Fatalf("scheduled gap previous lifecycle = %#v", window)
+	}
+}
+
+func TestQuotaLifecycleDoesNotReexposeCollapsedFragmentAsPrevious(t *testing.T) {
+	const durationSeconds = int64(24 * 60 * 60)
+	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+3*quotaLifecycleDayMS)
+	initial := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, durationSeconds, 70)
+	writeQuotaLifecycleObservation(t, service, "complete", quotaLifecycleBaseMS+quotaLifecycleHourMS, []WindowInput{initial})
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open collapsed-fragment database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var activationID, originalCycleID, originalSnapshotID int64
+	if err := db.QueryRow(`select activation_id, logical_window_id, cycle_id, id
+		from account_quota_snapshots order by id limit 1`).Scan(
+		&activationID, new(int64), &originalCycleID, &originalSnapshotID,
+	); err != nil {
+		t.Fatalf("read initial collapsed-fragment lifecycle: %v", err)
+	}
+
+	firstEndMS := quotaLifecycleBaseMS + durationSeconds*1000
+	fragmentStartMS := firstEndMS + 5*quotaLifecycleHourMS
+	currentStartMS := fragmentStartMS + 30*1000
+	invalidEndMS := fragmentStartMS + 2*60*1000
+	if _, err := db.Exec(`update account_quota_cycles set
+		state = 'closed', actual_end_ms = ?, end_reason = 'scheduled' where id = ?`,
+		firstEndMS, originalCycleID); err != nil {
+		t.Fatalf("close initial collapsed-fragment cycle: %v", err)
+	}
+
+	insertCycle := func(key, state string, startMS int64, endMS *int64, endReason string) int64 {
+		t.Helper()
+		result, insertErr := db.Exec(`insert into account_quota_cycles (
+			activation_id, provider_cycle_key, state, scheduled_start_ms, scheduled_end_ms,
+			actual_start_ms, actual_end_ms, duration_seconds, boundary_accuracy, end_reason,
+			created_at_ms, updated_at_ms
+		) values (?, ?, ?, ?, ?, ?, ?, ?, 'exact', ?, ?, ?)`,
+			activationID, key, state, startMS, startMS+durationSeconds*1000,
+			startMS, endMS, durationSeconds, endReason, startMS, startMS,
+		)
+		if insertErr != nil {
+			t.Fatalf("insert collapsed-fragment cycle %s: %v", key, insertErr)
+		}
+		id, insertErr := result.LastInsertId()
+		if insertErr != nil {
+			t.Fatalf("read collapsed-fragment cycle %s ID: %v", key, insertErr)
+		}
+		return id
+	}
+	fragmentEnd := currentStartMS
+	fragmentCycleID := insertCycle("weekly:fragment", "closed", fragmentStartMS, &fragmentEnd, "early_reset")
+	currentCycleID := insertCycle("weekly:current", "active", currentStartMS, nil, "")
+	_ = insertCycle("weekly:overlap", "closed", fragmentStartMS-2*quotaLifecycleHourMS, &invalidEndMS, "scheduled")
+
+	insertSnapshot := func(cycleID int64, sourceID string, observedAtMS, startMS int64, usedPercent float64) {
+		t.Helper()
+		_, insertErr := db.Exec(`insert into account_quota_snapshots (
+			observation_id, logical_window_id, activation_id, cycle_id, account_key, provider,
+			provider_window_id, window_kind, window_mode, model_scope_kind, model_scope_key,
+			model_ids_json, scope_fingerprint, content_hash, source, source_observation_id,
+			observed_at_ms, boundary_accuracy, cycle_start_ms, cycle_end_ms,
+			duration_seconds, used_percent, created_at_ms
+		) select observation_id, logical_window_id, activation_id, ?, account_key, provider,
+			provider_window_id, window_kind, window_mode, model_scope_kind, model_scope_key,
+			model_ids_json, scope_fingerprint, ?, 'inspection', ?, ?, 'exact', ?, ?, ?, ?, ?
+			from account_quota_snapshots where id = ?`,
+			cycleID, sourceID, sourceID, observedAtMS,
+			startMS, startMS+durationSeconds*1000, durationSeconds, usedPercent, observedAtMS,
+			originalSnapshotID,
+		)
+		if insertErr != nil {
+			t.Fatalf("insert collapsed-fragment snapshot %s: %v", sourceID, insertErr)
+		}
+	}
+	insertSnapshot(fragmentCycleID, "fragment-observation", fragmentStartMS+1_000, fragmentStartMS, 40)
+	insertSnapshot(currentCycleID, "current-observation", currentStartMS+1_000, currentStartMS, 38)
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != fragmentCycleID ||
+		window.PreviousCycle == nil || window.PreviousCycle.ID != originalCycleID ||
+		window.PreviousCycle.ID == fragmentCycleID || window.PreviousCycle.ActualEndMS == nil ||
+		*window.PreviousCycle.ActualEndMS != firstEndMS {
+		t.Fatalf("collapsed fragment previous lifecycle = %#v", window)
 	}
 }
 
@@ -2726,6 +2852,48 @@ func TestQuotaLifecycleNormalizesStoredEarlyResetBoundaryToFirstConfirmedObserva
 	}
 }
 
+func TestQuotaLifecycleDoesNotCollapseEarlyResetFragmentAcrossObservationGap(t *testing.T) {
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	firstRequestAtMS := quotaLifecycleBaseMS + 3*quotaLifecycleDayMS
+	providerStartMS := firstRequestAtMS + 30*1000
+	currentStartMS := providerStartMS + 2*60*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, currentStartMS+quotaLifecycleDayMS)
+	oldCycle := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, durationSeconds, 40)
+	writeQuotaLifecycleObservation(t, service, "complete", firstRequestAtMS-quotaLifecycleHourMS, []WindowInput{oldCycle})
+
+	reset := quotaLifecycleFixedWindow("weekly", "weekly", providerStartMS, durationSeconds, 1)
+	writeQuotaLifecycleObservation(t, service, "complete", firstRequestAtMS, []WindowInput{reset})
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open lifecycle database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var oldCycleID, currentCycleID int64
+	if err := db.QueryRow(`select id from account_quota_cycles
+		where end_reason = 'early_reset' limit 1`).Scan(&oldCycleID); err != nil {
+		t.Fatalf("read early-reset fragment cycle: %v", err)
+	}
+	if err := db.QueryRow(`select id from account_quota_cycles
+		where actual_end_ms is null limit 1`).Scan(&currentCycleID); err != nil {
+		t.Fatalf("read active cycle: %v", err)
+	}
+	if _, err := db.Exec(`update account_quota_cycles set actual_end_ms = ? where id = ?`, providerStartMS, oldCycleID); err != nil {
+		t.Fatalf("restore early-reset fragment end: %v", err)
+	}
+	if _, err := db.Exec(`update account_quota_cycles set actual_start_ms = ? where id = ?`, currentStartMS, currentCycleID); err != nil {
+		t.Fatalf("introduce early-reset observation gap: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID ||
+		window.CurrentCycle.ActualStartMS != currentStartMS || window.PreviousCycle == nil ||
+		window.PreviousCycle.ID != oldCycleID || window.PreviousCycle.EndReason != "early_reset" ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != providerStartMS {
+		t.Fatalf("early-reset gap lifecycle = %#v", window)
+	}
+}
+
 func TestQuotaLifecycleMarksConcurrentFiveHourAndWeeklyResetAsProviderReset(t *testing.T) {
 	resetAtMS := quotaLifecycleBaseMS + 3*quotaLifecycleDayMS
 	service := newQuotaSnapshotTestService(t, resetAtMS+2*quotaLifecycleDayMS)
@@ -2845,6 +3013,24 @@ func TestQuotaLifecycleDoesNotSplitCycleForSmallQuotaCorrection(t *testing.T) {
 	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != quotaLifecycleBaseMS ||
 		window.PreviousCycle != nil {
 		t.Fatalf("small quota correction split lifecycle = %#v", window)
+	}
+}
+
+func TestQuotaLifecycleDetectsLargeQuotaDropReset(t *testing.T) {
+	resetAtMS := quotaLifecycleBaseMS + 3*quotaLifecycleHourMS
+	service := newQuotaSnapshotTestService(t, resetAtMS+quotaLifecycleDayMS)
+	first := quotaLifecycleFixedWindow("weekly", "weekly", quotaLifecycleBaseMS, 7*24*60*60, 60)
+	writeQuotaLifecycleObservation(t, service, "complete", quotaLifecycleBaseMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	reset := quotaLifecycleFixedWindow("weekly", "weekly", resetAtMS, 7*24*60*60, 25)
+	writeQuotaLifecycleObservation(t, service, "complete", resetAtMS+1_000, []WindowInput{reset})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != resetAtMS ||
+		window.PreviousCycle == nil || window.PreviousCycle.ActualEndMS == nil ||
+		*window.PreviousCycle.ActualEndMS != resetAtMS || window.PreviousCycle.EndReason != "early_reset" ||
+		window.PreviousCycle.ForecastEligible {
+		t.Fatalf("large quota drop reset lifecycle = %#v", window)
 	}
 }
 
@@ -3356,6 +3542,46 @@ func TestQuotaLifecycleScheduledRolloverUsesScheduledBoundaryAfterIdleGap(t *tes
 		!window.PreviousCycle.ForecastEligible || window.PreviousCycle.ActualEndMS == nil ||
 		*window.PreviousCycle.ActualEndMS != rolloverAtMS {
 		t.Fatalf("scheduled rollover after idle gap = %#v", window)
+	}
+}
+
+func TestQuotaLifecycleExposesFiveHourAndWeeklyScheduledGapsAsPrevious(t *testing.T) {
+	const gapMS = int64(8 * 60 * 1000)
+	weeklyStartMS := quotaLifecycleBaseMS
+	fiveHourStartMS := quotaLifecycleBaseMS
+	weeklyEndMS := weeklyStartMS + 7*24*60*60*1000
+	fiveHourEndMS := fiveHourStartMS + 5*60*60*1000
+	weeklyNextStartMS := weeklyEndMS + gapMS
+	fiveHourNextStartMS := fiveHourEndMS + gapMS
+	service := newQuotaSnapshotTestService(t, weeklyNextStartMS+quotaLifecycleHourMS)
+
+	firstWeekly := quotaLifecycleFixedWindow("weekly", "weekly", weeklyStartMS, 7*24*60*60, 80)
+	firstFiveHour := quotaLifecycleFixedWindow("five-hour", "five_hour", fiveHourStartMS, 5*60*60, 70)
+	writeQuotaLifecycleObservation(t, service, "complete", quotaLifecycleBaseMS+quotaLifecycleHourMS, []WindowInput{
+		firstFiveHour,
+		firstWeekly,
+	})
+
+	secondWeekly := quotaLifecycleFixedWindow("weekly", "weekly", weeklyNextStartMS, 7*24*60*60, 1)
+	secondFiveHour := quotaLifecycleFixedWindow("five-hour", "five_hour", fiveHourNextStartMS, 5*60*60, 1)
+	writeQuotaLifecycleObservation(t, service, "complete", weeklyNextStartMS+quotaLifecycleHourMS, []WindowInput{
+		secondFiveHour,
+		secondWeekly,
+	})
+
+	windows := queryQuotaLifecycleWindows(t, service, false)
+	for id, bounds := range map[string][2]int64{
+		"five-hour": {fiveHourStartMS, fiveHourEndMS},
+		"weekly":    {weeklyStartMS, weeklyEndMS},
+	} {
+		wantStart, wantEnd := bounds[0], bounds[1]
+		window := windows[id]
+		if window.CurrentCycle == nil || window.PreviousCycle == nil ||
+			window.PreviousCycle.ActualStartMS != wantStart || window.PreviousCycle.ActualEndMS == nil ||
+			*window.PreviousCycle.ActualEndMS != wantEnd || window.PreviousCycle.EndReason != "scheduled" ||
+			window.PreviousCycle.ActivationID != window.CurrentCycle.ActivationID {
+			t.Fatalf("%s scheduled gap previous lifecycle = %#v", id, window)
+		}
 	}
 }
 

--- a/apps/web/src/features/accounts/model/accountQuotaWindowDefinitions.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaWindowDefinitions.test.ts
@@ -84,6 +84,43 @@ describe('accountQuotaWindowDefinitions', () => {
     ]);
   });
 
+  it('keeps an observation gap outside both lifecycle usage ranges', () => {
+    const [definition] = buildAccountQuotaWindowDefinitions([makeWindow({})], 30_000_000);
+    definition.currentCycle = {
+      id: 2,
+      activationId: 1,
+      state: 'active',
+      scheduledStartMs: 25_000_000,
+      scheduledEndMs: 38_000_000,
+      actualStartMs: 25_000_000,
+      actualEndMs: null,
+      durationSeconds: 18_000,
+      boundaryAccuracy: 'exact',
+      endReason: '',
+      parentCycleId: null,
+      forecastEligible: true,
+    };
+    definition.previousCycle = {
+      id: 1,
+      activationId: 1,
+      state: 'closed',
+      scheduledStartMs: 2_000_000,
+      scheduledEndMs: 20_000_000,
+      actualStartMs: 8_000_000,
+      actualEndMs: 20_000_000,
+      durationSeconds: 18_000,
+      boundaryAccuracy: 'exact',
+      endReason: 'scheduled',
+      parentCycleId: null,
+      forecastEligible: true,
+    };
+
+    expect(buildAccountQuotaUsageRanges(definition, 30_000_000)).toEqual([
+      { period: 'current', fromMs: 25_000_000, toMs: 30_000_000 },
+      { period: 'previous', fromMs: 8_000_000, toMs: 20_000_000 },
+    ]);
+  });
+
   it('does not invent a previous range for the first lifecycle cycle', () => {
     const [definition] = buildAccountQuotaWindowDefinitions([makeWindow({})], 30_000_000);
     definition.currentCycle = {

--- a/apps/web/src/features/accounts/model/accountWindowUsageRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountWindowUsageRows.test.ts
@@ -179,6 +179,83 @@ describe('accountWindowUsageRows', () => {
     expect(filterAccountWindowUsageByTargetRanges(currentEntries, usageByKey)).toHaveLength(0);
   });
 
+  it('creates distinct current and previous targets across a lifecycle gap', () => {
+    const row = makeRow({});
+    const definition: AccountQuotaWindowDefinition = {
+      key: '5h',
+      providerWindowId: '5h',
+      provider: 'codex',
+      label: '5h',
+      kind: 'five_hour',
+      windowMode: 'fixed',
+      modelScope: { kind: 'all', complete: true },
+      observationSource: 'api_query',
+      observedAtMs: 30_000,
+      boundaryAccuracy: 'exact',
+      cycleStartMs: 20_000,
+      cycleEndMs: 38_000,
+      durationSeconds: 18,
+      remainingPercent: 60,
+      usedPercent: 40,
+      stale: false,
+      display: {
+        key: '5h',
+        label: '5h',
+        kind: 'five_hour',
+        remainingPercent: 60,
+        usedPercent: 40,
+        resetLabel: 'reset',
+        resetAccuracy: 'exact',
+        limitWindowSeconds: 18,
+        resetAtMs: 38_000,
+        fromMs: 20_000,
+        toMs: 30_000,
+      },
+      currentCycle: {
+        id: 2,
+        activationId: 1,
+        state: 'active',
+        scheduledStartMs: 25_000,
+        scheduledEndMs: 38_000,
+        actualStartMs: 25_000,
+        actualEndMs: null,
+        durationSeconds: 18,
+        boundaryAccuracy: 'exact',
+        endReason: '',
+        parentCycleId: null,
+        forecastEligible: true,
+      },
+      previousCycle: {
+        id: 1,
+        activationId: 1,
+        state: 'closed',
+        scheduledStartMs: 2_000,
+        scheduledEndMs: 20_000,
+        actualStartMs: 8_000,
+        actualEndMs: 20_000,
+        durationSeconds: 18,
+        boundaryAccuracy: 'exact',
+        endReason: 'scheduled',
+        parentCycleId: null,
+        forecastEligible: true,
+      },
+    };
+
+    const entries = buildAccountWindowUsageTargetEntries(
+      [row],
+      new Map([[row.selectionKey, [definition]]]),
+      30_000
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.period)).toEqual(['current', 'previous']);
+    expect(entries.map((entry) => [entry.target.from_ms, entry.target.to_ms])).toEqual([
+      [25_000, 30_000],
+      [8_000, 20_000],
+    ]);
+    expect(entries[0].requestKey).not.toBe(entries[1].requestKey);
+  });
+
   it('uses unique window keys instead of provider order for legacy scoped responses', () => {
     const row = makeRow({});
     const alphaScope = { kind: 'models' as const, models: ['model-alpha'] };


### PR DESCRIPTION
## Summary

Fix Accounts quota detail losing the previous window usage after a scheduled rollover is first observed following an observation gap.

The lifecycle database already preserves the closed cycle and its usage history; this change restores the API linkage without changing write-side rollover or frontend production behavior.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Separate strict adjacent-cycle traversal used by early-reset fragment normalization from historical previous-cycle lookup used by the API view.
- Resolve the most recent closed cycle before the normalization cursor within the same activation, allowing scheduled observation gaps while preserving activation and mode-change barriers.
- Protect against collapsed fragments being re-exposed and against overlapping or timestamp-overflow candidates.
- Add Manager Server regressions for Issue #628, 5-hour/weekly gaps, activation/mode boundaries, fragment normalization, and existing reset behavior.
- Add Accounts model regressions for distinct current/previous usage targets across a lifecycle gap.

## User Impact

Accounts quota details can again display and query the most recently closed 5-hour or weekly window after a natural rollover followed by a delayed refresh. Existing usage history is reused; no usage data is reset or deleted.

## Compatibility / Runtime Notes

- CPA panel mode: No production frontend or CPA runtime contract changes.
- Manager Server mode: Same-activation closed cycles can now be returned as `previous_cycle` across observation gaps; strict adjacency remains limited to normalization.
- Full Docker / native packages: No packaging, configuration, or database migration changes.

## Data / Security Notes

No schema or migration changes. Existing `account_quota_cycles`, `account_quota_snapshots`, and usage history remain immutable and are only read differently.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the two commits to restore the prior strict previous-cycle lookup and remove the added regression coverage. No data rollback is required.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
go test ./...
go test -race ./internal/repository/quotasnapshot ./internal/service/quotasnapshot
npm run test (205 files / 2606 tests)
npm run type-check
npm run lint (0 errors; one existing Fast Refresh warning)
npm run build
git diff --check
```

## Screenshots / Recordings

N/A — no frontend production code or visible layout was changed.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

This is a backend lifecycle read-path correction with test-only frontend coverage; existing user-facing documentation does not describe this internal behavior.

## Related

Fixes #628