### PR TITLE
chore(release): prepare v1.12.6

### DIFF
--- a/docs/release-notes/v1.12.6-en.md
+++ b/docs/release-notes/v1.12.6-en.md
@@ -1,0 +1,42 @@
+# CPA Manager Plus v1.12.6
+
+> 45 commits · 113 files changed · +19022 / -1267
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.6/docs/release-notes/v1.12.6-zh.md)
+
+## Overview
+
+v1.12.6 focuses on secure CPA connection migration and rollback, provider-aware plan and quota presentation, safe Codex history continuity, and quota-window recovery across observation gaps. Manager Server keeps CPA Management Keys encrypted at rest and out of browser responses; installer upgrades preserve recoverable state; Accounts and Request Monitoring share current provider quota evidence; and historical reads fail closed when identity cannot be proved.
+
+## Highlights
+
+### Fixes
+
+- Manager Server configuration responses now expose only whether the CPA Management Key is configured; saved keys remain encrypted server-side, while setup and rotation use write-only input.
+- Docker and native installers import legacy CPA URL/key inputs into encrypted SQLite, validate health, administrator authentication, and CPA management access before removing legacy runtime wiring, and preserve external key files.
+- Migration snapshots and restores treat `usage.sqlite`, WAL/SHM/journal companions, and `data.key` as one complete file set; cancellation and failures retain a safe rollback path.
+- Legacy CPA connections follow explicit authority rules: complete `manager_config_v1` wins, compatible setup data can repair a partial manager record, and conflicting or unresolvable state requires `store-cpa-connection --repair-conflict` instead of silent rebinding.
+- Failed CPA imports retain a permission-restricted pending state and temporary key for safe retry, while malformed post-v2 persisted keys and missing or mismatched `data.key` fail closed without replacement-key creation.
+- Accounts and Request Monitoring now share provider quota refresh results and prevent stale cache generations or response-header evidence from overwriting newer quota state.
+- Codex account history and Monitoring account windows reuse legacy data only when explicit account identity and exact credential provenance match; ambiguous or foreign records remain separated, and `usage_events` stays immutable.
+- Accounts quota details can show the most recently closed 5-hour or weekly window after a natural rollover followed by an observation gap.
+- Request Monitoring plan filters preserve provider-scoped identity, so equivalent aliases aggregate within one provider without colliding with another provider's plans.
+
+### Refactor
+
+- Accounts, Monitoring, Inspection, Dashboard, and Usage Analytics use one provider-aware plan presentation path with compact/full labels, raw plan preservation, and visible fallbacks for unknown values.
+
+### Docs
+
+- Deployment and backup documentation now describe encrypted CPA storage, complete snapshot files, retry and conflict-repair procedures, and rollback cleanup boundaries.
+
+## Upgrade Notes
+
+- Existing deployments may run the connection-storage normalization migration during upgrade startup; keep `usage.sqlite`, WAL/SHM/journal files, and the matching `data.key` together in backups. The migration does not rewrite `usage_events`.
+- Valid persisted connections need no manual configuration change. If an old env/secret import fails, preserve the installer-managed pending file and temporary key for retry; external `CPA_MANAGEMENT_KEY_FILE` files are not deleted.
+- If the service reports corrupted post-v2 CPA connection storage or an unresolved conflict, do not replace `data.key`; stop Manager Server and use `store-cpa-connection --repair-conflict` with the explicitly verified URL and key file.
+- Monitoring integrations should use opaque `row.id` for state and `row.account` for display, and must not merge Codex accounts by project ID or display value alone.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.5...v1.12.6

--- a/docs/release-notes/v1.12.6-zh.md
+++ b/docs/release-notes/v1.12.6-zh.md
@@ -1,0 +1,42 @@
+# CPA Manager Plus v1.12.6
+
+> 45 commits · 113 files changed · +19022 / -1267
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.6/docs/release-notes/v1.12.6-en.md)
+
+## Overview
+
+v1.12.6 聚焦 CPA 连接迁移与回滚安全、跨 Provider 的计划与配额展示、Codex 历史身份连续性，以及观测间隔后的配额窗口恢复。Manager Server 现在将 CPA Management Key 保持在服务端加密存储中，不再返回浏览器；安装升级保留可恢复状态；Accounts 与 Request Monitoring 共享最新 Provider 配额证据；无法证明身份的历史数据继续安全失败。
+
+## Highlights
+
+### Fixes
+
+- Manager Server 配置接口现在只返回 CPA Management Key 是否已配置；已保存的密钥留在服务端加密存储中，setup 与轮换均使用只写入输入。
+- Docker 与原生安装器会将旧 CPA URL/Key 输入导入加密 SQLite，并在健康检查、管理员鉴权和 CPA 管理接口验证通过后才移除旧运行配置；外部密钥文件不会被删除。
+- 迁移快照与恢复将 `usage.sqlite`、WAL/SHM/journal 伴随文件和 `data.key` 视为一个完整文件集；取消或失败时保留安全回滚路径。
+- Legacy CPA 连接使用明确的 authority 规则：完整 `manager_config_v1` 优先，兼容的 setup 数据可修复 partial manager 记录；冲突或无法判断的状态要求 `store-cpa-connection --repair-conflict`，不会静默改绑。
+- CPA 导入失败时保留受限权限的 pending 状态和临时密钥以便安全重试；v2 之后损坏的持久化密钥以及缺失或错配的 `data.key` 会 fail closed，不会创建替代密钥。
+- Accounts 与 Request Monitoring 现在共享 Provider 配额刷新结果，并阻止过期缓存代次或响应头证据覆盖更新的配额状态。
+- Codex 账号历史和 Monitoring 账号窗口只在明确账号身份与精确凭证来源匹配时复用 legacy 数据；有歧义或不属于目标凭证的记录保持隔离，`usage_events` 始终不可变。
+- Accounts 配额详情在自然 rollover 后出现观测间隔时，仍可显示最近关闭的 5 小时或周配额窗口。
+- Request Monitoring 计划筛选器现在保留 Provider 作用域的身份；等价别名可以在同一 Provider 内归并，但不会与其他 Provider 的计划发生冲突。
+
+### Refactor
+
+- Accounts、Monitoring、Inspection、Dashboard 和 Usage Analytics 统一使用 Provider 感知的计划展示路径，支持 compact/full 标签、原始计划值保留和未知值可见回退。
+
+### Docs
+
+- 部署与备份文档补充加密 CPA 存储、完整快照文件、重试与冲突修复流程，以及回滚清理边界。
+
+## Upgrade Notes
+
+- 已有部署可能在升级启动时执行连接存储规范化迁移；请将 `usage.sqlite`、WAL/SHM/journal 和匹配的 `data.key` 一起备份。迁移不会改写 `usage_events`。
+- 有效的持久化连接不需要手动改配置。旧 env/secret 导入失败时，请保留安装器管理的 pending 文件和临时密钥以便重试；外部 `CPA_MANAGEMENT_KEY_FILE` 不会被删除。
+- 如果服务报告 v2 之后 CPA 连接存储损坏或存在未解决冲突，不要替换 `data.key`；停止 Manager Server 后，使用已明确核验的 URL 与密钥文件执行 `store-cpa-connection --repair-conflict`。
+- Monitoring 集成应使用不透明的 `row.id` 保存状态、使用 `row.account` 展示账号，不要仅按 project ID 或显示值合并 Codex 账号。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.5...v1.12.6

--- a/docs/release-posts/v1.12.6-telegram.html
+++ b/docs/release-posts/v1.12.6-telegram.html
@@ -1,0 +1,20 @@
+🚀 <b>8 月 28 日 · v1.12.6</b>
+
+✨ <b>更新内容</b>
+
+• CPA Management Key 现在只向浏览器返回已配置状态，已保存密钥留在服务端加密存储，设置与轮换均采用只写入方式。
+• Docker 与原生安装升级会先把旧 CPA 连接导入加密 SQLite，并在健康、管理员鉴权和 CPA 管理接口验证通过后再移除旧运行配置。
+• 失败或中断的 CPA 导入会保留可重试状态与临时密钥，并可按完整文件集恢复 SQLite、WAL/SHM/journal 与 data.key。
+• 历史 CPA 连接发生冲突时需要显式修复，Manager Server 不会静默替换既有连接。
+• Accounts、Request Monitoring、Dashboard、Inspection 和 Usage Analytics 现在使用统一的 Provider 感知计划展示，别名归并、未知值显示与跨 Provider 筛选更一致。
+• Accounts 与 Request Monitoring 会共享 Provider 配额刷新结果，并拦截过期缓存或响应头证据覆盖较新的配额。
+• Codex 历史用量与 Monitoring 账号窗口只在明确身份和凭证来源匹配时恢复，无法确认的记录不会被错误合并。
+• Accounts 配额详情可在自然 rollover 后的观测间隔中继续展示最近关闭的 5 小时或周配额窗口。
+• 损坏的 v2 CPA 持久化密钥或缺失、错配的 data.key 会安全失败，不会生成替代密钥。
+
+⚠️ <b>注意事项</b>
+
+• 升级已有部署前请将 <code>usage.sqlite</code>、WAL/SHM/journal 和匹配的 <code>data.key</code> 作为一组备份；<code>usage_events</code> 不会被改写。
+• 旧版 env/secret 导入失败时请保留安装器生成的 pending 文件和临时 Key 以便重试；外部 <code>CPA_MANAGEMENT_KEY_FILE</code> 不会被删除。
+• 如果出现损坏存储或冲突状态，请停止 Manager Server，并使用明确验证过的 URL 与密钥文件执行 <code>store-cpa-connection --repair-conflict</code>。
+• Monitoring 集成请使用 <code>row.id</code> 保存状态、使用 <code>row.account</code> 展示账号，不要仅按 project ID 或显示值合并 Codex 账号。


### PR DESCRIPTION
## Summary

Prepare the v1.12.6 bilingual release notes and the reviewed Telegram release post for the CPA Manager Plus release flow. The release content records the secure CPA connection migration, provider-aware plan and quota presentation, Codex history continuity, and quota-window recovery included in the frozen `dev` scope.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English technical release notes for v1.12.6 with reciprocal tag-pinned links and upgrade guidance.
- Add the reviewed Telegram HTML release post used by the tag-triggered release workflow.
- Record the release-specific backup, migration, compatibility, and identity-handling guidance for users upgrading from v1.12.5.

## User Impact

This is a release-documentation change. It gives users the v1.12.6 upgrade guidance and the exact user-facing summary that will accompany the release; the product changes described are already present on the frozen `dev` source.

## Compatibility / Runtime Notes

- CPA panel mode: The release notes cover the CPA panel compatibility path; this PR does not alter panel runtime code.
- Manager Server mode: The release notes document encrypted CPA Management Key storage and migration behavior; this PR does not alter server runtime code.
- Full Docker / native packages: The release workflow will package the frozen `main` promotion after the separate tag gate; this PR adds no package binaries.

## Data / Security Notes

No secrets, runtime databases, credentials, or generated artifacts are included. The notes document the requirement to back up `usage.sqlite`, WAL/SHM/journal companions, and the matching `data.key`, and state that `usage_events` remains immutable.

## Risk / Rollback

Risk level: Low

Rollback notes: This commit contains only versioned release documentation and the Telegram post. Before promotion or tagging, the release PR can be closed or reverted without changing runtime data; no tag is created by this PR.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
npm run release:validate -- --tag v1.12.6 --content-only
result: ok=true; Chinese=2035 characters; English=3885 characters; Telegram=1135 characters

Detached validation worktree was pinned to dev 72080f023f35f1e9bdd0907b9d5585d28b455334.
The three reviewed file digests matched the frozen manifest:
aa9f4a04761f764f284dcd7b4597eb9357dbbe5fe03658bfca08dd11d119b85d
bfcdedbbeec815f4be19365c79fb5e7d2b80c05aad224aed4fc522fc0a7eaa31
8c25900f6ca90f401cb75dfb8489274ce29b5dab6edce72574a3766bd2c23876
```

## Screenshots / Recordings

N/A — release notes and Telegram post only; no visible application UI changed in this PR.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision: The versioned bilingual release notes and reviewed Telegram post are the required documentation artifacts for v1.12.6.

## Related

N/A