### PR TITLE
fix(dashboard): link update badges to detected releases

### DIFF
--- a/apps/web/src/features/dashboard/components/VersionCard.module.scss
+++ b/apps/web/src/features/dashboard/components/VersionCard.module.scss
@@ -250,6 +250,7 @@
   border-radius: 4px;
   font-size: 10px;
   font-weight: 700;
+  text-decoration: none;
 
   &.badgeUpdate {
     background: var(--color-primary);

--- a/apps/web/src/features/dashboard/components/VersionCard.test.tsx
+++ b/apps/web/src/features/dashboard/components/VersionCard.test.tsx
@@ -1,0 +1,171 @@
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { ConnectionStatus } from '@/types';
+import { VersionCard } from './VersionCard';
+import styles from './VersionCard.module.scss';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    checkManagerLatest: vi.fn(),
+    checkLatest: vi.fn(),
+    showNotification: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.version ? `${key}:${String(options.version)}` : key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/stores', () => ({
+  useNotificationStore: (
+    selector: (state: { showNotification: typeof mocks.showNotification }) => unknown
+  ) => selector({ showNotification: mocks.showNotification }),
+}));
+
+vi.mock('@/services/api', () => ({
+  versionApi: {
+    checkManagerLatest: mocks.checkManagerLatest,
+    checkLatest: mocks.checkLatest,
+  },
+}));
+
+let renderer: ReactTestRenderer | null = null;
+
+const getText = (node: ReactTestInstance): string =>
+  node.children.map((child) => (typeof child === 'string' ? child : getText(child))).join('');
+
+const findAnchor = (renderer: ReactTestRenderer, className: string, text: string) =>
+  renderer.root.find(
+    (node) =>
+      node.type === 'a' && node.props.className?.includes(className) && getText(node).includes(text)
+  );
+
+const findBadge = (renderer: ReactTestRenderer, type: string, text: string) =>
+  renderer.root.find(
+    (node) =>
+      node.type === type &&
+      node.props.className?.includes(styles.badge) &&
+      node.props.className?.includes(styles.badgeUpdate) &&
+      getText(node).includes(text)
+  );
+
+const renderCard = async ({
+  appVersion = '1.12.6',
+  apiVersion = '7.2.143',
+  latestApp = '1.12.6',
+  latestApi = '7.2.143',
+  connectionStatus = 'connected' as ConnectionStatus,
+}: {
+  appVersion?: string;
+  apiVersion?: string;
+  latestApp?: string;
+  latestApi?: string;
+  connectionStatus?: ConnectionStatus;
+} = {}) => {
+  mocks.checkManagerLatest.mockResolvedValue({ tag_name: latestApp });
+  mocks.checkLatest.mockResolvedValue({ 'latest-version': latestApi });
+
+  await act(async () => {
+    renderer = create(
+      <MemoryRouter>
+        <VersionCard
+          appVersion={appVersion}
+          apiVersion={apiVersion}
+          cpaBase="http://cpa.local:8317"
+          connectionStatus={connectionStatus}
+          usageEnabled={false}
+          usageLoading={false}
+          collectorStatus={null}
+          collectorLoading={false}
+          errorLogCount={0}
+          errorLogsLoading={false}
+        />
+      </MemoryRouter>
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  if (!renderer) throw new Error('VersionCard did not render');
+  return renderer;
+};
+
+afterEach(() => {
+  if (renderer) {
+    act(() => renderer?.unmount());
+    renderer = null;
+  }
+  mocks.checkManagerLatest.mockReset();
+  mocks.checkLatest.mockReset();
+  mocks.showNotification.mockReset();
+});
+
+describe('VersionCard release links', () => {
+  it('keeps current Manager and Core versions linked to their installed releases', async () => {
+    const renderer = await renderCard();
+
+    expect(findAnchor(renderer, styles.versionLink, '1.12.6').props.href).toBe(
+      'https://github.com/seakee/CPA-Manager-Plus/releases/tag/v1.12.6'
+    );
+    expect(findAnchor(renderer, styles.versionLink, '7.2.143').props.href).toBe(
+      'https://github.com/router-for-me/CLIProxyAPI/releases/tag/v7.2.143'
+    );
+    expect(mocks.checkManagerLatest).toHaveBeenCalledTimes(1);
+    expect(mocks.checkLatest).toHaveBeenCalledTimes(1);
+  });
+
+  it('links a Core update badge to the detected latest Core release', async () => {
+    const renderer = await renderCard({ latestApi: 'v7.2.146' });
+    const badge = findBadge(renderer, 'a', 'v7.2.146');
+
+    expect(badge.props.href).toBe(
+      'https://github.com/router-for-me/CLIProxyAPI/releases/tag/v7.2.146'
+    );
+    expect(badge.props.target).toBe('_blank');
+    expect(badge.props.rel).toBe('noopener noreferrer');
+  });
+
+  it('links a Manager update badge to the detected latest Manager release', async () => {
+    const renderer = await renderCard({ latestApp: 'v1.12.7' });
+    const badge = findBadge(renderer, 'a', 'v1.12.7');
+
+    expect(badge.props.href).toBe(
+      'https://github.com/seakee/CPA-Manager-Plus/releases/tag/v1.12.7'
+    );
+    expect(badge.props.target).toBe('_blank');
+    expect(badge.props.rel).toBe('noopener noreferrer');
+  });
+
+  it('does not create a badge link for an invalid latest version', async () => {
+    const renderer = await renderCard({ latestApp: 'v1.12.7-5-gabcdef', latestApi: '' });
+
+    expect(
+      renderer.root.findAll(
+        (node) => node.type === 'a' && node.props.className?.includes(styles.badge)
+      )
+    ).toHaveLength(0);
+    expect(findAnchor(renderer, styles.versionLink, '1.12.6').props.href).toContain(
+      '/CPA-Manager-Plus/releases/tag/v1.12.6'
+    );
+  });
+
+  it('keeps the latest badge as plain text when there is no update', async () => {
+    const renderer = await renderCard();
+
+    expect(
+      renderer.root.findAll(
+        (node) =>
+          node.type === 'span' &&
+          node.props.className?.includes(styles.badgeLatest) &&
+          getText(node) === 'dashboard.version_is_latest'
+      )
+    ).toHaveLength(2);
+  });
+});

--- a/apps/web/src/features/dashboard/components/VersionCard.tsx
+++ b/apps/web/src/features/dashboard/components/VersionCard.tsx
@@ -54,17 +54,25 @@ interface HealthItem {
   to?: string;
 }
 
+interface VersionBadge {
+  label: string;
+  className: string;
+  releaseUrl?: string;
+}
+
 const renderBadge = (
   comparison: VersionComparison,
   latest: string,
+  releaseUrl: string,
   t: TFunction
-): { label: string; className: string } | null => {
+): VersionBadge | null => {
   if (comparison === null) return null;
   if (comparison > 0) {
     const display = latest.trim().replace(/^[vV]+/, '');
     return {
       label: t('dashboard.version_update_available', { version: `v${display}` }),
       className: styles.badgeUpdate,
+      releaseUrl: releaseUrl || undefined,
     };
   }
   if (comparison === 0) {
@@ -82,6 +90,21 @@ const renderVersionValue = (value: string, releaseUrl: string): ReactNode => {
     <a className={styles.versionLink} href={releaseUrl} target="_blank" rel="noopener noreferrer">
       <span className={styles.value}>{value}</span>
       <IconExternalLink size={12} />
+    </a>
+  );
+};
+
+const renderBadgeValue = (badge: VersionBadge | null): ReactNode => {
+  if (!badge) return null;
+
+  const className = `${styles.badge} ${badge.className}`;
+  if (!badge.releaseUrl) {
+    return <span className={className}>{badge.label}</span>;
+  }
+
+  return (
+    <a className={className} href={badge.releaseUrl} target="_blank" rel="noopener noreferrer">
+      {badge.label}
     </a>
   );
 };
@@ -211,14 +234,6 @@ export function VersionCard({
     }
   }, [apiVersion, showNotification, t]);
 
-  const appBadge = useMemo(
-    () => renderBadge(compareVersions(latest.latestApp, appVersion), latest.latestApp, t),
-    [appVersion, latest.latestApp, t]
-  );
-  const apiBadge = useMemo(
-    () => renderBadge(compareVersions(latest.latestApi, apiVersion), latest.latestApi, t),
-    [apiVersion, latest.latestApi, t]
-  );
   const appReleaseUrl = useMemo(
     () => buildDashboardVersionReleaseURL('manager', appVersion),
     [appVersion]
@@ -226,6 +241,34 @@ export function VersionCard({
   const apiReleaseUrl = useMemo(
     () => buildDashboardVersionReleaseURL('core', apiVersion),
     [apiVersion]
+  );
+  const latestAppReleaseUrl = useMemo(
+    () => buildDashboardVersionReleaseURL('manager', latest.latestApp),
+    [latest.latestApp]
+  );
+  const latestApiReleaseUrl = useMemo(
+    () => buildDashboardVersionReleaseURL('core', latest.latestApi),
+    [latest.latestApi]
+  );
+  const appBadge = useMemo(
+    () =>
+      renderBadge(
+        compareVersions(latest.latestApp, appVersion),
+        latest.latestApp,
+        latestAppReleaseUrl,
+        t
+      ),
+    [appVersion, latest.latestApp, latestAppReleaseUrl, t]
+  );
+  const apiBadge = useMemo(
+    () =>
+      renderBadge(
+        compareVersions(latest.latestApi, apiVersion),
+        latest.latestApi,
+        latestApiReleaseUrl,
+        t
+      ),
+    [apiVersion, latest.latestApi, latestApiReleaseUrl, t]
   );
 
   const buildTimeDisplay = serverBuildDate
@@ -347,9 +390,7 @@ export function VersionCard({
                   appVersion || t('dashboard.version_unknown'),
                   appReleaseUrl
                 )}
-                {appBadge && (
-                  <span className={`${styles.badge} ${appBadge.className}`}>{appBadge.label}</span>
-                )}
+                {renderBadgeValue(appBadge)}
               </div>
             </div>
           </div>
@@ -378,9 +419,7 @@ export function VersionCard({
                   apiVersion || t('dashboard.version_unknown'),
                   apiReleaseUrl
                 )}
-                {apiBadge && (
-                  <span className={`${styles.badge} ${apiBadge.className}`}>{apiBadge.label}</span>
-                )}
+                {renderBadgeValue(apiBadge)}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Link Dashboard update badges to the concrete release detected by the existing version checks.
Keep installed version links pointed at the currently installed versions.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Link Manager and Core update badges to their detected release tag.
- Keep invalid or unavailable latest versions as plain text.
- Add component coverage for current links, update links, invalid versions, and latest-state badges.

## User Impact

Users can open the release notes for the detected update directly from the Dashboard badge.

## Compatibility / Runtime Notes

- CPA panel mode: No API or runtime contract changes.
- Manager Server mode: Uses existing version-check results.
- Full Docker / native packages: No changes.

## Data / Security Notes

N/A. Release URLs continue to use the existing SemVer normalization and validation helper.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the single commit.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test
npm run build
git diff --check

206 test files passed
2614 tests passed
```

## Screenshots / Recordings

No screenshot or recording attached. The compact badge styling is preserved; the new link semantics are covered by component tests.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

This is a localized Dashboard interaction fix with no documentation or API changes.

## Related

Fixes #623