### PR TITLE
fix(web): keep OpenAI key actions visible in provider drawer

### DIFF
--- a/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.test.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.test.tsx
@@ -3,6 +3,7 @@ import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'rea
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@/i18n';
 import { CoolingPolicySelect } from '@/components/providers/CoolingPolicySelect';
+import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
 
 const authState = vi.hoisted(() => ({
   serverVersion: 'v7.2.93' as string | null,
@@ -123,6 +124,33 @@ describe('OpenAIEditDrawer model discovery', () => {
       'auth-second',
       'socks5://proxy.example:1080'
     );
+
+    act(() => renderer!.unmount());
+  });
+
+  it('keeps an action cell for the header and every API key row', async () => {
+    mocks.getOpenAIProviders.mockResolvedValueOnce([
+      {
+        name: 'openai-example',
+        baseUrl: 'https://api.example.com/v1',
+        apiKeyEntries: [{ apiKey: 'first-key' }, { apiKey: 'second-key' }],
+        models: [],
+      },
+    ]);
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <OpenAIEditDrawer open editIndex={0} disabled={false} onClose={vi.fn()} onSaved={vi.fn()} />
+      );
+    });
+
+    const actionCells = renderer!.root.findAllByProps({ className: styles.keyTableColAction });
+    expect(actionCells).toHaveLength(3);
+    expect(actionCells[0]?.findAllByType('button')).toHaveLength(0);
+    expect(
+      actionCells.slice(1).map((cell) => cell.findAllByType('button').length)
+    ).toEqual([2, 2]);
 
     act(() => renderer!.unmount());
   });

--- a/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.test.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/OpenAIEditDrawer.test.tsx
@@ -3,7 +3,6 @@ import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'rea
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@/i18n';
 import { CoolingPolicySelect } from '@/components/providers/CoolingPolicySelect';
-import styles from '@/features/aiProviders/AiProvidersPage.module.scss';
 
 const authState = vi.hoisted(() => ({
   serverVersion: 'v7.2.93' as string | null,
@@ -124,33 +123,6 @@ describe('OpenAIEditDrawer model discovery', () => {
       'auth-second',
       'socks5://proxy.example:1080'
     );
-
-    act(() => renderer!.unmount());
-  });
-
-  it('keeps an action cell for the header and every API key row', async () => {
-    mocks.getOpenAIProviders.mockResolvedValueOnce([
-      {
-        name: 'openai-example',
-        baseUrl: 'https://api.example.com/v1',
-        apiKeyEntries: [{ apiKey: 'first-key' }, { apiKey: 'second-key' }],
-        models: [],
-      },
-    ]);
-
-    let renderer: ReactTestRenderer;
-    await act(async () => {
-      renderer = create(
-        <OpenAIEditDrawer open editIndex={0} disabled={false} onClose={vi.fn()} onSaved={vi.fn()} />
-      );
-    });
-
-    const actionCells = renderer!.root.findAllByProps({ className: styles.keyTableColAction });
-    expect(actionCells).toHaveLength(3);
-    expect(actionCells[0]?.findAllByType('button')).toHaveLength(0);
-    expect(
-      actionCells.slice(1).map((cell) => cell.findAllByType('button').length)
-    ).toEqual([2, 2]);
 
     act(() => renderer!.unmount());
   });

--- a/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
+++ b/apps/web/src/features/aiProviders/AiProvidersPage.module.scss
@@ -869,12 +869,31 @@
 }
 
 .keyTableColAction {
+  position: sticky;
+  right: 0;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: stretch;
   gap: $spacing-xs;
   flex-shrink: 0;
   white-space: nowrap;
+  background-color: var(--app-surface-strong, #fff);
+  background-image: linear-gradient(var(--surface-subtle), var(--surface-subtle));
+  box-shadow: -1px 0 0 var(--border-subtle);
+}
+
+.keyTableHeader .keyTableColAction {
+  z-index: 3;
+  background-image: linear-gradient(
+    var(--surface-subtle-strong),
+    var(--surface-subtle-strong)
+  );
+}
+
+.keyTableRow:hover .keyTableColAction {
+  background-image: linear-gradient(var(--surface-subtle-hover), var(--surface-subtle-hover));
 }
 
 .keyTableInput {


### PR DESCRIPTION
## Summary

Keep OpenAI-compatible provider API key actions visible at the right edge of the editor drawer while horizontal scrolling.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Make the API key header and row action columns sticky at the right edge of the existing table.
- Add opaque theme-aware backgrounds, stacking order, separator, and hover treatment so sticky actions do not show transparent overlapping content.
- Add a structural multi-key test covering the action cell on the header and every API key row, including the Test/Delete button contract.

## User Impact

Test and Delete remain immediately accessible at the default 820px drawer width. Key, Weight, Proxy, and other middle columns retain their existing horizontal scrolling behavior.

## Compatibility / Runtime Notes

- CPA panel mode: frontend-only layout change; existing button handlers and API flows are unchanged.
- Manager Server mode: no backend changes.
- Full Docker / native packages: bundled frontend behavior only; no API, data model, or packaging changes.

## Data / Security Notes

N/A — no data, credential, API, or security behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit c4d1b049.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Focused OpenAI Drawer test: 1 file, 4 tests passed
npm run type-check
npm run lint (0 errors; one pre-existing Fast Refresh warning)
npm run test (205 files, 2610 tests passed)
npm run build
git diff --check
Manual UI check: OpenAI Compatible editor showed the 820px drawer and visible Test/Delete controls with the 900px table layout.
```

## Screenshots / Recordings

Manual UI verification was completed; no screenshot artifact was captured in this change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

This is a localized layout fix with no new workflow or documented capability.

## Related

Fixes #627