### PR TITLE
fix(accounts): add unconfirmed credential status filter

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -3369,6 +3369,22 @@ describe('AccountsPage replacement flows', () => {
     ).toHaveLength(0);
   });
 
+  it('offers the unconfirmed status filter with the metric label', async () => {
+    const renderer = await renderAccountsPage();
+    await flushPromises();
+
+    const statusSelect = renderer.root
+      .findAllByType(Select)
+      .find((node) => node.props.ariaLabel === 'accounts.status_filter');
+    if (!statusSelect) throw new Error('Accounts status filter not found');
+
+    expect(statusSelect.props.options).toEqual(
+      expect.arrayContaining([
+        { value: 'unconfirmed', label: 'accounts.metric_unconfirmed' },
+      ])
+    );
+  });
+
   it('loads request evidence for every account before applying the problem filter', async () => {
     mocks.files = Array.from({ length: 201 }, (_, index) =>
       makeCodexFile(

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -3729,12 +3729,16 @@ export function AccountsPage() {
         quotaBand: quotaBandFilter,
         search,
         codexStatusBySelectionKey,
+        pendingActionsByRowKey: actionCandidatesByRowKey,
+        quotaCooldownsByRowKey,
         requestEvidenceBySelectionKey,
       }),
     [
+      actionCandidatesByRowKey,
       codexStatusBySelectionKey,
       planFilterValue,
       providerFilter,
+      quotaCooldownsByRowKey,
       quotaBandFilter,
       requestEvidenceBySelectionKey,
       rows,
@@ -5947,7 +5951,9 @@ export function AccountsPage() {
       ? t('accounts.status_all')
       : isAccountCodexStatusFilter(statusFilter)
         ? t(`auth_files.codex_status_filter_${statusFilter}`)
-        : t(`accounts.status_${statusFilter}`);
+        : statusFilter === 'unconfirmed'
+          ? t('accounts.metric_unconfirmed')
+          : t(`accounts.status_${statusFilter}`);
   const selectedPlanFilterLabel =
     planFilter === 'all' ? t('accounts.plan_all') : getPlanOptionLabel(rows, planFilter, t);
   const selectedQuotaFilterLabel =
@@ -6213,6 +6219,7 @@ export function AccountsPage() {
           options={[
             { value: 'all', label: t('accounts.status_all') },
             { value: 'available', label: t('accounts.status_available') },
+            { value: 'unconfirmed', label: t('accounts.metric_unconfirmed') },
             { value: 'low', label: t('accounts.status_low') },
             { value: 'exhausted', label: t('accounts.status_exhausted') },
             { value: 'disabled', label: t('accounts.status_disabled') },

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -2251,7 +2251,7 @@ describe('accountRows', () => {
     const cooldownKey = byName.get('cooldown.json')?.selectionKey ?? '';
     const disabledKey = byName.get('disabled.json')?.selectionKey ?? '';
 
-    const metrics = buildAccountMetrics(rows, {
+    const operationalContext = {
       pendingActionsByRowKey: new Map([
         [attentionKey, [{ id: 1 }]],
         [disabledKey, [{ id: 2 }]],
@@ -2260,7 +2260,8 @@ describe('accountRows', () => {
         [cooldownKey, [{ id: 3 }]],
         [disabledKey, [{ id: 4 }]],
       ]),
-    });
+    };
+    const metrics = buildAccountMetrics(rows, operationalContext);
 
     expect(metrics).toEqual({
       total: 6,
@@ -2278,6 +2279,16 @@ describe('accountRows', () => {
         metrics.disabled +
         metrics.unconfirmed
     ).toBe(metrics.total);
+    expect(
+      filterAccountRows(rows, {
+        provider: 'all',
+        status: 'unconfirmed',
+        plan: 'all',
+        quotaBand: 'all',
+        search: '',
+        ...operationalContext,
+      }).map((row) => row.selectionKey)
+    ).toEqual([byName.get('unconfirmed.json')?.selectionKey]);
   });
 
   it('filters rows by quota band and search text', () => {

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -85,6 +85,7 @@ export const ACCOUNT_CODEX_STATUS_FILTERS = [
 export const ACCOUNT_STATUS_FILTERS = [
   'all',
   'available',
+  'unconfirmed',
   'disabled',
   'problem',
   'low',
@@ -220,14 +221,13 @@ export interface AccountMetricOperationalContext {
   requestEvidenceBySelectionKey?: AccountRequestEvidenceBySelectionKey;
 }
 
-export interface AccountRowFilters {
+export interface AccountRowFilters extends AccountMetricOperationalContext {
   provider: string;
   status: AccountStatusFilter;
   plan: string;
   quotaBand: AccountQuotaBand;
   search: string;
   codexStatusBySelectionKey?: ReadonlyMap<string, AuthFileCodexStatusSummary>;
-  requestEvidenceBySelectionKey?: AccountRequestEvidenceBySelectionKey;
 }
 
 export interface AccountPlanOption {
@@ -666,7 +666,7 @@ export const filterAccountRows = (rows: AccountRow[], filters: AccountRowFilters
         row,
         filters.status,
         filters.codexStatusBySelectionKey,
-        filters.requestEvidenceBySelectionKey
+        filters
       )
     ) {
       return false;
@@ -811,7 +811,7 @@ const matchesStatusFilter = (
   row: AccountRow,
   status: AccountStatusFilter,
   codexStatusBySelectionKey?: ReadonlyMap<string, AuthFileCodexStatusSummary>,
-  requestEvidenceBySelectionKey?: AccountRequestEvidenceBySelectionKey
+  context: AccountMetricOperationalContext = {}
 ) => {
   if (status === 'all') return true;
   if (isAccountCodexStatusFilter(status)) {
@@ -819,15 +819,22 @@ const matchesStatusFilter = (
     if (!codexStatus || !authFileMatchesCodexStatusFilter(codexStatus, status)) return false;
     if (status !== 'reauth') return true;
     return (
-      getRowRequestCredentialEvidence(row, requestEvidenceBySelectionKey)?.direction !== 'positive'
+      getRowRequestCredentialEvidence(row, context.requestEvidenceBySelectionKey)?.direction !==
+      'positive'
     );
   }
   if (status === 'available') {
-    return isAccountRowAvailable(row, requestEvidenceBySelectionKey);
+    return isAccountRowAvailable(row, context.requestEvidenceBySelectionKey);
   }
   if (status === 'disabled') return row.disabled;
+  if (status === 'unconfirmed') {
+    return classifyAccountMetricStatus(row, context) === 'unconfirmed';
+  }
   if (status === 'problem') {
-    const requestEvidenceInput = getRowRequestEvidenceInput(row, requestEvidenceBySelectionKey);
+    const requestEvidenceInput = getRowRequestEvidenceInput(
+      row,
+      context.requestEvidenceBySelectionKey
+    );
     const requestEvidence = resolveAccountRequestHealthEvidence(requestEvidenceInput);
     const currentRequestEvidence = isAccountRequestHealthEvidenceCurrent(row, requestEvidence)
       ? requestEvidence
@@ -845,7 +852,7 @@ const matchesStatusFilter = (
   if (status === 'inspection') {
     return isAccountInspectionActionable(
       row,
-      getRowRequestHealthEvidence(row, requestEvidenceBySelectionKey)
+      getRowRequestHealthEvidence(row, context.requestEvidenceBySelectionKey)
     );
   }
   return true;

--- a/apps/web/src/features/accounts/model/accountsWorkspaceUrlState.test.ts
+++ b/apps/web/src/features/accounts/model/accountsWorkspaceUrlState.test.ts
@@ -158,4 +158,26 @@ describe('accountsWorkspaceUrlState', () => {
       readAccountsWorkspaceUrlState(search, DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE).statusFilter
     ).toBe('disabled_with_reset');
   });
+
+  it('round-trips the unconfirmed status filter', () => {
+    const search = writeAccountsWorkspaceUrlSearch(
+      '',
+      {
+        ...DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE,
+        view: 'accounts',
+        healthMode: 'local',
+        statusFilter: 'unconfirmed',
+        account: null,
+        detailTab: 'overview',
+        editor: null,
+        editorProvider: '',
+      },
+      DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE
+    );
+
+    expect(search).toBe('?status=unconfirmed');
+    expect(
+      readAccountsWorkspaceUrlState(search, DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE).statusFilter
+    ).toBe('unconfirmed');
+  });
 });


### PR DESCRIPTION
## Summary

Add the missing `unconfirmed` status filter to the Accounts credential list so users can locate the credentials represented by the top-level “status pending confirmation” metric.

The filter reuses the same exclusive metric classification and operational/request-evidence context as `metrics.unconfirmed`, preserving exact collection parity.

## Scope

- [x] Frontend panel
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Manager Server
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `unconfirmed` to the Accounts status filter union and selector.
- Reuse `classifyAccountMetricStatus` with matching context when evaluating the filter.
- Preserve the filter through Accounts workspace URL state and add regression coverage for metric/filter identity parity.

## User Impact

Users can choose “Status pending confirmation” in the Accounts status selector and see the same credential set counted by the `unconfirmed` metric.

## Compatibility / Runtime Notes

- CPA panel mode: Shared frontend behavior is available; no backend or runtime flow changes.
- Manager Server mode: No Manager Server logic changes; the updated panel is served as usual.
- Full Docker / native packages: Full Docker uses the updated panel; native package contents and packaging behavior are unchanged.

## Data / Security Notes

N/A. No auth files, persisted data, credentials, security boundaries, or API contracts were changed.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this frontend-only commit/PR.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test
npm run build
git diff --check
Focused Accounts tests: 304 passed
Full suite: 205 files / 2611 tests passed
Lint completed with one pre-existing Fast Refresh warning
```

## Screenshots / Recordings

N/A — this is a small selector-option change covered by Accounts UI regression tests; no layout or interaction flow was redesigned.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation or release-note update is needed for this narrow filter addition.

## Related

Fixes #559