### PR TITLE
fix(usage): fill missing timeline buckets with zero values

### DIFF
--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
@@ -628,6 +628,96 @@ describe('UsageAnalyticsPage', () => {
     expect(cacheSeries?.data).toEqual([100]);
   });
 
+  it('keeps zero-request health buckets unavailable in charts and tooltips', () => {
+    const firstPoint = createTimelinePoint({
+      successRate: 0.9,
+      failureRate: 0.1,
+      averageLatencyMs: 500,
+    });
+    const emptyPoint = createTimelinePoint({
+      bucketMs: firstPoint.bucketMs + 60 * 60 * 1000,
+      bucketEndMs: firstPoint.bucketEndMs + 60 * 60 * 1000,
+      label: '06/04 13:00',
+      requestCount: 0,
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      successCount: 0,
+      failureCount: 0,
+      successRate: 0,
+      failureRate: 0,
+      averageLatencyMs: null,
+      p95LatencyMs: null,
+      p95TtftMs: null,
+      cacheHitRate: 0,
+      averageTokensPerRequest: 0,
+    });
+    const lastPoint = createTimelinePoint({
+      bucketMs: firstPoint.bucketMs + 2 * 60 * 60 * 1000,
+      bucketEndMs: firstPoint.bucketEndMs + 2 * 60 * 60 * 1000,
+      label: '06/04 14:00',
+      successCount: 10,
+      failureCount: 0,
+      successRate: 1,
+      failureRate: 0,
+      averageLatencyMs: 400,
+    });
+    mocks.usageState = createUsageState({
+      activeTab: 'trends',
+      timeline: [firstPoint, emptyPoint, lastPoint],
+      selectedBucket: null,
+      anomalyAnalysis: null,
+    });
+
+    const renderer = renderPage();
+    const healthChart = renderer.root.findAllByType(EChartsView).find((node) => {
+      const series = (node.props.option?.series ?? []) as Array<{ name?: string }>;
+      return series.some((item) => item.name === 'usage_analytics.success_rate');
+    });
+    const healthOption = healthChart?.props.option as
+      | {
+          series?: Array<{ name?: string; data?: Array<number | null> }>;
+          tooltip?: { formatter?: (params: unknown) => string };
+        }
+      | undefined;
+
+    expect(healthOption).toBeDefined();
+    const findSeriesData = (name: string) =>
+      healthOption?.series?.find((series) => series.name === name)?.data;
+    expect(findSeriesData('usage_analytics.success_rate')).toEqual([0.9, null, 1]);
+    expect(findSeriesData('usage_analytics.failure_rate')).toEqual([0.1, null, 0]);
+    expect(findSeriesData('usage_analytics.metric_average_latency')).toEqual([500, null, 400]);
+
+    const formatter = healthOption?.tooltip?.formatter;
+    if (!formatter) throw new Error('Health chart tooltip formatter not found');
+    const tooltip = formatter([
+      {
+        dataIndex: 1,
+        seriesName: 'usage_analytics.success_rate',
+        data: null,
+        marker: '',
+      },
+      {
+        dataIndex: 1,
+        seriesName: 'usage_analytics.failure_rate',
+        data: null,
+        marker: '',
+      },
+      {
+        dataIndex: 1,
+        seriesName: 'usage_analytics.metric_average_latency',
+        data: null,
+        marker: '',
+      },
+    ]);
+    expect(tooltip.match(/>-<\/strong>/g)).toHaveLength(3);
+    expect(tooltip).not.toContain('0.00%');
+    expect(tooltip).not.toContain('0ms');
+  });
+
   it('renders fine-grained cache buckets in rank tables', () => {
     const modelRow = createRankRow({
       cachedTokens: 0,

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -1045,11 +1045,17 @@ const buildHealthChartOption = (
       const point = typeof first?.dataIndex === 'number' ? timeline[first.dataIndex] : undefined;
       const rows = items
         .map((item) => {
-          const entry = item as { marker?: string; seriesName?: string; data?: number };
+          const entry = item as {
+            marker?: string;
+            seriesName?: string;
+            data?: number | null;
+          };
           const value =
-            entry.seriesName === t('usage_analytics.metric_average_latency')
-              ? formatUsageDurationMs(Number(entry.data ?? 0))
-              : formatPercent(Number(entry.data ?? 0));
+            entry.data === null || entry.data === undefined
+              ? '-'
+              : entry.seriesName === t('usage_analytics.metric_average_latency')
+                ? formatUsageDurationMs(entry.data)
+                : formatPercent(entry.data);
           return tooltipRowHtml(
             chartTheme,
             `${entry.marker ?? ''}${escapeHtml(entry.seriesName)}`,
@@ -1098,7 +1104,7 @@ const buildHealthChartOption = (
   ],
   series: [
     {
-      data: timeline.map((point) => point.successRate),
+      data: timeline.map((point) => (point.requestCount > 0 ? point.successRate : null)),
       lineStyle: { width: 2.5 },
       name: t('usage_analytics.success_rate'),
       showSymbol: timeline.length <= 36,
@@ -1107,7 +1113,7 @@ const buildHealthChartOption = (
       yAxisIndex: 0,
     },
     {
-      data: timeline.map((point) => point.failureRate),
+      data: timeline.map((point) => (point.requestCount > 0 ? point.failureRate : null)),
       lineStyle: { width: 2.5 },
       name: t('usage_analytics.failure_rate'),
       showSymbol: timeline.length <= 36,
@@ -1117,7 +1123,7 @@ const buildHealthChartOption = (
     },
     {
       barMaxWidth: 16,
-      data: timeline.map((point) => point.averageLatencyMs ?? 0),
+      data: timeline.map((point) => (point.requestCount > 0 ? point.averageLatencyMs : null)),
       name: t('usage_analytics.metric_average_latency'),
       type: 'bar',
       yAxisIndex: 1,

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -47,8 +47,7 @@ const NOW_MS = Date.UTC(2026, 5, 4, 12, 0, 0);
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 
-const localDateMs = (day: number, hour = 0) =>
-  new Date(2026, 7, day, hour, 0, 0, 0).getTime();
+const localDateMs = (day: number, hour = 0) => new Date(2026, 7, day, hour, 0, 0, 0).getTime();
 
 const expectZeroTimelinePoint = (point: UsageTimelinePoint) => {
   expect(point).toMatchObject({
@@ -286,7 +285,14 @@ describe('usage analytics adapters', () => {
     const toMs = localDateMs(10, 13);
     const mappedTimeline = buildUsageTimeline(
       [
-        { bucket_ms: fromMs + 2 * HOUR_MS, label: '', calls: 3, tokens: 30, success: 3, failure: 0 },
+        {
+          bucket_ms: fromMs + 2 * HOUR_MS,
+          label: '',
+          calls: 3,
+          tokens: 30,
+          success: 3,
+          failure: 0,
+        },
         { bucket_ms: fromMs, label: '', calls: 1, tokens: 10, success: 1, failure: 0 },
         { bucket_ms: fromMs + HOUR_MS, label: '', calls: 2, tokens: 20, success: 1, failure: 1 },
       ],
@@ -294,11 +300,13 @@ describe('usage analytics adapters', () => {
     );
     const timeline = fillUsageTimelineBuckets(mappedTimeline, { fromMs, toMs }, 'hour');
 
-    expect(timeline).toEqual(mappedTimeline.slice().sort((left, right) => left.bucketMs - right.bucketMs));
+    expect(timeline).toEqual(
+      mappedTimeline.slice().sort((left, right) => left.bucketMs - right.bucketMs)
+    );
     expect(timeline).toHaveLength(3);
   });
 
-  it('builds zero buckets for a successful empty analytics response', () => {
+  it('keeps a successful empty analytics response empty', () => {
     const fromMs = localDateMs(10, 10);
     const toMs = localDateMs(10, 13);
     const adapted = adaptUsageAnalyticsData(
@@ -310,8 +318,7 @@ describe('usage analytics adapters', () => {
       { fromMs, toMs }
     );
 
-    expect(adapted.timeline).toHaveLength(3);
-    adapted.timeline.forEach(expectZeroTimelinePoint);
+    expect(adapted.timeline).toEqual([]);
   });
 
   it('builds heatmap chart data from non-empty valid request buckets only', () => {
@@ -1679,6 +1686,69 @@ describe('usage anomaly drilldown', () => {
       'usage_analytics.cause_token_per_request_spike',
       'usage_analytics.cause_cache_hit_drop',
     ]);
+  });
+
+  it('does not treat zero-request buckets as health anomaly samples', () => {
+    const timeline = buildUsageTimeline(
+      [
+        {
+          bucket_ms: NOW_MS,
+          label: '',
+          calls: 10,
+          tokens: 100,
+          success: 9,
+          failure: 1,
+          input_tokens: 100,
+          cache_read_tokens: 80,
+          cost: 1,
+          average_latency_ms: 500,
+        },
+        {
+          bucket_ms: NOW_MS + HOUR_MS,
+          label: '',
+          calls: 0,
+          tokens: 0,
+          success: 0,
+          failure: 0,
+          input_tokens: 0,
+          cache_read_tokens: 0,
+          cost: 0,
+        },
+        {
+          bucket_ms: NOW_MS + 2 * HOUR_MS,
+          label: '',
+          calls: 10,
+          tokens: 100,
+          success: 5,
+          failure: 5,
+          input_tokens: 100,
+          cache_read_tokens: 80,
+          cost: 1,
+          average_latency_ms: 400,
+        },
+      ],
+      'hour'
+    );
+
+    const emptyAnalysis = analyzeUsageBucket(timeline, NOW_MS + HOUR_MS);
+    expect(emptyAnalysis?.changes).toMatchObject({
+      requestCount: -1,
+      cacheHitRate: 0,
+      averageTokensPerRequest: 0,
+      failureRate: 0,
+      averageLatencyMs: 0,
+    });
+    expect(emptyAnalysis?.anomalies).toEqual([]);
+
+    const recoveryAnalysis = analyzeUsageBucket(timeline, NOW_MS + 2 * HOUR_MS);
+    expect(recoveryAnalysis?.changes).toMatchObject({
+      requestCount: 1,
+      cacheHitRate: 0,
+      averageTokensPerRequest: 0,
+      failureRate: 0,
+      averageLatencyMs: 0,
+    });
+    expect(recoveryAnalysis?.anomalies).toEqual([]);
   });
 
   it('uses direction-aware anomaly cause copy', () => {

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -4,9 +4,10 @@ import type {
   MonitoringAnalyticsResponse,
 } from '@/services/api/usageService';
 import { buildSourceInfoMap } from '@/utils/sourceResolver';
-import type { UsageRankRow } from './usageAnalyticsModel';
+import type { UsageRankRow, UsageTimelinePoint } from './usageAnalyticsModel';
 import {
   analyzeUsageBucket,
+  adaptUsageAnalyticsData,
   buildApiKeyTrendSeries,
   buildApiKeyRows,
   buildCredentialRows,
@@ -31,6 +32,7 @@ import {
   buildUsageCredentialTimeline,
   buildUsageApiKeyTimeline,
   buildUsageTimeline,
+  fillUsageTimelineBuckets,
   computeCacheHitRate,
   computeRowAverageCostPerCall,
   computeRowCacheHitRate,
@@ -44,6 +46,32 @@ import {
 const NOW_MS = Date.UTC(2026, 5, 4, 12, 0, 0);
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
+
+const localDateMs = (day: number, hour = 0) =>
+  new Date(2026, 7, day, hour, 0, 0, 0).getTime();
+
+const expectZeroTimelinePoint = (point: UsageTimelinePoint) => {
+  expect(point).toMatchObject({
+    requestCount: 0,
+    totalTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    reasoningTokens: 0,
+    estimatedCost: 0,
+    successCount: 0,
+    failureCount: 0,
+    successRate: 0,
+    failureRate: 0,
+    cacheHitRate: 0,
+    averageTokensPerRequest: 0,
+  });
+  expect(point.averageLatencyMs).toBeNull();
+  expect(point.p95LatencyMs).toBeNull();
+  expect(point.p95TtftMs).toBeNull();
+};
 
 describe('usage analytics request model', () => {
   it('resolves time ranges and default granularity rules', () => {
@@ -169,6 +197,123 @@ describe('usage analytics request model', () => {
 });
 
 describe('usage analytics adapters', () => {
+  it('fills a missing middle hourly bucket with zero metrics', () => {
+    const fromMs = localDateMs(10, 10);
+    const toMs = localDateMs(10, 13);
+    const timeline = fillUsageTimelineBuckets(
+      buildUsageTimeline(
+        [
+          { bucket_ms: fromMs, label: '', calls: 2, tokens: 20, success: 2, failure: 0 },
+          {
+            bucket_ms: fromMs + 2 * HOUR_MS,
+            label: '',
+            calls: 3,
+            tokens: 30,
+            success: 3,
+            failure: 0,
+          },
+        ],
+        'hour'
+      ),
+      { fromMs, toMs },
+      'hour'
+    );
+
+    expect(timeline.map((point) => point.bucketMs)).toEqual([
+      fromMs,
+      fromMs + HOUR_MS,
+      fromMs + 2 * HOUR_MS,
+    ]);
+    expectZeroTimelinePoint(timeline[1]);
+    expect(timeline[1].bucketEndMs).toBe(fromMs + 2 * HOUR_MS);
+  });
+
+  it('fills missing daily buckets and respects the exclusive range end', () => {
+    const fromMs = localDateMs(10);
+    const toMs = localDateMs(13);
+    const timeline = fillUsageTimelineBuckets(
+      buildUsageTimeline(
+        [
+          { bucket_ms: fromMs, label: '', calls: 1, tokens: 10, success: 1, failure: 0 },
+          {
+            bucket_ms: localDateMs(12),
+            label: '',
+            calls: 2,
+            tokens: 20,
+            success: 2,
+            failure: 0,
+          },
+        ],
+        'day'
+      ),
+      { fromMs, toMs },
+      'day'
+    );
+
+    expect(timeline.map((point) => point.bucketMs)).toEqual([
+      localDateMs(10),
+      localDateMs(11),
+      localDateMs(12),
+    ]);
+    expectZeroTimelinePoint(timeline[1]);
+    expect(timeline.some((point) => point.bucketMs === toMs)).toBe(false);
+  });
+
+  it('fills both leading and trailing buckets without changing real points', () => {
+    const fromMs = localDateMs(10);
+    const toMs = localDateMs(14);
+    const realPoint = buildUsageTimeline(
+      [{ bucket_ms: localDateMs(12), label: '', calls: 4, tokens: 40, success: 3, failure: 1 }],
+      'day'
+    )[0];
+    const timeline = fillUsageTimelineBuckets([realPoint], { fromMs, toMs }, 'day');
+
+    expect(timeline.map((point) => point.bucketMs)).toEqual([
+      localDateMs(10),
+      localDateMs(11),
+      localDateMs(12),
+      localDateMs(13),
+    ]);
+    expectZeroTimelinePoint(timeline[0]);
+    expectZeroTimelinePoint(timeline[1]);
+    expectZeroTimelinePoint(timeline[3]);
+    expect(timeline[2]).toBe(realPoint);
+    expect(timeline[2]).toMatchObject({ requestCount: 4, totalTokens: 40, failureCount: 1 });
+  });
+
+  it('returns a complete timeline unchanged apart from ordering', () => {
+    const fromMs = localDateMs(10, 10);
+    const toMs = localDateMs(10, 13);
+    const mappedTimeline = buildUsageTimeline(
+      [
+        { bucket_ms: fromMs + 2 * HOUR_MS, label: '', calls: 3, tokens: 30, success: 3, failure: 0 },
+        { bucket_ms: fromMs, label: '', calls: 1, tokens: 10, success: 1, failure: 0 },
+        { bucket_ms: fromMs + HOUR_MS, label: '', calls: 2, tokens: 20, success: 1, failure: 1 },
+      ],
+      'hour'
+    );
+    const timeline = fillUsageTimelineBuckets(mappedTimeline, { fromMs, toMs }, 'hour');
+
+    expect(timeline).toEqual(mappedTimeline.slice().sort((left, right) => left.bucketMs - right.bucketMs));
+    expect(timeline).toHaveLength(3);
+  });
+
+  it('builds zero buckets for a successful empty analytics response', () => {
+    const fromMs = localDateMs(10, 10);
+    const toMs = localDateMs(10, 13);
+    const adapted = adaptUsageAnalyticsData(
+      { generated_at_ms: 1, granularity: 'hour', timeline: [] },
+      'hour',
+      '',
+      undefined,
+      undefined,
+      { fromMs, toMs }
+    );
+
+    expect(adapted.timeline).toHaveLength(3);
+    adapted.timeline.forEach(expectZeroTimelinePoint);
+  });
+
   it('builds heatmap chart data from non-empty valid request buckets only', () => {
     expect(
       buildUsageHeatmapChartData([

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   MonitoringAnalyticsApiKeyStatRow,
   MonitoringAnalyticsResponse,
@@ -225,6 +225,64 @@ describe('usage analytics adapters', () => {
     ]);
     expectZeroTimelinePoint(timeline[1]);
     expect(timeline[1].bucketEndMs).toBe(fromMs + 2 * HOUR_MS);
+  });
+
+  it('does not synthesize a duplicate local hour across DST fall-back', () => {
+    vi.stubEnv('TZ', 'America/New_York');
+
+    try {
+      const firstMidnight = Date.parse('2026-11-01T04:00:00.000Z');
+      const firstOneAm = Date.parse('2026-11-01T05:00:00.000Z');
+      const repeatedOneAm = Date.parse('2026-11-01T06:00:00.000Z');
+      const twoAm = Date.parse('2026-11-01T07:00:00.000Z');
+      const threeAm = Date.parse('2026-11-01T08:00:00.000Z');
+      const mappedTimeline = buildUsageTimeline(
+        [
+          {
+            bucket_ms: firstMidnight,
+            label: '',
+            calls: 1,
+            tokens: 10,
+            success: 1,
+            failure: 0,
+            cost: 1,
+          },
+          {
+            bucket_ms: firstOneAm,
+            label: '',
+            calls: 2,
+            tokens: 20,
+            success: 2,
+            failure: 0,
+            cost: 2,
+          },
+          {
+            bucket_ms: twoAm,
+            label: '',
+            calls: 3,
+            tokens: 30,
+            success: 3,
+            failure: 0,
+            cost: 3,
+          },
+        ],
+        'hour'
+      );
+      const timeline = fillUsageTimelineBuckets(
+        mappedTimeline,
+        { fromMs: firstMidnight, toMs: threeAm },
+        'hour'
+      );
+
+      expect(timeline.map((point) => point.bucketMs)).toEqual([firstMidnight, firstOneAm, twoAm]);
+      expect(timeline.some((point) => point.bucketMs === repeatedOneAm)).toBe(false);
+      expect(timeline).toEqual(mappedTimeline);
+      expect(timeline.map((point) => point.requestCount)).toEqual([1, 2, 3]);
+      expect(timeline.map((point) => point.totalTokens)).toEqual([10, 20, 30]);
+      expect(timeline.map((point) => point.estimatedCost)).toEqual([1, 2, 3]);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it('fills missing daily buckets and respects the exclusive range end', () => {

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -659,8 +659,11 @@ const getNextUsageBucketStartMs = (
   bucketMs: number,
   granularity: UsageAnalyticsResolvedGranularity
 ) => {
-  if (granularity === 'hour') return bucketMs + HOUR_MS;
   const date = new Date(bucketMs);
+  if (granularity === 'hour') {
+    date.setHours(date.getHours() + 1, 0, 0, 0);
+    return date.getTime();
+  }
   date.setDate(date.getDate() + 1);
   return date.getTime();
 };

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -65,6 +65,11 @@ export type UsageAnalyticsCustomRange = {
   endMs: number;
 };
 
+export type UsageAnalyticsRangeBounds = {
+  fromMs: number;
+  toMs: number;
+};
+
 export type UsageAnalyticsFiltersState = {
   timeRange: UsageAnalyticsTimeRange;
   customRange: UsageAnalyticsCustomRange | null;
@@ -640,10 +645,30 @@ const localDayStartMs = (timestampMs: number) => {
   return date.getTime();
 };
 
+const getLocalBucketStartMs = (
+  timestampMs: number,
+  granularity: UsageAnalyticsResolvedGranularity
+) => {
+  if (granularity === 'day') return localDayStartMs(timestampMs);
+  const date = new Date(timestampMs);
+  date.setMinutes(0, 0, 0);
+  return date.getTime();
+};
+
+const getNextUsageBucketStartMs = (
+  bucketMs: number,
+  granularity: UsageAnalyticsResolvedGranularity
+) => {
+  if (granularity === 'hour') return bucketMs + HOUR_MS;
+  const date = new Date(bucketMs);
+  date.setDate(date.getDate() + 1);
+  return date.getTime();
+};
+
 export const getUsageRangeBounds = (
   filters: Pick<UsageAnalyticsFiltersState, 'timeRange' | 'customRange'>,
   nowMs: number
-) => {
+): UsageAnalyticsRangeBounds | null => {
   if (filters.timeRange === 'custom') {
     const range = filters.customRange;
     if (
@@ -928,6 +953,80 @@ export const buildUsageTimeline = (
       averageTokensPerRequest: requestCount > 0 ? totalTokens / requestCount : 0,
     };
   });
+
+const sortUsageTimeline = (timeline: UsageTimelinePoint[]) =>
+  timeline.slice().sort((left, right) => left.bucketMs - right.bucketMs);
+
+const buildEmptyUsageTimelinePoint = (
+  bucketMs: number,
+  granularity: UsageAnalyticsResolvedGranularity
+): UsageTimelinePoint => ({
+  bucketMs,
+  bucketEndMs: bucketMs + getBucketSizeMs(granularity),
+  label: formatLocalBucketLabel(bucketMs, granularity),
+  requestCount: 0,
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cachedTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  reasoningTokens: 0,
+  estimatedCost: 0,
+  successCount: 0,
+  failureCount: 0,
+  successRate: 0,
+  failureRate: 0,
+  averageLatencyMs: null,
+  p95LatencyMs: null,
+  p95TtftMs: null,
+  cacheHitRate: 0,
+  averageTokensPerRequest: 0,
+});
+
+export const fillUsageTimelineBuckets = (
+  timeline: UsageTimelinePoint[] = [],
+  bounds: UsageAnalyticsRangeBounds | null | undefined,
+  granularity: UsageAnalyticsResolvedGranularity
+): UsageTimelinePoint[] => {
+  const sortedTimeline = sortUsageTimeline(timeline);
+  if (
+    !bounds ||
+    !Number.isFinite(bounds.fromMs) ||
+    !Number.isFinite(bounds.toMs) ||
+    bounds.fromMs >= bounds.toMs
+  ) {
+    return sortedTimeline;
+  }
+
+  const pointsByBucket = new Map<number, UsageTimelinePoint[]>();
+  timeline.forEach((point) => {
+    const bucketKey = getLocalBucketStartMs(point.bucketMs, granularity);
+    const points = pointsByBucket.get(bucketKey);
+    if (points) {
+      points.push(point);
+    } else {
+      pointsByBucket.set(bucketKey, [point]);
+    }
+  });
+
+  const filledTimeline: UsageTimelinePoint[] = [];
+  const firstBucketMs = getLocalBucketStartMs(bounds.fromMs, granularity);
+  for (
+    let bucketMs = firstBucketMs;
+    bucketMs < bounds.toMs;
+    bucketMs = getNextUsageBucketStartMs(bucketMs, granularity)
+  ) {
+    const points = pointsByBucket.get(bucketMs);
+    if (points) {
+      filledTimeline.push(...points);
+    } else {
+      filledTimeline.push(buildEmptyUsageTimelinePoint(bucketMs, granularity));
+    }
+  }
+
+  return sortUsageTimeline(filledTimeline);
+};
 
 export const buildUsageCredentialTimeline = (
   timeline: MonitoringAnalyticsCredentialTimelinePoint[] = [],
@@ -2385,10 +2484,14 @@ export const adaptUsageAnalyticsData = (
   granularity: UsageAnalyticsResolvedGranularity,
   keyword = '',
   apiKeyDisplayMap?: UsageApiKeyDisplayMap,
-  credentialDisplayContext?: UsageCredentialDisplayContext
+  credentialDisplayContext?: UsageCredentialDisplayContext,
+  timelineBounds?: UsageAnalyticsRangeBounds | null
 ) => {
   const summary = buildUsageSummary(data?.summary);
-  const timeline = buildUsageTimeline(data?.timeline ?? [], granularity);
+  const mappedTimeline = buildUsageTimeline(data?.timeline ?? [], granularity);
+  const timeline = data
+    ? fillUsageTimelineBuckets(mappedTimeline, timelineBounds, granularity)
+    : mappedTimeline;
   const credentialTimeline = buildUsageCredentialTimeline(
     data?.credential_timeline ?? [],
     granularity,

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -990,6 +990,9 @@ export const fillUsageTimelineBuckets = (
   granularity: UsageAnalyticsResolvedGranularity
 ): UsageTimelinePoint[] => {
   const sortedTimeline = sortUsageTimeline(timeline);
+  if (sortedTimeline.length === 0) {
+    return sortedTimeline;
+  }
   if (
     !bounds ||
     !Number.isFinite(bounds.fromMs) ||
@@ -2578,6 +2581,10 @@ export const analyzeUsageBucket = (
   if (index < 0) return null;
   const point = timeline[index];
   const previousPoint = index > 0 ? timeline[index - 1] : null;
+  const comparisonPoint =
+    previousPoint && previousPoint.requestCount > 0 && point.requestCount > 0
+      ? previousPoint
+      : null;
   const changes = {
     requestCount: previousPoint ? percentChange(point.requestCount, previousPoint.requestCount) : 0,
     totalTokens: previousPoint ? percentChange(point.totalTokens, previousPoint.totalTokens) : 0,
@@ -2592,14 +2599,16 @@ export const analyzeUsageBucket = (
     estimatedCost: previousPoint
       ? percentChange(point.estimatedCost, previousPoint.estimatedCost)
       : 0,
-    cacheHitRate: previousPoint ? point.cacheHitRate - previousPoint.cacheHitRate : 0,
-    averageTokensPerRequest: previousPoint
-      ? percentChange(point.averageTokensPerRequest, previousPoint.averageTokensPerRequest)
+    cacheHitRate: comparisonPoint ? point.cacheHitRate - comparisonPoint.cacheHitRate : 0,
+    averageTokensPerRequest: comparisonPoint
+      ? percentChange(point.averageTokensPerRequest, comparisonPoint.averageTokensPerRequest)
       : 0,
-    failureRate: previousPoint ? point.failureRate - previousPoint.failureRate : 0,
+    failureRate: comparisonPoint ? point.failureRate - comparisonPoint.failureRate : 0,
     averageLatencyMs:
-      previousPoint && previousPoint.averageLatencyMs !== null && point.averageLatencyMs !== null
-        ? percentChange(point.averageLatencyMs, previousPoint.averageLatencyMs)
+      comparisonPoint &&
+      comparisonPoint.averageLatencyMs !== null &&
+      point.averageLatencyMs !== null
+        ? percentChange(point.averageLatencyMs, comparisonPoint.averageLatencyMs)
         : 0,
   };
   const anomalies: UsageAnomaly[] = [];

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -33,6 +33,13 @@ const emptyAnalyticsResponse = {
   generated_at_ms: 1,
   granularity: 'hour',
 };
+const HOUR_MS = 60 * 60 * 1000;
+
+const localHourStartMs = (timestampMs: number) => {
+  const date = new Date(timestampMs);
+  date.setMinutes(0, 0, 0);
+  return date.getTime();
+};
 
 describe('useUsageAnalytics request orchestration', () => {
   let renderer: ReactTestRenderer | null = null;
@@ -49,6 +56,8 @@ describe('useUsageAnalytics request orchestration', () => {
     const main = Boolean(params.include?.summary);
     const credentialTimeline = Boolean(params.include?.credential_timeline);
     const apiKeyTimeline = Boolean(params.include?.api_key_timeline);
+    const mainTimelineStartMs =
+      typeof params.fromMs === 'number' ? localHourStartMs(params.fromMs) : 0;
     const mainData = params.include?.credential_stats
       ? {
           ...emptyAnalyticsResponse,
@@ -77,7 +86,7 @@ describe('useUsageAnalytics request orchestration', () => {
             ...emptyAnalyticsResponse,
             timeline: [
               {
-                bucket_ms: 1,
+                bucket_ms: mainTimelineStartMs,
                 label: '00:00',
                 calls: 5,
                 tokens: 500,
@@ -85,7 +94,7 @@ describe('useUsageAnalytics request orchestration', () => {
                 failure: 0,
               },
               {
-                bucket_ms: 3_600_001,
+                bucket_ms: mainTimelineStartMs + 2 * HOUR_MS,
                 label: '01:00',
                 calls: 5,
                 tokens: 500,
@@ -138,7 +147,7 @@ describe('useUsageAnalytics request orchestration', () => {
                 api_key_timeline: [
                   {
                     api_key_hash: 'key-a',
-                    bucket_ms: 1,
+                    bucket_ms: mainTimelineStartMs,
                     calls: 2,
                     tokens: 200,
                     success: 2,
@@ -146,7 +155,7 @@ describe('useUsageAnalytics request orchestration', () => {
                   },
                   {
                     api_key_hash: 'key-a',
-                    bucket_ms: 3_600_001,
+                    bucket_ms: mainTimelineStartMs + 2 * HOUR_MS,
                     calls: 4,
                     tokens: 400,
                     success: 4,
@@ -261,6 +270,29 @@ describe('useUsageAnalytics request orchestration', () => {
     expect(selectorsAfterTab?.dataScopeKey).toBe(selectorScope);
   });
 
+  it('fills missing buckets in the main usage timeline from the active range', async () => {
+    await renderHook();
+
+    const overview = lastParams((params) => Boolean(params.include?.summary));
+    expect(typeof overview?.fromMs).toBe('number');
+    const firstBucketMs = localHourStartMs(overview?.fromMs as number);
+
+    expect(latestResult?.timeline.slice(0, 3).map((point) => point.bucketMs)).toEqual([
+      firstBucketMs,
+      firstBucketMs + HOUR_MS,
+      firstBucketMs + 2 * HOUR_MS,
+    ]);
+    expect(latestResult?.timeline[1]).toMatchObject({
+      requestCount: 0,
+      totalTokens: 0,
+      successCount: 0,
+      failureCount: 0,
+      averageLatencyMs: null,
+      p95LatencyMs: null,
+      p95TtftMs: null,
+    });
+  });
+
   it('loads exact timeline buckets for the visible client keys on overview and trends', async () => {
     await renderHook();
 
@@ -271,7 +303,9 @@ describe('useUsageAnalytics request orchestration', () => {
       activeTab: 'overview',
       apiKeyHashes: ['key-a'],
     });
-    expect(latestResult?.apiKeyTrendSeries[0].points.map((point) => point.value)).toEqual([2, 4]);
+    expect(latestResult?.apiKeyTrendSeries[0].points.slice(0, 3).map((point) => point.value)).toEqual(
+      [2, 0, 4]
+    );
 
     await act(async () => {
       latestResult?.setActiveTab('trends');
@@ -323,6 +357,7 @@ describe('useUsageAnalytics request orchestration', () => {
       selectedCredentialID: 'credential-a.json',
     });
     expect(latestResult?.credentialTrendSeries).toHaveLength(1);
+    expect(latestResult?.timeline).toEqual([]);
   });
 
   it('exposes selected credential timeline loading and error states', async () => {

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -344,6 +344,7 @@ export function useUsageAnalytics() {
   const filterSelectorsData = filterSelectorsAnalytics.dataStale
     ? null
     : filterSelectorsAnalytics.data;
+  const timelineBounds = include.timeline ? bounds : null;
   const adapted = useMemo(
     () =>
       adaptUsageAnalyticsData(
@@ -351,13 +352,15 @@ export function useUsageAnalytics() {
         resolvedGranularity,
         filters.apiKeyKeyword,
         apiKeyDisplayMap,
-        credentialDisplayContext
+        credentialDisplayContext,
+        timelineBounds
       ),
     [
       analyticsData,
       apiKeyDisplayMap,
       credentialDisplayContext,
       filters.apiKeyKeyword,
+      timelineBounds,
       resolvedGranularity,
     ]
   );


### PR DESCRIPTION
## Summary

Fixes #573 by normalizing the main Usage Analytics timeline against the active range and resolved granularity.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Preserve `buildUsageTimeline` as the raw server-point mapper.
- Fill missing local hourly/daily buckets with zero-valued usage metrics.
- Keep real server buckets unchanged and leave latency/percentile metrics as `null` for zero-request buckets.
- Apply normalization only when the main timeline is requested; entity-specific timelines remain unchanged.
- Add model and hook tests for middle, leading, trailing, complete, empty, latency, range-end, and inherited API-key trend cases.

## User Impact

Trend charts now keep dates/hours with no requests visible as zero-usage buckets instead of removing those points from the x-axis. Missing latency samples remain unavailable rather than being displayed as 0 ms.

## Compatibility / Runtime Notes

- CPA panel mode: frontend-only behavior change; no API or configuration changes.
- Manager Server mode: no Manager Server changes.
- Full Docker / native packages: no packaging or runtime contract changes; rebuilt panels use the same normalized frontend behavior.

## Data / Security Notes

N/A. No SQLite, aggregate, API schema, credential, or security changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this PR to restore the previous Usage Analytics timeline behavior.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
npm run test
npm run build
git diff --check
```

Type check, tests, build, and diff checks passed. Lint passed with one pre-existing Fast Refresh warning in `AccountHealthBadge.tsx`; no errors.

## Screenshots / Recordings

N/A — no layout or styling change; this is chart data normalization.

## Docs

- [x] Not needed — explanation included below

Docs decision: No documentation or navigation changes are required for this internal presentation-layer fix.

## Related

Fixes #573