### PR TITLE
fix(manager-server): bound Codex legacy identity scans

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -21,10 +21,16 @@ type legacyAccountIdentityPredicate struct {
 	args []any
 }
 
+// maxCodexLegacyIdentityProbe is the largest matching set this check will
+// inspect per predicate. The request path cannot scan an unbounded
+// usage_events bucket; a larger set is treated as inconclusive and refused.
+const maxCodexLegacyIdentityProbe = 512
+
 // ResolveCodexLegacyAccountKey returns the file/index account key only when
-// every matching usage event remains attributable to the requested Codex
-// account. A false result is intentionally non-error: callers must fail
-// closed and continue with the stable key only.
+// every inspected matching usage event remains attributable to the requested
+// Codex account. Sets larger than maxCodexLegacyIdentityProbe are refused.
+// A false result is intentionally non-error: callers must fail closed and
+// continue with the stable key only.
 func ResolveCodexLegacyAccountKey(
 	ctx context.Context,
 	queryer SQLQueryer,
@@ -34,27 +40,52 @@ func ResolveCodexLegacyAccountKey(
 	if !valid {
 		return "", false, nil
 	}
-
-	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
-		rows, err := queryer.QueryContext(ctx, `select
-			coalesce(e.provider, ''),
-			coalesce(e.auth_provider_snapshot, ''),
-			coalesce(e.auth_account_id_snapshot, ''),
-			coalesce(e.auth_project_id_snapshot, '')
-		from usage_events e
-		where `+predicate.sql, predicate.args...)
-		if err != nil {
-			return "", false, err
-		}
-		allowed, err := scanLegacyAccountIdentity(rows, targetAccountID)
-		if err != nil {
-			return "", false, err
-		}
-		if !allowed {
-			return "", false, nil
-		}
+	allowed, err := inspectCodexLegacyIdentity(ctx, queryer, authFile, authIndex, targetAccountID)
+	if err != nil || !allowed {
+		return "", false, err
 	}
 	return legacyKey, true, nil
+}
+
+func inspectCodexLegacyIdentity(
+	ctx context.Context,
+	queryer SQLQueryer,
+	authFile, authIndex, targetAccountID string,
+) (bool, error) {
+	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
+		allowed, err := inspectCodexLegacyIdentityPredicate(ctx, queryer, predicate, targetAccountID)
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func inspectCodexLegacyIdentityPredicate(
+	ctx context.Context,
+	queryer SQLQueryer,
+	predicate legacyAccountIdentityPredicate,
+	targetAccountID string,
+) (bool, error) {
+	args := make([]any, 0, len(predicate.args)+1)
+	args = append(args, predicate.args...)
+	args = append(args, maxCodexLegacyIdentityProbe+1)
+	rows, err := queryer.QueryContext(ctx, `select
+		coalesce(e.provider, ''),
+		coalesce(e.auth_provider_snapshot, ''),
+		coalesce(e.auth_account_id_snapshot, ''),
+		coalesce(e.auth_project_id_snapshot, '')
+	from usage_events e
+	where `+predicate.sql+`
+	order by e.timestamp_ms desc, e.id desc
+	limit ?`, args...)
+	if err != nil {
+		return false, err
+	}
+	return scanLegacyAccountIdentity(rows, targetAccountID, maxCodexLegacyIdentityProbe)
 }
 
 // ResolveCodexLegacyAccountKey evaluates the same check through a short
@@ -79,23 +110,12 @@ func (r *repository) ResolveCodexLegacyAccountKey(
 }
 
 func codexLegacyTarget(fields usageidentity.Fields) (string, string, string, string, bool) {
-	provider := normalizeIdentityProvider(fields.AuthProviderSnapshot)
 	targetAccountID := strings.TrimSpace(fields.AuthAccountIDSnapshot)
-	if provider != "codex" || targetAccountID == "" {
+	if !codexLegacyIdentityRequested(fields) {
 		return "", "", "", "", false
 	}
-
-	authFile := strings.TrimSpace(fields.AuthFileSnapshot)
-	if authFile == "" {
-		source := strings.TrimSpace(fields.Source)
-		account := strings.TrimSpace(fields.AccountSnapshot)
-		label := strings.TrimSpace(fields.AuthLabelSnapshot)
-		if source != "" && !strings.EqualFold(source, account) && !strings.EqualFold(source, label) {
-			authFile = source
-		}
-	}
-	authIndex := strings.TrimSpace(fields.AuthIndex)
-	if authFile == "" || authIndex == "" {
+	authFile, authIndex, ok := codexLegacyCredential(fields)
+	if !ok {
 		return "", "", "", "", false
 	}
 	legacyKey, valid := usageidentity.LegacyAccountKey(fields)
@@ -103,6 +123,33 @@ func codexLegacyTarget(fields usageidentity.Fields) (string, string, string, str
 		return "", "", "", "", false
 	}
 	return legacyKey, targetAccountID, authFile, authIndex, true
+}
+
+func codexLegacyIdentityRequested(fields usageidentity.Fields) bool {
+	return normalizeIdentityProvider(fields.AuthProviderSnapshot) == "codex" &&
+		strings.TrimSpace(fields.AuthAccountIDSnapshot) != ""
+}
+
+func codexLegacyCredential(fields usageidentity.Fields) (string, string, bool) {
+	authFile := strings.TrimSpace(fields.AuthFileSnapshot)
+	if authFile == "" {
+		authFile = codexLegacySourceFile(fields)
+	}
+	authIndex := strings.TrimSpace(fields.AuthIndex)
+	if authFile == "" || authIndex == "" {
+		return "", "", false
+	}
+	return authFile, authIndex, true
+}
+
+func codexLegacySourceFile(fields usageidentity.Fields) string {
+	source := strings.TrimSpace(fields.Source)
+	account := strings.TrimSpace(fields.AccountSnapshot)
+	label := strings.TrimSpace(fields.AuthLabelSnapshot)
+	if source == "" || strings.EqualFold(source, account) || strings.EqualFold(source, label) {
+		return ""
+	}
+	return source
 }
 
 func legacyAccountIdentityPredicates(authFile, authIndex string) []legacyAccountIdentityPredicate {
@@ -144,46 +191,66 @@ func legacySourceIdentityGuards() string {
 		and (e.auth_label_snapshot is null or lower(trim(e.source)) <> lower(trim(e.auth_label_snapshot)))`
 }
 
-func scanLegacyAccountIdentity(rows *sql.Rows, targetAccountID string) (bool, error) {
+func scanLegacyAccountIdentity(rows *sql.Rows, targetAccountID string, maxRows int) (bool, error) {
 	defer rows.Close()
-	seenIDs := map[string]struct{}{}
+	seenRows := 0
 	for rows.Next() {
-		var provider, authProvider, accountID, projectID string
-		if err := rows.Scan(&provider, &authProvider, &accountID, &projectID); err != nil {
+		ok, err := consumeLegacyIdentityRow(rows, &seenRows, maxRows, targetAccountID)
+		if err != nil {
 			return false, err
 		}
-		hasProvider := false
-		for _, value := range []string{provider, authProvider} {
-			normalized := normalizeIdentityProvider(value)
-			if normalized == "" {
-				continue
-			}
-			hasProvider = true
-			if normalized != "codex" {
-				return false, nil
-			}
-		}
-		if !hasProvider {
+		if !ok {
 			return false, nil
 		}
+	}
+	return true, rows.Err()
+}
 
-		for _, value := range []string{
-			strings.TrimSpace(accountID),
-			usageidentity.CodexAccountIDFromSnapshot(projectID),
-		} {
-			if value == "" {
-				continue
-			}
-			if value != targetAccountID {
-				return false, nil
-			}
-			seenIDs[value] = struct{}{}
-			if len(seenIDs) > 1 {
-				return false, nil
-			}
+func consumeLegacyIdentityRow(rows *sql.Rows, seenRows *int, maxRows int, targetAccountID string) (bool, error) {
+	*seenRows++
+	if *seenRows > maxRows {
+		return false, nil
+	}
+	var provider, authProvider, accountID, projectID string
+	if err := rows.Scan(&provider, &authProvider, &accountID, &projectID); err != nil {
+		return false, err
+	}
+	return legacyIdentityRowAllowed(provider, authProvider, accountID, projectID, targetAccountID), nil
+}
+
+func legacyIdentityRowAllowed(provider, authProvider, accountID, projectID, targetAccountID string) bool {
+	return legacyIdentityProviderAllowed(provider, authProvider) &&
+		legacyIdentityAccountIDsAllowed(accountID, projectID, targetAccountID)
+}
+
+func legacyIdentityProviderAllowed(provider, authProvider string) bool {
+	hasProvider := false
+	for _, value := range []string{provider, authProvider} {
+		normalized := normalizeIdentityProvider(value)
+		if normalized == "" {
+			continue
+		}
+		hasProvider = true
+		if normalized != "codex" {
+			return false
 		}
 	}
-	return rows.Err() == nil, rows.Err()
+	return hasProvider
+}
+
+func legacyIdentityAccountIDsAllowed(accountID, projectID, targetAccountID string) bool {
+	for _, value := range []string{
+		strings.TrimSpace(accountID),
+		usageidentity.CodexAccountIDFromSnapshot(projectID),
+	} {
+		if value == "" {
+			continue
+		}
+		if value != targetAccountID {
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeIdentityProvider(value string) string {

--- a/apps/manager-server/internal/repository/usageevent/account_identity_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_test.go
@@ -2,6 +2,9 @@ package usageevent
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -64,6 +67,22 @@ func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *te
 			name: "missing provider blocks",
 			mutate: func(events []usage.Event) []usage.Event {
 				events = append(events, identityTestEvent("missing-provider", 3, "codex-a.json", "auth-a", "", ""))
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "aliased non-codex provider blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events = append(events, identityTestEvent("grok-provider", 3, "codex-a.json", "auth-a", "x-ai", ""))
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "marked project snapshot mismatch blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events[0].AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-b")
 				return events
 			},
 			wantAllowed: false,
@@ -144,6 +163,142 @@ func TestResolveCodexLegacyAccountKeyAcceptsLegacySourceFile(t *testing.T) {
 	if !allowed || !valid || key != want {
 		t.Fatalf("source legacy identity = key:%q allowed:%v, want key:%q allowed:true", key, allowed, want)
 	}
+}
+
+func TestResolveCodexLegacyAccountKeySkipsNonCodexTargets(t *testing.T) {
+	cases := []usageidentity.Fields{
+		{
+			AuthProviderSnapshot:  "openai",
+			AuthAccountIDSnapshot: "account-a",
+			AuthFileSnapshot:      "codex-a.json",
+			AuthIndex:             "auth-a",
+		},
+		{
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "",
+			AuthFileSnapshot:      "codex-a.json",
+			AuthIndex:             "auth-a",
+		},
+		{
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "account-a",
+			AuthFileSnapshot:      "",
+			AuthIndex:             "auth-a",
+			AccountSnapshot:       "same@example.com",
+			Source:                "same@example.com",
+		},
+		{
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "account-a",
+			AuthFileSnapshot:      "codex-a.json",
+			AuthIndex:             "",
+		},
+		{
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "account-a",
+			AuthFileSnapshot:      "",
+			AuthIndex:             "auth-a",
+			Source:                "",
+		},
+		{
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "account-a",
+			AuthFileSnapshot:      "",
+			AuthIndex:             "auth-a",
+			AuthLabelSnapshot:     "ops",
+			Source:                "ops",
+		},
+	}
+	for _, fields := range cases {
+		key, allowed, err := ResolveCodexLegacyAccountKey(context.Background(), panicLegacyIdentityQueryer{}, fields)
+		if err != nil || allowed || key != "" {
+			t.Fatalf("non-codex target = key:%q allowed:%v err:%v, want skip", key, allowed, err)
+		}
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyReturnsQueryError(t *testing.T) {
+	_, allowed, err := ResolveCodexLegacyAccountKey(
+		context.Background(),
+		stubLegacyIdentityQueryer{err: errors.New("query failed")},
+		codexLegacyIdentityTestFields(),
+	)
+	if err == nil || allowed {
+		t.Fatalf("query error = allowed:%v err:%v, want error", allowed, err)
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyAllowsMatchingSetAtProbeLimit(t *testing.T) {
+	key, allowed := resolveLegacyIdentityWithMatchingEvents(t, maxCodexLegacyIdentityProbe)
+	want, valid := usageidentity.LegacyAccountKey(codexLegacyIdentityTestFields())
+	if !valid || !allowed || key != want {
+		t.Fatalf("at-limit identity = key:%q allowed:%v, want key:%q allowed:true", key, allowed, want)
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyRefusesMatchingSetBeyondProbeLimit(t *testing.T) {
+	key, allowed := resolveLegacyIdentityWithMatchingEvents(t, maxCodexLegacyIdentityProbe+1)
+	if allowed || key != "" {
+		t.Fatalf("over-limit identity = key:%q allowed:%v, want refused", key, allowed)
+	}
+}
+
+func resolveLegacyIdentityWithMatchingEvents(t *testing.T, n int) (string, bool) {
+	t.Helper()
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+	events := make([]usage.Event, 0, n)
+	for i := 0; i < n; i++ {
+		accountID := ""
+		if i%3 == 0 {
+			accountID = "account-a"
+		}
+		events = append(events, identityTestEvent(
+			fmt.Sprintf("probe-%d", i),
+			int64(i+1),
+			"codex-a.json",
+			"auth-a",
+			"codex",
+			accountID,
+		))
+	}
+	if _, err := repo.InsertBatch(context.Background(), events); err != nil {
+		t.Fatalf("insert identity events: %v", err)
+	}
+	key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), codexLegacyIdentityTestFields())
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	return key, allowed
+}
+
+func codexLegacyIdentityTestFields() usageidentity.Fields {
+	return usageidentity.Fields{
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "same@example.com",
+		Source:                "codex-a.json",
+	}
+}
+
+type stubLegacyIdentityQueryer struct {
+	err error
+}
+
+func (s stubLegacyIdentityQueryer) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, s.err
+}
+
+type panicLegacyIdentityQueryer struct{}
+
+func (panicLegacyIdentityQueryer) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	panic("legacy identity query should not run for skipped targets")
 }
 
 func identityTestEvent(hash string, offset int64, file, authIndex, provider, accountID string) usage.Event {


### PR DESCRIPTION
## Summary

Bound `ResolveCodexLegacyAccountKey` so account-history does not scan every matching `usage_events` row for a hot Codex credential. Sets larger than 512 matching rows per predicate are treated as inconclusive and refused (fail closed to the stable key).

> Community and maintenance PRs must target `dev`. Repository automation
> retargets other pull requests to `dev`; this can change the diff and make
> existing review comments outdated. `main` accepts only a promotion PR whose
> source is this repository's `dev` branch.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Account-history Codex legacy-key checks now inspect at most 512 newest matching `usage_events` rows per predicate (`ORDER BY timestamp_ms DESC, id DESC LIMIT 513`).
- Matching sets larger than that bound are refused so callers keep the stable Codex account key.
- Identity helpers were split so each function stays CRAP ≤ 6; tests cover the bound, overflow refusal, skip paths, and query errors.

## User Impact

Accounts / monitoring `account-history` no longer hangs for ~30s then HTTP 500 on large Codex credentials. Totals still load from rollups. Legacy file/index merge is skipped when the matching set is too large to prove.

## Compatibility / Runtime Notes

- CPA panel mode: same Manager Server read path; no panel API change.
- Manager Server mode: same.
- Full Docker / native packages: same binary behavior; no config or queue change. Does not rewrite `usage_events`.

## Data / Security Notes

Read-only bounded scan of existing `usage_events` identity columns. No change to `fail_body` / `raw_json` exposure. `usage_events` is not deleted or rewritten.

## Risk / Rollback

Risk level: Low

Rollback notes: revert this commit. Large Codex credentials return to unbounded identity scans (possible 30s timeout). Fail-closed refusal of oversized sets may skip legacy-key merge that previously succeeded after a full scan.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
cd apps/manager-server && go test -count=1 -timeout 90s -run TestResolveCodexLegacyAccountKey ./internal/repository/usageevent
# ok
# gocyclo on account_identity.go: all functions ≤ 4
# targeted mutation of bound/fail-closed conditions: 16 killed, 0 lived
```

Production reproduction (v1.12.6): hottest Codex credential ~456932 matching `usage_events` rows; unbounded identity SELECT did not finish within the 30s client timeout; `LIMIT 501` returned in 6.3ms. Indexed `RecentAccountRequests` (PR #575) was already fast.

## Screenshots / Recordings

N/A — backend read-path only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: behavior fix on an existing API; no new user-facing capability or config. Release notes can mention it when this lands in a version.

## Related

Refs #574 (recent-request LIMIT n; this is a separate unbounded scan on the same account-history request)
