### PR TITLE
fix(manager-server): refresh expired quota cycle boundary from fresh observation

### DIFF
--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1081,8 +1081,9 @@ func reconcileCycle(
 			return id, active.ID, true, err
 		}
 	}
+	refreshExpiredBoundary := cycleBoundaryShouldRefreshExpiredCurrent(active, *snapshot)
 	if cycleMatches {
-		if cycleBoundaryShouldUpgrade(active, *snapshot) {
+		if cycleBoundaryShouldUpgrade(active, *snapshot) || refreshExpiredBoundary {
 			if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 				scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
 				duration_seconds = ?, boundary_accuracy = ?, last_observation_id = ?, updated_at_ms = ?
@@ -1108,7 +1109,8 @@ func reconcileCycle(
 		}
 		return active.ID, 0, false, nil
 	}
-	if isConfirmedLifecycleBoundary(*snapshot) && cycleBoundaryShouldUpgrade(active, *snapshot) {
+	if isConfirmedLifecycleBoundary(*snapshot) &&
+		(cycleBoundaryShouldUpgrade(active, *snapshot) || refreshExpiredBoundary) {
 		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 			scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
 			duration_seconds = ?, boundary_accuracy = ?, last_observation_id = ?, updated_at_ms = ?
@@ -1176,6 +1178,31 @@ func confirmedResetTransitionMS(cycle model.AccountQuotaCycle, snapshot model.Ac
 
 func cycleBoundaryShouldUpgrade(cycle model.AccountQuotaCycle, snapshot model.AccountQuotaSnapshot) bool {
 	return boundaryAccuracyValue(snapshot.BoundaryAccuracy) > boundaryAccuracyValue(cycle.BoundaryAccuracy)
+}
+
+// cycleBoundaryShouldRefreshExpiredCurrent reports whether a confirmed fresh
+// boundary that still covers the observation time must replace an active cycle
+// whose scheduled end has already passed. This is a temporal-validity
+// correction rather than a precision upgrade: once the stored scheduled end is
+// in the past it can no longer represent the current window, even when its
+// accuracy rank is higher than the fresh evidence. The cycle keeps its
+// identity, so no rollover, reset, or additional cycle is created.
+func cycleBoundaryShouldRefreshExpiredCurrent(
+	cycle model.AccountQuotaCycle,
+	snapshot model.AccountQuotaSnapshot,
+) bool {
+	if !isConfirmedLifecycleBoundary(snapshot) ||
+		cycle.ScheduledEndMS == nil ||
+		cycle.DurationSeconds == nil ||
+		snapshot.CycleEndMS == nil ||
+		snapshot.DurationSeconds == nil {
+		return false
+	}
+	if *cycle.DurationSeconds != *snapshot.DurationSeconds {
+		return false
+	}
+	return snapshot.ObservedAtMS >= *cycle.ScheduledEndMS &&
+		*snapshot.CycleEndMS > snapshot.ObservedAtMS
 }
 
 func quotaCounterResetDetected(

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1063,6 +1063,14 @@ func reconcileCycle(
 		id, restoreErr := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
 		return id, 0, false, restoreErr
 	}
+	temporallyInvalidBoundary := cycleBoundaryIsTemporallyInvalidAgainstActive(active, *snapshot)
+	if temporallyInvalidBoundary {
+		// The incoming boundary is already expired while the active cycle's
+		// scheduled end still covers the observation time. Sanitize the
+		// evidence to the current boundary before any lifecycle transition
+		// consumes it; the counter and observation time stay untouched.
+		applyActiveCycleBoundary(snapshot, active)
+	}
 	cycleMatches := cycleMatchesSnapshot(active, *snapshot)
 	if isConfirmedLifecycleBoundary(*snapshot) {
 		counterReset, err := quotaCounterResetDetected(ctx, tx, active, *snapshot)
@@ -1082,10 +1090,7 @@ func reconcileCycle(
 		}
 	}
 	refreshExpiredBoundary := cycleBoundaryShouldRefreshExpiredCurrent(active, *snapshot)
-	actualStartMS := *snapshot.CycleStartMS
-	if refreshExpiredBoundary {
-		actualStartMS = correctedActiveCycleActualStart(active, *snapshot)
-	}
+	actualStartMS := correctedActiveCycleActualStart(active, *snapshot)
 	if cycleMatches {
 		if cycleBoundaryCanReplaceActive(active, *snapshot) || refreshExpiredBoundary {
 			if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
@@ -1209,11 +1214,26 @@ func cycleBoundaryShouldRefreshExpiredCurrent(
 		*snapshot.CycleEndMS > snapshot.ObservedAtMS
 }
 
+// cycleBoundaryIsTemporallyInvalidAgainstActive reports whether an incoming
+// boundary is already expired while the active cycle's scheduled end still
+// covers the observation time. Such evidence is temporally stale: temporal
+// validity outranks accuracy, so it must not move a current cycle into the
+// past.
+func cycleBoundaryIsTemporallyInvalidAgainstActive(
+	cycle model.AccountQuotaCycle,
+	snapshot model.AccountQuotaSnapshot,
+) bool {
+	if cycle.ScheduledEndMS == nil ||
+		snapshot.CycleEndMS == nil {
+		return false
+	}
+	return *cycle.ScheduledEndMS > snapshot.ObservedAtMS &&
+		*snapshot.CycleEndMS <= snapshot.ObservedAtMS
+}
+
 // cycleBoundaryCanReplaceActive reports whether an incoming higher-accuracy
-// boundary may replace the active cycle boundary. While the stored scheduled
-// end still covers the observation time, an already expired incoming boundary
-// must not win on precision alone: temporal validity outranks accuracy, so
-// accepting it would move a current cycle back into the past.
+// boundary may replace the active cycle boundary. A temporally stale incoming
+// boundary never qualifies, even on a precision upgrade.
 func cycleBoundaryCanReplaceActive(
 	cycle model.AccountQuotaCycle,
 	snapshot model.AccountQuotaSnapshot,
@@ -1221,19 +1241,16 @@ func cycleBoundaryCanReplaceActive(
 	if snapshot.CycleEndMS == nil {
 		return false
 	}
-	if cycle.ScheduledEndMS != nil &&
-		*cycle.ScheduledEndMS > snapshot.ObservedAtMS &&
-		*snapshot.CycleEndMS <= snapshot.ObservedAtMS {
+	if cycleBoundaryIsTemporallyInvalidAgainstActive(cycle, snapshot) {
 		return false
 	}
 	return cycleBoundaryShouldUpgrade(cycle, snapshot)
 }
 
-// correctedActiveCycleActualStart keeps an independently confirmed
-// actual_start_ms while an expired-boundary correction moves the scheduled
-// boundary. Counter-reset detection is the only writer that separates
-// actual_start_ms from the scheduled start, so a difference marks a confirmed
-// reset transition that boundary evidence alone must not overwrite.
+// correctedActiveCycleActualStart preserves an independently established
+// actual transition when the active cycle's actual start differs from its
+// scheduled start. Boundary evidence updates scheduled timing and must not
+// rewrite that transition.
 func correctedActiveCycleActualStart(
 	cycle model.AccountQuotaCycle,
 	snapshot model.AccountQuotaSnapshot,

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1063,6 +1063,11 @@ func reconcileCycle(
 		id, restoreErr := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
 		return id, 0, false, restoreErr
 	}
+	// Canonicalization below replaces stale timing geometry with the active
+	// boundary, so the incoming evidence authority must be captured first:
+	// geometry correction must not promote estimated or unknown evidence into
+	// confirmed lifecycle authority.
+	incomingBoundaryConfirmed := isConfirmedLifecycleBoundary(*snapshot)
 	temporallyInvalidBoundary := cycleBoundaryIsTemporallyInvalidAgainstActive(active, *snapshot)
 	if temporallyInvalidBoundary {
 		// The incoming boundary is already expired while the active cycle's
@@ -1072,7 +1077,12 @@ func reconcileCycle(
 		applyActiveCycleBoundary(snapshot, active)
 	}
 	cycleMatches := cycleMatchesSnapshot(active, *snapshot)
-	if isConfirmedLifecycleBoundary(*snapshot) {
+	// Counter-reset reconciliation splits lifecycle state, so it needs a
+	// canonical boundary that is still current at the observation time to
+	// carry the transition. An already expired boundary keeps its usage-drop
+	// evidence but cannot drive the split on its own.
+	counterResetBoundaryCurrent := cycleBoundaryCoversObservation(*snapshot)
+	if incomingBoundaryConfirmed && counterResetBoundaryCurrent {
 		counterReset, err := quotaCounterResetDetected(ctx, tx, active, *snapshot)
 		if err != nil {
 			return 0, 0, false, err
@@ -1229,6 +1239,16 @@ func cycleBoundaryIsTemporallyInvalidAgainstActive(
 	}
 	return *cycle.ScheduledEndMS > snapshot.ObservedAtMS &&
 		*snapshot.CycleEndMS <= snapshot.ObservedAtMS
+}
+
+// cycleBoundaryCoversObservation reports whether the snapshot's canonical
+// boundary still extends beyond the observation time. Counter-reset
+// reconciliation needs a boundary that is current at the observation to carry
+// the transition; an expired boundary keeps its usage-drop evidence but cannot
+// split lifecycle state on its own.
+func cycleBoundaryCoversObservation(snapshot model.AccountQuotaSnapshot) bool {
+	return snapshot.CycleEndMS != nil &&
+		*snapshot.CycleEndMS > snapshot.ObservedAtMS
 }
 
 // cycleBoundaryCanReplaceActive reports whether an incoming higher-accuracy

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1082,15 +1082,19 @@ func reconcileCycle(
 		}
 	}
 	refreshExpiredBoundary := cycleBoundaryShouldRefreshExpiredCurrent(active, *snapshot)
+	actualStartMS := *snapshot.CycleStartMS
+	if refreshExpiredBoundary {
+		actualStartMS = correctedActiveCycleActualStart(active, *snapshot)
+	}
 	if cycleMatches {
-		if cycleBoundaryShouldUpgrade(active, *snapshot) || refreshExpiredBoundary {
+		if cycleBoundaryCanReplaceActive(active, *snapshot) || refreshExpiredBoundary {
 			if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 				scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
 				duration_seconds = ?, boundary_accuracy = ?, last_observation_id = ?, updated_at_ms = ?
 				where id = ?`,
 				snapshot.CycleStartMS,
 				snapshot.CycleEndMS,
-				*snapshot.CycleStartMS,
+				actualStartMS,
 				snapshot.DurationSeconds,
 				snapshot.BoundaryAccuracy,
 				observationID,
@@ -1110,14 +1114,14 @@ func reconcileCycle(
 		return active.ID, 0, false, nil
 	}
 	if isConfirmedLifecycleBoundary(*snapshot) &&
-		(cycleBoundaryShouldUpgrade(active, *snapshot) || refreshExpiredBoundary) {
+		(cycleBoundaryCanReplaceActive(active, *snapshot) || refreshExpiredBoundary) {
 		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 			scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
 			duration_seconds = ?, boundary_accuracy = ?, last_observation_id = ?, updated_at_ms = ?
 			where id = ?`,
 			snapshot.CycleStartMS,
 			snapshot.CycleEndMS,
-			*snapshot.CycleStartMS,
+			actualStartMS,
 			snapshot.DurationSeconds,
 			snapshot.BoundaryAccuracy,
 			observationID,
@@ -1203,6 +1207,42 @@ func cycleBoundaryShouldRefreshExpiredCurrent(
 	}
 	return snapshot.ObservedAtMS >= *cycle.ScheduledEndMS &&
 		*snapshot.CycleEndMS > snapshot.ObservedAtMS
+}
+
+// cycleBoundaryCanReplaceActive reports whether an incoming higher-accuracy
+// boundary may replace the active cycle boundary. While the stored scheduled
+// end still covers the observation time, an already expired incoming boundary
+// must not win on precision alone: temporal validity outranks accuracy, so
+// accepting it would move a current cycle back into the past.
+func cycleBoundaryCanReplaceActive(
+	cycle model.AccountQuotaCycle,
+	snapshot model.AccountQuotaSnapshot,
+) bool {
+	if snapshot.CycleEndMS == nil {
+		return false
+	}
+	if cycle.ScheduledEndMS != nil &&
+		*cycle.ScheduledEndMS > snapshot.ObservedAtMS &&
+		*snapshot.CycleEndMS <= snapshot.ObservedAtMS {
+		return false
+	}
+	return cycleBoundaryShouldUpgrade(cycle, snapshot)
+}
+
+// correctedActiveCycleActualStart keeps an independently confirmed
+// actual_start_ms while an expired-boundary correction moves the scheduled
+// boundary. Counter-reset detection is the only writer that separates
+// actual_start_ms from the scheduled start, so a difference marks a confirmed
+// reset transition that boundary evidence alone must not overwrite.
+func correctedActiveCycleActualStart(
+	cycle model.AccountQuotaCycle,
+	snapshot model.AccountQuotaSnapshot,
+) int64 {
+	if cycle.ScheduledStartMS != nil &&
+		cycle.ActualStartMS != *cycle.ScheduledStartMS {
+		return cycle.ActualStartMS
+	}
+	return *snapshot.CycleStartMS
 }
 
 func quotaCounterResetDetected(

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1251,9 +1251,31 @@ func cycleBoundaryCoversObservation(snapshot model.AccountQuotaSnapshot) bool {
 		*snapshot.CycleEndMS > snapshot.ObservedAtMS
 }
 
+// cycleBoundaryWouldRegressExpiredActive reports whether an already expired
+// incoming boundary is materially older than the active boundary. Differences
+// within the provider jitter stay the same canonical boundary and may still be
+// upgraded for precision; a larger backward movement would rewind a previously
+// refreshed boundary into the past. The difference is computed after the
+// ordering precondition, so the subtraction cannot overflow or go negative.
+func cycleBoundaryWouldRegressExpiredActive(
+	cycle model.AccountQuotaCycle,
+	snapshot model.AccountQuotaSnapshot,
+) bool {
+	if cycle.ScheduledEndMS == nil ||
+		snapshot.CycleEndMS == nil ||
+		*snapshot.CycleEndMS > snapshot.ObservedAtMS ||
+		*cycle.ScheduledEndMS <= *snapshot.CycleEndMS {
+		return false
+	}
+	return *cycle.ScheduledEndMS-*snapshot.CycleEndMS >
+		quotaBoundaryJitterMS
+}
+
 // cycleBoundaryCanReplaceActive reports whether an incoming higher-accuracy
 // boundary may replace the active cycle boundary. A temporally stale incoming
-// boundary never qualifies, even on a precision upgrade.
+// boundary never qualifies, even on a precision upgrade, and neither does an
+// expired boundary that is materially older than the active one: accuracy
+// alone must not rewind a known boundary into the past.
 func cycleBoundaryCanReplaceActive(
 	cycle model.AccountQuotaCycle,
 	snapshot model.AccountQuotaSnapshot,
@@ -1262,6 +1284,9 @@ func cycleBoundaryCanReplaceActive(
 		return false
 	}
 	if cycleBoundaryIsTemporallyInvalidAgainstActive(cycle, snapshot) {
+		return false
+	}
+	if cycleBoundaryWouldRegressExpiredActive(cycle, snapshot) {
 		return false
 	}
 	return cycleBoundaryShouldUpgrade(cycle, snapshot)

--- a/apps/manager-server/internal/service/quotasnapshot/service.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service.go
@@ -1030,13 +1030,7 @@ func mergeLifecycleWindows(
 		window.CurrentCycle = quotaCycleResponse(state.CurrentCycle, true)
 		window.PreviousCycle = quotaCycleResponse(state.PreviousCycle, false)
 		if state.CurrentCycle != nil {
-			// The window exposes the provider's canonical scheduled boundary.
-			// actual_start_ms may carry a confirmed counter-reset transition
-			// that differs from the scheduled start and is not a display start.
 			start := state.CurrentCycle.ActualStartMS
-			if state.CurrentCycle.ScheduledStartMS != nil {
-				start = *state.CurrentCycle.ScheduledStartMS
-			}
 			window.CycleStartMS = &start
 			window.CycleEndMS = copyInt64Pointer(state.CurrentCycle.ScheduledEndMS)
 			window.DurationSeconds = copyInt64Pointer(state.CurrentCycle.DurationSeconds)

--- a/apps/manager-server/internal/service/quotasnapshot/service.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service.go
@@ -1030,7 +1030,13 @@ func mergeLifecycleWindows(
 		window.CurrentCycle = quotaCycleResponse(state.CurrentCycle, true)
 		window.PreviousCycle = quotaCycleResponse(state.PreviousCycle, false)
 		if state.CurrentCycle != nil {
+			// The window exposes the provider's canonical scheduled boundary.
+			// actual_start_ms may carry a confirmed counter-reset transition
+			// that differs from the scheduled start and is not a display start.
 			start := state.CurrentCycle.ActualStartMS
+			if state.CurrentCycle.ScheduledStartMS != nil {
+				start = *state.CurrentCycle.ScheduledStartMS
+			}
 			window.CycleStartMS = &start
 			window.CycleEndMS = copyInt64Pointer(state.CurrentCycle.ScheduledEndMS)
 			window.DurationSeconds = copyInt64Pointer(state.CurrentCycle.DurationSeconds)

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -4024,6 +4024,147 @@ func TestQuotaLifecycleExpiredBoundaryEvidenceCannotCreateStaleResetCycle(t *tes
 	}
 }
 
+func TestQuotaLifecycleUnreliableExpiredBoundaryCannotGainResetAuthority(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	staleAtMS := refreshAtMS + 10*60*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, staleAtMS+50*60*1000)
+
+	first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 45)
+	fresh.Source = "response_header"
+	fresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-expired-refresh", "codex:quota-windows",
+			refreshAtMS, []WindowInput{fresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write fresh overlapping observation: %v", err)
+	}
+	refreshed := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if refreshed.CurrentCycle == nil || refreshed.CurrentCycle.ScheduledStartMS == nil ||
+		*refreshed.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		refreshed.CurrentCycle.ScheduledEndMS == nil || *refreshed.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		refreshed.CurrentCycle.BoundaryAccuracy != "derived" || refreshed.PreviousCycle != nil || refreshed.Stale {
+		t.Fatalf("fresh derived boundary was not refreshed: %#v", refreshed)
+	}
+	currentCycleID := refreshed.CurrentCycle.ID
+
+	stale := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 1)
+	stale.Source = "api_query"
+	stale.BoundaryAccuracy = "estimated"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-stale-unreliable", "codex:quota-windows",
+			staleAtMS, []WindowInput{stale},
+		),
+	}}); err != nil {
+		t.Fatalf("write stale unreliable observation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID || window.PreviousCycle != nil {
+		t.Fatalf("unreliable expired boundary gained reset authority: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS {
+		t.Fatalf("unreliable boundary changed the current boundary: %#v", window.CurrentCycle)
+	}
+	if window.Stale {
+		t.Fatalf("current cycle became stale after unreliable evidence: %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open unreliable-evidence database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count unreliable-evidence cycles: %v", err)
+	}
+	if cycleCount != 1 {
+		t.Fatalf("unreliable-evidence cycle count = %d, want 1", cycleCount)
+	}
+}
+
+func TestQuotaLifecycleStaleBoundaryAfterActiveExpiryCannotResetLifecycle(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	staleAtMS := freshEndMS + 10*60*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, staleAtMS+50*60*1000)
+
+	first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 45)
+	fresh.Source = "response_header"
+	fresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-expired-refresh", "codex:quota-windows",
+			refreshAtMS, []WindowInput{fresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write fresh overlapping observation: %v", err)
+	}
+	refreshed := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if refreshed.CurrentCycle == nil || refreshed.CurrentCycle.ScheduledStartMS == nil ||
+		*refreshed.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		refreshed.CurrentCycle.ScheduledEndMS == nil || *refreshed.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		refreshed.PreviousCycle != nil {
+		t.Fatalf("fresh derived boundary was not refreshed: %#v", refreshed)
+	}
+	currentCycleID := refreshed.CurrentCycle.ID
+
+	stale := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 1)
+	stale.Source = "api_query"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-stale-after-expiry", "codex:quota-windows",
+			staleAtMS, []WindowInput{stale},
+		),
+	}}); err != nil {
+		t.Fatalf("write stale observation after active expiry: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID || window.PreviousCycle != nil {
+		t.Fatalf("stale boundary after active expiry split the lifecycle: %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open post-expiry database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var staleFragments, cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles
+		where actual_end_ms is not null and actual_end_ms <= actual_start_ms`).Scan(&staleFragments); err != nil {
+		t.Fatalf("count post-expiry fragments: %v", err)
+	}
+	if staleFragments != 0 {
+		t.Fatalf("post-expiry zero-length fragments = %d, want 0", staleFragments)
+	}
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count post-expiry cycles: %v", err)
+	}
+	if cycleCount != 1 {
+		t.Fatalf("post-expiry cycle count = %d, want 1", cycleCount)
+	}
+}
+
 func TestQuotaLifecycleReclassifiesLegacyCodexSparkAllScope(t *testing.T) {
 	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
 	legacy := quotaLifecycleFixedWindow(

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3730,6 +3730,135 @@ func TestQuotaLifecycleKeepsExpiredBoundaryGuardBeforeScheduledEnd(t *testing.T)
 	}
 }
 
+func TestQuotaLifecycleDoesNotReplaceFreshCurrentBoundaryWithLaterExpiredExactEvidence(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	expiredAtMS := refreshAtMS + 10*60*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, expiredAtMS+50*60*1000)
+
+	first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 45)
+	fresh.Source = "response_header"
+	fresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-expired-refresh", "codex:quota-windows",
+			refreshAtMS, []WindowInput{fresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write fresh overlapping observation: %v", err)
+	}
+	refreshed := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if refreshed.CurrentCycle == nil || refreshed.CurrentCycle.ScheduledStartMS == nil ||
+		*refreshed.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		refreshed.CurrentCycle.ScheduledEndMS == nil || *refreshed.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		refreshed.CurrentCycle.BoundaryAccuracy != "derived" || refreshed.Stale {
+		t.Fatalf("fresh derived boundary was not refreshed: %#v", refreshed)
+	}
+	currentCycleID := refreshed.CurrentCycle.ID
+
+	expired := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 46)
+	writeQuotaLifecycleObservation(t, service, "complete", expiredAtMS, []WindowInput{expired})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID || window.PreviousCycle != nil {
+		t.Fatalf("expired exact evidence split or replaced the cycle: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		window.CurrentCycle.BoundaryAccuracy != "derived" {
+		t.Fatalf("expired exact evidence replaced the current boundary: %#v", window.CurrentCycle)
+	}
+	if window.CycleStartMS == nil || *window.CycleStartMS != freshStartMS ||
+		window.CycleEndMS == nil || *window.CycleEndMS != freshEndMS || window.Stale {
+		t.Fatalf("window boundary did not keep the fresh current cycle: %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open expired-evidence database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count expired-evidence cycles: %v", err)
+	}
+	if cycleCount != 1 {
+		t.Fatalf("expired-evidence cycle count = %d, want 1", cycleCount)
+	}
+}
+
+func TestQuotaLifecycleExpiredBoundaryRefreshPreservesConfirmedResetTransition(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	resetAtMS := firstStartMS + 4*quotaLifecycleHourMS
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	service, path := newQuotaSnapshotTestServiceWithPath(t, refreshAtMS+quotaLifecycleHourMS)
+
+	initial := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 75)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+3*quotaLifecycleHourMS, []WindowInput{initial})
+
+	reset := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 1)
+	writeQuotaLifecycleObservation(t, service, "complete", resetAtMS, []WindowInput{reset})
+
+	resetted := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if resetted.PreviousCycle == nil || resetted.PreviousCycle.ActualEndMS == nil ||
+		*resetted.PreviousCycle.ActualEndMS != resetAtMS ||
+		resetted.CurrentCycle == nil || resetted.CurrentCycle.ActualStartMS != resetAtMS ||
+		resetted.CurrentCycle.ScheduledStartMS == nil || *resetted.CurrentCycle.ScheduledStartMS != firstStartMS ||
+		resetted.CurrentCycle.ScheduledEndMS == nil || *resetted.CurrentCycle.ScheduledEndMS != firstEndMS {
+		t.Fatalf("same-boundary counter reset = %#v", resetted)
+	}
+	currentCycleID := resetted.CurrentCycle.ID
+	previousCycleID := resetted.PreviousCycle.ID
+
+	fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 10)
+	writeQuotaLifecycleObservation(t, service, "complete", refreshAtMS, []WindowInput{fresh})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID ||
+		window.PreviousCycle == nil || window.PreviousCycle.ID != previousCycleID {
+		t.Fatalf("expired refresh changed cycle identity: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS {
+		t.Fatalf("expired refresh did not update scheduled boundary: %#v", window.CurrentCycle)
+	}
+	if window.CurrentCycle.ActualStartMS != resetAtMS {
+		t.Fatalf("confirmed reset transition was overwritten: %#v", window.CurrentCycle)
+	}
+	if window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != resetAtMS ||
+		window.CurrentCycle.ActualStartMS != *window.PreviousCycle.ActualEndMS {
+		t.Fatalf("previous cycle no longer meets the confirmed transition: %#v", window)
+	}
+	if window.CycleStartMS == nil || *window.CycleStartMS != freshStartMS ||
+		window.CycleEndMS == nil || *window.CycleEndMS != freshEndMS || window.Stale {
+		t.Fatalf("window canonical boundary = %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open reset-transition database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count reset-transition cycles: %v", err)
+	}
+	if cycleCount != 2 {
+		t.Fatalf("reset-transition cycle count = %d, want 2", cycleCount)
+	}
+}
+
 func TestQuotaLifecycleReclassifiesLegacyCodexSparkAllScope(t *testing.T) {
 	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
 	legacy := quotaLifecycleFixedWindow(

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -4103,7 +4103,10 @@ func TestQuotaLifecycleStaleBoundaryAfterActiveExpiryCannotResetLifecycle(t *tes
 	freshEndMS := freshStartMS + durationSeconds*1000
 	refreshAtMS := firstEndMS + quotaLifecycleHourMS
 	staleAtMS := freshEndMS + 10*60*1000
-	service, path := newQuotaSnapshotTestServiceWithPath(t, staleAtMS+50*60*1000)
+	nextRefreshAtMS := staleAtMS + 10*60*1000
+	nextStartMS := freshEndMS - quotaLifecycleHourMS
+	nextEndMS := nextStartMS + durationSeconds*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, nextRefreshAtMS+40*60*1000)
 
 	first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
 	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
@@ -4143,6 +4146,15 @@ func TestQuotaLifecycleStaleBoundaryAfterActiveExpiryCannotResetLifecycle(t *tes
 	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID || window.PreviousCycle != nil {
 		t.Fatalf("stale boundary after active expiry split the lifecycle: %#v", window)
 	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		window.CurrentCycle.ActualStartMS != freshStartMS ||
+		window.CurrentCycle.BoundaryAccuracy != "derived" {
+		t.Fatalf("stale exact evidence rewound the active boundary: %#v", window.CurrentCycle)
+	}
+	if !window.Stale {
+		t.Fatalf("expired preserved boundary must report stale rather than roll back: %#v", window)
+	}
 
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -4162,6 +4174,87 @@ func TestQuotaLifecycleStaleBoundaryAfterActiveExpiryCannotResetLifecycle(t *tes
 	}
 	if cycleCount != 1 {
 		t.Fatalf("post-expiry cycle count = %d, want 1", cycleCount)
+	}
+
+	nextFresh := quotaLifecycleFixedWindow("five-hour", "five_hour", nextStartMS, durationSeconds, 2)
+	nextFresh.Source = "response_header"
+	nextFresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-next-fresh", "codex:quota-windows",
+			nextRefreshAtMS, []WindowInput{nextFresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write next fresh observation: %v", err)
+	}
+
+	window = queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID ||
+		window.PreviousCycle != nil || window.Stale {
+		t.Fatalf("next fresh boundary misrouted after stale evidence: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != nextStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != nextEndMS ||
+		window.CurrentCycle.ActualStartMS != nextStartMS ||
+		window.CurrentCycle.BoundaryAccuracy != "derived" {
+		t.Fatalf("next fresh boundary did not refresh the same cycle: %#v", window.CurrentCycle)
+	}
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count post-refresh cycles: %v", err)
+	}
+	if cycleCount != 1 {
+		t.Fatalf("post-refresh cycle count = %d, want 1", cycleCount)
+	}
+}
+
+func TestQuotaLifecycleAllowsHigherAccuracyCorrectionWithinBoundaryJitter(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	activeStartMS := quotaLifecycleBaseMS + 3*quotaLifecycleHourMS + 30*1000
+	correctedStartMS := quotaLifecycleBaseMS + 3*quotaLifecycleHourMS
+	upgradeAtMS := activeStartMS + 2*quotaLifecycleHourMS
+	service, path := newQuotaSnapshotTestServiceWithPath(t, upgradeAtMS+quotaLifecycleHourMS)
+
+	active := quotaLifecycleFixedWindow("five-hour", "five_hour", activeStartMS, durationSeconds, 45)
+	active.Source = "response_header"
+	active.BoundaryAccuracy = "derived"
+	writeQuotaLifecycleObservation(t, service, "complete", activeStartMS+quotaLifecycleHourMS, []WindowInput{active})
+	initial := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if initial.CurrentCycle == nil {
+		t.Fatalf("initial derived lifecycle = %#v", initial)
+	}
+	cycleID := initial.CurrentCycle.ID
+
+	corrected := quotaLifecycleFixedWindow("five-hour", "five_hour", correctedStartMS, durationSeconds, 46)
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-jitter-upgrade", "codex:quota-windows",
+			upgradeAtMS, []WindowInput{corrected},
+		),
+	}}); err != nil {
+		t.Fatalf("write jitter upgrade observation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != cycleID || window.PreviousCycle != nil ||
+		window.CurrentCycle.BoundaryAccuracy != "exact" {
+		t.Fatalf("jitter-range accuracy upgrade was rejected: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != correctedStartMS ||
+		window.CurrentCycle.ActualStartMS != correctedStartMS {
+		t.Fatalf("jitter upgrade boundary = %#v", window.CurrentCycle)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open jitter-upgrade database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count jitter-upgrade cycles: %v", err)
+	}
+	if cycleCount != 1 {
+		t.Fatalf("jitter-upgrade cycle count = %d, want 1", cycleCount)
 	}
 }
 

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3630,6 +3630,106 @@ func TestQuotaLifecycleRejectsUnreliableScheduledRolloverBoundary(t *testing.T) 
 	}
 }
 
+func TestQuotaLifecycleRefreshesExpiredBoundaryFromFreshOverlappingObservation(t *testing.T) {
+	tests := []struct {
+		name                string
+		source              string
+		sourceObservationID string
+		freshAccuracy       string
+	}{
+		{name: "exact api boundary", source: "api_query", sourceObservationID: "api-expired-refresh", freshAccuracy: "exact"},
+		{name: "derived header boundary", source: "response_header", sourceObservationID: "header-expired-refresh", freshAccuracy: "derived"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			const durationSeconds = int64(5 * 60 * 60)
+			firstStartMS := quotaLifecycleBaseMS
+			firstEndMS := firstStartMS + durationSeconds*1000
+			freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+			freshEndMS := freshStartMS + durationSeconds*1000
+			refreshAtMS := firstEndMS + quotaLifecycleHourMS
+			service, path := newQuotaSnapshotTestServiceWithPath(t, refreshAtMS+quotaLifecycleHourMS)
+
+			first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
+			writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+			initial := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+			if initial.CurrentCycle == nil {
+				t.Fatalf("initial fixed lifecycle = %#v", initial)
+			}
+			initialCycleID := initial.CurrentCycle.ID
+
+			fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 45)
+			fresh.Source = testCase.source
+			fresh.BoundaryAccuracy = testCase.freshAccuracy
+			if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+				quotaLifecycleWriteEntryWithObservation(
+					"complete", testCase.source, testCase.sourceObservationID, "codex:quota-windows",
+					refreshAtMS, []WindowInput{fresh},
+				),
+			}}); err != nil {
+				t.Fatalf("write fresh overlapping observation: %v", err)
+			}
+
+			window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+			if window.CurrentCycle == nil || window.CurrentCycle.ID != initialCycleID || window.PreviousCycle != nil {
+				t.Fatalf("expired boundary refresh split the cycle: %#v", window)
+			}
+			if window.CurrentCycle.ActualStartMS != freshStartMS ||
+				window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+				window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS ||
+				window.CurrentCycle.DurationSeconds == nil || *window.CurrentCycle.DurationSeconds != durationSeconds ||
+				window.CurrentCycle.BoundaryAccuracy != testCase.freshAccuracy {
+				t.Fatalf("expired cycle boundary was not refreshed: %#v", window.CurrentCycle)
+			}
+			if window.CycleStartMS == nil || *window.CycleStartMS != freshStartMS ||
+				window.CycleEndMS == nil || *window.CycleEndMS != freshEndMS {
+				t.Fatalf("window boundary did not follow refreshed cycle: %#v", window)
+			}
+			if window.Stale {
+				t.Fatalf("refreshed window must not be stale: %#v", window)
+			}
+
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatalf("open expired-refresh database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			var cycleCount int
+			if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+				t.Fatalf("count expired-refresh cycles: %v", err)
+			}
+			if cycleCount != 1 {
+				t.Fatalf("expired-refresh cycle count = %d, want 1", cycleCount)
+			}
+		})
+	}
+}
+
+func TestQuotaLifecycleKeepsExpiredBoundaryGuardBeforeScheduledEnd(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	candidateStartMS := firstStartMS + 2*quotaLifecycleHourMS
+	service := newQuotaSnapshotTestService(t, firstEndMS-quotaLifecycleHourMS)
+
+	first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	candidate := quotaLifecycleFixedWindow("five-hour", "five_hour", candidateStartMS, durationSeconds, 45)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+4*quotaLifecycleHourMS, []WindowInput{candidate})
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ActualStartMS != firstStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != firstEndMS ||
+		window.PreviousCycle != nil {
+		t.Fatalf("pre-expiry candidate changed lifecycle = %#v", window)
+	}
+	if window.CycleStartMS == nil || *window.CycleStartMS != firstStartMS ||
+		window.CycleEndMS == nil || *window.CycleEndMS != firstEndMS {
+		t.Fatalf("pre-expiry candidate adopted fresh boundary = %#v", window)
+	}
+}
+
 func TestQuotaLifecycleReclassifiesLegacyCodexSparkAllScope(t *testing.T) {
 	service, path := newQuotaSnapshotTestServiceWithPath(t, quotaLifecycleBaseMS+quotaLifecycleDayMS)
 	legacy := quotaLifecycleFixedWindow(

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3705,6 +3705,69 @@ func TestQuotaLifecycleRefreshesExpiredBoundaryFromFreshOverlappingObservation(t
 	}
 }
 
+func TestQuotaLifecycleRefreshesExpiredCalendarBoundaryFromFreshOverlappingObservation(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	service, path := newQuotaSnapshotTestServiceWithPath(t, refreshAtMS+quotaLifecycleHourMS)
+
+	first := quotaLifecycleFixedWindow("calendar-week", "weekly", firstStartMS, durationSeconds, 40)
+	first.WindowMode = "calendar"
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+	initial := queryQuotaLifecycleWindows(t, service, false)["calendar-week"]
+	if initial.CurrentCycle == nil {
+		t.Fatalf("initial calendar lifecycle = %#v", initial)
+	}
+	initialCycleID := initial.CurrentCycle.ID
+
+	fresh := quotaLifecycleFixedWindow("calendar-week", "weekly", freshStartMS, durationSeconds, 45)
+	fresh.WindowMode = "calendar"
+	fresh.Source = "response_header"
+	fresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-calendar-refresh", "codex:quota-windows",
+			refreshAtMS, []WindowInput{fresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write fresh overlapping calendar observation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["calendar-week"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != initialCycleID || window.PreviousCycle != nil {
+		t.Fatalf("calendar expired refresh split the cycle: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		window.CurrentCycle.DurationSeconds == nil || *window.CurrentCycle.DurationSeconds != durationSeconds ||
+		window.CurrentCycle.BoundaryAccuracy != "derived" {
+		t.Fatalf("calendar cycle boundary was not refreshed: %#v", window.CurrentCycle)
+	}
+	if window.CycleStartMS == nil || *window.CycleStartMS != freshStartMS ||
+		window.CycleEndMS == nil || *window.CycleEndMS != freshEndMS {
+		t.Fatalf("window boundary did not follow refreshed calendar cycle: %#v", window)
+	}
+	if window.Stale {
+		t.Fatalf("refreshed calendar window must not be stale: %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open calendar-refresh database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count calendar-refresh cycles: %v", err)
+	}
+	if cycleCount != 1 {
+		t.Fatalf("calendar-refresh cycle count = %d, want 1", cycleCount)
+	}
+}
+
 func TestQuotaLifecycleKeepsExpiredBoundaryGuardBeforeScheduledEnd(t *testing.T) {
 	const durationSeconds = int64(5 * 60 * 60)
 	firstStartMS := quotaLifecycleBaseMS

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3840,9 +3840,9 @@ func TestQuotaLifecycleExpiredBoundaryRefreshPreservesConfirmedResetTransition(t
 		window.CurrentCycle.ActualStartMS != *window.PreviousCycle.ActualEndMS {
 		t.Fatalf("previous cycle no longer meets the confirmed transition: %#v", window)
 	}
-	if window.CycleStartMS == nil || *window.CycleStartMS != freshStartMS ||
+	if window.CycleStartMS == nil || *window.CycleStartMS != resetAtMS ||
 		window.CycleEndMS == nil || *window.CycleEndMS != freshEndMS || window.Stale {
-		t.Fatalf("window canonical boundary = %#v", window)
+		t.Fatalf("window boundary = %#v", window)
 	}
 
 	db, err := sql.Open("sqlite", path)
@@ -3856,6 +3856,171 @@ func TestQuotaLifecycleExpiredBoundaryRefreshPreservesConfirmedResetTransition(t
 	}
 	if cycleCount != 2 {
 		t.Fatalf("reset-transition cycle count = %d, want 2", cycleCount)
+	}
+}
+
+func TestQuotaLifecycleAccuracyUpgradeAfterExpiredRefreshPreservesConfirmedResetTransition(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	resetAtMS := firstStartMS + 4*quotaLifecycleHourMS
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	upgradeAtMS := refreshAtMS + 10*60*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, upgradeAtMS+50*60*1000)
+
+	initial := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 75)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+3*quotaLifecycleHourMS, []WindowInput{initial})
+
+	reset := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 1)
+	writeQuotaLifecycleObservation(t, service, "complete", resetAtMS, []WindowInput{reset})
+
+	resetted := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if resetted.PreviousCycle == nil || resetted.PreviousCycle.ActualEndMS == nil ||
+		*resetted.PreviousCycle.ActualEndMS != resetAtMS ||
+		resetted.CurrentCycle == nil || resetted.CurrentCycle.ActualStartMS != resetAtMS ||
+		resetted.CurrentCycle.ScheduledStartMS == nil || *resetted.CurrentCycle.ScheduledStartMS != firstStartMS ||
+		resetted.CurrentCycle.ScheduledEndMS == nil || *resetted.CurrentCycle.ScheduledEndMS != firstEndMS {
+		t.Fatalf("same-boundary counter reset = %#v", resetted)
+	}
+	currentCycleID := resetted.CurrentCycle.ID
+	previousCycleID := resetted.PreviousCycle.ID
+
+	fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 10)
+	fresh.Source = "response_header"
+	fresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-expired-refresh", "codex:quota-windows",
+			refreshAtMS, []WindowInput{fresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write expired refresh observation: %v", err)
+	}
+	refreshed := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if refreshed.CurrentCycle == nil || refreshed.CurrentCycle.ID != currentCycleID ||
+		refreshed.CurrentCycle.ScheduledStartMS == nil || *refreshed.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		refreshed.CurrentCycle.ScheduledEndMS == nil || *refreshed.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		refreshed.CurrentCycle.BoundaryAccuracy != "derived" || refreshed.CurrentCycle.ActualStartMS != resetAtMS ||
+		refreshed.PreviousCycle == nil || refreshed.PreviousCycle.ID != previousCycleID ||
+		refreshed.PreviousCycle.ActualEndMS == nil || *refreshed.PreviousCycle.ActualEndMS != resetAtMS {
+		t.Fatalf("expired refresh lost the confirmed transition: %#v", refreshed)
+	}
+
+	upgrade := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 11)
+	upgrade.Source = "api_query"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-boundary-upgrade", "codex:quota-windows",
+			upgradeAtMS, []WindowInput{upgrade},
+		),
+	}}); err != nil {
+		t.Fatalf("write accuracy upgrade observation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != currentCycleID ||
+		window.PreviousCycle == nil || window.PreviousCycle.ID != previousCycleID {
+		t.Fatalf("accuracy upgrade changed cycle identity: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		window.CurrentCycle.BoundaryAccuracy != "exact" || window.CurrentCycle.ActualStartMS != resetAtMS {
+		t.Fatalf("accuracy upgrade overwrote the confirmed transition: %#v", window.CurrentCycle)
+	}
+	if window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != resetAtMS ||
+		window.CurrentCycle.ActualStartMS != *window.PreviousCycle.ActualEndMS {
+		t.Fatalf("previous cycle no longer meets the confirmed transition: %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open accuracy-upgrade database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count accuracy-upgrade cycles: %v", err)
+	}
+	if cycleCount != 2 {
+		t.Fatalf("accuracy-upgrade cycle count = %d, want 2", cycleCount)
+	}
+}
+
+func TestQuotaLifecycleExpiredBoundaryEvidenceCannotCreateStaleResetCycle(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	firstStartMS := quotaLifecycleBaseMS
+	firstEndMS := firstStartMS + durationSeconds*1000
+	freshStartMS := firstStartMS + 3*quotaLifecycleHourMS
+	freshEndMS := freshStartMS + durationSeconds*1000
+	refreshAtMS := firstEndMS + quotaLifecycleHourMS
+	staleAtMS := refreshAtMS + 10*60*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, staleAtMS+50*60*1000)
+
+	first := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 40)
+	writeQuotaLifecycleObservation(t, service, "complete", firstStartMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	fresh := quotaLifecycleFixedWindow("five-hour", "five_hour", freshStartMS, durationSeconds, 45)
+	fresh.Source = "response_header"
+	fresh.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-expired-refresh", "codex:quota-windows",
+			refreshAtMS, []WindowInput{fresh},
+		),
+	}}); err != nil {
+		t.Fatalf("write fresh overlapping observation: %v", err)
+	}
+	refreshed := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if refreshed.CurrentCycle == nil || refreshed.CurrentCycle.ScheduledStartMS == nil ||
+		*refreshed.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		refreshed.CurrentCycle.ScheduledEndMS == nil || *refreshed.CurrentCycle.ScheduledEndMS != freshEndMS ||
+		refreshed.CurrentCycle.BoundaryAccuracy != "derived" || refreshed.Stale {
+		t.Fatalf("fresh derived boundary was not refreshed: %#v", refreshed)
+	}
+
+	stale := quotaLifecycleFixedWindow("five-hour", "five_hour", firstStartMS, durationSeconds, 1)
+	stale.Source = "api_query"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-stale-reset-evidence", "codex:quota-windows",
+			staleAtMS, []WindowInput{stale},
+		),
+	}}); err != nil {
+		t.Fatalf("write stale expired observation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.PreviousCycle == nil {
+		t.Fatalf("stale boundary evidence did not reconcile a reset: %#v", window)
+	}
+	if window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != freshStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != freshEndMS {
+		t.Fatalf("stale boundary drove the reset cycle timing: %#v", window.CurrentCycle)
+	}
+	if window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != staleAtMS ||
+		window.CurrentCycle.ActualStartMS != staleAtMS {
+		t.Fatalf("canonicalized counter reset transition = %#v", window)
+	}
+	if window.PreviousCycle.ActualStartMS >= *window.PreviousCycle.ActualEndMS {
+		t.Fatalf("zero-length reset fragment = %#v", window.PreviousCycle)
+	}
+	if window.Stale {
+		t.Fatalf("current cycle is stale after canonicalized reset: %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open stale-reset database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count stale-reset cycles: %v", err)
+	}
+	if cycleCount != 2 {
+		t.Fatalf("stale-reset cycle count = %d, want 2", cycleCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

A fixed/calendar quota cycle whose stored scheduled end had already passed kept overriding fresh provider evidence: a manual refresh flashed the correct reset time and then reverted to the old reset time flagged as a stale snapshot. When a confirmed fresh boundary with the same duration is observed at or after the stored scheduled end and still covers the observation time, the active cycle is now refreshed in place. Follow-up review fixes harden this with temporal-validity guards, reset-transition preservation, stale-evidence canonicalization, authority/coverage gates on counter-reset reconciliation, and a stale-backward replacement guard.

> Community and maintenance PRs must target `dev`. Repository automation
> retargets other pull requests to `dev`; this can change the diff and make
> existing review comments outdated. `main` accepts only a promotion PR whose
> source is this repository's `dev` branch.

## Scope

- [x] Manager Server
- [ ] Frontend panel
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `cycleBoundaryShouldRefreshExpiredCurrent` to `reconcileCycle`: a temporal-validity correction that updates the active fixed/calendar cycle boundary in place when a confirmed snapshot (exact/derived, non-provisional) with the same duration is observed at or after the stored scheduled end while its own cycle end still covers the observation time. Accuracy rank is intentionally not compared: an expired exact boundary cannot outrank a fresh confirmed derived one.
- Add `cycleBoundaryIsTemporallyInvalidAgainstActive` as the shared temporal predicate and `cycleBoundaryCanReplaceActive` for active-cycle replacement: an incoming higher-accuracy boundary cannot replace the active cycle while the stored scheduled end still covers the observation time and the incoming end is already expired. A later expired exact observation can no longer drag a fresh derived current boundary back into the past. Closed-cycle restore (`restoreOrInsertCycle`) keeps the original pure accuracy comparison.
- Every active-cycle boundary update preserves an independently established `actual_start_ms` (`correctedActiveCycleActualStart`), not only the expired-refresh path: a confirmed counter-reset transition (where `actual_start_ms != scheduled_start_ms`) survives subsequent accuracy upgrades, keeping `previous.actual_end_ms == current.actual_start_ms` without gap or overlap.
- Temporally invalid incoming boundaries are canonicalized to the current active boundary before counter-reset reconciliation: a stale expired observation keeps its counter drop (real reset evidence) but can no longer drive reset timing, so it cannot create an immediately stale reset cycle or a zero-length fragment. Counter reset remains higher priority than the expired-boundary correction.
- Preserve the incoming boundary's original lifecycle authority across canonicalization (`incomingBoundaryConfirmed` captured before the mutation). Replacing stale timing geometry with the active boundary cannot promote estimated/unknown evidence into confirmed exact/derived lifecycle evidence, so unreliable stale boundaries can no longer gain counter-reset transition authority through geometry correction.
- Counter-reset reconciliation now requires the post-canonicalization boundary to still cover the observation time (`cycleBoundaryCoversObservation`). If both the active boundary and the incoming boundary are already expired, the usage drop is retained as observation evidence but cannot split lifecycle state into a zero-length or immediately stale cycle. This does not reconstruct expired cycles: a legitimately stale boundary with a counter drop against a still-current active boundary keeps resetting onto the canonical current boundary as before.
- Prevent an already-expired, materially older boundary from replacing a newer active boundary solely because its accuracy rank is higher (`cycleBoundaryWouldRegressExpiredActive`, applied in `cycleBoundaryCanReplaceActive`). This closes the remaining post-expiry rollback path where a stale exact API observation could move a previously refreshed derived boundary back into the past. Differences within `quotaBoundaryJitterMS` remain the same canonical provider boundary and keep qualifying for precision upgrades. The guard only affects active-cycle replacement; counter-reset eligibility, pre-reset canonicalization, closed-cycle restore, scheduled rollover, and provisional-zero handling are unchanged.
- Wire the refresh into the existing `cycleMatches` and boundary-upgrade branches after counter-reset detection, reusing the current update SQL. Cycle identity is preserved; no rollover, reset, extra cycle, or previous-cycle change is introduced, and counter-reset/provisional-zero precedence is untouched.
- Add regression tests: exact and derived fresh boundaries repairing an expired cycle (same cycle ID, single `account_quota_cycles` row, `stale=false`); the pre-expiry conservative guard that still rejects a shifted boundary observed before the scheduled end; rejection of a later expired exact observation against a fresh current derived boundary; preservation of a confirmed reset transition across an expired-boundary refresh and across a subsequent ordinary accuracy upgrade (2 cycles, adjacent transition, no third cycle); a stale expired boundary with a strong counter drop that still resets onto the canonical current boundary (no stale reset cycle, no zero-length fragment); an unreliable (estimated) stale boundary that cannot gain reset authority through canonicalization; an extended post-expiry regression asserting the scheduled/actual boundary and accuracy themselves remain unchanged and that a subsequent fresh overlapping boundary refreshes the same cycle in place rather than being misclassified as a scheduled rollover; a jitter regression pinning that a higher-accuracy correction within `quotaBoundaryJitterMS` still upgrades; and a calendar-mode regression mirroring the fixed-window refresh scenario so the declared fixed/calendar contract is locked on both modes (test-only: it passes against the current implementation without production changes).

## User Impact

After a manual refresh (or any new quota observation) that lands at or after the current cycle's stored end, the quota panel keeps the provider's current reset time instead of flashing it and reverting to the expired reset time with a snapshot-expired warning — for both fixed and calendar quota windows. The correction is stable: later out-of-order, lagged, or unreliable higher-accuracy evidence can no longer revert or rewind it, confirmed reset transitions remain intact, and the next genuinely fresh boundary keeps refreshing the same cycle instead of being misrouted into a rollover.

## Compatibility / Runtime Notes

- CPA panel mode: quota windows are served by the same Manager Server lifecycle, so refreshed boundaries surface correctly here as well; no panel-only changes.
- Manager Server mode: reconcile behavior changes only for the expired-boundary case and its guards; auth, setup, proxy, and collector flows are untouched. Flat quota API field semantics are unchanged.
- Full Docker / native packages: no packaging, config, or startup changes. Previously stored wrong boundaries are corrected lazily by the next normal quota observation or manual refresh; no startup scan.

## Data / Security Notes

No schema, migration, or data backfill. No new tables or columns; existing `account_quota_cycles` rows are updated in place with provider-confirmed boundaries. No admin keys, CPA Management Keys, usage data, or logs touched.

## Risk / Rollback

Risk level: Medium

Rollback notes: revert the six commits. Boundaries already rewritten after rollout remain valid provider evidence, and preserved reset transitions keep their lifecycle meaning, so no cleanup task or manual database maintenance is required in either direction.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence (run on the latest dev baseline, merge-base `ed46b46c`):

```text
cd apps/manager-server
go test ./internal/service/quotasnapshot    # ok, includes regression tests (red before each fix, green after; calendar test green as-is)
go test ./internal/repository/quotasnapshot # ok
go test ./internal/usageidentity            # ok
go test ./...                               # 57 packages ok, no failures
go test -race ./internal/service/quotasnapshot ./internal/repository/quotasnapshot  # ok
go vet ./internal/repository/quotasnapshot/ ./internal/service/quotasnapshot/       # clean
gofmt -l internal/repository/quotasnapshot internal/service/quotasnapshot           # no output
```

State machine re-checked against the twelve review scenarios: expired+exact-current refresh (A), expired+derived-current refresh (B), expired exact rejected against current derived (C), conservative pre-expiry keep (D), reset transition preserved across scheduled correction (E), counter reset outranking expired refresh (F), accuracy upgrade after a preserved transition keeps the transition (G), a stale expired boundary with counter evidence canonicalized before reset reconciliation (H), an unreliable stale boundary that cannot gain reset authority through canonicalization (I), a stale boundary observed after the active cycle's own expiry that cannot split or rewind the lifecycle (J), the full stale-then-fresh chain where the next fresh overlapping boundary refreshes the same cycle in place without a false scheduled rollover (K), and a calendar expired cycle refreshed in place by a fresh confirmed overlapping calendar boundary (L).

Frontend type-check/lint/build were skipped: backend-only change, no frontend files touched.

## Screenshots / Recordings

N/A — backend-only change; no visible UI surface changed.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: bug fix restoring intended quota reset-time display behavior; no user-visible capability, configuration, or workflow added.

## Related

N/A