### PR TITLE
fix(web): keep fallback API key groups out of client filters

### DIFF
--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.test.tsx
@@ -828,6 +828,43 @@ describe('UsageAnalyticsPage', () => {
     expect(text).not.toContain('usage_analytics.common_views_title');
   });
 
+  it('excludes fallback API key IDs from API key filter options', () => {
+    mocks.usageState = createUsageState({
+      filterOptions: {
+        models: ['gpt-4o'],
+        api_key_hashes: [' real-filter-hash ', 'unknown-client-api-key:filter-option'],
+        api_key_stats: [
+          {
+            id: 'unknown-client-api-key:stats-row',
+            api_key_hash: '',
+          },
+        ],
+        providers: ['openai'],
+        auth_files: ['auth.json'],
+      },
+      apiKeyRows: [
+        createRankRow({
+          id: 'real-row-hash',
+          label: 'Real API key',
+          apiKeyHash: 'real-row-hash',
+        }),
+        createRankRow({
+          id: 'unknown-client-api-key:rank-row',
+          label: 'Unknown client API key',
+          apiKeyHash: 'unknown-client-api-key:rank-row',
+        }),
+      ],
+    });
+    const renderer = renderPage();
+    const apiKeySelect = renderer.root
+      .findAllByType(Select)
+      .find((node) => node.props.ariaLabel === 'usage_analytics.filter_api_key');
+
+    const values = apiKeySelect?.props.options.map((option: { value: string }) => option.value);
+    expect(values).toEqual(expect.arrayContaining(['all', 'real-filter-hash', 'real-row-hash']));
+    expect(values).toHaveLength(3);
+  });
+
   it('does not render selected filter chips for active filters', () => {
     mocks.usageState = createUsageState({
       filters: {
@@ -878,6 +915,51 @@ describe('UsageAnalyticsPage', () => {
     expect(event.stopPropagation).toHaveBeenCalledTimes(1);
     expect(mocks.copyToClipboard).toHaveBeenCalledWith('sk-client-key-original');
     expect(usageState.setSelectedApiKeyHash).not.toHaveBeenCalled();
+  });
+
+  it('keeps fallback API key rows visible without filter or drilldown actions', () => {
+    const fallbackRow = createRankRow({
+      id: 'unknown-client-api-key:rank-row',
+      label: 'Unknown client API key',
+      apiKeyHash: 'unknown-client-api-key:rank-row',
+      model: undefined,
+      contexts: [],
+      models: [],
+    });
+    const usageState = createUsageState({
+      activeTab: 'apiKeys',
+      apiKeyRows: [fallbackRow],
+      selectedApiKey: fallbackRow,
+      keyAnomalies: [
+        {
+          id: fallbackRow.id,
+          label: fallbackRow.label,
+          severity: 'medium',
+          reasonKey: 'usage_analytics.anomaly_reason_error_rate',
+          triggeredAtMs: 1_780_000_000_000,
+          row: fallbackRow,
+        },
+      ],
+    });
+    mocks.usageState = usageState;
+    const renderer = renderPage();
+    const rankRow = renderer.root
+      .findAllByType('tr')
+      .find((node) => getText(node).includes('Unknown client API key'));
+    if (!rankRow) throw new Error('Fallback API key rank row not found');
+
+    act(() => {
+      rankRow.props.onClick();
+    });
+
+    expect(getText(renderer.root)).toContain('Unknown client API key');
+    expect(usageState.setSelectedApiKeyHash).not.toHaveBeenCalled();
+    expect(
+      renderer.root
+        .findAllByType('button')
+        .filter((node) => getText(node).includes('usage_analytics.view_request_details'))
+    ).toHaveLength(0);
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it('renders the API Key tab with key-dimension cards, unit-economics columns, and anomaly drilldown', () => {
@@ -950,11 +1032,13 @@ describe('UsageAnalyticsPage', () => {
       selectedApiKeyTrendSeries: [],
     });
     const renderer = renderPage();
-    const rankSection = renderer.root.findAllByType('section').find((section) =>
-      section
-        .findAllByType('h2')
-        .some((heading) => getText(heading) === 'usage_analytics.api_key_rank_title')
-    );
+    const rankSection = renderer.root
+      .findAllByType('section')
+      .find((section) =>
+        section
+          .findAllByType('h2')
+          .some((heading) => getText(heading) === 'usage_analytics.api_key_rank_title')
+      );
     if (!rankSection) throw new Error('API key rank section not found');
     const rankBody = rankSection.findAllByType('tbody')[0];
     if (!rankBody) throw new Error('API key rank body not found');
@@ -993,11 +1077,13 @@ describe('UsageAnalyticsPage', () => {
       selectedApiKeyTrendSeries: [],
     });
     const renderer = renderPage();
-    const rankSection = renderer.root.findAllByType('section').find((section) =>
-      section
-        .findAllByType('h2')
-        .some((heading) => getText(heading) === 'usage_analytics.api_key_rank_title')
-    );
+    const rankSection = renderer.root
+      .findAllByType('section')
+      .find((section) =>
+        section
+          .findAllByType('h2')
+          .some((heading) => getText(heading) === 'usage_analytics.api_key_rank_title')
+      );
     if (!rankSection) throw new Error('API key rank section not found');
     const rankBody = rankSection.findAllByType('tbody')[0];
     if (!rankBody) throw new Error('API key rank body not found');

--- a/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
+++ b/apps/web/src/features/usage-analytics/UsageAnalyticsPage.tsx
@@ -47,6 +47,7 @@ import {
   formatHeatmapMetricValue,
   formatLocalDateTime,
   formatMetricValue,
+  getSelectableApiKeyHash,
   getUsageCacheTokens,
   hasUsageData,
   maskApiKeyHash,
@@ -2083,11 +2084,13 @@ function EntityTrendChart({
 }
 
 function KeyAnomalyTable({
+  canOpen,
   locale,
   rows,
   onOpen,
   type = 'apiKey',
 }: {
+  canOpen?: (row: UsageKeyAnomalyRow) => boolean;
   locale: string;
   rows: UsageKeyAnomalyRow[];
   onOpen?: (row: UsageKeyAnomalyRow) => void;
@@ -2120,27 +2123,42 @@ function KeyAnomalyTable({
               <td colSpan={onOpen ? 7 : 6}>{t('usage_analytics.anomaly_none')}</td>
             </tr>
           ) : (
-            rows.slice(0, 8).map((row) => (
-              <tr key={row.id}>
-                <td>{type === 'credential' ? row.label : getApiKeyRowDisplayLabel(row.row)}</td>
-                <td>{t(row.reasonKey)}</td>
-                <td>
-                  <span className={`${styles.severityBadge} ${styles[`severity${row.severity}`]}`}>
-                    {t(`usage_analytics.severity_${row.severity}`)}
-                  </span>
-                </td>
-                <td>{row.triggeredAtMs ? formatLocalDateTime(row.triggeredAtMs, locale) : '-'}</td>
-                <td>{formatMetricValue('estimatedCost', row.row.estimatedCost)}</td>
-                <td>{formatPercent(row.row.failureCount / Math.max(row.row.requestCount, 1))}</td>
-                {onOpen ? (
+            rows.slice(0, 8).map((row) => {
+              const rowCanOpen = Boolean(onOpen && (canOpen?.(row) ?? true));
+              return (
+                <tr key={row.id}>
+                  <td>{type === 'credential' ? row.label : getApiKeyRowDisplayLabel(row.row)}</td>
+                  <td>{t(row.reasonKey)}</td>
                   <td>
-                    <button type="button" className={styles.linkButton} onClick={() => onOpen(row)}>
-                      {t('usage_analytics.view_request_details')}
-                    </button>
+                    <span
+                      className={`${styles.severityBadge} ${styles[`severity${row.severity}`]}`}
+                    >
+                      {t(`usage_analytics.severity_${row.severity}`)}
+                    </span>
                   </td>
-                ) : null}
-              </tr>
-            ))
+                  <td>
+                    {row.triggeredAtMs ? formatLocalDateTime(row.triggeredAtMs, locale) : '-'}
+                  </td>
+                  <td>{formatMetricValue('estimatedCost', row.row.estimatedCost)}</td>
+                  <td>{formatPercent(row.row.failureCount / Math.max(row.row.requestCount, 1))}</td>
+                  {onOpen ? (
+                    <td>
+                      {rowCanOpen ? (
+                        <button
+                          type="button"
+                          className={styles.linkButton}
+                          onClick={() => onOpen(row)}
+                        >
+                          {t('usage_analytics.view_request_details')}
+                        </button>
+                      ) : (
+                        '-'
+                      )}
+                    </td>
+                  ) : null}
+                </tr>
+              );
+            })
           )}
         </tbody>
       </table>
@@ -2345,20 +2363,21 @@ function UsageAnalyticsPageInner() {
 
   const incomingOptionCache = useMemo<StableUsageOptionCache>(() => {
     const apiKeys = mergeSelectOptions([
-      ...(usage.filterOptions?.api_key_hashes ?? []).map((hash) => ({
-        value: hash,
-        label: resolveUsageApiKeyLabel(hash, usage.apiKeyDisplayMap),
-      })),
-      ...(usage.filterOptions?.api_key_stats ?? []).map((row) => {
-        const hash = row.api_key_hash || row.id;
-        return {
-          value: hash,
-          label: resolveUsageApiKeyLabel(hash, usage.apiKeyDisplayMap),
-        };
+      ...(usage.filterOptions?.api_key_hashes ?? []).flatMap((value) => {
+        const hash = getSelectableApiKeyHash(value);
+        return hash
+          ? [{ value: hash, label: resolveUsageApiKeyLabel(hash, usage.apiKeyDisplayMap) }]
+          : [];
       }),
-      ...usage.apiKeyRows.map((row) => {
-        const hash = row.apiKeyHash || row.id;
-        return { value: hash, label: row.label };
+      ...(usage.filterOptions?.api_key_stats ?? []).flatMap((row) => {
+        const hash = getSelectableApiKeyHash(row.api_key_hash);
+        return hash
+          ? [{ value: hash, label: resolveUsageApiKeyLabel(hash, usage.apiKeyDisplayMap) }]
+          : [];
+      }),
+      ...usage.apiKeyRows.flatMap((row) => {
+        const hash = getSelectableApiKeyHash(row.apiKeyHash);
+        return hash ? [{ value: hash, label: row.label }] : [];
       }),
     ]);
 
@@ -2419,8 +2438,10 @@ function UsageAnalyticsPageInner() {
     },
     [showNotification, t]
   );
-  const buildApiKeyMonitoringUrl = (apiKeyHash: string, status?: UsageAnalyticsStatus) =>
-    usage.bounds
+  const buildApiKeyMonitoringUrl = (value: string, status?: UsageAnalyticsStatus) => {
+    const apiKeyHash = getSelectableApiKeyHash(value);
+    if (!apiKeyHash) return '';
+    return usage.bounds
       ? buildMonitoringDetailUrl(
           { bucketMs: usage.bounds.fromMs, bucketEndMs: usage.bounds.toMs },
           {
@@ -2430,6 +2451,7 @@ function UsageAnalyticsPageInner() {
           }
         )
       : `/monitoring?api_key_hash=${encodeURIComponent(apiKeyHash)}`;
+  };
   const buildCredentialMonitoringUrl = (
     row: Pick<UsageRankRow, 'authFile' | 'projectId'> | null | undefined,
     status?: UsageAnalyticsStatus
@@ -2448,7 +2470,7 @@ function UsageAnalyticsPageInner() {
           row?.projectId || ''
         )}`;
   const openApiKeyCombinationHeatmap = () => {
-    const apiKeyHash = usage.selectedApiKey?.apiKeyHash || usage.selectedApiKey?.id || '';
+    const apiKeyHash = getSelectableApiKeyHash(usage.selectedApiKey?.apiKeyHash);
     if (apiKeyHash) {
       updateFilters({ apiKeyHash });
     }
@@ -2469,28 +2491,28 @@ function UsageAnalyticsPageInner() {
       buildStableSelectOptions(allModelOptionLabel, displayOptionCache.models, usage.filters.model),
     [allModelOptionLabel, displayOptionCache.models, usage.filters.model]
   );
-  const apiKeyOptions = useMemo<SelectOption[]>(
-    () => [
+  const apiKeyOptions = useMemo<SelectOption[]>(() => {
+    const selectedApiKeyHash = getSelectableApiKeyHash(usage.filters.apiKeyHash);
+    return [
       { value: 'all', label: allApiKeyOptionLabel },
-      ...mergeSelectOptions(
-        [
-          ...displayOptionCache.apiKeys,
-          usage.filters.apiKeyHash !== 'all'
-            ? {
-                value: usage.filters.apiKeyHash,
-                label: resolveUsageApiKeyLabel(usage.filters.apiKeyHash, usage.apiKeyDisplayMap),
-              }
-            : null,
-        ].filter((option): option is SelectOption => Boolean(option?.value))
-      ),
-    ],
-    [
-      allApiKeyOptionLabel,
-      displayOptionCache.apiKeys,
-      usage.apiKeyDisplayMap,
-      usage.filters.apiKeyHash,
-    ]
-  );
+      ...mergeSelectOptions([
+        ...displayOptionCache.apiKeys,
+        ...(selectedApiKeyHash
+          ? [
+              {
+                value: selectedApiKeyHash,
+                label: resolveUsageApiKeyLabel(selectedApiKeyHash, usage.apiKeyDisplayMap),
+              },
+            ]
+          : []),
+      ]),
+    ];
+  }, [
+    allApiKeyOptionLabel,
+    displayOptionCache.apiKeys,
+    usage.apiKeyDisplayMap,
+    usage.filters.apiKeyHash,
+  ]);
   const providerOptions = useMemo<SelectOption[]>(
     () =>
       buildStableSelectOptions(
@@ -3225,7 +3247,10 @@ function UsageAnalyticsPageInner() {
                 rows={visibleApiKeyRows}
                 type="apiKey"
                 selectedId={usage.selectedApiKey?.apiKeyHash}
-                onSelect={(row) => usage.setSelectedApiKeyHash(row.apiKeyHash || row.id)}
+                onSelect={(row) => {
+                  const apiKeyHash = getSelectableApiKeyHash(row.apiKeyHash);
+                  if (apiKeyHash) usage.setSelectedApiKeyHash(apiKeyHash);
+                }}
                 onCopyApiKey={(row) => {
                   if (row.apiKeyCopyValue) void handleCopyApiKey(row.apiKeyCopyValue);
                 }}
@@ -3264,20 +3289,21 @@ function UsageAnalyticsPageInner() {
                 row={usage.selectedApiKey}
                 type="apiKey"
                 action={
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() =>
-                      navigate(
-                        buildApiKeyMonitoringUrl(
-                          usage.selectedApiKey?.apiKeyHash || usage.selectedApiKey?.id || ''
-                        )
-                      )
-                    }
-                  >
-                    <IconExternalLink size={14} />
-                    {t('usage_analytics.view_request_details')}
-                  </Button>
+                  getSelectableApiKeyHash(usage.selectedApiKey.apiKeyHash) ? (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        const target = buildApiKeyMonitoringUrl(
+                          usage.selectedApiKey?.apiKeyHash || ''
+                        );
+                        if (target) navigate(target);
+                      }}
+                    >
+                      <IconExternalLink size={14} />
+                      {t('usage_analytics.view_request_details')}
+                    </Button>
+                  ) : undefined
                 }
               />
             ) : null}
@@ -3289,18 +3315,18 @@ function UsageAnalyticsPageInner() {
                 </button>
               </div>
               <KeyAnomalyTable
+                canOpen={(row) => Boolean(getSelectableApiKeyHash(row.row.apiKeyHash))}
                 rows={usage.keyAnomalies}
                 locale={i18n.language}
-                onOpen={(row) =>
-                  navigate(
-                    buildApiKeyMonitoringUrl(
-                      row.row.apiKeyHash || row.id,
-                      row.reasonKey === 'usage_analytics.anomaly_reason_error_rate'
-                        ? 'failed'
-                        : usage.filters.status
-                    )
-                  )
-                }
+                onOpen={(row) => {
+                  const target = buildApiKeyMonitoringUrl(
+                    row.row.apiKeyHash || '',
+                    row.reasonKey === 'usage_analytics.anomaly_reason_error_rate'
+                      ? 'failed'
+                      : usage.filters.status
+                  );
+                  if (target) navigate(target);
+                }}
               />
             </div>
           </section>

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.test.ts
@@ -38,6 +38,7 @@ import {
   computeRowCacheHitRate,
   getUsageCacheTokens,
   getUsageRangeBounds,
+  getSelectableApiKeyHash,
   maskApiKeyHash,
   resolveUsageGranularity,
   USAGE_ANALYTICS_DEFAULT_FILTERS,
@@ -73,6 +74,22 @@ const expectZeroTimelinePoint = (point: UsageTimelinePoint) => {
 };
 
 describe('usage analytics request model', () => {
+  it('keeps synthetic fallback groups out of API key filters', () => {
+    expect(getSelectableApiKeyHash('unknown-client-api-key:source:auth:provider')).toBe('');
+    expect(getSelectableApiKeyHash(' UNKNOWN-CLIENT-API-KEY:legacy ')).toBe('');
+    expect(getSelectableApiKeyHash('all')).toBe('');
+    expect(getSelectableApiKeyHash(' ABCDEF1234567890 ')).toBe('abcdef1234567890');
+    expect(
+      buildUsageAnalyticsFilters({ apiKeyHash: 'unknown-client-api-key:analytics-filter' })
+    ).not.toHaveProperty('api_key_hashes');
+    expect(
+      buildMonitoringDetailUrl(
+        { bucketMs: 1000, bucketEndMs: 2000 },
+        { apiKeyHash: 'unknown-client-api-key:monitoring-link' }
+      )
+    ).not.toContain('api_key_hash');
+  });
+
   it('resolves time ranges and default granularity rules', () => {
     expect(USAGE_ANALYTICS_DEFAULT_FILTERS.timeRange).toBe('24h');
     expect(getUsageRangeBounds({ timeRange: '24h', customRange: null }, NOW_MS)).toEqual({
@@ -1027,11 +1044,13 @@ describe('usage analytics adapters', () => {
       createRow('key-c', 50, 20),
     ]);
 
-    expect(rows.map(({ apiKeyHash, requestCount, estimatedCost }) => ({
-      apiKeyHash,
-      requestCount,
-      estimatedCost,
-    }))).toEqual([
+    expect(
+      rows.map(({ apiKeyHash, requestCount, estimatedCost }) => ({
+        apiKeyHash,
+        requestCount,
+        estimatedCost,
+      }))
+    ).toEqual([
       { apiKeyHash: 'key-b', requestCount: 100, estimatedCost: 20 },
       { apiKeyHash: 'key-c', requestCount: 50, estimatedCost: 20 },
       { apiKeyHash: 'key-a', requestCount: 1000, estimatedCost: 1 },

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -1928,9 +1928,10 @@ export const buildEntityTrendSeries = (
   rows: UsageRankRow[],
   timeline: UsageTimelinePoint[],
   metric: UsageTrendMetricKey,
-  limit = 4
+  limit = 4,
+  shareRows = rows
 ): UsageEntityTrendSeries[] => {
-  const total = sumUsageRows(rows, metric);
+  const total = sumUsageRows(shareRows, metric);
   const colors = ['#2563eb', '#0ea5a7', '#f59e0b', '#ef4444', '#64748b'];
   return rows
     .filter((row) => usageRankMetricValue(row, metric) > 0)

--- a/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
+++ b/apps/web/src/features/usage-analytics/usageAnalyticsModel.ts
@@ -608,6 +608,13 @@ const isActiveSelectValue = (value: string | null | undefined) => {
 
 const normalizeLowerSelectValue = (value: string) => value.trim().toLowerCase();
 
+const UNKNOWN_CLIENT_API_KEY_PREFIX = 'unknown-client-api-key:';
+
+export const getSelectableApiKeyHash = (value: string | null | undefined) => {
+  const hash = normalizeLowerSelectValue(String(value ?? ''));
+  return hash && hash !== 'all' && !hash.startsWith(UNKNOWN_CLIENT_API_KEY_PREFIX) ? hash : '';
+};
+
 export const padDateUnit = (value: number) => String(value).padStart(2, '0');
 
 export const formatDateTimeLocalValue = (date: Date) =>
@@ -735,14 +742,14 @@ export const buildUsageAnalyticsFilters = (
 ): MonitoringAnalyticsFilters => {
   const payload: MonitoringAnalyticsFilters = {};
   const model = filters.model ?? 'all';
-  const apiKeyHash = filters.apiKeyHash ?? 'all';
+  const apiKeyHash = getSelectableApiKeyHash(filters.apiKeyHash);
   const provider = filters.provider ?? 'all';
   const authFile = filters.authFile ?? 'all';
   if (isActiveSelectValue(model)) {
     payload.models = [model.trim()];
   }
-  if (isActiveSelectValue(apiKeyHash)) {
-    payload.api_key_hashes = [normalizeLowerSelectValue(apiKeyHash)];
+  if (apiKeyHash) {
+    payload.api_key_hashes = [apiKeyHash];
   }
   if (isActiveSelectValue(provider)) {
     payload.providers = [normalizeLowerSelectValue(provider)];
@@ -2741,7 +2748,7 @@ export const buildMonitoringDetailUrl = (
   params.set('from_ms', String(point.bucketMs));
   params.set('to_ms', String(point.bucketEndMs));
   const model = filters.model ?? 'all';
-  const apiKeyHash = filters.apiKeyHash ?? 'all';
+  const apiKeyHash = getSelectableApiKeyHash(filters.apiKeyHash);
   const provider = filters.provider ?? 'all';
   const authFile = filters.authFile ?? 'all';
   const searchQuery = filters.searchQuery ?? '';
@@ -2750,8 +2757,8 @@ export const buildMonitoringDetailUrl = (
   if (isActiveSelectValue(model)) {
     params.set('model', model.trim());
   }
-  if (isActiveSelectValue(apiKeyHash)) {
-    params.set('api_key_hash', normalizeLowerSelectValue(apiKeyHash));
+  if (apiKeyHash) {
+    params.set('api_key_hash', apiKeyHash);
   }
   if (isActiveSelectValue(provider)) {
     params.set('provider', normalizeLowerSelectValue(provider));

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -7,6 +7,7 @@ import {
   type UseMonitoringAnalyticsParams,
   type UseMonitoringAnalyticsReturn,
 } from '@/features/monitoring/hooks/useMonitoringAnalytics';
+import type { MonitoringAnalyticsApiKeyStatRow } from '@/services/api/usageService';
 import { useUsageAnalytics } from './useUsageAnalytics';
 
 vi.mock('@/features/monitoring/hooks/useMonitoringAnalytics', () => ({
@@ -35,6 +36,27 @@ const emptyAnalyticsResponse = {
 };
 const HOUR_MS = 60 * 60 * 1000;
 
+const createApiKeyStatRow = (
+  overrides: Partial<MonitoringAnalyticsApiKeyStatRow> = {}
+): MonitoringAnalyticsApiKeyStatRow => ({
+  id: 'key-a',
+  api_key_hash: 'key-a',
+  calls: 6,
+  success_calls: 6,
+  failure_calls: 0,
+  success_rate: 1,
+  input_tokens: 600,
+  output_tokens: 0,
+  cached_tokens: 0,
+  cache_read_tokens: 0,
+  cache_creation_tokens: 0,
+  total_tokens: 600,
+  cost: 0.6,
+  average_latency_ms: null,
+  last_seen_ms: 1,
+  ...overrides,
+});
+
 const localHourStartMs = (timestampMs: number) => {
   const date = new Date(timestampMs);
   date.setMinutes(0, 0, 0);
@@ -47,6 +69,7 @@ describe('useUsageAnalytics request orchestration', () => {
   let selectorError = '';
   let credentialTimelineError = '';
   let credentialTimelineLoading = false;
+  let apiKeyStats: MonitoringAnalyticsApiKeyStatRow[] = [createApiKeyStatRow()];
   const mainRefresh = vi.fn();
   const selectorRefresh = vi.fn();
   const auxiliaryRefresh = vi.fn();
@@ -102,25 +125,7 @@ describe('useUsageAnalytics request orchestration', () => {
                 failure: 0,
               },
             ],
-            api_key_stats: [
-              {
-                id: 'key-a',
-                api_key_hash: 'key-a',
-                calls: 6,
-                success_calls: 6,
-                failure_calls: 0,
-                success_rate: 1,
-                input_tokens: 600,
-                output_tokens: 0,
-                cached_tokens: 0,
-                cache_read_tokens: 0,
-                cache_creation_tokens: 0,
-                total_tokens: 600,
-                cost: 0.6,
-                average_latency_ms: null,
-                last_seen_ms: 1,
-              },
-            ],
+            api_key_stats: apiKeyStats,
           }
         : emptyAnalyticsResponse;
     return {
@@ -204,6 +209,7 @@ describe('useUsageAnalytics request orchestration', () => {
     selectorError = '';
     credentialTimelineError = '';
     credentialTimelineLoading = false;
+    apiKeyStats = [createApiKeyStatRow()];
     latestResult = null;
     mainRefresh.mockReset();
     selectorRefresh.mockReset();
@@ -217,10 +223,10 @@ describe('useUsageAnalytics request orchestration', () => {
     renderer = null;
   });
 
-  const renderHook = async () => {
+  const renderHook = async (initialEntry = '/usage-analytics') => {
     await act(async () => {
       renderer = create(
-        <MemoryRouter initialEntries={['/usage-analytics']}>
+        <MemoryRouter initialEntries={[initialEntry]}>
           <Harness />
         </MemoryRouter>
       );
@@ -303,9 +309,9 @@ describe('useUsageAnalytics request orchestration', () => {
       activeTab: 'overview',
       apiKeyHashes: ['key-a'],
     });
-    expect(latestResult?.apiKeyTrendSeries[0].points.slice(0, 3).map((point) => point.value)).toEqual(
-      [2, 0, 4]
-    );
+    expect(
+      latestResult?.apiKeyTrendSeries[0].points.slice(0, 3).map((point) => point.value)
+    ).toEqual([2, 0, 4]);
 
     await act(async () => {
       latestResult?.setActiveTab('trends');
@@ -317,6 +323,67 @@ describe('useUsageAnalytics request orchestration', () => {
       activeTab: 'trends',
       apiKeyHashes: ['key-a'],
     });
+  });
+
+  it('never uses fallback API key IDs for default selections or timeline requests', async () => {
+    apiKeyStats = [
+      createApiKeyStatRow({
+        id: 'unknown-client-api-key:missing-client-key',
+        api_key_hash: '',
+      }),
+      createApiKeyStatRow({ id: 'real-key-row', api_key_hash: ' real-key-hash ' }),
+    ];
+    await renderHook();
+
+    const overviewTimeline = lastParams((params) => Boolean(params.include?.api_key_timeline));
+    expect(overviewTimeline?.filters).toMatchObject({ api_key_hashes: ['real-key-hash'] });
+    expect(latestResult?.selectedApiKey?.apiKeyHash).toBe('real-key-hash');
+
+    await act(async () => {
+      latestResult?.setActiveTab('apiKeys');
+      await Promise.resolve();
+    });
+
+    const selectedTimeline = lastParams(
+      (params) => Boolean(params.include?.timeline) && !params.include?.summary
+    );
+    expect(selectedTimeline?.filters).toMatchObject({ api_key_hashes: ['real-key-hash'] });
+
+    await act(async () => {
+      latestResult?.setSelectedApiKeyHash('unknown-client-api-key:missing-client-key');
+      await Promise.resolve();
+    });
+
+    const fallbackSelectionTimeline = lastParams(
+      (params) => Boolean(params.include?.timeline) && !params.include?.summary
+    );
+    expect(fallbackSelectionTimeline?.filters).toMatchObject({ api_key_hashes: ['real-key-hash'] });
+    expect(latestResult?.selectedApiKey?.apiKeyHash).toBe('real-key-hash');
+  });
+
+  it('omits an initial fallback API key filter from analytics requests', async () => {
+    await renderHook('/usage-analytics?api_key_hash=unknown-client-api-key%3Alegacy-filter');
+
+    const main = lastParams((params) => Boolean(params.include?.summary));
+    expect(main?.filters).not.toHaveProperty('api_key_hashes');
+  });
+
+  it('keeps a fallback-only aggregate visible without enabling a key timeline request', async () => {
+    apiKeyStats = [
+      createApiKeyStatRow({
+        id: 'unknown-client-api-key:missing-client-key',
+        api_key_hash: '',
+      }),
+    ];
+    await renderHook();
+
+    const selectedTimeline = lastParams(
+      (params) => Boolean(params.include?.timeline) && !params.include?.summary
+    );
+    expect(latestResult?.selectedApiKey?.id).toBe('unknown-client-api-key:missing-client-key');
+    expect(selectedTimeline?.fromMs).toBeUndefined();
+    expect(selectedTimeline?.toMs).toBeUndefined();
+    expect(selectedTimeline?.filters).not.toHaveProperty('api_key_hashes');
   });
 
   it('does not couple selector failures to the main page error and refreshes both requests', async () => {

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -70,6 +70,7 @@ describe('useUsageAnalytics request orchestration', () => {
   let credentialTimelineError = '';
   let credentialTimelineLoading = false;
   let apiKeyTimelineAvailable = true;
+  let mainTimelineBucketCalls = 5;
   let apiKeyStats: MonitoringAnalyticsApiKeyStatRow[] = [createApiKeyStatRow()];
   const mainRefresh = vi.fn();
   const selectorRefresh = vi.fn();
@@ -112,17 +113,17 @@ describe('useUsageAnalytics request orchestration', () => {
               {
                 bucket_ms: mainTimelineStartMs,
                 label: '00:00',
-                calls: 5,
-                tokens: 500,
-                success: 5,
+                calls: mainTimelineBucketCalls,
+                tokens: mainTimelineBucketCalls * 100,
+                success: mainTimelineBucketCalls,
                 failure: 0,
               },
               {
                 bucket_ms: mainTimelineStartMs + 2 * HOUR_MS,
                 label: '01:00',
-                calls: 5,
-                tokens: 500,
-                success: 5,
+                calls: mainTimelineBucketCalls,
+                tokens: mainTimelineBucketCalls * 100,
+                success: mainTimelineBucketCalls,
                 failure: 0,
               },
             ],
@@ -211,6 +212,7 @@ describe('useUsageAnalytics request orchestration', () => {
     credentialTimelineError = '';
     credentialTimelineLoading = false;
     apiKeyTimelineAvailable = true;
+    mainTimelineBucketCalls = 5;
     apiKeyStats = [createApiKeyStatRow()];
     latestResult = null;
     mainRefresh.mockReset();
@@ -415,6 +417,34 @@ describe('useUsageAnalytics request orchestration', () => {
     expect(latestResult?.apiKeyRows).toHaveLength(1);
     expect(latestResult?.apiKeyRows[0].id).toBe('unknown-client-api-key:missing-client-key');
     expect(latestResult?.apiKeyTrendSeries).toEqual([]);
+  });
+
+  it('uses complete API key totals for approximate trend shares while hiding fallback rows', async () => {
+    apiKeyStats = [
+      createApiKeyStatRow({
+        id: 'unknown-client-api-key:missing-client-key',
+        api_key_hash: '',
+        calls: 90,
+      }),
+      createApiKeyStatRow({
+        id: 'real-key-row',
+        api_key_hash: 'real-key-hash',
+        calls: 10,
+      }),
+    ];
+    mainTimelineBucketCalls = 50;
+    apiKeyTimelineAvailable = false;
+
+    await renderHook();
+
+    expect(latestResult?.apiKeyRows.map((row) => row.id)).toEqual([
+      'unknown-client-api-key:missing-client-key',
+      'real-key-hash',
+    ]);
+    expect(latestResult?.apiKeyTrendSeries.map((series) => series.id)).toEqual(['real-key-hash']);
+    expect(
+      latestResult?.apiKeyTrendSeries[0].points.slice(0, 3).map((point) => point.value)
+    ).toEqual([5, 0, 5]);
   });
 
   it('omits an initial fallback API key filter from analytics requests', async () => {

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.test.tsx
@@ -69,6 +69,7 @@ describe('useUsageAnalytics request orchestration', () => {
   let selectorError = '';
   let credentialTimelineError = '';
   let credentialTimelineLoading = false;
+  let apiKeyTimelineAvailable = true;
   let apiKeyStats: MonitoringAnalyticsApiKeyStatRow[] = [createApiKeyStatRow()];
   const mainRefresh = vi.fn();
   const selectorRefresh = vi.fn();
@@ -146,7 +147,7 @@ describe('useUsageAnalytics request orchestration', () => {
             }
         : main
           ? mainData
-          : apiKeyTimeline
+          : apiKeyTimeline && apiKeyTimelineAvailable
             ? {
                 ...emptyAnalyticsResponse,
                 api_key_timeline: [
@@ -209,6 +210,7 @@ describe('useUsageAnalytics request orchestration', () => {
     selectorError = '';
     credentialTimelineError = '';
     credentialTimelineLoading = false;
+    apiKeyTimelineAvailable = true;
     apiKeyStats = [createApiKeyStatRow()];
     latestResult = null;
     mainRefresh.mockReset();
@@ -359,6 +361,60 @@ describe('useUsageAnalytics request orchestration', () => {
     );
     expect(fallbackSelectionTimeline?.filters).toMatchObject({ api_key_hashes: ['real-key-hash'] });
     expect(latestResult?.selectedApiKey?.apiKeyHash).toBe('real-key-hash');
+  });
+
+  it('uses only real API keys for exact trend series while keeping a leading fallback rank row', async () => {
+    apiKeyStats = [
+      createApiKeyStatRow({
+        id: 'unknown-client-api-key:missing-client-key',
+        api_key_hash: '',
+        calls: 100,
+        cost: 100,
+      }),
+      ...['key-a', 'key-b', 'key-c', 'key-d'].map((apiKeyHash, index) =>
+        createApiKeyStatRow({
+          id: apiKeyHash,
+          api_key_hash: apiKeyHash,
+          calls: 10 - index,
+          cost: 10 - index,
+        })
+      ),
+    ];
+
+    await renderHook();
+
+    const apiKeyTimeline = lastParams((params) => Boolean(params.include?.api_key_timeline));
+    expect(latestResult?.apiKeyRows[0].id).toBe('unknown-client-api-key:missing-client-key');
+    expect(apiKeyTimeline?.filters).toMatchObject({
+      api_key_hashes: ['key-a', 'key-b', 'key-c', 'key-d'],
+    });
+    expect(latestResult?.apiKeyTrendSeries.map((series) => series.id)).toEqual([
+      'key-a',
+      'key-b',
+      'key-c',
+      'key-d',
+    ]);
+    expect(
+      latestResult?.apiKeyTrendSeries[0].points.slice(0, 3).map((point) => point.value)
+    ).toEqual([2, 0, 4]);
+  });
+
+  it('does not approximate fallback-only API key rows as trend series', async () => {
+    apiKeyStats = [
+      createApiKeyStatRow({
+        id: 'unknown-client-api-key:missing-client-key',
+        api_key_hash: '',
+        calls: 100,
+        cost: 100,
+      }),
+    ];
+    apiKeyTimelineAvailable = false;
+
+    await renderHook();
+
+    expect(latestResult?.apiKeyRows).toHaveLength(1);
+    expect(latestResult?.apiKeyRows[0].id).toBe('unknown-client-api-key:missing-client-key');
+    expect(latestResult?.apiKeyTrendSeries).toEqual([]);
   });
 
   it('omits an initial fallback API key filter from analytics requests', async () => {

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -35,6 +35,7 @@ import {
   buildUsageAnalyticsFilterSelectorsInclude,
   buildUsageAnalyticsInclude,
   buildUsageTimeline,
+  getSelectableApiKeyHash,
   getUsageRangeBounds,
   resolveUsageGranularity,
   USAGE_ANALYTICS_DEFAULT_FILTERS,
@@ -100,9 +101,10 @@ export function useUsageAnalytics() {
   const [initialUiState] = useState<UsageAnalyticsUiState>(() =>
     buildUsageAnalyticsUiStateFromSearchParams(searchParams, readUsageAnalyticsUiState())
   );
-  const [filters, setFiltersState] = useState<UsageAnalyticsFiltersState>(
-    () => initialUiState.filters
-  );
+  const [filters, setFiltersState] = useState<UsageAnalyticsFiltersState>(() => ({
+    ...initialUiState.filters,
+    apiKeyHash: getSelectableApiKeyHash(initialUiState.filters.apiKeyHash) || 'all',
+  }));
   const [activeTabState, setActiveTabState] = useState<UsageAnalyticsTab>(
     () => initialUiState.activeTab
   );
@@ -234,7 +236,14 @@ export function useUsageAnalytics() {
     () => resolveUsageGranularity(filters, nowMs),
     [filters, nowMs]
   );
-  const analyticsFilters = useMemo(() => buildUsageAnalyticsFilters(filters), [filters]);
+  const analyticsFilters = useMemo(
+    () =>
+      buildUsageAnalyticsFilters({
+        ...filters,
+        apiKeyHash: getSelectableApiKeyHash(filters.apiKeyHash) || 'all',
+      }),
+    [filters]
+  );
 
   useEffect(() => {
     const nextState = { activeTab: activeTabState, filters };
@@ -368,9 +377,7 @@ export function useUsageAnalytics() {
     if (activeTabState !== 'overview' && activeTabState !== 'trends') return [];
     return Array.from(
       new Set(
-        adapted.apiKeyRows
-          .map((row) => row.apiKeyHash || row.id)
-          .filter((value) => value.trim() !== '')
+        adapted.apiKeyRows.map((row) => getSelectableApiKeyHash(row.apiKeyHash)).filter(Boolean)
       )
     ).slice(0, API_KEY_TREND_SERIES_LIMIT);
   }, [activeTabState, adapted.apiKeyRows]);
@@ -463,7 +470,11 @@ export function useUsageAnalytics() {
   const selectedModel =
     adapted.modelRows.find((row) => row.id === selectedModelId) ?? adapted.modelRows[0] ?? null;
   const selectedApiKey =
-    adapted.apiKeyRows.find((row) => row.apiKeyHash === selectedApiKeyHash) ??
+    adapted.apiKeyRows.find((row) => {
+      const apiKeyHash = getSelectableApiKeyHash(row.apiKeyHash);
+      return Boolean(apiKeyHash) && apiKeyHash === selectedApiKeyHash;
+    }) ??
+    adapted.apiKeyRows.find((row) => Boolean(getSelectableApiKeyHash(row.apiKeyHash))) ??
     adapted.apiKeyRows[0] ??
     null;
   const selectedCredential =
@@ -493,7 +504,7 @@ export function useUsageAnalytics() {
           ),
     [adapted.apiKeyRows, adapted.timeline, apiKeyTimeline, hasExactAPIKeyTimeline, trendMetric]
   );
-  const selectedApiKeyFilterHash = selectedApiKey?.apiKeyHash || selectedApiKey?.id || '';
+  const selectedApiKeyFilterHash = getSelectableApiKeyHash(selectedApiKey?.apiKeyHash);
   const selectedApiKeyTimelineFilters = useMemo(
     () =>
       selectedApiKeyFilterHash
@@ -671,7 +682,13 @@ export function useUsageAnalytics() {
   );
   const setFilters = useCallback((patch: Partial<UsageAnalyticsFiltersState>) => {
     setFiltersState((current) => {
-      const next = { ...current, ...patch };
+      const next = {
+        ...current,
+        ...patch,
+        ...(patch.apiKeyHash === undefined
+          ? {}
+          : { apiKeyHash: getSelectableApiKeyHash(patch.apiKeyHash) || 'all' }),
+      };
       writeUsageAnalyticsUiState({ filters: next });
       return next;
     });
@@ -713,6 +730,10 @@ export function useUsageAnalytics() {
 
   const selectHeatmapDate = useCallback((key: string) => {
     setSelectedHeatmapDateKey(key || USAGE_HEATMAP_ALL_DATES_KEY);
+  }, []);
+
+  const selectApiKeyHash = useCallback((hash: string) => {
+    setSelectedApiKeyHash(getSelectableApiKeyHash(hash));
   }, []);
 
   const refresh = useCallback(() => {
@@ -810,7 +831,7 @@ export function useUsageAnalytics() {
     selectedModel,
     setSelectedModelId,
     selectedApiKey,
-    setSelectedApiKeyHash,
+    setSelectedApiKeyHash: selectApiKeyHash,
     selectedCredential,
     setSelectedCredentialId,
   };

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -373,14 +373,16 @@ export function useUsageAnalytics() {
       resolvedGranularity,
     ]
   );
+  const apiKeyTrendRows = useMemo(
+    () => adapted.apiKeyRows.filter((row) => Boolean(getSelectableApiKeyHash(row.apiKeyHash))),
+    [adapted.apiKeyRows]
+  );
   const apiKeyTrendHashes = useMemo(() => {
     if (activeTabState !== 'overview' && activeTabState !== 'trends') return [];
     return Array.from(
-      new Set(
-        adapted.apiKeyRows.map((row) => getSelectableApiKeyHash(row.apiKeyHash)).filter(Boolean)
-      )
+      new Set(apiKeyTrendRows.map((row) => getSelectableApiKeyHash(row.apiKeyHash)))
     ).slice(0, API_KEY_TREND_SERIES_LIMIT);
-  }, [activeTabState, adapted.apiKeyRows]);
+  }, [activeTabState, apiKeyTrendRows]);
   const apiKeyTrendFilters = useMemo(
     () =>
       apiKeyTrendHashes.length > 0
@@ -490,19 +492,19 @@ export function useUsageAnalytics() {
     () =>
       hasExactAPIKeyTimeline
         ? buildApiKeyTrendSeries(
-            adapted.apiKeyRows,
+            apiKeyTrendRows,
             adapted.timeline,
             apiKeyTimeline,
             trendMetric,
             API_KEY_TREND_SERIES_LIMIT
           )
         : buildEntityTrendSeries(
-            adapted.apiKeyRows,
+            apiKeyTrendRows,
             adapted.timeline,
             trendMetric,
             API_KEY_TREND_SERIES_LIMIT
           ),
-    [adapted.apiKeyRows, adapted.timeline, apiKeyTimeline, hasExactAPIKeyTimeline, trendMetric]
+    [apiKeyTimeline, apiKeyTrendRows, adapted.timeline, hasExactAPIKeyTimeline, trendMetric]
   );
   const selectedApiKeyFilterHash = getSelectableApiKeyHash(selectedApiKey?.apiKeyHash);
   const selectedApiKeyTimelineFilters = useMemo(

--- a/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
+++ b/apps/web/src/features/usage-analytics/useUsageAnalytics.ts
@@ -502,9 +502,17 @@ export function useUsageAnalytics() {
             apiKeyTrendRows,
             adapted.timeline,
             trendMetric,
-            API_KEY_TREND_SERIES_LIMIT
+            API_KEY_TREND_SERIES_LIMIT,
+            adapted.apiKeyRows
           ),
-    [apiKeyTimeline, apiKeyTrendRows, adapted.timeline, hasExactAPIKeyTimeline, trendMetric]
+    [
+      apiKeyTimeline,
+      apiKeyTrendRows,
+      adapted.apiKeyRows,
+      adapted.timeline,
+      hasExactAPIKeyTimeline,
+      trendMetric,
+    ]
   );
   const selectedApiKeyFilterHash = getSelectableApiKeyHash(selectedApiKey?.apiKeyHash);
   const selectedApiKeyTimelineFilters = useMemo(


### PR DESCRIPTION
## Summary

Keep synthetic fallback API key groups visible in usage aggregates without treating their internal row IDs as downstream client API key hashes. This prevents empty or misleading analytics, timeline, heatmap, and monitoring drilldown filters for historical events that lack a client key hash.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Centralize client-key selectability rules and enforce them in analytics payload and monitoring-link builders.
- Exclude synthetic fallback IDs from selector options, persisted filters, trends, heatmaps, and drilldown actions while retaining their aggregate rows.
- Cover mixed, stale-filter, and fallback-only datasets with model, hook, and rendered-page regressions.

## User Impact

The client API key selector now contains only real downstream key hashes. Historical fallback groups remain visible in usage rankings, but no longer expose key-specific actions that cannot return a valid result.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; usage analytics is Manager Server-backed.
- Manager Server mode: frontend-only behavior change; API contracts are unchanged.
- Full Docker / native packages: inherit the corrected bundled frontend without config changes.

## Data / Security Notes

No migration, historical rewrite, secret handling, or raw usage export changes. Synthetic IDs are recognized by their existing `unknown-client-api-key:` prefix.

## Risk / Rollback

Risk level: Low

Rollback notes: revert the single frontend commit. Stored events and aggregate data are untouched.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run type-check
npm run lint
  0 errors; one pre-existing react-refresh warning in AccountHealthBadge.tsx
npx -y node@24 ../../node_modules/vitest/vitest.mjs run src ../../tests
  213 files, 2788 tests passed
VERSION=dev npm run build
  single-file dist/index.html built successfully
```

## Screenshots / Recordings

Local demo mode was checked with the client API key selector open. Synthetic fallback behavior is additionally covered by rendered-page tests because the public demo fixtures intentionally contain only real client keys.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [x] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: bug fix only; no public capability or configuration change.

## Related

Fixes #656
