### PR TITLE
fix(accounts): hide stale quota from account list

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -7148,6 +7148,141 @@ describe('AccountsPage replacement flows', () => {
     expect(treeText(renderer)).not.toContain('SUM');
   });
 
+  it('does not render a stale persisted quota snapshot as current account-list quota', async () => {
+    const nowMs = Date.now();
+    const rowKey = 'codex.json\u0000auth-1';
+    mocks.files = [
+      {
+        ...makeCodexFile('codex.json', 'auth-1', 'codex@example.com'),
+        disabled: true,
+      } as AuthFileItem,
+    ];
+    mocks.location = {
+      pathname: '/accounts',
+      search: `?account=${encodeURIComponent(rowKey)}&tab=quota`,
+    };
+    mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(mocks.files[0], {
+      status: 'success',
+      fetchedAtMs: nowMs - 1_000,
+      quotaInventoryObserved: true,
+      windows: [
+        {
+          id: 'five-hour',
+          label: 'Five hours',
+          usedPercent: 20,
+          resetLabel: new Date(nowMs + 5 * 60 * 60 * 1000).toISOString(),
+          resetAtMs: nowMs + 5 * 60 * 60 * 1000,
+          resetAccuracy: 'exact',
+          limitWindowSeconds: 5 * 60 * 60,
+        },
+      ],
+    });
+    vi.mocked(accountQuotaSnapshotApi.query).mockResolvedValue({
+      generated_at_ms: nowMs,
+      items: [
+        {
+          row_key: rowKey,
+          account_key: rowKey,
+          provider: 'codex',
+          windows: [
+            {
+              provider_window_id: 'five-hour',
+              window_kind: 'five_hour',
+              window_mode: 'fixed',
+              model_scope_kind: 'all',
+              source: 'response_header',
+              observed_at_ms: nowMs,
+              boundary_accuracy: 'derived',
+              cycle_start_ms: nowMs - 5 * 60 * 60 * 1000,
+              cycle_end_ms: nowMs - 1,
+              duration_seconds: 5 * 60 * 60,
+              used_percent: 95,
+              remaining_percent: 5,
+              stale: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    await flushPromises();
+    await flushPromises();
+
+    const accountCard = findAccountCardByKey(renderer, rowKey);
+    expect(accountCard.findAllByProps({ 'data-account-quota-empty': 'true' })).toHaveLength(1);
+    expect(readText(accountCard)).not.toContain('20%');
+    expect(readText(accountCard)).not.toContain('5%');
+  });
+
+  it('renders a current merged quota snapshot on the account list', async () => {
+    const nowMs = Date.now();
+    const rowKey = 'codex.json\u0000auth-1';
+    mocks.files = [
+      {
+        ...makeCodexFile('codex.json', 'auth-1', 'codex@example.com'),
+        disabled: true,
+      } as AuthFileItem,
+    ];
+    mocks.location = {
+      pathname: '/accounts',
+      search: `?account=${encodeURIComponent(rowKey)}&tab=quota`,
+    };
+    mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(mocks.files[0], {
+      status: 'success',
+      fetchedAtMs: nowMs - 1_000,
+      quotaInventoryObserved: true,
+      windows: [
+        {
+          id: 'five-hour',
+          label: 'Five hours',
+          usedPercent: 20,
+          resetLabel: new Date(nowMs + 5 * 60 * 60 * 1000).toISOString(),
+          resetAtMs: nowMs + 5 * 60 * 60 * 1000,
+          resetAccuracy: 'exact',
+          limitWindowSeconds: 5 * 60 * 60,
+        },
+      ],
+    });
+    vi.mocked(accountQuotaSnapshotApi.query).mockResolvedValue({
+      generated_at_ms: nowMs,
+      items: [
+        {
+          row_key: rowKey,
+          account_key: rowKey,
+          provider: 'codex',
+          windows: [
+            {
+              provider_window_id: 'five-hour',
+              window_kind: 'five_hour',
+              window_mode: 'fixed',
+              model_scope_kind: 'all',
+              source: 'response_header',
+              observed_at_ms: nowMs,
+              boundary_accuracy: 'derived',
+              cycle_start_ms: nowMs - 60 * 60 * 1000,
+              cycle_end_ms: nowMs + 4 * 60 * 60 * 1000,
+              duration_seconds: 5 * 60 * 60,
+              used_percent: 65,
+              remaining_percent: 35,
+              stale: false,
+              availability: 'active',
+            },
+          ],
+        },
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    await flushPromises();
+    await flushPromises();
+
+    const accountCard = findAccountCardByKey(renderer, rowKey);
+    expect(accountCard.findAllByProps({ 'data-account-quota-empty': 'true' })).toHaveLength(0);
+    expect(readText(accountCard)).toContain('35%');
+    expect(readText(accountCard)).not.toContain('80%');
+  });
+
   it('selects account cards by row click while selection mode is active', async () => {
     const renderer = await renderAccountsPage();
 

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -868,6 +868,11 @@ const getRemainingBarClass = (row: AccountRow) => {
   return styles.quotaBarNeutral;
 };
 
+const isCurrentAccountListQuotaWindow = (definition: AccountQuotaWindowDefinition): boolean =>
+  !definition.stale &&
+  definition.availability !== 'pending_absent' &&
+  definition.availability !== 'inactive';
+
 export function AccountsPage() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -4185,16 +4190,21 @@ export function AccountsPage() {
     return result;
   }, [quotaDisplayWindowsByRowKey]);
   const effectiveQuotaWindowDefinitionsByRowKey = useMemo(() => {
+    const providerByRowKey = new Map(
+      [...pageRows, ...(selectedRow ? [selectedRow] : [])].map((row) => [
+        row.selectionKey,
+        row.provider,
+      ])
+    );
     const result = new Map<string, AccountQuotaWindowDefinition[]>();
     quotaWindowDefinitionsByRowKey.forEach((definitions, rowKey) => {
-      const provider = selectedRow?.selectionKey === rowKey ? selectedRow.provider : undefined;
       result.set(
         rowKey,
         mergeAccountQuotaSnapshotWindows(
           definitions,
           quotaSnapshotWindowsByRowKey.get(rowKey) ?? [],
           {
-            provider,
+            provider: providerByRowKey.get(rowKey),
             getLabel: (snapshot) => {
               const kind = snapshot.window_kind;
               if (kind === 'rolling_24h') {
@@ -4211,7 +4221,7 @@ export function AccountsPage() {
       );
     });
     return result;
-  }, [quotaSnapshotWindowsByRowKey, quotaWindowDefinitionsByRowKey, selectedRow, t]);
+  }, [pageRows, quotaSnapshotWindowsByRowKey, quotaWindowDefinitionsByRowKey, selectedRow, t]);
   const accountWindowUsageTargets = useMemo(() => {
     if (!selectedRow) return [];
     const windowsByRowKey = new Map<string, AccountQuotaWindowDefinition[]>();
@@ -6796,8 +6806,42 @@ export function AccountsPage() {
           {rowsToRender.map((row) => {
             const recommendation = recommendationBySelectionKey.get(row.selectionKey) ?? null;
             const accountHistory = accountHistoryByRowKey.get(row.selectionKey) ?? null;
-            const quotaWindows =
+            const baseQuotaWindows =
               quotaDisplayWindowsByRowKey.get(row.selectionKey) ?? buildQuotaDisplayWindows(row);
+            const snapshotWindows = quotaSnapshotWindowsByRowKey.get(row.selectionKey);
+            const effectiveDefinitions = snapshotWindows
+              ? mergeAccountQuotaSnapshotWindows(
+                  buildAccountQuotaWindowDefinitions(baseQuotaWindows),
+                  snapshotWindows,
+                  { provider: row.provider }
+                )
+              : null;
+            const quotaWindows = effectiveDefinitions
+              ? effectiveDefinitions
+                  .filter(isCurrentAccountListQuotaWindow)
+                  .map((definition) => ({
+                    ...definition.display,
+                    remainingPercent: definition.remainingPercent,
+                    usedPercent: definition.usedPercent,
+                    resetAtMs: definition.cycleEndMs,
+                    resetAccuracy:
+                      definition.boundaryAccuracy === 'exact'
+                        ? ('exact' as const)
+                        : definition.boundaryAccuracy === 'derived' ||
+                            definition.boundaryAccuracy === 'estimated'
+                          ? ('estimated' as const)
+                          : ('unknown' as const),
+                    fromMs: definition.cycleStartMs,
+                    toMs: definition.cycleEndMs,
+                    observationSource: definition.observationSource,
+                    observedAtMs: definition.observedAtMs,
+                    windowMode: definition.windowMode,
+                    cycleStartMs: definition.cycleStartMs,
+                    cycleEndMs: definition.cycleEndMs,
+                    limitWindowSeconds: definition.durationSeconds,
+                    modelScope: definition.modelScope,
+                  }))
+              : baseQuotaWindows;
             const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
             const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
             const item = buildAccountListItem(row, {


### PR DESCRIPTION
## Summary
- use persisted quota lifecycle snapshots when rendering account-list quota bars
- hide stale, pending-absent, and inactive windows from the current quota summary
- preserve lifecycle/history data in the account detail view
- resolve each row provider correctly instead of only the selected row

## Tests
- npm --workspace apps/web run test -- src/features/accounts/AccountsPage.test.tsx
- npm run type-check
- npm run lint
- npm run test

All 2,611 tests pass. Lint reports one pre-existing Fast Refresh warning and no errors.