### PR TITLE
docs(release): prepare v1.12.7 release

### DIFF
--- a/docs/release-notes/v1.12.7-en.md
+++ b/docs/release-notes/v1.12.7-en.md
@@ -1,0 +1,53 @@
+# CPA Manager Plus v1.12.7
+
+> 64 commits · 81 files changed · +7899 / -429
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.7/docs/release-notes/v1.12.7-zh.md)
+
+## Overview
+
+v1.12.7 focuses on stable quota-lifecycle evidence, immediate API-key persistence, Claude request-fingerprint configuration, and clearer Usage Analytics, Request Monitoring, and Dashboard interactions. Quota state no longer incorrectly reuses old evidence around expired boundaries, credential re-enablement, or provisional cycles; the panel makes ranges, zero-valued data, ranking context, and save outcomes clearer; and SQLite startup failures now include actionable environment guidance.
+
+## Highlights
+
+### Features
+
+- Request Monitoring adds a Yesterday quick range based on the previous complete local calendar day.
+- Claude provider editors add a Request Fingerprint setting, support claude-code-cli, and verify the value actually persisted by CPA.
+
+### Fixes
+
+- API-key Create, Replace, and Delete operations are persisted immediately through the CPA management API after modal confirmation, while other Visual configuration drafts remain unchanged.
+- API-key mutations stop safely on uncertain results, unconfirmed host capabilities, or malformed canonical lists and require re-establishing current state before continuing.
+- In Manager-hosted mode, API-key Replace/Delete wait for confirmed panel-host and Manager Alias capabilities; CPA-panel mode continues to support direct CPA management.
+- Dashboard Manager and Core update badges now link to the concrete Release detected by version checks; invalid or unavailable versions remain plain text.
+- OpenAI-compatible provider API-key editor drawers keep the header and each row's Test/Delete actions visible during horizontal scrolling.
+- Accounts adds a credential status filter matching the top-level “pending confirmation” metric.
+- Usage Analytics fills missing hourly or daily buckets with zero values while keeping latency and percentile metrics unavailable for no-request buckets.
+- Usage Analytics API-key ranking context now shows the current filtered total, the Top 8 limit, and cost-based ordering; existing ordering and row actions remain unchanged.
+- Codex 5-hour quota views preserve confirmed usage from the previous cycle and suppress the current range and forecast while the current lifecycle boundary is unconfirmed.
+- Re-enabling a credential starts a fresh quota cooldown cycle instead of reusing the old recovery deadline or xAI cycle evidence; extension behavior within one disabled cycle is unchanged.
+- Fixed and calendar quota windows repair the reset time in place when new confirmed evidence arrives at an expired boundary, avoiding a rollback to the expired boundary or an incorrect lifecycle split.
+- Codex quota requests use the current codex-tui client identity.
+- Manager Server startup diagnostics now provide targeted guidance when the SQLite temporary directory or database file is not writable, with read-only-root filesystem requirements documented for deployment.
+
+### Docs
+
+- SQLite Docker deployment, /tmp, and database WAL/SHM requirements are consolidated in the English and Chinese docs-site pages.
+- The release process documentation now requires mapping every promotion PR from the exact previous-main to frozen-dev range and recording the complete Related list.
+
+## Upgrade Notes
+
+- This release adds no SQLite schema, migration, or backfill; existing quota-cycle rows are corrected in place by the next normal quota observation or manual refresh, and usage_events is not rewritten.
+- When running Manager Server with a read-only root filesystem, provide a writable operating-system temporary directory (for example, a Kubernetes emptyDir at /tmp) and ensure the SQLite database and WAL/SHM companion files are writable; standard Docker/Compose deployments need no extra configuration.
+- Request Fingerprint is optional; legacy experimental-cch-signing is not auto-migrated, and older CPA builds that do not apply fingerprint-profile report that the value was saved but not applied.
+- API-key changes are written to CPA immediately after confirmation; an unsaved Source YAML draft blocks related API-key operations and CPA-target switching, uncertain results require the prompted refresh, and Visual drafts still require separate saving.
+- When the current quota boundary is unconfirmed, the panel retains reliable previous-cycle usage but does not show the current cycle range or forecast; expired boundaries are corrected on the next observation or manual refresh rather than through a startup history scan.
+
+## Acknowledgements
+
+- [@nekopara-ai](https://github.com/nekopara-ai) - Contributed quota cooldown-cycle handling after credentials are re-enabled.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.6...v1.12.7

--- a/docs/release-notes/v1.12.7-zh.md
+++ b/docs/release-notes/v1.12.7-zh.md
@@ -1,0 +1,53 @@
+# CPA Manager Plus v1.12.7
+
+> 64 commits · 81 files changed · +7899 / -429
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.7/docs/release-notes/v1.12.7-en.md)
+
+## Overview
+
+v1.12.7 聚焦配额生命周期证据的稳定性、API Key 管理的即时持久化、Claude 请求指纹配置，以及 Usage Analytics、Request Monitoring 和 Dashboard 的操作清晰度。配额在过期边界、凭证重新启用和待确认周期下不再错误沿用旧状态；面板会更明确地展示时间范围、零值数据、排名上下文和保存结果；SQLite 启动错误也提供了可执行的环境修复提示。
+
+## Highlights
+
+### Features
+
+- Request Monitoring 新增“昨天”快捷范围，按本地完整日计算上一日的监控数据。
+- Claude provider 编辑器新增 Request Fingerprint 配置，可选择 claude-code-cli 并核验 CPA 实际保存结果。
+
+### Fixes
+
+- API Key 在弹窗确认后立即通过 CPA 管理接口创建、替换或删除，其他 Visual 配置草稿保持不变。
+- API Key 变更遇到不确定结果、异常主机能力或格式错误的规范列表时会安全停止后续操作，并要求重新建立最新状态。
+- Manager-hosted 模式下的 API Key Replace/Delete 会等待面板主机与 Manager Alias 能力确认；CPA panel 模式仍可直接使用 CPA 管理接口。
+- Dashboard 的 Manager 与 Core 更新提示现在链接到版本检查检测到的具体 Release；无效或不可用的版本仍显示为纯文本。
+- OpenAI-compatible provider 的 API Key 编辑抽屉横向滚动时保持表头和每行的 Test/Delete 操作可见。
+- Accounts 新增与顶部“待确认”指标一致的 credential 状态筛选。
+- Usage Analytics 主时间线补齐无请求的小时或日期为零值，并保留无请求桶的延迟和百分位指标为空。
+- Usage Analytics 的 API Key 排名上下文现在显示当前筛选总数、Top 8 限制和按成本排序；既有排序和其他行操作保持不变。
+- Codex 5 小时配额在当前生命周期边界待确认时保留上一周期已确认用量，并暂停当前周期范围与预测。
+- 凭证重新启用后会创建新的配额冷却周期，避免沿用旧恢复时间或 xAI 周期证据；同一禁用周期内的延长行为保持不变。
+- 固定和日历配额窗口在过期边界收到新的已确认证据时会就地修正 reset 时间，避免回退到过期边界或错误拆分生命周期。
+- Codex 配额请求使用当前 codex-tui 客户端标识。
+- Manager Server 在 SQLite 临时目录或数据库文件不可写时提供针对性的启动诊断，并在部署文档中说明只读根文件系统的可写要求。
+
+### Docs
+
+- SQLite Docker 部署要求、/tmp 临时目录和数据库 WAL/SHM 文件要求已集中到中英文文档站页面。
+- Release process 文档现在要求从精确的 previous-main 到 frozen-dev 范围映射所有 promotion PR，并记录完整的 Related 清单。
+
+## Upgrade Notes
+
+- 本版本不新增 SQLite schema、迁移或回填；现有配额周期记录会在下一次正常配额观察或手动刷新时按新的证据就地修正，usage_events 不会被改写。
+- 使用只读根文件系统部署 Manager Server 时，请为操作系统临时目录提供可写挂载（例如 Kubernetes 在 /tmp 使用 emptyDir），并确保 SQLite 数据库文件及 WAL/SHM 伴随文件可写；普通 Docker/Compose 部署无需额外配置。
+- Claude 的 Request Fingerprint 是可选配置；旧的 experimental-cch-signing 不会自动迁移，较旧 CPA 如果未应用 fingerprint-profile，面板会报告“已保存但未生效”。
+- API Key 在弹窗确认后立即写入 CPA；未保存的 Source YAML 会阻止相关 API Key 操作和切换 CPA 目标，结果不确定时请按提示刷新，Visual 草稿仍需单独保存。
+- 当前配额边界尚未确认时，面板会保留上一周期可靠用量，但不会显示当前周期范围或预测；已过期边界在下一次观察或手动刷新时修正，不会在升级启动时扫描历史数据。
+
+## Acknowledgements
+
+- [@nekopara-ai](https://github.com/nekopara-ai) - 补充凭证重新启用后的配额冷却周期处理，避免新一轮事件沿用旧周期。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.6...v1.12.7

--- a/docs/release-posts/v1.12.7-telegram.html
+++ b/docs/release-posts/v1.12.7-telegram.html
@@ -1,0 +1,31 @@
+🚀 <b>8 月 31 日 · v1.12.7</b>
+
+✨ <b>更新内容</b>
+
+• Request Monitoring 新增“昨天”快捷范围，按本地完整日动态展示上一天数据。
+• Claude Provider 编辑器新增 Request Fingerprint，可选择 <code>claude-code-cli</code> 并核验 CPA 实际保存结果。
+• Codex 配额请求使用当前 <code>codex-tui</code> 客户端标识。
+• API Key 在弹窗确认后立即通过 CPA 保存，其他 Visual 配置草稿保持不变。
+• API Key 遇到不确定结果或格式异常的 CPA 列表时会安全停止后续操作，并要求刷新确认最新状态。
+• Manager-hosted 模式会在确认面板主机与 Alias 能力后才允许 API Key Replace/Delete，CPA panel 模式仍可直接管理。
+• Accounts 可用“待确认”状态筛选与顶部待确认指标一致的凭证。
+• Codex 5 小时配额在当前边界待确认时保留上一周期用量，并暂停当前周期范围和预测。
+• 凭证重新启用后会开启新的配额冷却周期，避免沿用旧恢复时间和 xAI 周期证据。
+• 固定和日历配额窗口在过期边界收到新证据时会稳定更新 reset 时间，避免回退到过期边界。
+• Usage Analytics 补齐无请求的小时或日期为 0，并保留无延迟样本为空。
+• Usage Analytics API Key 排名明确显示当前筛选总数、Top 8 限制和按成本排序。
+• Dashboard 更新提示可直接打开版本检查检测到的具体 Release 说明。
+• OpenAI-compatible API Key 编辑抽屉横向滚动时仍可直接使用 Test 和 Delete。
+• Manager Server 在 SQLite 临时目录或数据库文件不可写时给出可操作的启动诊断。
+
+⚠️ <b>注意事项</b>
+
+• 使用只读根文件系统部署 Manager Server 时，请为临时目录提供可写挂载，并确保 SQLite 数据库及 WAL/SHM 伴随文件可写；普通 Docker/Compose 部署无需额外配置。
+• Claude 的 Request Fingerprint 是可选配置；旧的 <code>experimental-cch-signing</code> 不会自动迁移，较旧 CPA 若未应用 <code>fingerprint-profile</code> 会在保存后提示。
+• API Key 确认后立即写入 CPA；未保存的 Source YAML 会阻止相关操作和切换 CPA 目标，结果不确定时请按提示刷新，Visual 草稿仍需单独保存。
+• 当前配额边界尚未确认时，面板会保留上一周期可靠用量，但不会显示当前周期范围或预测。
+• 本版本不新增数据库 schema、迁移或回填；<code>usage_events</code> 不会被改写，已过期边界在下一次观察或手动刷新时修正。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/nekopara-ai">@nekopara-ai</a> - 补充凭证重新启用后的配额冷却周期处理，避免新一轮事件沿用旧周期。


### PR DESCRIPTION
## Summary

Prepare the v1.12.7 formal release notes and the reviewed Actions-only Telegram release post for the frozen dev integration range.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.7 release notes with reciprocal tag-pinned language links.
- Add the reviewed v1.12.7 Telegram HTML post for the tag-triggered release workflow.
- Record the user-visible quota, API-key, provider, monitoring, analytics, dashboard, and SQLite diagnostic changes included in the frozen dev range.

## User Impact

Users receive the v1.12.7 release documentation for clearer quota state, immediate API-key persistence, Claude fingerprint configuration, improved monitoring and analytics presentation, and actionable SQLite startup guidance.

## Compatibility / Runtime Notes

- CPA panel mode: Release documentation covers the shared panel behavior; no new runtime contract is introduced by this PR.
- Manager Server mode: No Manager Server runtime code is changed by this release-content PR.
- Full Docker / native packages: The release workflow will build the normal bundled panel and native artifacts; this PR adds only versioned release content.

## Data / Security Notes

N/A. This PR adds release notes and a Telegram post only; it does not change databases, credentials, auth files, usage data, or runtime configuration.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this release-content PR before promotion if the reviewed release content must be corrected. No runtime state is changed by the files themselves.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
npm run --silent release:validate -- --tag v1.12.7 --content-only: passed
Chinese notes: 2308 characters
English notes: 4850 characters
Telegram HTML: 1424 characters
Release commit diff: exactly the three required added files
git diff --check: passed
```

## Screenshots / Recordings

N/A — release-content-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

This PR adds the formal v1.12.7 release notes and the reviewed Telegram release post required by the protected release workflow. The release-note language links are tag-pinned GitHub blob URLs.

## Related

N/A