### PR TITLE
🐛 fix(accounts): compact history usage values

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -631,8 +631,9 @@
 
 .accountHistoryGrid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 76px));
-  justify-content: center;
+  width: 100%;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  justify-content: stretch;
   gap: 10px 8px;
   min-width: 0;
 }
@@ -642,14 +643,15 @@
   align-items: center;
   gap: 5px;
   min-width: 0;
-  max-width: 76px;
   color: var(--text-primary);
 
   strong {
+    flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     font-size: 12.75px;
     font-weight: 800;
+    font-variant-numeric: tabular-nums;
     line-height: 1.15;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -9052,14 +9052,19 @@ describe('AccountsPage replacement flows', () => {
         title: 'accounts.history_title:1,234,567:1,000,190,000:$12,345.67:98.32%',
       })
     ).toBeTruthy();
-    expect(
-      renderer.root.findByProps({ title: 'accounts.history_requests: 1,234,567' })
-    ).toBeTruthy();
-    expect(
-      renderer.root.findByProps({ title: 'accounts.history_tokens: 1,000,190,000' })
-    ).toBeTruthy();
-    expect(renderer.root.findByProps({ title: 'accounts.history_cost: $12,345.67' })).toBeTruthy();
-    expect(renderer.root.findByProps({ title: 'accounts.history_success: 98.32%' })).toBeTruthy();
+    const historyMetricAriaLabels = [
+      'accounts.history_requests: 1,234,567',
+      'accounts.history_tokens: 1,000,190,000',
+      'accounts.history_cost: $12,345.67',
+      'accounts.history_success: 98.32%',
+    ];
+    const historyMetrics = renderer.root.findAll((node) =>
+      historyMetricAriaLabels.includes(node.props['aria-label'])
+    );
+    expect(historyMetrics.map((metric) => metric.props['aria-label'])).toEqual(
+      historyMetricAriaLabels
+    );
+    historyMetrics.forEach((metric) => expect(metric.props).not.toHaveProperty('title'));
     expect(cardText).not.toContain('accounts.history_requests');
     expect(cardText).not.toContain('accounts.history_tokens');
     expect(cardText).not.toContain('accounts.history_cost');

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -483,6 +483,10 @@ const { mocks } = vi.hoisted(() => {
         if (typeof options.name === 'string') parts.push(options.name);
         if (typeof options.count === 'number') parts.push(String(options.count));
         if (typeof options.message === 'string') parts.push(options.message);
+        if (typeof options.requests === 'string') parts.push(options.requests);
+        if (typeof options.tokens === 'string') parts.push(options.tokens);
+        if (typeof options.cost === 'string') parts.push(options.cost);
+        if (typeof options.rate === 'string') parts.push(options.rate);
         return parts.length > 0 ? `${key}:${parts.join(':')}` : key;
       },
     },
@@ -9000,12 +9004,12 @@ describe('AccountsPage replacement flows', () => {
           row_key: 'healthy.json\u0000auth-1',
           account_key: 'healthy@example.com',
           matched: true,
-          total_requests: 1234,
-          success_calls: 1218,
-          failure_calls: 16,
-          total_tokens: 5678900,
-          total_cost: 12.34,
-          success_rate: 0.987,
+          total_requests: 1_234_567,
+          success_calls: 1_218_000,
+          failure_calls: 16_567,
+          total_tokens: 1_000_190_000,
+          total_cost: 12_345.67,
+          success_rate: 0.98321,
           first_seen_ms: 1,
           last_seen_ms: 2,
           sync_status: 'ready',
@@ -9038,10 +9042,24 @@ describe('AccountsPage replacement flows', () => {
     );
     const accountHistoryRequest = mocks.getAccountHistory.mock.calls[0]?.[2];
     expect(accountHistoryRequest).not.toHaveProperty('catch_up');
-    expect(cardText).toContain('1.2K');
-    expect(cardText).toContain('5.7M');
-    expect(cardText).toContain('$12.34');
-    expect(cardText).toContain('98.7%');
+    expect(cardText).toContain('1.2M');
+    expect(cardText).toContain('1.0B');
+    expect(cardText).toContain('$12.35K');
+    expect(cardText).toContain('98.3%');
+    expect(cardText).not.toContain('1000.2M');
+    expect(
+      renderer.root.findByProps({
+        title: 'accounts.history_title:1,234,567:1,000,190,000:$12,345.67:98.32%',
+      })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({ title: 'accounts.history_requests: 1,234,567' })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({ title: 'accounts.history_tokens: 1,000,190,000' })
+    ).toBeTruthy();
+    expect(renderer.root.findByProps({ title: 'accounts.history_cost: $12,345.67' })).toBeTruthy();
+    expect(renderer.root.findByProps({ title: 'accounts.history_success: 98.32%' })).toBeTruthy();
     expect(cardText).not.toContain('accounts.history_requests');
     expect(cardText).not.toContain('accounts.history_tokens');
     expect(cardText).not.toContain('accounts.history_cost');
@@ -9075,14 +9093,14 @@ describe('AccountsPage replacement flows', () => {
         (node) => node.type === 'strong' && typeof node.props['aria-describedby'] === 'string'
       )
       .map((node) => readText(node));
-    expect(compactSummaryValues).toEqual(expect.arrayContaining(['1.2K', '5.7M']));
+    expect(compactSummaryValues).toEqual(expect.arrayContaining(['1.2M', '1.0B']));
     const summaryTooltips = quotaSummary
       .findAll((node) => node.props.role === 'tooltip')
       .map((node) => readText(node));
     expect(summaryTooltips).toEqual(
       expect.arrayContaining([
-        'accounts.detail_total_requests1,234',
-        'accounts.detail_total_tokens5,678,900',
+        'accounts.detail_total_requests1,234,567',
+        'accounts.detail_total_tokens1,000,190,000',
       ])
     );
   });

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -183,9 +183,8 @@ import {
   DETAIL_EVENTS_RANGE_MS,
   PAGE_SIZE_OPTIONS,
   buildAntigravityQuotaMatrix,
-  formatCompactNumber,
+  formatHistoryNumber,
   formatHistorySuccessRate,
-  formatMoney,
   formatPercent,
   formatQuotaResetDisplay,
   formatQuotaResetTooltipParams,
@@ -198,6 +197,7 @@ import {
   type AccountsView,
   type DetailTab,
 } from '@/features/accounts/model/accountsPagePresentation';
+import { formatCompactNumber, formatCompactUsd, formatUsd } from '@/utils/usage';
 import {
   getAuthFileCodexInspectionKeyForFile,
   getAuthFileCodexInspectionKeyForIdentity,
@@ -6848,7 +6848,8 @@ export function AccountsPage() {
               t,
               accountHistory,
               accountHistoryLoading,
-              accountHistoryError
+              accountHistoryError,
+              i18n.language
             );
             const accountHistoryFootnote = accountHistoryError
               ? row.usage.success + row.usage.failure > 0
@@ -6860,6 +6861,22 @@ export function AccountsPage() {
                   ? t('accounts.history_syncing')
                   : null;
             const recentRequestCount = row.usage.success + row.usage.failure;
+            const accountHistoryRequestExactValue = accountHistoryMatched
+              ? formatHistoryNumber(accountHistory.total_requests, i18n.language)
+              : recentRequestCount > 0
+                ? formatHistoryNumber(recentRequestCount, i18n.language)
+                : '-';
+            const accountHistoryTokenExactValue = accountHistoryMatched
+              ? formatHistoryNumber(accountHistory.total_tokens, i18n.language)
+              : '-';
+            const accountHistoryCostExactValue = accountHistoryMatched
+              ? formatUsd(accountHistory.total_cost)
+              : '-';
+            const accountHistorySuccessExactValue = accountHistoryMatched
+              ? formatHistorySuccessRate(accountHistory.success_rate, 2)
+              : row.usage.successRate !== null
+                ? formatPercent(row.usage.successRate, 2)
+                : '-';
             const accountHistoryRequestValue = accountHistoryMatched
               ? formatCompactNumber(accountHistory.total_requests)
               : recentRequestCount > 0
@@ -6869,7 +6886,7 @@ export function AccountsPage() {
               ? formatCompactNumber(accountHistory.total_tokens)
               : '-';
             const accountHistoryCostValue = accountHistoryMatched
-              ? formatMoney(accountHistory.total_cost)
+              ? formatCompactUsd(accountHistory.total_cost)
               : '-';
             const accountHistorySuccessValue = accountHistoryMatched
               ? formatHistorySuccessRate(accountHistory.success_rate)
@@ -6989,8 +7006,8 @@ export function AccountsPage() {
                   <div className={styles.accountHistoryGrid}>
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricRequests}`}
-                      aria-label={`${t('accounts.history_requests')} ${accountHistoryRequestValue}`}
-                      title={t('accounts.history_requests')}
+                      aria-label={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
+                      title={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconSend size={13} />
@@ -6999,8 +7016,8 @@ export function AccountsPage() {
                     </div>
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricTokens}`}
-                      aria-label={`${t('accounts.history_tokens')} ${accountHistoryTokenValue}`}
-                      title={t('accounts.history_tokens')}
+                      aria-label={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
+                      title={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconBinary size={13} />
@@ -7009,8 +7026,8 @@ export function AccountsPage() {
                     </div>
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricCost}`}
-                      aria-label={`${t('accounts.history_cost')} ${accountHistoryCostValue}`}
-                      title={t('accounts.history_cost')}
+                      aria-label={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
+                      title={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconDollarSign size={13} />
@@ -7019,8 +7036,8 @@ export function AccountsPage() {
                     </div>
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricSuccess}`}
-                      aria-label={`${t('accounts.history_success')} ${accountHistorySuccessValue}`}
-                      title={t('accounts.history_success')}
+                      aria-label={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
+                      title={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconCheck size={13} />

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -7007,7 +7007,6 @@ export function AccountsPage() {
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricRequests}`}
                       aria-label={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
-                      title={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconSend size={13} />
@@ -7017,7 +7016,6 @@ export function AccountsPage() {
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricTokens}`}
                       aria-label={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
-                      title={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconBinary size={13} />
@@ -7027,7 +7025,6 @@ export function AccountsPage() {
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricCost}`}
                       aria-label={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
-                      title={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconDollarSign size={13} />
@@ -7037,7 +7034,6 @@ export function AccountsPage() {
                     <div
                       className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricSuccess}`}
                       aria-label={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
-                      title={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
                     >
                       <span className={styles.accountHistoryIcon}>
                         <IconCheck size={13} />

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
@@ -171,6 +171,20 @@ describe('QuotaWindowCard', () => {
     ]);
   });
 
+  it('uses the shared compact formatter for large token counts', () => {
+    const renderer = renderCard(
+      makeWindow({
+        currentUsage: usage({ totalTokens: 1_000_190_000 }),
+      })
+    );
+    const currentText = readText(
+      renderer.root.findByProps({ 'data-quota-usage-period': 'current' })
+    );
+
+    expect(currentText).toContain('1.0B');
+    expect(currentText).not.toContain('1000.2M');
+  });
+
   it('uses complete fixed-cycle boundaries instead of the current data cutoff', () => {
     const cycleStartMs = Date.parse('2026-08-05T10:00:00Z');
     const cycleEndMs = Date.parse('2026-08-05T15:00:00Z');

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
@@ -30,7 +30,7 @@ import type {
   AccountDetailWindowUsageSummary,
 } from '@/features/accounts/model/accountDetailViewModel';
 import { formatQuotaResetDisplay } from '@/features/accounts/model/accountsPagePresentation';
-import { formatUsd } from '@/utils/usage';
+import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import { isCodexMainQuotaModelScope } from '@/utils/quota/codexQuota';
 import { QuotaProgressBar } from './QuotaProgressBar';
 import styles from './QuotaWindowCard.module.scss';
@@ -56,13 +56,8 @@ const formatPercent = (value: number | null | undefined, digits = 0): string => 
   return `${value.toFixed(digits)}%`;
 };
 
-const formatCompactNumber = (value: number | null | undefined): string => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return '-';
-  if (value < 1_000) return String(Math.round(value));
-  if (value < 1_000_000) return `${(value / 1_000).toFixed(value < 10_000 ? 1 : 0)}K`;
-  if (value < 1_000_000_000) return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}M`;
-  return `${(value / 1_000_000_000).toFixed(1)}B`;
-};
+const formatOptionalCompactNumber = (value: number | null | undefined): string =>
+  typeof value !== 'number' || !Number.isFinite(value) ? '-' : formatCompactNumber(value);
 
 const formatMoney = (value: number | null | undefined): string => {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '-';
@@ -240,13 +235,13 @@ const UsageMetricList = ({
       icon={<IconChartLine size={16} />}
       tone="blue"
       label={labels.requests}
-      value={formatCompactNumber(usage.totalRequests)}
+      value={formatOptionalCompactNumber(usage.totalRequests)}
     />
     <MetricItem
       icon={<IconBinary size={16} />}
       tone="teal"
       label={labels.tokens}
-      value={formatCompactNumber(usage.totalTokens)}
+      value={formatOptionalCompactNumber(usage.totalTokens)}
     />
     <MetricItem
       icon={<IconDollarSign size={16} />}
@@ -343,13 +338,13 @@ const ForecastColumn = ({
           icon={<IconChartLine size={16} />}
           tone="blue"
           label={labels.requests}
-          value={formatCompactNumber(forecast.requests)}
+          value={formatOptionalCompactNumber(forecast.requests)}
         />
         <MetricItem
           icon={<IconBinary size={16} />}
           tone="teal"
           label={labels.tokens}
-          value={formatCompactNumber(forecast.tokens)}
+          value={formatOptionalCompactNumber(forecast.tokens)}
         />
         <MetricItem
           icon={<IconDollarSign size={16} />}

--- a/apps/web/src/features/accounts/components/accountDetail/AccountDetailFieldList.test.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountDetailFieldList.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { AccountDetailFieldValue } from './AccountDetailFieldList';
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en-US' },
+    }),
+  };
+});
+
+const renderNumber = (value: number): string =>
+  renderToStaticMarkup(
+    <AccountDetailFieldValue
+      field={{
+        key: 'test-number',
+        labelKey: 'accounts.test_number',
+        value,
+        valueKind: 'number',
+      }}
+    />
+  );
+
+describe('AccountDetailFieldValue', () => {
+  it.each([
+    [12.5, '12.5'],
+    [999.99, '999.99'],
+    [1_000, '1.0K'],
+    [12_500, '12.5K'],
+    [1_000_190_000, '1.0B'],
+  ])('preserves generic number presentation for %s', (value, expected) => {
+    expect(renderNumber(value)).toBe(expected);
+  });
+});

--- a/apps/web/src/features/accounts/components/accountDetail/AccountDetailFieldList.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountDetailFieldList.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { AccountDetailField } from '@/features/accounts/model/accountDetailViewModel';
 import {
-  formatCompactNumber,
   formatMoney,
   formatPercent,
   formatQuotaResetTimestamp,
@@ -10,6 +9,7 @@ import {
   translateDetailEnum,
 } from '@/features/accounts/model/accountsPagePresentation';
 import { CopyableText } from '@/features/accounts/components/CopyableText';
+import { formatCompactNumber } from '@/utils/usage';
 
 export function AccountDetailFieldValue({ field }: { field: AccountDetailField }) {
   const { t, i18n } = useTranslation();

--- a/apps/web/src/features/accounts/components/accountDetail/AccountDetailFieldList.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountDetailFieldList.tsx
@@ -11,6 +11,11 @@ import {
 import { CopyableText } from '@/features/accounts/components/CopyableText';
 import { formatCompactNumber } from '@/utils/usage';
 
+const formatDetailNumber = (value: number): string => {
+  if (!Number.isFinite(value)) return '-';
+  return Math.abs(value) < 1_000 ? String(value) : formatCompactNumber(value);
+};
+
 export function AccountDetailFieldValue({ field }: { field: AccountDetailField }) {
   const { t, i18n } = useTranslation();
   if (field.value === null || field.value === '') return <>-</>;
@@ -59,7 +64,7 @@ export function AccountDetailFieldValue({ field }: { field: AccountDetailField }
   if (field.valueKind === 'number') {
     return (
       <>
-        {typeof field.value === 'number' ? formatCompactNumber(field.value) : String(field.value)}
+        {typeof field.value === 'number' ? formatDetailNumber(field.value) : String(field.value)}
       </>
     );
   }

--- a/apps/web/src/features/accounts/components/accountDetail/AccountDiagnosticsTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountDiagnosticsTab.tsx
@@ -19,7 +19,6 @@ import type { AccountDetailViewModel } from '@/features/accounts/model/accountDe
 import type { AccountRow } from '@/features/accounts/model/accountRows';
 import type { MonitoringAnalyticsEventRow } from '@/services/api';
 import {
-  formatCompactNumber,
   formatDurationMs,
   formatPercent,
   formatTimestamp,
@@ -27,6 +26,7 @@ import {
   getEventStatusText,
   translateDetailEnum,
 } from '@/features/accounts/model/accountsPagePresentation';
+import { formatCompactNumber } from '@/utils/usage';
 import { CopyableText } from '../CopyableText';
 import { AccountDetailFieldList } from './AccountDetailFieldList';
 import styles from '@/features/accounts/AccountsPage.module.scss';

--- a/apps/web/src/features/accounts/components/accountDetail/AccountOverviewTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountOverviewTab.tsx
@@ -14,13 +14,13 @@ import type {
 } from '@/features/accounts/model/accountDetailViewModel';
 import type { AccountListHealthStatusKey } from '@/features/accounts/model/accountListPresentation';
 import {
-  formatCompactNumber,
   formatMoney,
   formatPercent,
   formatQuotaResetTooltipParams,
   formatTimestamp,
   formatTimestampTitle,
 } from '@/features/accounts/model/accountsPagePresentation';
+import { formatCompactNumber } from '@/utils/usage';
 import { UsageSummaryGrid } from '@/features/usage-analytics/components/UsageSummaryCards';
 import type {
   UsageSummaryCard,

--- a/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
@@ -14,10 +14,10 @@ import type {
   AccountDetailViewModel,
 } from '@/features/accounts/model/accountDetailViewModel';
 import {
-  formatCompactNumber,
+  formatPercent,
   formatQuotaResetTimestamp,
 } from '@/features/accounts/model/accountsPagePresentation';
-import { formatUsd } from '@/utils/usage';
+import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import { isCodexMainQuotaModelScope } from '@/utils/quota/codexQuota';
 import { QuotaWindowCard } from '../QuotaWindowCard';
 import styles from '@/features/accounts/AccountsPage.module.scss';
@@ -209,11 +209,7 @@ export function AccountQuotaTab({
             icon={<IconCheck size={20} />}
             tone="green"
             label={t('accounts.detail_success_rate')}
-            value={
-              history?.successRate !== null && history?.successRate !== undefined
-                ? `${history.successRate.toFixed(2)}%`
-                : '-'
-            }
+            value={formatPercent(history?.successRate, 2)}
           />
         </div>
       </section>

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
@@ -1,7 +1,8 @@
+import type { TFunction } from 'i18next';
 import { describe, expect, it } from 'vitest';
+import type { MonitoringAccountHistoryItem } from '@/services/api';
 import {
   buildAntigravityQuotaMatrix,
-  formatCompactNumber,
   formatHistorySuccessRate,
   formatMoney,
   formatQuotaResetDisplay,
@@ -9,6 +10,7 @@ import {
   formatQuotaResetTooltipParams,
   formatTimestamp,
   formatTimestampTitle,
+  getAccountHistoryTitle,
   parsePriorityValue,
   quotaStatusLabelKey,
 } from './accountsPagePresentation';
@@ -19,11 +21,31 @@ describe('accountsPagePresentation', () => {
   it('keeps account sort and metric formatting semantics stable', () => {
     expect(parsePriorityValue(' -12 ')).toBe(-12);
     expect(parsePriorityValue('1.2')).toBeNull();
-    expect(formatCompactNumber(999)).toBe('999');
-    expect(formatCompactNumber(12_500)).toBe('12.5K');
     expect(formatHistorySuccessRate(0.975)).toBe('97.5%');
     expect(formatMoney(12.34)).toBe('$12.34');
     expect(quotaStatusLabelKey('exhausted')).toBe('accounts.quota_status_exhausted');
+  });
+
+  it('uses exact values in the account history summary title', () => {
+    const item = {
+      matched: true,
+      total_requests: 1_234_567,
+      total_tokens: 1_000_190_000,
+      total_cost: 12_345.67,
+      success_rate: 0.98321,
+      sync_status: 'ready',
+    } as MonitoringAccountHistoryItem;
+    const t = ((key: string, options?: Record<string, unknown>) =>
+      `${key}:${options?.requests ?? ''}:${options?.tokens ?? ''}:${options?.cost ?? ''}:${options?.rate ?? ''}`) as TFunction;
+
+    const title = getAccountHistoryTitle(t, item, false, '', 'en-US');
+
+    expect(title).toContain('1,234,567');
+    expect(title).toContain('1,000,190,000');
+    expect(title).toContain('$12,345.67');
+    expect(title).toContain('98.32%');
+    expect(title).not.toContain('1.2M');
+    expect(title).not.toContain('1000.2M');
   });
 
   it('formats detail timestamps with optional seconds using a numeric local format', () => {

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.ts
@@ -102,35 +102,36 @@ export const getProviderLabel = (provider: string, t: TFunction) => {
   return provider.charAt(0).toUpperCase() + provider.slice(1);
 };
 
-export const formatPercent = (value: number | null, digits = 0) =>
-  value === null ? '-' : `${value.toFixed(digits)}%`;
+export const formatPercent = (value: number | null | undefined, digits = 0) =>
+  typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(digits)}%` : '-';
 
 export const formatMoney = (value: number) => formatUsd(value);
 
-export const formatCompactNumber = (value: number) => {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
-  return String(value);
+export const formatHistoryNumber = (value: number, locale: string) => {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) return '-';
+  return new Intl.NumberFormat(locale || undefined).format(numberValue);
 };
 
-export const formatHistorySuccessRate = (value: number | null | undefined) =>
-  typeof value === 'number' && Number.isFinite(value) ? formatPercent(value * 100, 1) : '-';
+export const formatHistorySuccessRate = (value: number | null | undefined, digits = 1) =>
+  typeof value === 'number' && Number.isFinite(value) ? formatPercent(value * 100, digits) : '-';
 
 export const getAccountHistoryTitle = (
   t: TFunction,
   item: MonitoringAccountHistoryItem | null,
   loading: boolean,
-  error: string
+  error: string,
+  locale = 'en-US'
 ) => {
   if (error) return t('accounts.history_unavailable');
   if (loading && !item) return t('accounts.history_loading');
   if (!item || !item.matched) return t('accounts.history_empty');
   if (item.sync_status === 'pending') return t('accounts.history_pending_title');
   return t('accounts.history_title', {
-    requests: formatCompactNumber(item.total_requests),
-    tokens: formatCompactNumber(item.total_tokens),
+    requests: formatHistoryNumber(item.total_requests, locale),
+    tokens: formatHistoryNumber(item.total_tokens, locale),
     cost: formatMoney(item.total_cost),
-    rate: formatHistorySuccessRate(item.success_rate),
+    rate: formatHistorySuccessRate(item.success_rate, 2),
   });
 };
 

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -55,6 +55,11 @@ describe('formatCompactUsd', () => {
     expect(formatCompactUsd(1_000_000)).toBe('$1.00M');
     expect(formatCompactUsd(1_234_567.89)).toBe('$1.23M');
     expect(formatCompactUsd(1_000_000_000)).toBe('$1.00B');
+    expect(formatCompactUsd(999.994)).toBe('$999.99');
+    expect(formatCompactUsd(999.999)).toBe('$1.00K');
+    expect(formatCompactUsd(999_999.999)).toBe('$1.00M');
+    expect(formatCompactUsd(999_999_999.999)).toBe('$1.00B');
+    expect(formatCompactUsd(-999.999)).toBe('$-1.00K');
   });
 
   it('uses the existing invalid-value fallback', () => {

--- a/apps/web/src/utils/usage.test.ts
+++ b/apps/web/src/utils/usage.test.ts
@@ -10,6 +10,7 @@ import {
   compatibleCachedTokens,
   extractTotalTokens,
   formatCompactNumber,
+  formatCompactUsd,
   formatUsd,
   getServiceTierMultiplier,
   inferCacheInputMode,
@@ -26,14 +27,39 @@ afterEach(() => {
 });
 
 describe('formatCompactNumber', () => {
-  it('keeps large values compact as data grows beyond millions', () => {
+  it('keeps large values compact across units and rounding boundaries', () => {
+    expect(formatCompactNumber(0)).toBe('0');
     expect(formatCompactNumber(999)).toBe('999');
-    expect(formatCompactNumber(1_200)).toBe('1.2K');
-    expect(formatCompactNumber(999_950)).toBe('1.0M');
-    expect(formatCompactNumber(2_795_200_000)).toBe('2.8B');
-    expect(formatCompactNumber(1_200_000_000_000)).toBe('1.2T');
+    expect(formatCompactNumber(1_000)).toBe('1.0K');
+    expect(formatCompactNumber(777_770)).toBe('777.8K');
+    expect(formatCompactNumber(888_880_000)).toBe('888.9M');
+    expect(formatCompactNumber(999_999_999)).toBe('1.0B');
+    expect(formatCompactNumber(1_000_000_000)).toBe('1.0B');
+    expect(formatCompactNumber(1_000_190_000)).toBe('1.0B');
+    expect(formatCompactNumber(1_250_000_000)).toBe('1.3B');
+    expect(formatCompactNumber(1_000_000_000_000)).toBe('1.0T');
     expect(formatCompactNumber(-2_500_000_000_000_000)).toBe('-2.5P');
     expect(formatCompactNumber(Number.POSITIVE_INFINITY)).toBe('0');
+  });
+});
+
+describe('formatCompactUsd', () => {
+  it('keeps small amounts precise and compacts larger amounts with rollover', () => {
+    expect(formatCompactUsd(0)).toBe('$0.00');
+    expect(formatCompactUsd(12.3)).toBe('$12.30');
+    expect(formatCompactUsd(999.99)).toBe('$999.99');
+    expect(formatCompactUsd(1_000)).toBe('$1.00K');
+    expect(formatCompactUsd(1_234.56)).toBe('$1.23K');
+    expect(formatCompactUsd(12_345.67)).toBe('$12.35K');
+    expect(formatCompactUsd(999_999.99)).toBe('$1.00M');
+    expect(formatCompactUsd(1_000_000)).toBe('$1.00M');
+    expect(formatCompactUsd(1_234_567.89)).toBe('$1.23M');
+    expect(formatCompactUsd(1_000_000_000)).toBe('$1.00B');
+  });
+
+  it('uses the existing invalid-value fallback', () => {
+    expect(formatCompactUsd(Number.NaN)).toBe('$0.00');
+    expect(formatCompactUsd(Number.POSITIVE_INFINITY)).toBe('$0.00');
   });
 });
 

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -1497,24 +1497,25 @@ export function clearModelPrices(): void {
   }
 }
 
+const COMPACT_NUMBER_UNITS = [
+  { threshold: 1_000_000_000_000_000, suffix: 'P' },
+  { threshold: 1_000_000_000_000, suffix: 'T' },
+  { threshold: 1_000_000_000, suffix: 'B' },
+  { threshold: 1_000_000, suffix: 'M' },
+  { threshold: 1_000, suffix: 'K' },
+];
+
 export function formatCompactNumber(value: number): string {
   const num = Number(value);
   if (!Number.isFinite(num)) return '0';
 
   const abs = Math.abs(num);
   if (abs === 0) return '0';
-  const units = [
-    { threshold: 1_000_000_000_000_000, suffix: 'P' },
-    { threshold: 1_000_000_000_000, suffix: 'T' },
-    { threshold: 1_000_000_000, suffix: 'B' },
-    { threshold: 1_000_000, suffix: 'M' },
-    { threshold: 1_000, suffix: 'K' },
-  ];
-  const unit = units.find((item) => abs >= item.threshold);
+  const unit = COMPACT_NUMBER_UNITS.find((item) => abs >= item.threshold);
 
   if (unit) {
     const formatted = (num / unit.threshold).toFixed(1);
-    const nextUnit = units[units.indexOf(unit) - 1];
+    const nextUnit = COMPACT_NUMBER_UNITS[COMPACT_NUMBER_UNITS.indexOf(unit) - 1];
     if (nextUnit && Math.abs(Number(formatted)) >= 1000) {
       return `${(num / nextUnit.threshold).toFixed(1)}${nextUnit.suffix}`;
     }
@@ -1535,6 +1536,24 @@ export function formatUsd(value: number, fractionDigits = 2): string {
     maximumFractionDigits: digits,
   });
   return `$${parts}`;
+}
+
+export function formatCompactUsd(value: number): string {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '$0.00';
+
+  const abs = Math.abs(num);
+  if (abs < 1_000) return formatUsd(num);
+
+  const unit = COMPACT_NUMBER_UNITS.find((item) => abs >= item.threshold);
+  if (!unit) return formatUsd(num);
+
+  const formatted = (num / unit.threshold).toFixed(2);
+  const nextUnit = COMPACT_NUMBER_UNITS[COMPACT_NUMBER_UNITS.indexOf(unit) - 1];
+  if (nextUnit && Math.abs(Number(formatted)) >= 1000) {
+    return `${formatUsd(num / nextUnit.threshold)}${nextUnit.suffix}`;
+  }
+  return `${formatUsd(num / unit.threshold)}${unit.suffix}`;
 }
 
 const resolveDurationLocale = (locale?: string): string | undefined =>

--- a/apps/web/src/utils/usage.ts
+++ b/apps/web/src/utils/usage.ts
@@ -1542,10 +1542,11 @@ export function formatCompactUsd(value: number): string {
   const num = Number(value);
   if (!Number.isFinite(num)) return '$0.00';
 
-  const abs = Math.abs(num);
-  if (abs < 1_000) return formatUsd(num);
+  const rounded = Number(num.toFixed(2));
+  const roundedAbs = Math.abs(rounded);
+  if (roundedAbs < 1_000) return formatUsd(num);
 
-  const unit = COMPACT_NUMBER_UNITS.find((item) => abs >= item.threshold);
+  const unit = COMPACT_NUMBER_UNITS.find((item) => roundedAbs >= item.threshold);
   if (!unit) return formatUsd(num);
 
   const formatted = (num / unit.threshold).toFixed(2);


### PR DESCRIPTION
## Summary

Fix the Accounts credential-list history usage presentation by sharing the standard compact number formatter, adding compact USD formatting, and showing exact values in history tooltips. This follow-up resolves review findings for native-title ownership, USD rounding boundaries, and generic detail-number precision.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Use the shared `formatCompactNumber()` for Accounts request/token summaries and add shared `formatCompactUsd()` for finite-width cost summaries.
- Remove the Accounts presentation and `QuotaWindowCard` duplicate compact-number implementations.
- Keep one exact four-value native `title` on the history region; history metrics retain exact `aria-label` values without child titles competing with the summary.
- Make compact USD unit selection account for two-decimal rounding rollover, including negative boundary values.
- Preserve fractional generic detail numbers below 1,000 while routing larger values through the shared compact formatter.
- Release the history 2x2 grid's fixed internal width while retaining ellipsis as an extreme-value fallback.

## User Impact

Accounts history values remain compact and readable as cumulative usage grows: for example, 1.2M requests, 1.0B tokens, $12.35K cost, and 98.3% success. Hovering any history metric reaches the same exact four-value summary title, while assistive technology retains each metric's exact aria-label.

## Compatibility / Runtime Notes

- CPA panel mode: frontend presentation-only change; no CPA API contract changes.
- Manager Server mode: no Manager Server changes.
- Full Docker / native packages: no runtime, packaging, or data changes; the bundled frontend uses the same presentation behavior.

## Data / Security Notes

N/A — no API, SQLite, usage rollup, historical data, migration, authentication, or security changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the three commits on this branch; no persistent data or server state is affected.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/features/accounts/AccountsPage.test.tsx src/features/accounts/components/accountDetail/AccountDetailFieldList.test.tsx src/utils/usage.test.ts
  passed (3 files, 318 tests)
npm run test                               passed (214 files, 2791 tests)
npm run type-check                         passed
npm run lint                               passed (one pre-existing warning in AccountHealthBadge.tsx)
npm run build                              passed
npm run build:demo                         passed
git diff --check                           passed
```

Manual UI validation used the local demo preview at `http://127.0.0.1:4180/#/demo/accounts` with 1920px, 1360px, and 1025px desktop widths, Chinese/English languages, and light/dark themes. Each of the four history metrics was hovered; all had no own title and resolved to the same parent summary title. The history grid measured 180px with two 86px columns, and its client and scroll widths matched without page-level horizontal overflow. The compact values rendered by the demo fixture remained intact, and the requested longer capacity values 888.88M, 777.77K, $999.99, and 98.3% fit in the detached layout probe without truncation. The collapsed-sidebar layout kept quota and actions usable; the expanded-sidebar fixed-column overflow at narrow desktop widths remains a pre-existing limitation outside this patch.

## Screenshots / Recordings

Manual screenshots were captured during local demo-preview validation for the Accounts history layout and theme/language checks. They remain generated local test artifacts and are not included in the source change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation or user-facing capability contract changed; this is a presentation correctness fix.

## Related

N/A