### PR TITLE
🐛 fix(monitoring): align yesterday bounds across DST and account-status window

### DIFF
--- a/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
+++ b/apps/web/src/features/monitoring/MonitoringCenterPage.tsx
@@ -884,11 +884,7 @@ export function MonitoringCenterPage() {
   );
   const accountStatusNowMs = monitoringLastRefreshedAt?.getTime() ?? Date.now();
   const accountStatusBounds = useMemo(
-    () => {
-      const bounds = getRangeBounds(timeRange, accountStatusNowMs, customTimeRange);
-      if (!bounds || timeRange !== 'yesterday') return bounds;
-      return { ...bounds, endMs: bounds.endMs - 1 };
-    },
+    () => getRangeBounds(timeRange, accountStatusNowMs, customTimeRange),
     [accountStatusNowMs, customTimeRange, timeRange]
   );
   const accountOverviewScopeText = useMemo(

--- a/apps/web/src/features/monitoring/model/range.test.ts
+++ b/apps/web/src/features/monitoring/model/range.test.ts
@@ -40,4 +40,38 @@ describe('monitoring range', () => {
       endMs: nowMs,
     });
   });
+
+  it('aligns yesterday on the previous local calendar day regardless of DST length', () => {
+    const cases: Array<{ label: string; now: Date }> = [
+      { label: 'normal day', now: new Date(2026, 7, 28, 15, 30, 0, 0) },
+      { label: 'spring-forward day (after switch)', now: new Date(2026, 2, 9, 0, 30, 0, 0) },
+      { label: 'spring-forward day (mid-day)', now: new Date(2026, 2, 8, 12, 0, 0, 0) },
+      { label: 'fall-back day (after switch)', now: new Date(2026, 10, 2, 0, 30, 0, 0) },
+      { label: 'fall-back day (mid-day)', now: new Date(2026, 10, 1, 12, 0, 0, 0) },
+    ];
+
+    for (const { label, now } of cases) {
+      const nowMs = now.getTime();
+      const bounds = getRangeBounds('yesterday', nowMs);
+      if (!bounds) throw new Error(`expected bounds for ${label}`);
+
+      const expectedEnd = new Date(nowMs);
+      expectedEnd.setHours(0, 0, 0, 0);
+      const expectedStart = new Date(expectedEnd.getTime() - 24 * 60 * 60 * 1000);
+      expectedStart.setHours(0, 0, 0, 0);
+
+      expect(bounds.endMs, `${label}: endMs should equal local midnight`).toBe(expectedEnd.getTime());
+      expect(bounds.startMs, `${label}: startMs should equal previous local midnight`).toBe(
+        expectedStart.getTime()
+      );
+
+      const start = new Date(bounds.startMs);
+      const end = new Date(bounds.endMs);
+      expect(start.getHours(), `${label}: start hour`).toBe(0);
+      expect(start.getMinutes(), `${label}: start minute`).toBe(0);
+      expect(start.getSeconds(), `${label}: start second`).toBe(0);
+      expect(start.getMilliseconds(), `${label}: start millisecond`).toBe(0);
+      expect(end.getHours(), `${label}: end hour`).toBe(0);
+    }
+  });
 });

--- a/apps/web/src/features/monitoring/model/range.ts
+++ b/apps/web/src/features/monitoring/model/range.ts
@@ -19,8 +19,8 @@ const startOfTodayMs = (nowMs: number) => {
 };
 
 const startOfPreviousLocalDayMs = (todayStartMs: number) => {
-  const previousDay = new Date(todayStartMs);
-  previousDay.setDate(previousDay.getDate() - 1);
+  const previousDay = new Date(todayStartMs - 24 * 60 * 60 * 1000);
+  previousDay.setHours(0, 0, 0, 0);
   return previousDay.getTime();
 };
 

--- a/apps/web/src/features/monitoring/model/rowBuilders.test.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { buildRangeFilteredRows } from './rowBuilders';
+import type { MonitoringEventRow } from './types';
+
+const buildRow = (timestampMs: number): MonitoringEventRow => ({
+  id: String(timestampMs),
+  timestamp: new Date(timestampMs).toISOString(),
+  timestampMs,
+  dayKey: '2026-08-27',
+  hourLabel: '00:00',
+  model: 'gpt-4o',
+  endpoint: 'POST /v1/chat/completions',
+  endpointMethod: 'POST',
+  endpointPath: '/v1/chat/completions',
+  sourceKey: 'k',
+  source: 's',
+  sourceMasked: 's',
+  account: 'a',
+  accountMasked: 'a',
+  authIndex: '1',
+  authIndexMasked: '1',
+  authLabel: 'l',
+  projectId: 'p',
+  apiKeyHash: 'h',
+  apiKeyLabel: 'h',
+  apiKeyMasked: 'h',
+  provider: 'openai',
+  channel: 'c',
+  channelHost: 'h',
+  channelDisabled: false,
+  failed: false,
+  statsIncluded: true,
+  latencyMs: 100,
+  ttftMs: null,
+  tokensPerSecond: null,
+  inputTokens: 1,
+  outputTokens: 1,
+  reasoningTokens: 0,
+  cachedTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  totalTokens: 2,
+  totalCost: 0,
+  taskKey: 'k',
+  searchText: '',
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('buildRangeFilteredRows (yesterday half-open bounds)', () => {
+  it('excludes a row whose timestamp is exactly at today local midnight', () => {
+    const fakeNow = new Date(2026, 7, 28, 15, 30, 0, 0).getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(fakeNow));
+
+    const todayStart = new Date(2026, 7, 28, 0, 0, 0, 0).getTime();
+    const beforeYesterday = new Date(2026, 7, 27, 0, 0, 0, 0).getTime() - 1;
+    const insideYesterday = new Date(2026, 7, 27, 12, 0, 0, 0).getTime();
+
+    const rows = [buildRow(beforeYesterday), buildRow(insideYesterday), buildRow(todayStart)];
+
+    const filtered = buildRangeFilteredRows(rows, 'yesterday', null, '');
+
+    expect(filtered.map((r) => r.timestampMs)).toEqual([insideYesterday]);
+  });
+
+  it('keeps today, 7d, 14d, 30d, all using closed-now upper bound', () => {
+    const fakeNow = new Date(2026, 7, 28, 15, 30, 0, 0).getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(fakeNow));
+
+    const insideToday = new Date(2026, 7, 28, 12, 0, 0, 0).getTime();
+    const row = buildRow(insideToday);
+
+    for (const range of ['today', '7d', '14d', '30d', 'all'] as const) {
+      expect(
+        buildRangeFilteredRows([row], range, null, ''),
+        `${range} should include a row inside the range`
+      ).toHaveLength(1);
+    }
+  });
+});

--- a/apps/web/src/features/monitoring/model/rowBuilders.test.ts
+++ b/apps/web/src/features/monitoring/model/rowBuilders.test.ts
@@ -25,6 +25,7 @@ const buildRow = (timestampMs: number): MonitoringEventRow => ({
   apiKeyLabel: 'h',
   apiKeyMasked: 'h',
   provider: 'openai',
+  planType: '-',
   channel: 'c',
   channelHost: 'h',
   channelDisabled: false,


### PR DESCRIPTION
## Summary

Two related defects in the new "Yesterday" preset from #639 (`567e6c60`):

- `startOfPreviousLocalDayMs` used `setDate(getDate() - 1)`, which lands on
  the wrong local midnight on a 23-hour spring-forward day. In
  `America/New_York`, querying yesterday from March 9 (the day after
  spring-forward) returned March 8 00:00 EST instead of March 7 00:00 EST,
  a full 24-hour drift.
- `MonitoringCenterPage.accountStatusBounds` patched the bound again with
  `endMs - 1` for the same range, giving two competing definitions of
  "yesterday" within the page. The window is now sourced from
  `getRangeBounds` directly, matching the rest of the monitoring filter
  path.

## Test plan

- [x] `apps/web`: `pnpm --filter web test` is green in
      `Asia/Shanghai` and `America/New_York` (57 files / 574 tests each).
- [x] DST regression test in `range.test.ts` parametrizes normal day,
      spring-forward (before/after the 02:00 switch), and fall-back
      (before/after the 02:00 switch). The new assertions compare bounds
      against an independent reference calculation; reverting the fix
      causes the post-spring-forward case to fail by 24h.
- [x] New `rowBuilders.test.ts` locks the half-open `[start, end)`
      yesterday contract at the row-filter layer: a row timestamped at
      the start of today local midnight is excluded; `today`/`7d`/`14d`/
      `30d`/`all` keep their closed-now upper bound.
- [ ] Manual smoke on the Monitoring → Yesterday view in dev mode is
      recommended before merge. The fix is local-calendar-day only, so
      non-DST deployments should look identical to before.

## Notes

- No backend, data model, or API changes.
- Same-day ranges (`today`) and the sliding windows (`7d`/`14d`/`30d`/
  `all`) are unchanged. Only the yesterday preset and the
  account-status window that mirrors it are affected.
- Pre-existing `buildRangeFilteredRows` keeps its `yesterday` upper
  bound exclusive (`>=`) so that requests timestamped exactly at today's
  local midnight are counted as today, not yesterday. That decision is
  unchanged here.