### PR TITLE
feat: show and edit static provider display names

### DIFF
--- a/apps/web/src/components/providers/ProviderDetailDrawer/ProviderDetailDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderDetailDrawer/ProviderDetailDrawer.tsx
@@ -229,6 +229,9 @@ export function ProviderDetailDrawer({
             <div className={styles.disabledBadge}>{t('ai_providers.config_disabled_badge')}</div>
           )}
           {row.kind !== 'openai' && (
+            <FieldRow label={t('ai_providers.display_name_label')} value={row.raw.displayName} />
+          )}
+          {row.kind !== 'openai' && (
             <FieldRow label={t('common.api_key')} value={maskApiKey(row.raw.apiKey)} />
           )}
           <FieldRow label={t('common.base_url')} value={row.baseUrl} />

--- a/apps/web/src/components/providers/ProviderEditDrawer/ClaudeEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/ClaudeEditDrawer.tsx
@@ -65,6 +65,7 @@ const DEFAULT_ANTHROPIC_VERSION = '2023-06-01';
 
 const buildEmptyForm = (): ProviderFormState => ({
   apiKey: '',
+  displayName: '',
   authIndex: '',
   priority: undefined,
   weight: undefined,
@@ -116,6 +117,7 @@ const areCloakConfigsEqual = (
 
 const buildClaudeBaseline = (form: ProviderFormState) => ({
   apiKey: String(form.apiKey ?? '').trim(),
+  displayName: String(form.displayName ?? '').trim(),
   authIndex: normalizeAuthIndex(form.authIndex) ?? '',
   priority:
     form.priority !== undefined && Number.isFinite(form.priority)
@@ -272,6 +274,7 @@ export function ClaudeEditDrawer({
     const comparableWeight = getCredentialWeightComparisonValue(form.weight);
     return (
       baseline.apiKey !== form.apiKey.trim() ||
+      baseline.displayName !== String(form.displayName ?? '').trim() ||
       baseline.authIndex !== (normalizeAuthIndex(form.authIndex) ?? '') ||
       baseline.priority !== normalizedPriority ||
       baseline.weight !== comparableWeight ||
@@ -321,11 +324,7 @@ export function ClaudeEditDrawer({
 
   const configuredModelNames = useMemo(
     () =>
-      new Set(
-        form.modelEntries
-          .map((entry) => entry.name.trim().toLowerCase())
-          .filter(Boolean)
-      ),
+      new Set(form.modelEntries.map((entry) => entry.name.trim().toLowerCase()).filter(Boolean)),
     [form.modelEntries]
   );
 
@@ -441,9 +440,7 @@ export function ClaudeEditDrawer({
             hasCustomXApiKey ? 'yes' : 'no'
           }, customAuthorization=${hasAuthorization ? 'yes' : 'no'}]`
         : '';
-      setModelDiscoveryError(
-        `${t('ai_providers.claude_models_fetch_error')}: ${message}${diag}`
-      );
+      setModelDiscoveryError(`${t('ai_providers.claude_models_fetch_error')}: ${message}${diag}`);
     } finally {
       setModelDiscoveryFetching(false);
     }
@@ -474,15 +471,18 @@ export function ClaudeEditDrawer({
     });
   }, [configuredModelNames, discoveredModels]);
 
-  const toggleModelDiscoverySelection = useCallback((name: string) => {
-    if (configuredModelNames.has(name.toLowerCase())) return;
-    setModelDiscoverySelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
-      return next;
-    });
-  }, [configuredModelNames]);
+  const toggleModelDiscoverySelection = useCallback(
+    (name: string) => {
+      if (configuredModelNames.has(name.toLowerCase())) return;
+      setModelDiscoverySelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(name)) next.delete(name);
+        else next.add(name);
+        return next;
+      });
+    },
+    [configuredModelNames]
+  );
 
   const handleSelectVisibleModels = useCallback(() => {
     setModelDiscoverySelected((prev) => {
@@ -611,6 +611,7 @@ export function ClaudeEditDrawer({
     try {
       const payload: ProviderKeyConfig = {
         apiKey: form.apiKey.trim(),
+        displayName: form.displayName?.trim() || undefined,
         priority: form.priority !== undefined ? Math.trunc(form.priority) : undefined,
         weight: normalizeCredentialWeight(form.weight),
         prefix: form.prefix?.trim() || undefined,
@@ -739,6 +740,13 @@ export function ClaudeEditDrawer({
               required
             />
             <Input
+              label={t('ai_providers.display_name_label')}
+              placeholder={t('ai_providers.display_name_placeholder')}
+              value={form.displayName ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, displayName: e.target.value }))}
+              disabled={saving || disabled || isTesting}
+            />
+            <Input
               label={t('ai_providers.claude_add_modal_url_label')}
               value={form.baseUrl ?? ''}
               onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
@@ -797,9 +805,7 @@ export function ClaudeEditDrawer({
                 disabled={saving || disabled || isTesting}
                 ariaLabel={t('ai_providers.rebuild_mid_system_message_label')}
               />
-              <div className="hint">
-                {t('ai_providers.rebuild_mid_system_message_hint')}
-              </div>
+              <div className="hint">{t('ai_providers.rebuild_mid_system_message_hint')}</div>
             </div>
 
             <div className="form-group">
@@ -1102,9 +1108,7 @@ export function ClaudeEditDrawer({
                                 )}
                               </div>
                               {model.description && (
-                                <div className={styles.modelDiscoveryDesc}>
-                                  {model.description}
-                                </div>
+                                <div className={styles.modelDiscoveryDesc}>{model.description}</div>
                               )}
                             </div>
                           }

--- a/apps/web/src/components/providers/ProviderEditDrawer/CodexEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/CodexEditDrawer.tsx
@@ -62,6 +62,7 @@ const XAI_API_BASE_URL = 'https://api.x.ai/v1';
 
 const buildEmptyForm = (baseUrl = ''): ProviderFormState => ({
   apiKey: '',
+  displayName: '',
   priority: undefined,
   weight: undefined,
   prefix: '',
@@ -88,6 +89,7 @@ const normalizeModelEntries = (entries: ProviderFormState['modelEntries']) =>
 
 const buildCodexBaseline = (form: ProviderFormState) => ({
   apiKey: String(form.apiKey ?? '').trim(),
+  displayName: String(form.displayName ?? '').trim(),
   authIndex: normalizeAuthIndex(form.authIndex) ?? '',
   priority:
     form.priority !== undefined && Number.isFinite(form.priority)
@@ -235,6 +237,7 @@ export function CodexEditDrawer({
     const comparableWeight = getCredentialWeightComparisonValue(form.weight);
     return (
       baseline.apiKey !== form.apiKey.trim() ||
+      baseline.displayName !== String(form.displayName ?? '').trim() ||
       baseline.authIndex !== (normalizeAuthIndex(form.authIndex) ?? '') ||
       baseline.priority !== normalizedPriority ||
       baseline.weight !== comparableWeight ||
@@ -511,6 +514,7 @@ export function CodexEditDrawer({
     try {
       const payload: ProviderKeyConfig = {
         apiKey: form.apiKey.trim(),
+        displayName: form.displayName?.trim() || undefined,
         priority: form.priority !== undefined ? Math.trunc(form.priority) : undefined,
         weight: normalizeCredentialWeight(form.weight),
         prefix: form.prefix?.trim() || undefined,
@@ -663,6 +667,13 @@ export function CodexEditDrawer({
               onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
               disabled={disabled || saving}
               required
+            />
+            <Input
+              label={t('ai_providers.display_name_label')}
+              placeholder={t('ai_providers.display_name_placeholder')}
+              value={form.displayName ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, displayName: e.target.value }))}
+              disabled={disabled || saving}
             />
             <Input
               label={t('ai_providers.codex_add_modal_url_label')}

--- a/apps/web/src/components/providers/ProviderEditDrawer/GeminiEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/GeminiEditDrawer.tsx
@@ -10,11 +10,7 @@ import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
 import { CoolingPolicySelect } from '@/components/providers/CoolingPolicySelect';
 import { modelsApi, providersApi } from '@/services/api';
 import { useConfigStore, useNotificationStore } from '@/stores';
-import {
-  coolingPolicyFromOverride,
-  coolingPolicyToOverride,
-  type GeminiKeyConfig,
-} from '@/types';
+import { coolingPolicyFromOverride, coolingPolicyToOverride, type GeminiKeyConfig } from '@/types';
 import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
 import { normalizeAuthIndex } from '@/utils/authIndex';
 import {
@@ -47,6 +43,7 @@ type GeminiFormBaseline = ReturnType<typeof buildGeminiBaseline>;
 
 const buildEmptyForm = (): GeminiFormState => ({
   apiKey: '',
+  displayName: '',
   priority: undefined,
   weight: undefined,
   prefix: '',
@@ -76,6 +73,7 @@ const normalizeModelEntries = (entries: Array<{ name: string; alias: string }>) 
 
 const buildGeminiBaseline = (form: GeminiFormState) => ({
   apiKey: String(form.apiKey ?? '').trim(),
+  displayName: String(form.displayName ?? '').trim(),
   authIndex: normalizeAuthIndex(form.authIndex) ?? '',
   priority:
     form.priority !== undefined && Number.isFinite(form.priority)
@@ -208,6 +206,7 @@ export function GeminiEditDrawer({
     const comparableWeight = getCredentialWeightComparisonValue(form.weight);
     return (
       baseline.apiKey !== form.apiKey.trim() ||
+      baseline.displayName !== String(form.displayName ?? '').trim() ||
       baseline.authIndex !== (normalizeAuthIndex(form.authIndex) ?? '') ||
       baseline.priority !== normalizedPriority ||
       baseline.weight !== comparableWeight ||
@@ -338,6 +337,7 @@ export function GeminiEditDrawer({
       }));
       const payload: GeminiKeyConfig = {
         apiKey,
+        displayName: form.displayName?.trim() || undefined,
         priority: form.priority !== undefined ? Math.trunc(form.priority) : undefined,
         weight: normalizeCredentialWeight(form.weight),
         prefix: form.prefix?.trim() || undefined,
@@ -363,16 +363,20 @@ export function GeminiEditDrawer({
         }
       }
       const syncedList = isInteractions
-        ? await providersApi.getInteractionsKeys().catch(() =>
-            editIndex !== null
-              ? configs.map((item, index) => (index === editIndex ? payload : item))
-              : [...configs, payload]
-          )
-        : await providersApi.getGeminiKeys().catch(() =>
-            editIndex !== null
-              ? configs.map((item, index) => (index === editIndex ? payload : item))
-              : [...configs, payload]
-          );
+        ? await providersApi
+            .getInteractionsKeys()
+            .catch(() =>
+              editIndex !== null
+                ? configs.map((item, index) => (index === editIndex ? payload : item))
+                : [...configs, payload]
+            )
+        : await providersApi
+            .getGeminiKeys()
+            .catch(() =>
+              editIndex !== null
+                ? configs.map((item, index) => (index === editIndex ? payload : item))
+                : [...configs, payload]
+            );
       updateConfigValue(configSection, syncedList);
       clearCache(configSection);
       showNotification(
@@ -507,6 +511,13 @@ export function GeminiEditDrawer({
               onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
               disabled={disabled || saving}
               required
+            />
+            <Input
+              label={t('ai_providers.display_name_label')}
+              placeholder={t('ai_providers.display_name_placeholder')}
+              value={form.displayName ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, displayName: e.target.value }))}
+              disabled={disabled || saving}
             />
             <Input
               label={t('ai_providers.gemini_base_url_label')}

--- a/apps/web/src/components/providers/ProviderEditDrawer/VertexEditDrawer.tsx
+++ b/apps/web/src/components/providers/ProviderEditDrawer/VertexEditDrawer.tsx
@@ -7,11 +7,23 @@ import { HeaderInputList } from '@/components/ui/HeaderInputList';
 import { ModelInputList } from '@/components/ui/ModelInputList';
 import { providersApi } from '@/services/api';
 import { useConfigStore, useNotificationStore } from '@/stores';
-import { coolingPolicyFromOverride, coolingPolicyToOverride, type ProviderKeyConfig } from '@/types';
+import {
+  coolingPolicyFromOverride,
+  coolingPolicyToOverride,
+  type ProviderKeyConfig,
+} from '@/types';
 import { buildHeaderObject, headersToEntries, normalizeHeaderEntries } from '@/utils/headers';
-import { areKeyValueEntriesEqual, areModelEntriesEqual, areStringArraysEqual } from '@/utils/compare';
+import {
+  areKeyValueEntriesEqual,
+  areModelEntriesEqual,
+  areStringArraysEqual,
+} from '@/utils/compare';
 import { excludedModelsToText, parseExcludedModels } from '@/components/providers/utils';
-import { CoolingPolicySelect, CredentialWeightInput, type VertexFormState } from '@/components/providers';
+import {
+  CoolingPolicySelect,
+  CredentialWeightInput,
+  type VertexFormState,
+} from '@/components/providers';
 import {
   getCredentialWeightComparisonValue,
   getCredentialWeightError,
@@ -31,6 +43,7 @@ type VertexFormBaseline = ReturnType<typeof buildVertexBaseline>;
 
 const buildEmptyForm = (): VertexFormState => ({
   apiKey: '',
+  displayName: '',
   weight: undefined,
   prefix: '',
   baseUrl: '',
@@ -54,7 +67,11 @@ const normalizeModelEntries = (entries: Array<{ name: string; alias: string }>) 
 
 const buildVertexBaseline = (form: VertexFormState) => ({
   apiKey: String(form.apiKey ?? '').trim(),
-  priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null,
+  displayName: String(form.displayName ?? '').trim(),
+  priority:
+    form.priority !== undefined && Number.isFinite(form.priority)
+      ? Math.trunc(form.priority)
+      : null,
   weight: normalizeCredentialWeight(form.weight) ?? null,
   prefix: String(form.prefix ?? '').trim(),
   baseUrl: String(form.baseUrl ?? '').trim(),
@@ -71,7 +88,13 @@ const getErrorMessage = (err: unknown) => {
   return '';
 };
 
-export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }: VertexEditDrawerProps) {
+export function VertexEditDrawer({
+  open,
+  editIndex,
+  disabled,
+  onClose,
+  onSaved,
+}: VertexEditDrawerProps) {
   const { t } = useTranslation();
   const { showNotification } = useNotificationStore();
   const fetchConfig = useConfigStore((state) => state.fetchConfig);
@@ -83,7 +106,9 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [form, setForm] = useState<VertexFormState>(buildEmptyForm);
-  const [baseline, setBaseline] = useState<VertexFormBaseline>(buildVertexBaseline(buildEmptyForm()));
+  const [baseline, setBaseline] = useState<VertexFormBaseline>(
+    buildVertexBaseline(buildEmptyForm())
+  );
   const [loaded, setLoaded] = useState(false);
 
   const initialData = useMemo(() => {
@@ -92,7 +117,10 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
   }, [configs, editIndex]);
   const invalidIndex = editIndex !== null && !initialData;
 
-  const title = editIndex !== null ? t('ai_providers.vertex_edit_modal_title') : t('ai_providers.vertex_add_modal_title');
+  const title =
+    editIndex !== null
+      ? t('ai_providers.vertex_edit_modal_title')
+      : t('ai_providers.vertex_add_modal_title');
 
   useEffect(() => {
     if (!open) return;
@@ -102,8 +130,11 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
     Promise.all([fetchConfig('vertex-api-key'), providersApi.getVertexConfigs()])
       .then(([configResult, vertexResult]) => {
         if (cancelled) return;
-        const list = Array.isArray(vertexResult) ? (vertexResult as ProviderKeyConfig[])
-          : Array.isArray(configResult) ? (configResult as ProviderKeyConfig[]) : [];
+        const list = Array.isArray(vertexResult)
+          ? (vertexResult as ProviderKeyConfig[])
+          : Array.isArray(configResult)
+            ? (configResult as ProviderKeyConfig[])
+            : [];
         setConfigs(list);
         updateConfigValue('vertex-api-key', list);
         clearCache('vertex-api-key');
@@ -117,7 +148,9 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
         setLoading(false);
         setLoaded(true);
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [open, clearCache, fetchConfig, t, updateConfigValue]);
 
   useEffect(() => {
@@ -127,7 +160,9 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
         ...initialData,
         disableCooling: coolingPolicyFromOverride(initialData.disableCooling),
         headers: headersToEntries(initialData.headers),
-        modelEntries: initialData.models?.map((m) => ({ name: m.name, alias: m.alias ?? '' })) ?? [{ name: '', alias: '' }],
+        modelEntries: initialData.models?.map((m) => ({ name: m.name, alias: m.alias ?? '' })) ?? [
+          { name: '', alias: '' },
+        ],
         excludedText: excludedModelsToText(initialData.excludedModels),
       };
       setForm(nextForm);
@@ -143,10 +178,14 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
     !disabled && !saving && !loading && !invalidIndex && !getCredentialWeightError(form.weight);
 
   const isDirty = useMemo(() => {
-    const normalizedPriority = form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : null;
+    const normalizedPriority =
+      form.priority !== undefined && Number.isFinite(form.priority)
+        ? Math.trunc(form.priority)
+        : null;
     const comparableWeight = getCredentialWeightComparisonValue(form.weight);
     return (
       baseline.apiKey !== form.apiKey.trim() ||
+      baseline.displayName !== String(form.displayName ?? '').trim() ||
       baseline.priority !== normalizedPriority ||
       baseline.weight !== comparableWeight ||
       baseline.prefix !== String(form.prefix ?? '').trim() ||
@@ -163,12 +202,20 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
     if (!canSave) return;
     const apiKey = form.apiKey.trim();
     if (!apiKey) {
-      showNotification(t('ai_providers.vertex_key_required', { defaultValue: 'Please enter a Vertex API Key' }), 'error');
+      showNotification(
+        t('ai_providers.vertex_key_required', { defaultValue: 'Please enter a Vertex API Key' }),
+        'error'
+      );
       return;
     }
     const baseUrl = (form.baseUrl ?? '').trim();
     if (!baseUrl) {
-      showNotification(t('ai_providers.vertex_base_url_required', { defaultValue: 'Please enter the Vertex Base URL' }), 'error');
+      showNotification(
+        t('ai_providers.vertex_base_url_required', {
+          defaultValue: 'Please enter the Vertex Base URL',
+        }),
+        'error'
+      );
       return;
     }
     setSaving(true);
@@ -176,18 +223,24 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
     try {
       const payload: ProviderKeyConfig = {
         apiKey: form.apiKey.trim(),
-        priority: form.priority !== undefined && Number.isFinite(form.priority) ? Math.trunc(form.priority) : undefined,
+        displayName: form.displayName?.trim() || undefined,
+        priority:
+          form.priority !== undefined && Number.isFinite(form.priority)
+            ? Math.trunc(form.priority)
+            : undefined,
         weight: normalizeCredentialWeight(form.weight),
         prefix: form.prefix?.trim() || undefined,
         baseUrl: (form.baseUrl ?? '').trim() || undefined,
         proxyUrl: form.proxyUrl?.trim() || undefined,
         headers: buildHeaderObject(form.headers),
-        models: form.modelEntries.map((entry) => {
-          const name = entry.name.trim();
-          const alias = entry.alias.trim();
-          if (!name || !alias) return null;
-          return { name, alias };
-        }).filter(Boolean) as ProviderKeyConfig['models'],
+        models: form.modelEntries
+          .map((entry) => {
+            const name = entry.name.trim();
+            const alias = entry.alias.trim();
+            if (!name || !alias) return null;
+            return { name, alias };
+          })
+          .filter(Boolean) as ProviderKeyConfig['models'],
         excludedModels: parseExcludedModels(form.excludedText),
         disableCooling: coolingPolicyToOverride(form.disableCooling),
       };
@@ -196,14 +249,21 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
       } else {
         await providersApi.createVertexConfig(payload);
       }
-      const syncedList = await providersApi.getVertexConfigs().catch(() =>
-        editIndex !== null
-          ? configs.map((item, index) => (index === editIndex ? payload : item))
-          : [...configs, payload]
-      );
+      const syncedList = await providersApi
+        .getVertexConfigs()
+        .catch(() =>
+          editIndex !== null
+            ? configs.map((item, index) => (index === editIndex ? payload : item))
+            : [...configs, payload]
+        );
       updateConfigValue('vertex-api-key', syncedList);
       clearCache('vertex-api-key');
-      showNotification(editIndex !== null ? t('notification.vertex_config_updated') : t('notification.vertex_config_added'), 'success');
+      showNotification(
+        editIndex !== null
+          ? t('notification.vertex_config_updated')
+          : t('notification.vertex_config_added'),
+        'success'
+      );
       onSaved();
       onClose();
     } catch (err: unknown) {
@@ -212,7 +272,18 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
     } finally {
       setSaving(false);
     }
-  }, [canSave, clearCache, configs, editIndex, form, onClose, onSaved, showNotification, t, updateConfigValue]);
+  }, [
+    canSave,
+    clearCache,
+    configs,
+    editIndex,
+    form,
+    onClose,
+    onSaved,
+    showNotification,
+    t,
+    updateConfigValue,
+  ]);
 
   const handleClose = useCallback(() => {
     if (isDirty && !saving) {
@@ -240,30 +311,60 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
         {invalidIndex && <div className="hint">{t('common.invalid_provider_index')}</div>}
         {!loading && !invalidIndex && (
           <>
-            <Input label={t('ai_providers.vertex_add_modal_key_label')} placeholder={t('ai_providers.vertex_add_modal_key_placeholder')}
-              value={form.apiKey} onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
-              disabled={disabled || saving} required />
-            <Input label={t('ai_providers.vertex_add_modal_url_label')} placeholder={t('ai_providers.vertex_add_modal_url_placeholder')}
-              value={form.baseUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
-              disabled={disabled || saving} required />
-            <Input label={t('ai_providers.prefix_label')} placeholder={t('ai_providers.prefix_placeholder')}
-              value={form.prefix ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
-              hint={t('ai_providers.prefix_hint')} disabled={disabled || saving} />
+            <Input
+              label={t('ai_providers.vertex_add_modal_key_label')}
+              placeholder={t('ai_providers.vertex_add_modal_key_placeholder')}
+              value={form.apiKey}
+              onChange={(e) => setForm((prev) => ({ ...prev, apiKey: e.target.value }))}
+              disabled={disabled || saving}
+              required
+            />
+            <Input
+              label={t('ai_providers.display_name_label')}
+              placeholder={t('ai_providers.display_name_placeholder')}
+              value={form.displayName ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, displayName: e.target.value }))}
+              disabled={disabled || saving}
+            />
+            <Input
+              label={t('ai_providers.vertex_add_modal_url_label')}
+              placeholder={t('ai_providers.vertex_add_modal_url_placeholder')}
+              value={form.baseUrl ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, baseUrl: e.target.value }))}
+              disabled={disabled || saving}
+              required
+            />
+            <Input
+              label={t('ai_providers.prefix_label')}
+              placeholder={t('ai_providers.prefix_placeholder')}
+              value={form.prefix ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, prefix: e.target.value }))}
+              hint={t('ai_providers.prefix_hint')}
+              disabled={disabled || saving}
+            />
             <CredentialWeightInput
               value={form.weight}
               onChange={(weight) => setForm((prev) => ({ ...prev, weight }))}
               disabled={disabled || saving}
             />
-            <Input label={t('ai_providers.vertex_add_modal_proxy_label')} placeholder={t('ai_providers.vertex_add_modal_proxy_placeholder')}
-              value={form.proxyUrl ?? ''} onChange={(e) => setForm((prev) => ({ ...prev, proxyUrl: e.target.value }))}
+            <Input
+              label={t('ai_providers.vertex_add_modal_proxy_label')}
+              placeholder={t('ai_providers.vertex_add_modal_proxy_placeholder')}
+              value={form.proxyUrl ?? ''}
+              onChange={(e) => setForm((prev) => ({ ...prev, proxyUrl: e.target.value }))}
               hint={t('ai_providers.model_discovery_proxy_version_hint')}
-              disabled={disabled || saving} />
-            <HeaderInputList entries={form.headers}
+              disabled={disabled || saving}
+            />
+            <HeaderInputList
+              entries={form.headers}
               onChange={(entries) => setForm((prev) => ({ ...prev, headers: entries }))}
-              addLabel={t('common.custom_headers_add')} keyPlaceholder={t('common.custom_headers_key_placeholder')}
+              addLabel={t('common.custom_headers_add')}
+              keyPlaceholder={t('common.custom_headers_key_placeholder')}
               valuePlaceholder={t('common.custom_headers_value_placeholder')}
-              removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
-              disabled={disabled || saving} />
+              removeButtonTitle={t('common.delete')}
+              removeButtonAriaLabel={t('common.delete')}
+              disabled={disabled || saving}
+            />
             <CoolingPolicySelect
               value={form.disableCooling}
               onChange={(value) => setForm((prev) => ({ ...prev, disableCooling: value }))}
@@ -273,18 +374,27 @@ export function VertexEditDrawer({ open, editIndex, disabled, onClose, onSaved }
             />
             <div className="form-group">
               <label>{t('ai_providers.vertex_models_label')}</label>
-              <ModelInputList entries={form.modelEntries}
+              <ModelInputList
+                entries={form.modelEntries}
                 onChange={(entries) => setForm((prev) => ({ ...prev, modelEntries: entries }))}
                 addLabel={t('ai_providers.vertex_models_add_btn')}
-                namePlaceholder={t('common.model_name_placeholder')} aliasPlaceholder={t('common.model_alias_placeholder')}
-                removeButtonTitle={t('common.delete')} removeButtonAriaLabel={t('common.delete')}
-                disabled={disabled || saving} />
+                namePlaceholder={t('common.model_name_placeholder')}
+                aliasPlaceholder={t('common.model_alias_placeholder')}
+                removeButtonTitle={t('common.delete')}
+                removeButtonAriaLabel={t('common.delete')}
+                disabled={disabled || saving}
+              />
             </div>
             <div className="form-group">
               <label>{t('ai_providers.excluded_models_label')}</label>
-              <textarea className="input" placeholder={t('ai_providers.excluded_models_placeholder')}
-                value={form.excludedText} onChange={(e) => setForm((prev) => ({ ...prev, excludedText: e.target.value }))}
-                rows={4} disabled={disabled || saving} />
+              <textarea
+                className="input"
+                placeholder={t('ai_providers.excluded_models_placeholder')}
+                value={form.excludedText}
+                onChange={(e) => setForm((prev) => ({ ...prev, excludedText: e.target.value }))}
+                rows={4}
+                disabled={disabled || saving}
+              />
               <div className="hint">{t('ai_providers.excluded_models_hint')}</div>
             </div>
           </>

--- a/apps/web/src/components/providers/ProviderTable/rowData.ts
+++ b/apps/web/src/components/providers/ProviderTable/rowData.ts
@@ -15,13 +15,7 @@ import {
 } from '../utils';
 
 export type ProviderKind =
-  | 'gemini'
-  | 'interactions'
-  | 'codex'
-  | 'xai'
-  | 'claude'
-  | 'vertex'
-  | 'openai';
+  'gemini' | 'interactions' | 'codex' | 'xai' | 'claude' | 'vertex' | 'openai';
 
 export const PROVIDER_KINDS: readonly ProviderKind[] = [
   'gemini',
@@ -104,8 +98,8 @@ function buildKeyConfigRow(
     key: `${kind}:${getProviderConfigKey(config, originalIndex)}`,
     kind,
     originalIndex,
-    label: maskApiKey(config.apiKey),
-    sortName: getKeyConfigSortName(config),
+    label: config.displayName?.trim() || maskApiKey(config.apiKey),
+    sortName: config.displayName?.trim() || getKeyConfigSortName(config),
     baseUrl: config.baseUrl ?? '',
     priority: config.priority,
     modelNames,
@@ -122,6 +116,7 @@ function buildKeyConfigRow(
     statusData: getProviderRecentStatusData(usageByProvider, kind, config.apiKey, config.baseUrl),
     haystack: buildHaystack([
       config.apiKey,
+      config.displayName,
       config.prefix,
       config.baseUrl,
       config.proxyUrl,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -422,6 +422,8 @@
   },
   "ai_providers": {
     "title": "AI Providers Configuration",
+    "display_name_label": "Display name",
+    "display_name_placeholder": "e.g. Sub2API primary",
     "delete_second_title": "Confirm permanent deletion",
     "delete_second_confirm": "Final confirmation: permanently delete {{provider}} configuration {{target}}? This action cannot be undone.",
     "delete_second_action": "Delete permanently",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -423,7 +423,7 @@
   "ai_providers": {
     "title": "AI Providers Configuration",
     "display_name_label": "Display name",
-    "display_name_placeholder": "e.g. Sub2API primary",
+    "display_name_placeholder": "e.g. Work account",
     "delete_second_title": "Confirm permanent deletion",
     "delete_second_confirm": "Final confirmation: permanently delete {{provider}} configuration {{target}}? This action cannot be undone.",
     "delete_second_action": "Delete permanently",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -426,6 +426,8 @@
   },
   "ai_providers": {
     "title": "Конфигурация AI-провайдеров",
+    "display_name_label": "Отображаемое имя",
+    "display_name_placeholder": "например: основной Sub2API",
     "delete_second_title": "Подтвердите окончательное удаление",
     "delete_second_confirm": "Последнее подтверждение: окончательно удалить конфигурацию {{provider}} {{target}}? Это действие нельзя отменить.",
     "delete_second_action": "Удалить навсегда",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -427,7 +427,7 @@
   "ai_providers": {
     "title": "Конфигурация AI-провайдеров",
     "display_name_label": "Отображаемое имя",
-    "display_name_placeholder": "например: основной Sub2API",
+    "display_name_placeholder": "например: рабочий аккаунт",
     "delete_second_title": "Подтвердите окончательное удаление",
     "delete_second_confirm": "Последнее подтверждение: окончательно удалить конфигурацию {{provider}} {{target}}? Это действие нельзя отменить.",
     "delete_second_action": "Удалить навсегда",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -421,7 +421,7 @@
   "ai_providers": {
     "title": "AI 提供商配置",
     "display_name_label": "备注名",
-    "display_name_placeholder": "例如：Sub2API 主账号",
+    "display_name_placeholder": "例如：工作账号",
     "delete_second_title": "再次确认永久删除",
     "delete_second_confirm": "这是最后一次确认：确定永久删除 {{provider}} 配置 {{target}} 吗？此操作不可恢复。",
     "delete_second_action": "永久删除",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -420,6 +420,8 @@
   },
   "ai_providers": {
     "title": "AI 提供商配置",
+    "display_name_label": "备注名",
+    "display_name_placeholder": "例如：Sub2API 主账号",
     "delete_second_title": "再次确认永久删除",
     "delete_second_confirm": "这是最后一次确认：确定永久删除 {{provider}} 配置 {{target}} 吗？此操作不可恢复。",
     "delete_second_action": "永久删除",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -420,6 +420,8 @@
   },
   "ai_providers": {
     "title": "AI 供應商設定",
+    "display_name_label": "備註名稱",
+    "display_name_placeholder": "例如：Sub2API 主帳號",
     "delete_second_title": "再次確認永久刪除",
     "delete_second_confirm": "這是最後一次確認：確定永久刪除 {{provider}} 設定 {{target}} 嗎？此操作無法復原。",
     "delete_second_action": "永久刪除",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -421,7 +421,7 @@
   "ai_providers": {
     "title": "AI 供應商設定",
     "display_name_label": "備註名稱",
-    "display_name_placeholder": "例如：Sub2API 主帳號",
+    "display_name_placeholder": "例如：工作帳號",
     "delete_second_title": "再次確認永久刪除",
     "delete_second_confirm": "這是最後一次確認：確定永久刪除 {{provider}} 設定 {{target}} 嗎？此操作無法復原。",
     "delete_second_action": "永久刪除",

--- a/apps/web/src/services/api/providers.ts
+++ b/apps/web/src/services/api/providers.ts
@@ -40,6 +40,8 @@ const LEGACY_CCH_FIELDS = [
 const COMMON_PROVIDER_KEY_FIELDS = [
   'api-key',
   'apiKey',
+  'display-name',
+  'displayName',
   ...AUTH_INDEX_FIELDS,
   'priority',
   'weight',
@@ -675,6 +677,7 @@ const serializeApiKeyEntry = (entry: ApiKeyEntry) => {
 
 const serializeProviderKey = (config: ProviderKeyConfig) => {
   const payload: Record<string, unknown> = {};
+  if (config.displayName?.trim()) payload['display-name'] = config.displayName.trim();
   const apiKey = config.apiKey?.trim();
   if (apiKey) payload['api-key'] = apiKey;
   const authIndex = serializeAuthIndex(config.authIndex);
@@ -745,6 +748,7 @@ const serializeClaudeUpdatePayload = (original: ProviderKeyConfig, value: Provid
 
 const serializeVertexKey = (config: ProviderKeyConfig) => {
   const payload: Record<string, unknown> = {};
+  if (config.displayName?.trim()) payload['display-name'] = config.displayName.trim();
   const apiKey = config.apiKey?.trim();
   if (apiKey) payload['api-key'] = apiKey;
   const authIndex = serializeAuthIndex(config.authIndex);
@@ -767,6 +771,7 @@ const serializeVertexKey = (config: ProviderKeyConfig) => {
 
 const serializeGeminiKey = (config: GeminiKeyConfig) => {
   const payload: Record<string, unknown> = {};
+  if (config.displayName?.trim()) payload['display-name'] = config.displayName.trim();
   const apiKey = config.apiKey?.trim();
   if (!apiKey) {
     throw new Error('API key is required for Gemini and Interactions providers');

--- a/apps/web/src/services/api/transformers.ts
+++ b/apps/web/src/services/api/transformers.ts
@@ -204,6 +204,8 @@ const normalizeProviderKeyConfig = (item: unknown): ProviderKeyConfig | null => 
   if (!trimmed && !authIndex) return null;
 
   const config: ProviderKeyConfig = { apiKey: trimmed };
+  const displayName = normalizePrefix(record?.['display-name'] ?? record?.displayName);
+  if (displayName) config.displayName = displayName;
   const priority = record?.priority ?? record?.['priority'];
   if (priority !== undefined && priority !== null && String(priority).trim() !== '') {
     const parsed = Number(priority);
@@ -301,6 +303,8 @@ const normalizeGeminiKeyConfig = (item: unknown): GeminiKeyConfig | null => {
   if (!trimmed && !authIndex) return null;
 
   const config: GeminiKeyConfig = { apiKey: trimmed };
+  const displayName = normalizePrefix(record?.['display-name'] ?? record?.displayName);
+  if (displayName) config.displayName = displayName;
   const priority = record?.priority ?? record?.['priority'];
   if (priority !== undefined && priority !== null && String(priority).trim() !== '') {
     const parsed = Number(priority);

--- a/apps/web/src/types/provider.ts
+++ b/apps/web/src/types/provider.ts
@@ -40,6 +40,7 @@ export type ClaudeFingerprintProfile = '' | 'claude-code-cli';
 
 export interface GeminiKeyConfig {
   apiKey: string;
+  displayName?: string;
   priority?: number;
   weight?: number;
   prefix?: string;
@@ -54,6 +55,7 @@ export interface GeminiKeyConfig {
 
 export interface ProviderKeyConfig {
   apiKey: string;
+  displayName?: string;
   priority?: number;
   weight?: number;
   prefix?: string;

--- a/apps/web/src/utils/sourceResolver.test.ts
+++ b/apps/web/src/utils/sourceResolver.test.ts
@@ -43,6 +43,25 @@ describe('source resolver', () => {
     expect(resolved.identityKey).toBe('xai:0');
   });
 
+  it('uses static provider display names for usage sources', () => {
+    const sourceInfoMap = buildSourceInfoMap({
+      codexApiKeys: [
+        {
+          apiKey: 'sk-1234567890abcdef',
+          displayName: 'Work Codex',
+          authIndex: 'codex-api-key-1',
+          baseUrl: 'https://api.first.example/v1',
+        },
+      ],
+    });
+
+    const resolved = resolveSourceDisplay('', 'codex-api-key-1', sourceInfoMap, new Map());
+
+    expect(resolved.displayName).toBe('Work Codex');
+    expect(resolved.type).toBe('codex');
+    expect(resolved.identityKey).toBe('codex:0');
+  });
+
   it('keeps shared upstream names when one key is registered under Codex and Claude', () => {
     const sharedKey = 'sk-shared1234567890abcdef';
     const sourceInfoMap = buildSourceInfoMap({

--- a/apps/web/src/utils/sourceResolver.ts
+++ b/apps/web/src/utils/sourceResolver.ts
@@ -87,7 +87,12 @@ const extractHost = (baseUrl: string | undefined) => {
 };
 
 const buildProviderDisplayNames = (
-  items: Array<{ prefix?: string; name?: string; baseUrl?: string }>,
+  items: Array<{
+    prefix?: string;
+    name?: string;
+    baseUrl?: string;
+    displayName?: string;
+  }>,
   fallbackLabel: string
 ) => {
   const hostCounts = new Map<string, number>();
@@ -102,6 +107,9 @@ const buildProviderDisplayNames = (
 
   const hostOrdinals = new Map<string, number>();
   return items.map((item, index) => {
+    const displayName = item.displayName?.trim();
+    if (displayName) return displayName;
+
     const prefix = item.prefix?.trim();
     if (prefix) return prefix;
 
@@ -175,6 +183,7 @@ export function buildSourceInfoMap(input: SourceInfoMapInput): SourceInfoMap {
   const providers: Array<{
     items: Array<{
       apiKey?: string;
+      displayName?: string;
       prefix?: string;
       authIndex?: string;
       excludedModels?: string[];


### PR DESCRIPTION
## Summary

- add optional `display-name` support to static provider config types and API serialization
- show the display name in provider lists, details, search, and sorting, with masked API-key fallback
- add display-name fields to static provider edit drawers
- keep OpenAI Compatibility on its existing technical `name` field and keep usage statistics keyed by the original API key and base URL

This frontend change pairs with the CLIProxyAPI backend `display-name` field.