### PR TITLE
feat(accounts): add quota detail shortcuts

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -5276,9 +5276,15 @@
     border-left: 0;
   }
 
+  .accountCardEvidence,
+  .accountCardBusiness {
+    padding-top: 8px;
+  }
+
   .accountCardDetailTrigger.accountCardEvidence,
   .accountCardDetailTrigger.accountCardBusiness {
     padding-inline: 0;
+    padding-top: 8px;
   }
 
   .accountCardHealth,
@@ -5401,6 +5407,11 @@
   .accountCardRecommendation {
     padding-top: 8px;
     border-top: 1px solid color-mix(in srgb, var(--accounts-border) 64%, transparent);
+  }
+
+  .accountCardDetailTrigger.accountCardEvidence,
+  .accountCardDetailTrigger.accountCardBusiness {
+    padding-top: 8px;
   }
 
   .accountCardLine,

--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -629,6 +629,37 @@
   gap: 6px;
 }
 
+.accountCardDetailTrigger {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  appearance: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
+  cursor: pointer;
+  transition: background-color 0.14s ease;
+
+  &:hover {
+    background: color-mix(in srgb, var(--primary-color) 4%, transparent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary-color) 48%, transparent);
+    outline-offset: -2px;
+    border-radius: 6px;
+  }
+}
+
+.accountCardDetailTrigger.accountCardEvidence,
+.accountCardDetailTrigger.accountCardBusiness {
+  padding: 0 6px 0 10px;
+}
+
 .accountHistoryGrid {
   display: grid;
   width: 100%;
@@ -977,10 +1008,6 @@
   min-width: 0;
 }
 
-.quotaWindowGridHasMore {
-  padding-right: 34px;
-}
-
 .quotaWindowCard {
   display: grid;
   align-content: center;
@@ -1110,32 +1137,6 @@
   font-weight: 850;
   line-height: 1;
   text-align: right;
-}
-
-.quotaMoreButton {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 26px;
-  height: 22px;
-  padding: 0 7px;
-  border: 1px solid color-mix(in srgb, var(--accounts-border) 82%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accounts-muted-surface) 82%, var(--accounts-surface));
-  color: var(--accounts-muted);
-  font-size: 11px;
-  font-weight: 800;
-  cursor: pointer;
-
-  &:hover {
-    border-color: color-mix(in srgb, var(--accounts-primary) 36%, var(--accounts-border));
-    background: color-mix(in srgb, var(--accounts-primary) 8%, var(--accounts-surface));
-    color: var(--accounts-primary);
-  }
 }
 
 .providerPill,
@@ -5275,6 +5276,11 @@
     border-left: 0;
   }
 
+  .accountCardDetailTrigger.accountCardEvidence,
+  .accountCardDetailTrigger.accountCardBusiness {
+    padding-inline: 0;
+  }
+
   .accountCardHealth,
   .accountCardLatestRequest,
   .accountCardEvidence,
@@ -5480,18 +5486,6 @@
     > .badge {
       justify-self: stretch;
     }
-  }
-
-  .quotaWindowGridHasMore {
-    padding-right: 0;
-    padding-bottom: 28px;
-  }
-
-  .quotaMoreButton {
-    top: auto;
-    right: auto;
-    bottom: 0;
-    left: 0;
   }
 
   .batchActions {

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -2472,7 +2472,8 @@ describe('AccountsPage replacement flows', () => {
     expect(mocks.loadModelAlias).not.toHaveBeenCalled();
     expect(mocks.getAnalytics).not.toHaveBeenCalled();
     expect(mocks.getAccountWindowUsage).not.toHaveBeenCalled();
-    expect(getAccountListItemTexts(renderer)[0]).toContain('accounts.quota_source_none');
+    expect(getAccountListItemTexts(renderer)[0]).toContain('accounts.quota_standard_none');
+    expect(getAccountListItemTexts(renderer)[0]).not.toContain('accounts.quota_source_none');
     expect(getAccountListItemTexts(renderer)[0]).not.toContain('20%');
     expect(mocks.quotaState.setCodexQuota).not.toHaveBeenCalled();
   });
@@ -6969,7 +6970,8 @@ describe('AccountsPage replacement flows', () => {
     const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
     const text = readText(card);
 
-    expect(text).toContain('accounts.quota_source_none');
+    expect(text).toContain('accounts.quota_standard_none');
+    expect(text).not.toContain('accounts.quota_source_none');
     expect(text).not.toContain('30D');
     expect(text).not.toContain('PAYG');
 
@@ -6985,6 +6987,60 @@ describe('AccountsPage replacement flows', () => {
     expect(readText(otherQuotaGroup)).toContain('xai_quota.monthly_credits');
     expect(readText(otherQuotaGroup)).toContain('xai_quota.pay_as_you_go_label');
     expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
+  });
+
+  it('keeps a fixed xAI billing period in detail standard mode while hiding it from the list', async () => {
+    const file = {
+      name: 'xai-fixed-billing.json',
+      type: 'xai',
+      provider: 'xai',
+      authIndex: 'xai-fixed-billing-1',
+      account: 'xai-fixed-billing@example.com',
+      priority: 0,
+      disabled: false,
+    } as AuthFileItem;
+    mocks.files = [file];
+    mocks.quotaState.xaiQuota = buildCredentialScopedQuotaRecord(file, {
+      status: 'success',
+      billing: {
+        periodType: 'monthly',
+        usagePercent: 20,
+        periodStart: '2026-08-01T00:00:00Z',
+        periodEnd: '2026-09-01T00:00:00Z',
+        productUsage: [{ product: 'Grok Code Fast', usagePercent: 20 }],
+        monthlyLimitCents: 10_000,
+        usedCents: 2_000,
+        includedUsedCents: 2_000,
+        onDemandCapCents: null,
+        onDemandUsedCents: null,
+        onDemandUsedPercent: null,
+        billingPeriodStart: '2026-08-01T00:00:00Z',
+        billingPeriodEnd: '2026-09-01T00:00:00Z',
+        usedPercent: 20,
+      },
+    });
+
+    const renderer = await renderAccountsPage();
+    const selectionKey = getAuthFileSelectionKey(file);
+    const card = findAccountCardByKey(renderer, selectionKey);
+    const cardText = readText(card);
+    expect(cardText).toContain('accounts.quota_standard_none');
+    expect(cardText).not.toContain('accounts.quota_source_none');
+    expect(cardText).not.toContain('30D');
+    expect(cardText).not.toContain('Grok Code Fast');
+
+    await act(async () => {
+      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick();
+    });
+    await flushPromises();
+
+    const standardGroup = renderer.root.findByProps({ 'data-quota-window-group': 'standard' });
+    const otherGroup = renderer.root.findByProps({ 'data-quota-window-group': 'other' });
+    expect(standardGroup.findAllByType(QuotaWindowCard)).toHaveLength(1);
+    expect(standardGroup.findByProps({ 'data-quota-card-mode': 'standard' })).toBeTruthy();
+    expect(standardGroup.findByProps({ 'data-quota-standard-comparison': 'true' })).toBeTruthy();
+    expect(readText(otherGroup)).toContain('xai_quota.monthly_credits');
+    expect(readText(otherGroup)).toContain('Grok Code Fast');
   });
 
   it('keeps Antigravity Pro model groups out of the list and in quota details', async () => {
@@ -7058,7 +7114,7 @@ describe('AccountsPage replacement flows', () => {
     expect(matrices).toHaveLength(0);
     expect(
       readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
-    ).toContain('accounts.quota_source_none');
+    ).toContain('accounts.quota_standard_none');
 
     await act(async () => {
       findAccountDetailRegion(
@@ -7132,7 +7188,7 @@ describe('AccountsPage replacement flows', () => {
     expect(matrices).toHaveLength(0);
     expect(
       readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
-    ).toContain('accounts.quota_source_none');
+    ).toContain('accounts.quota_standard_none');
 
     await act(async () => {
       findAccountDetailRegion(
@@ -7231,8 +7287,14 @@ describe('AccountsPage replacement flows', () => {
     await flushPromises();
 
     const historyRegion = findAccountDetailRegion(renderer, selectionKey, 'history');
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
     expect(historyRegion.type).toBe('button');
     expect(historyRegion.props['data-account-detail-trigger']).toBe('history');
+    expect(historyRegion.props['aria-label']).toBe(
+      'accounts.list_header_historical_usage: accounts.open_detail:codex.json: accounts.detail_tab_quota'
+    );
+    expect(quotaRegion.props['aria-label']).not.toBe(historyRegion.props['aria-label']);
+    expect(historyRegion.findAllByType('div')).toHaveLength(0);
     expect(readText(historyRegion)).toContain('12');
 
     await act(async () => {
@@ -7272,8 +7334,12 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.type).toBe('button');
     expect(quotaRegion.props['data-account-detail-trigger']).toBe('quota');
     expect(quotaRegion.props['aria-label']).toBe(
-      'accounts.open_detail:codex.json: accounts.detail_tab_quota'
+      'accounts.list_header_quota: accounts.open_detail:codex.json: accounts.detail_tab_quota'
     );
+    expect(quotaRegion.props['aria-label']).not.toBe(
+      'accounts.list_header_historical_usage: accounts.open_detail:codex.json: accounts.detail_tab_quota'
+    );
+    expect(quotaRegion.findAllByType('div')).toHaveLength(0);
     expect(readText(quotaRegion)).toContain('5H');
 
     await act(async () => {
@@ -7331,7 +7397,8 @@ describe('AccountsPage replacement flows', () => {
     const card = findAccountCardByKey(renderer, selectionKey);
     const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
 
-    expect(readText(card)).toContain('accounts.quota_source_none');
+    expect(readText(card)).toContain('accounts.quota_standard_none');
+    expect(readText(card)).not.toContain('accounts.quota_source_none');
     expect(readText(card)).not.toContain('Spark model quota');
 
     await act(async () => {

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -2472,7 +2472,7 @@ describe('AccountsPage replacement flows', () => {
     expect(mocks.loadModelAlias).not.toHaveBeenCalled();
     expect(mocks.getAnalytics).not.toHaveBeenCalled();
     expect(mocks.getAccountWindowUsage).not.toHaveBeenCalled();
-    expect(getAccountListItemTexts(renderer)[0]).toContain('accounts.quota_standard_none');
+    expect(getAccountListItemTexts(renderer)[0]).toContain('accounts.quota_details_only');
     expect(getAccountListItemTexts(renderer)[0]).not.toContain('accounts.quota_source_none');
     expect(getAccountListItemTexts(renderer)[0]).not.toContain('20%');
     expect(mocks.quotaState.setCodexQuota).not.toHaveBeenCalled();
@@ -6967,20 +6967,19 @@ describe('AccountsPage replacement flows', () => {
     });
 
     const renderer = await renderAccountsPage();
-    const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
+    const selectionKey = getAuthFileSelectionKey(mocks.files[0]);
+    const card = findAccountCardByKey(renderer, selectionKey);
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
     const text = readText(card);
 
-    expect(text).toContain('accounts.quota_standard_none');
+    expect(text).toContain('accounts.quota_details_only');
     expect(text).not.toContain('accounts.quota_source_none');
     expect(text).not.toContain('30D');
     expect(text).not.toContain('PAYG');
+    expect(quotaRegion.props['aria-label']).toContain('accounts.quota_details_only');
 
     await act(async () => {
-      findAccountDetailRegion(
-        renderer,
-        getAuthFileSelectionKey(mocks.files[0]),
-        'quota'
-      ).props.onClick();
+      quotaRegion.props.onClick();
     });
 
     const otherQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'other' });
@@ -7023,11 +7022,13 @@ describe('AccountsPage replacement flows', () => {
     const renderer = await renderAccountsPage();
     const selectionKey = getAuthFileSelectionKey(file);
     const card = findAccountCardByKey(renderer, selectionKey);
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
     const cardText = readText(card);
-    expect(cardText).toContain('accounts.quota_standard_none');
+    expect(cardText).toContain('accounts.quota_details_only');
     expect(cardText).not.toContain('accounts.quota_source_none');
     expect(cardText).not.toContain('30D');
     expect(cardText).not.toContain('Grok Code Fast');
+    expect(quotaRegion.props['aria-label']).toContain('accounts.quota_details_only');
 
     await act(async () => {
       findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick();
@@ -7114,7 +7115,7 @@ describe('AccountsPage replacement flows', () => {
     expect(matrices).toHaveLength(0);
     expect(
       readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
-    ).toContain('accounts.quota_standard_none');
+    ).toContain('accounts.quota_details_only');
 
     await act(async () => {
       findAccountDetailRegion(
@@ -7188,7 +7189,7 @@ describe('AccountsPage replacement flows', () => {
     expect(matrices).toHaveLength(0);
     expect(
       readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
-    ).toContain('accounts.quota_standard_none');
+    ).toContain('accounts.quota_details_only');
 
     await act(async () => {
       findAccountDetailRegion(
@@ -7252,6 +7253,8 @@ describe('AccountsPage replacement flows', () => {
     ]);
 
     expect(renderer.root.findAllByProps({ 'data-account-quota-empty': 'true' })).toHaveLength(1);
+    expect(treeText(renderer)).toContain('accounts.quota_source_none');
+    expect(treeText(renderer)).not.toContain('accounts.quota_details_only');
     expect(treeText(renderer)).not.toContain('SUM');
   });
 
@@ -7290,9 +7293,11 @@ describe('AccountsPage replacement flows', () => {
     const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
     expect(historyRegion.type).toBe('button');
     expect(historyRegion.props['data-account-detail-trigger']).toBe('history');
-    expect(historyRegion.props['aria-label']).toBe(
-      'accounts.list_header_historical_usage: accounts.open_detail:codex.json: accounts.detail_tab_quota'
-    );
+    const historyLabel = historyRegion.props['aria-label'] as string;
+    expect(historyLabel).toContain('accounts.list_header_historical_usage');
+    expect(historyLabel).toContain('accounts.history_title:12:1,200:$0.12:83.33%');
+    expect(historyLabel).toContain('accounts.open_detail:codex.json');
+    expect(historyLabel).toContain('accounts.detail_tab_quota');
     expect(quotaRegion.props['aria-label']).not.toBe(historyRegion.props['aria-label']);
     expect(historyRegion.findAllByType('div')).toHaveLength(0);
     expect(readText(historyRegion)).toContain('12');
@@ -7330,15 +7335,17 @@ describe('AccountsPage replacement flows', () => {
 
     const renderer = await renderAccountsPage();
     const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
+    const historyRegion = findAccountDetailRegion(renderer, selectionKey, 'history');
 
     expect(quotaRegion.type).toBe('button');
     expect(quotaRegion.props['data-account-detail-trigger']).toBe('quota');
-    expect(quotaRegion.props['aria-label']).toBe(
-      'accounts.list_header_quota: accounts.open_detail:codex.json: accounts.detail_tab_quota'
-    );
-    expect(quotaRegion.props['aria-label']).not.toBe(
-      'accounts.list_header_historical_usage: accounts.open_detail:codex.json: accounts.detail_tab_quota'
-    );
+    const quotaLabel = quotaRegion.props['aria-label'] as string;
+    expect(quotaLabel).toContain('accounts.list_header_quota');
+    expect(quotaLabel).toContain('Five hours');
+    expect(quotaLabel).toContain('80%');
+    expect(quotaLabel).toContain('accounts.open_detail:codex.json');
+    expect(quotaLabel).toContain('accounts.detail_tab_quota');
+    expect(quotaLabel).not.toBe(historyRegion.props['aria-label']);
     expect(quotaRegion.findAllByType('div')).toHaveLength(0);
     expect(readText(quotaRegion)).toContain('5H');
 
@@ -7368,6 +7375,7 @@ describe('AccountsPage replacement flows', () => {
 
     expect(readText(historyRegion)).toContain('-');
     expect(historyRegion.props.disabled).not.toBe(true);
+    expect(historyRegion.props['aria-label']).toContain('accounts.history_empty');
 
     await act(async () => {
       historyRegion.props.onClick();
@@ -7378,7 +7386,7 @@ describe('AccountsPage replacement flows', () => {
     expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
   });
 
-  it('keeps an empty standard quota region openable when only model quota exists', async () => {
+  it('keeps a details-only quota region openable when only model quota exists', async () => {
     const file = mocks.files[0];
     const selectionKey = getAuthFileSelectionKey(file);
     mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(file, {
@@ -7397,9 +7405,10 @@ describe('AccountsPage replacement flows', () => {
     const card = findAccountCardByKey(renderer, selectionKey);
     const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
 
-    expect(readText(card)).toContain('accounts.quota_standard_none');
+    expect(readText(card)).toContain('accounts.quota_details_only');
     expect(readText(card)).not.toContain('accounts.quota_source_none');
     expect(readText(card)).not.toContain('Spark model quota');
+    expect(quotaRegion.props['aria-label']).toContain('accounts.quota_details_only');
 
     await act(async () => {
       quotaRegion.props.onClick();

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -216,6 +216,20 @@ const makeCodexQuotaData = (
   rateLimitResetCreditsError: null,
 });
 
+const makeCodexQuotaWindow = (
+  overrides: Partial<CodexQuotaState['windows'][number]> = {}
+): CodexQuotaState['windows'][number] => ({
+  id: 'five-hour',
+  label: 'Five hours',
+  usedPercent: 20,
+  resetLabel: 'later',
+  resetAtMs: Date.now() + 6 * 60 * 60 * 1000,
+  resetAccuracy: 'exact',
+  limitWindowSeconds: 5 * 60 * 60,
+  modelScope: CODEX_MAIN_SCOPE,
+  ...overrides,
+});
+
 const buildCredentialScopedQuotaRecord = <TState extends object>(
   file: AuthFileItem,
   state: TState
@@ -975,6 +989,18 @@ const findAccountCardButtonByAriaLabel = (
     .find((node) => node.props['aria-label'] === label);
   if (!button) throw new Error(`Card button not found: ${label}`);
   return button;
+};
+
+const findAccountDetailRegion = (
+  renderer: ReactTestRenderer,
+  selectionKey: string,
+  kind: 'history' | 'quota'
+) => {
+  const region = findAccountCardByKey(renderer, selectionKey).findAll(
+    (node) => node.props['data-account-detail-region'] === kind
+  )[0];
+  if (!region) throw new Error(`Account detail region not found: ${kind}`);
+  return region;
 };
 
 const findAccountCardInputByAriaLabel = (
@@ -2446,7 +2472,8 @@ describe('AccountsPage replacement flows', () => {
     expect(mocks.loadModelAlias).not.toHaveBeenCalled();
     expect(mocks.getAnalytics).not.toHaveBeenCalled();
     expect(mocks.getAccountWindowUsage).not.toHaveBeenCalled();
-    expect(getAccountListItemTexts(renderer)[0]).toContain('20%');
+    expect(getAccountListItemTexts(renderer)[0]).toContain('accounts.quota_source_none');
+    expect(getAccountListItemTexts(renderer)[0]).not.toContain('20%');
     expect(mocks.quotaState.setCodexQuota).not.toHaveBeenCalled();
   });
 
@@ -3383,9 +3410,7 @@ describe('AccountsPage replacement flows', () => {
     if (!statusSelect) throw new Error('Accounts status filter not found');
 
     expect(statusSelect.props.options).toEqual(
-      expect.arrayContaining([
-        { value: 'unconfirmed', label: 'accounts.metric_unconfirmed' },
-      ])
+      expect.arrayContaining([{ value: 'unconfirmed', label: 'accounts.metric_unconfirmed' }])
     );
   });
 
@@ -6914,7 +6939,7 @@ describe('AccountsPage replacement flows', () => {
     expect(getAccountListItemTexts(renderer)[0]).toContain('high.json');
   });
 
-  it('renders xAI monthly and pay-as-you-go quota windows on account cards', async () => {
+  it('keeps xAI billing and pay-as-you-go windows in quota details only', async () => {
     mocks.files = [
       {
         name: 'xai.json',
@@ -6941,13 +6966,28 @@ describe('AccountsPage replacement flows', () => {
     });
 
     const renderer = await renderAccountsPage();
-    const text = treeText(renderer);
+    const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
+    const text = readText(card);
 
-    expect(text).toContain('30D');
-    expect(text).toContain('PAYG');
+    expect(text).toContain('accounts.quota_source_none');
+    expect(text).not.toContain('30D');
+    expect(text).not.toContain('PAYG');
+
+    await act(async () => {
+      findAccountDetailRegion(
+        renderer,
+        getAuthFileSelectionKey(mocks.files[0]),
+        'quota'
+      ).props.onClick();
+    });
+
+    const otherQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'other' });
+    expect(readText(otherQuotaGroup)).toContain('xai_quota.monthly_credits');
+    expect(readText(otherQuotaGroup)).toContain('xai_quota.pay_as_you_go_label');
+    expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
   });
 
-  it('renders Antigravity Pro model groups as a two-row quota matrix', async () => {
+  it('keeps Antigravity Pro model groups out of the list and in quota details', async () => {
     mocks.files = [
       {
         name: 'antigravity-pro-matrix.json',
@@ -7015,33 +7055,27 @@ describe('AccountsPage replacement flows', () => {
     const matrices = renderer.root.findAll(
       (node) => typeof node.props['data-account-quota-matrix'] === 'string'
     );
-    expect(matrices).toHaveLength(1);
-    const matrix = matrices[0];
-    const matrixRows = matrix.findAll(
-      (node) => typeof node.props['data-account-quota-matrix-row'] === 'string'
-    );
-    const matrixCells = matrix.findAll(
-      (node) => typeof node.props['data-account-quota-matrix-cell'] === 'string'
-    );
+    expect(matrices).toHaveLength(0);
+    expect(
+      readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
+    ).toContain('accounts.quota_source_none');
 
-    expect(matrixRows.map((node) => node.props['data-account-quota-matrix-row'])).toEqual([
-      'five_hour',
-      'weekly',
-    ]);
-    expect(matrixCells).toHaveLength(4);
-    expect(readText(matrix)).toContain('5H');
-    expect(readText(matrix)).toContain('7D');
-    expect(readText(matrix)).toContain('Claude');
-    expect(readText(matrix)).toContain('Gemini');
-    expect(readText(matrix)).toContain('11%');
-    expect(readText(matrix)).toContain('96%');
-    expect(readText(matrix)).toContain('19%');
-    expect(readText(matrix)).toContain('4%');
-    expect(readText(matrix)).not.toContain('Claude/GPT');
-    expect(readText(matrix)).not.toContain('accounts.quota_more_windows');
+    await act(async () => {
+      findAccountDetailRegion(
+        renderer,
+        getAuthFileSelectionKey(mocks.files[0]),
+        'quota'
+      ).props.onClick();
+    });
+
+    const modelQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
+    expect(modelQuotaGroup.findAllByType(QuotaWindowCard)).toHaveLength(4);
+    expect(readText(modelQuotaGroup)).toContain('antigravity_quota.group_claude_gpt_models');
+    expect(readText(modelQuotaGroup)).toContain('antigravity_quota.group_gemini_models');
+    expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
   });
 
-  it('renders Antigravity Free weekly groups as a single-row quota matrix', async () => {
+  it('keeps Antigravity Free model groups out of the list and in quota details', async () => {
     mocks.files = [
       {
         name: 'antigravity-free-weekly.json',
@@ -7095,27 +7129,24 @@ describe('AccountsPage replacement flows', () => {
     const matrices = renderer.root.findAll(
       (node) => typeof node.props['data-account-quota-matrix'] === 'string'
     );
-    expect(matrices).toHaveLength(1);
-    const matrix = matrices[0];
-    const matrixRows = matrix.findAll(
-      (node) => typeof node.props['data-account-quota-matrix-row'] === 'string'
-    );
-    const matrixCells = matrix.findAll(
-      (node) => typeof node.props['data-account-quota-matrix-cell'] === 'string'
-    );
+    expect(matrices).toHaveLength(0);
+    expect(
+      readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
+    ).toContain('accounts.quota_source_none');
 
-    expect(matrixRows.map((node) => node.props['data-account-quota-matrix-row'])).toEqual([
-      'weekly',
-    ]);
-    expect(matrixCells).toHaveLength(2);
-    expect(readText(matrix)).toContain('7D');
-    expect(readText(matrix)).toContain('Claude');
-    expect(readText(matrix)).toContain('Gemini');
-    expect(readText(matrix)).toContain('31%');
-    expect(readText(matrix)).toContain('76%');
-    expect(readText(matrix)).not.toContain('5H');
-    expect(readText(matrix)).not.toContain('Claude/GPT');
-    expect(readText(matrix)).not.toContain('accounts.quota_more_windows');
+    await act(async () => {
+      findAccountDetailRegion(
+        renderer,
+        getAuthFileSelectionKey(mocks.files[0]),
+        'quota'
+      ).props.onClick();
+    });
+
+    const modelQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
+    expect(modelQuotaGroup.findAllByType(QuotaWindowCard)).toHaveLength(2);
+    expect(readText(modelQuotaGroup)).toContain('antigravity_quota.group_claude_gpt_models');
+    expect(readText(modelQuotaGroup)).toContain('antigravity_quota.group_gemini_models');
+    expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
   });
 
   it('keeps the accounts view in card mode without table controls', async () => {
@@ -7166,6 +7197,305 @@ describe('AccountsPage replacement flows', () => {
 
     expect(renderer.root.findAllByProps({ 'data-account-quota-empty': 'true' })).toHaveLength(1);
     expect(treeText(renderer)).not.toContain('SUM');
+  });
+
+  it('opens the quota detail from the full historical usage region', async () => {
+    const file = mocks.files[0];
+    const selectionKey = getAuthFileSelectionKey(file);
+    mocks.panelFeatureAvailability = {
+      checking: false,
+      managerServiceBase: 'http://manager.local:18317',
+      requestMonitoringAvailable: true,
+      serverCodexInspectionAvailable: false,
+    };
+    mocks.getAccountHistory.mockResolvedValue(
+      makeAccountHistoryResponse([
+        {
+          row_key: selectionKey,
+          account_key: 'codex@example.com',
+          matched: true,
+          total_requests: 12,
+          success_calls: 10,
+          failure_calls: 2,
+          total_tokens: 1_200,
+          total_cost: 0.12,
+          success_rate: 10 / 12,
+          first_seen_ms: 1,
+          last_seen_ms: 2,
+          sync_status: 'ready',
+        },
+      ])
+    );
+
+    const renderer = await renderAccountsPage();
+    await flushPromises();
+
+    const historyRegion = findAccountDetailRegion(renderer, selectionKey, 'history');
+    expect(historyRegion.type).toBe('button');
+    expect(historyRegion.props['data-account-detail-trigger']).toBe('history');
+    expect(readText(historyRegion)).toContain('12');
+
+    await act(async () => {
+      historyRegion.props.onClick();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+    expect(findHostButtonByText(renderer, 'accounts.detail_tab_quota').props['aria-selected']).toBe(
+      true
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      {
+        pathname: '/accounts',
+        search: `?account=${encodeURIComponent(selectionKey)}&tab=quota`,
+      },
+      { replace: true }
+    );
+  });
+
+  it('opens the quota detail from the full quota information region', async () => {
+    const file = mocks.files[0];
+    const selectionKey = getAuthFileSelectionKey(file);
+    mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(file, {
+      status: 'success',
+      windows: [
+        makeCodexQuotaWindow({
+          resetAtMs: Date.now() + 5 * 60 * 60 * 1000 - 60_000,
+        }),
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
+
+    expect(quotaRegion.type).toBe('button');
+    expect(quotaRegion.props['data-account-detail-trigger']).toBe('quota');
+    expect(quotaRegion.props['aria-label']).toBe(
+      'accounts.open_detail:codex.json: accounts.detail_tab_quota'
+    );
+    expect(readText(quotaRegion)).toContain('5H');
+
+    await act(async () => {
+      quotaRegion.props.onClick();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+    expect(findHostButtonByText(renderer, 'accounts.detail_tab_quota').props['aria-selected']).toBe(
+      true
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      {
+        pathname: '/accounts',
+        search: `?account=${encodeURIComponent(selectionKey)}&tab=quota`,
+      },
+      { replace: true }
+    );
+  });
+
+  it('keeps an empty historical usage region openable', async () => {
+    const selectionKey = getAuthFileSelectionKey(mocks.files[0]);
+    const renderer = await renderAccountsPage();
+    const historyRegion = findAccountDetailRegion(renderer, selectionKey, 'history');
+
+    expect(readText(historyRegion)).toContain('-');
+    expect(historyRegion.props.disabled).not.toBe(true);
+
+    await act(async () => {
+      historyRegion.props.onClick();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+  });
+
+  it('keeps an empty standard quota region openable when only model quota exists', async () => {
+    const file = mocks.files[0];
+    const selectionKey = getAuthFileSelectionKey(file);
+    mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(file, {
+      status: 'success',
+      windows: [
+        makeCodexQuotaWindow({
+          id: 'spark-model',
+          label: 'Spark model quota',
+          resetAtMs: Date.now() + 5 * 60 * 60 * 1000 - 60_000,
+          modelScope: { kind: 'family', key: 'codex_spark', complete: true },
+        }),
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    const card = findAccountCardByKey(renderer, selectionKey);
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
+
+    expect(readText(card)).toContain('accounts.quota_source_none');
+    expect(readText(card)).not.toContain('Spark model quota');
+
+    await act(async () => {
+      quotaRegion.props.onClick();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
+    expect(renderer.root.findByProps({ 'data-quota-window-group': 'model' })).toBeTruthy();
+    expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+  });
+
+  it('uses card selection instead of opening details for both shortcut regions in selection mode', async () => {
+    const selectionKey = getAuthFileSelectionKey(mocks.files[0]);
+    const renderer = await renderAccountsPage();
+
+    await act(async () => {
+      findHostButtonByText(renderer, 'accounts.selection_mode_enter').props.onClick();
+    });
+
+    const card = findAccountCardByKey(renderer, selectionKey);
+    const historyRegion = findAccountDetailRegion(renderer, selectionKey, 'history');
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
+    expect(historyRegion.type).toBe('div');
+    expect(quotaRegion.type).toBe('div');
+    expect(historyRegion.props['data-account-detail-trigger']).toBeUndefined();
+    expect(quotaRegion.props['data-account-detail-trigger']).toBeUndefined();
+
+    await act(async () => {
+      card.props.onClick();
+      card.props.onClick();
+    });
+
+    expect(mocks.toggleSelect).toHaveBeenNthCalledWith(1, selectionKey);
+    expect(mocks.toggleSelect).toHaveBeenNthCalledWith(2, selectionKey);
+    expect(renderer.root.findAllByType(AccountQuotaTab)).toHaveLength(0);
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('keeps shortcut navigation behind the existing dirty configuration guard', async () => {
+    const selectionKey = getAuthFileSelectionKey(mocks.files[0]);
+    mocks.configurationDirty = true;
+    mocks.location = {
+      pathname: '/accounts',
+      search: `?account=${encodeURIComponent(selectionKey)}&tab=config`,
+    };
+    const renderer = await renderAccountsPage();
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
+
+    await act(async () => {
+      quotaRegion.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(mocks.showConfirmation).toHaveBeenCalledTimes(1);
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(
+      findHostButtonByText(renderer, 'accounts.detail_tab_config').props['aria-selected']
+    ).toBe(true);
+
+    const firstConfirmation = mocks.showConfirmation.mock.calls[0]?.[0] as {
+      onCancel: () => void;
+    };
+    await act(async () => {
+      firstConfirmation.onCancel();
+      await Promise.resolve();
+    });
+    await flushPromises();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByType(AccountQuotaTab)).toHaveLength(0);
+
+    await act(async () => {
+      quotaRegion.props.onClick();
+      await Promise.resolve();
+    });
+    const secondConfirmation = mocks.showConfirmation.mock.calls[1]?.[0] as {
+      onConfirm: () => void;
+    };
+    await act(async () => {
+      secondConfirmation.onConfirm();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    expect(mocks.configurationReset).toHaveBeenCalledTimes(1);
+    expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      {
+        pathname: '/accounts',
+        search: `?account=${encodeURIComponent(selectionKey)}&tab=quota`,
+      },
+      { replace: true }
+    );
+  });
+
+  it('shows every standard window while keeping model and other quota in the detail tab', async () => {
+    const file = mocks.files[0];
+    const selectionKey = getAuthFileSelectionKey(file);
+    const nowMs = Date.now();
+    const standardWindow = (
+      id: string,
+      label: string,
+      limitWindowSeconds: number,
+      usedPercent: number
+    ) =>
+      makeCodexQuotaWindow({
+        id,
+        label,
+        limitWindowSeconds,
+        usedPercent,
+        resetAtMs: nowMs + limitWindowSeconds * 1000 - 60_000,
+        modelScope: CODEX_MAIN_SCOPE,
+      });
+    mocks.quotaState.codexQuota = buildCredentialScopedQuotaRecord(file, {
+      status: 'success',
+      windows: [
+        standardWindow('five-hour', 'Five hours', 5 * 60 * 60, 20),
+        standardWindow('weekly', 'Weekly', 7 * 24 * 60 * 60, 30),
+        standardWindow('monthly', 'Monthly', 30 * 24 * 60 * 60, 40),
+        makeCodexQuotaWindow({
+          id: 'spark-model',
+          label: 'Spark model quota',
+          resetAtMs: nowMs + 5 * 60 * 60 * 1000 - 60_000,
+          modelScope: { kind: 'family', key: 'codex_spark', complete: true },
+        }),
+        makeCodexQuotaWindow({
+          id: 'billing',
+          label: 'Billing credits',
+          usedPercent: 10,
+          resetLabel: '-',
+          resetAtMs: null,
+          limitWindowSeconds: null,
+          modelScope: { kind: 'all', complete: true },
+        }),
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    const cardText = getAccountCardText(renderer, selectionKey);
+    expect(cardText).toContain('5H');
+    expect(cardText).toContain('7D');
+    expect(cardText).toContain('30D');
+    expect(cardText).not.toContain('Spark model quota');
+    expect(cardText).not.toContain('Billing credits');
+    expect(cardText).not.toMatch(/\+\d+/);
+
+    await act(async () => {
+      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick();
+      await Promise.resolve();
+    });
+    await flushPromises();
+
+    const standardGroup = renderer.root.findByProps({ 'data-quota-window-group': 'standard' });
+    const modelGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
+    const otherGroup = renderer.root.findByProps({ 'data-quota-window-group': 'other' });
+    expect(standardGroup.findAllByType(QuotaWindowCard)).toHaveLength(3);
+    expect(modelGroup.findAllByType(QuotaWindowCard)).toHaveLength(1);
+    expect(otherGroup.findAllByType(QuotaWindowCard)).toHaveLength(1);
+    expect(readText(standardGroup)).toContain('Five hours');
+    expect(readText(standardGroup)).toContain('Weekly');
+    expect(readText(standardGroup)).toContain('Monthly');
+    expect(readText(modelGroup)).toContain('Spark model quota');
+    expect(readText(otherGroup)).toContain('Billing credits');
   });
 
   it('selects account cards by row click while selection mode is active', async () => {

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent, MouseEvent as ReactMouseEvent, SetStateAction } from 'react';
+import type {
+  KeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  SetStateAction,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate, type BlockerFunction } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -160,6 +165,7 @@ import {
 import {
   buildAccountQuotaDisplayWindows,
   getQuotaWindowShortLabel,
+  isStandardAccountQuotaWindow,
   type AccountQuotaDisplayWindow,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
 import {
@@ -326,6 +332,41 @@ import type {
 } from '@/features/monitoring/model/credentialInspectionSnapshot';
 import { getServerCredentialMutationSyncKey } from '@/features/monitoring/model/credentialInspectionSnapshot';
 import styles from './AccountsPage.module.scss';
+
+const renderAccountDetailTrigger = ({
+  isSelectionMode,
+  className,
+  title,
+  ariaLabel,
+  kind,
+  onOpen,
+  children,
+}: {
+  isSelectionMode: boolean;
+  className: string;
+  title: string;
+  ariaLabel: string;
+  kind: 'history' | 'quota';
+  onOpen: () => void;
+  children: ReactNode;
+}) =>
+  isSelectionMode ? (
+    <div className={className} title={title} data-account-detail-region={kind}>
+      {children}
+    </div>
+  ) : (
+    <button
+      type="button"
+      className={`${className} ${styles.accountCardDetailTrigger}`}
+      title={title}
+      aria-label={ariaLabel}
+      data-account-detail-region={kind}
+      data-account-detail-trigger={kind}
+      onClick={onOpen}
+    >
+      {children}
+    </button>
+  );
 
 const MAX_CONCURRENT_QUOTA_REFRESHES_PER_PROVIDER = 1;
 const MAX_CONCURRENT_QUOTA_REFRESH_PROVIDERS = 3;
@@ -6805,6 +6846,7 @@ export function AccountsPage() {
             const accountHistory = accountHistoryByRowKey.get(row.selectionKey) ?? null;
             const quotaWindows =
               quotaDisplayWindowsByRowKey.get(row.selectionKey) ?? buildQuotaDisplayWindows(row);
+            const standardQuotaWindows = quotaWindows.filter(isStandardAccountQuotaWindow);
             const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
             const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
             const item = buildAccountListItem(row, {
@@ -6815,17 +6857,10 @@ export function AccountsPage() {
               quotaWindows,
               requestEvidence: requestEvidenceBySelectionKey.get(row.selectionKey),
             });
-            const antigravityQuotaMatrix = buildAntigravityQuotaMatrix(row, quotaWindows);
-            const displayQuotaWindows = antigravityQuotaMatrix ? [] : quotaWindows.slice(0, 2);
-            const displayedQuotaWindowCount = antigravityQuotaMatrix
-              ? antigravityQuotaMatrix.windowKeys.size
-              : displayQuotaWindows.length;
-            const hiddenQuotaWindowCount = Math.max(
-              0,
-              quotaWindows.length - displayedQuotaWindowCount
-            );
+            const antigravityQuotaMatrix = buildAntigravityQuotaMatrix(row, standardQuotaWindows);
+            const displayQuotaWindows = antigravityQuotaMatrix ? [] : standardQuotaWindows;
             const quotaWindowTitle =
-              quotaWindows
+              standardQuotaWindows
                 .map((window) => {
                   const label = window.groupLabel
                     ? `${window.groupLabel} ${window.label}`
@@ -7002,134 +7037,129 @@ export function AccountsPage() {
                   />
                 </div>
 
-                <div className={styles.accountCardEvidence} title={accountHistoryTitle}>
-                  <div className={styles.accountHistoryGrid}>
-                    <div
-                      className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricRequests}`}
-                      aria-label={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
-                    >
-                      <span className={styles.accountHistoryIcon}>
-                        <IconSend size={13} />
-                      </span>
-                      <strong>{accountHistoryRequestValue}</strong>
-                    </div>
-                    <div
-                      className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricTokens}`}
-                      aria-label={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
-                    >
-                      <span className={styles.accountHistoryIcon}>
-                        <IconBinary size={13} />
-                      </span>
-                      <strong>{accountHistoryTokenValue}</strong>
-                    </div>
-                    <div
-                      className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricCost}`}
-                      aria-label={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
-                    >
-                      <span className={styles.accountHistoryIcon}>
-                        <IconDollarSign size={13} />
-                      </span>
-                      <strong>{accountHistoryCostValue}</strong>
-                    </div>
-                    <div
-                      className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricSuccess}`}
-                      aria-label={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
-                    >
-                      <span className={styles.accountHistoryIcon}>
-                        <IconCheck size={13} />
-                      </span>
-                      <strong>{accountHistorySuccessValue}</strong>
-                    </div>
-                  </div>
-                  {accountHistoryFootnote ? (
-                    <span className={styles.accountHistoryFootnote}>{accountHistoryFootnote}</span>
-                  ) : null}
-                </div>
+                {renderAccountDetailTrigger({
+                  isSelectionMode,
+                  className: styles.accountCardEvidence,
+                  title: accountHistoryTitle,
+                  ariaLabel: `${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
+                  kind: 'history',
+                  onOpen: () => void openAccountDetail(row, 'quota'),
+                  children: (
+                    <>
+                      <div className={styles.accountHistoryGrid}>
+                        <div
+                          className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricRequests}`}
+                          aria-label={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
+                        >
+                          <span className={styles.accountHistoryIcon}>
+                            <IconSend size={13} />
+                          </span>
+                          <strong>{accountHistoryRequestValue}</strong>
+                        </div>
+                        <div
+                          className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricTokens}`}
+                          aria-label={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
+                        >
+                          <span className={styles.accountHistoryIcon}>
+                            <IconBinary size={13} />
+                          </span>
+                          <strong>{accountHistoryTokenValue}</strong>
+                        </div>
+                        <div
+                          className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricCost}`}
+                          aria-label={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
+                        >
+                          <span className={styles.accountHistoryIcon}>
+                            <IconDollarSign size={13} />
+                          </span>
+                          <strong>{accountHistoryCostValue}</strong>
+                        </div>
+                        <div
+                          className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricSuccess}`}
+                          aria-label={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
+                        >
+                          <span className={styles.accountHistoryIcon}>
+                            <IconCheck size={13} />
+                          </span>
+                          <strong>{accountHistorySuccessValue}</strong>
+                        </div>
+                      </div>
+                      {accountHistoryFootnote ? (
+                        <span className={styles.accountHistoryFootnote}>
+                          {accountHistoryFootnote}
+                        </span>
+                      ) : null}
+                    </>
+                  ),
+                })}
 
-                <div className={styles.accountCardBusiness}>
-                  <div
-                    className={[
-                      styles.quotaWindowGrid,
-                      hiddenQuotaWindowCount > 0 ? styles.quotaWindowGridHasMore : '',
-                    ]
-                      .filter(Boolean)
-                      .join(' ')}
-                    title={quotaWindowTitle}
-                  >
-                    {antigravityQuotaMatrix ? (
-                      <AccountQuotaMatrix
-                        accountKey={row.selectionKey}
-                        matrix={antigravityQuotaMatrix}
-                      />
-                    ) : displayQuotaWindows.length > 0 ? (
-                      displayQuotaWindows.map((window) => {
-                        const windowRemaining = window.remainingPercent;
-                        const windowWidth = Math.max(0, Math.min(100, windowRemaining ?? 0));
-                        const resetLabel =
-                          window.resetLabel && window.resetLabel !== '-' ? window.resetLabel : '';
-                        const resetDisplayLabel = formatQuotaResetDisplay(
-                          window.resetAtMs,
-                          resetLabel,
-                          i18n.language
-                        );
-                        const shortLabel = getQuotaWindowShortLabel(window);
-                        return (
-                          <div
-                            key={window.key}
-                            className={styles.quotaWindowCard}
-                            title={`${window.label}: ${formatPercent(windowRemaining)}`}
-                          >
-                            <div className={styles.quotaWindowPrimaryLine}>
-                              <span className={styles.quotaWindowSummary} title={window.label}>
-                                {shortLabel}
-                              </span>
-                              <div className={styles.quotaTrack} aria-hidden="true">
+                {renderAccountDetailTrigger({
+                  isSelectionMode,
+                  className: styles.accountCardBusiness,
+                  title: quotaWindowTitle,
+                  ariaLabel: `${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
+                  kind: 'quota',
+                  onOpen: () => void openAccountDetail(row, 'quota'),
+                  children: (
+                    <div className={styles.quotaWindowGrid} title={quotaWindowTitle}>
+                      {antigravityQuotaMatrix ? (
+                        <AccountQuotaMatrix
+                          accountKey={row.selectionKey}
+                          matrix={antigravityQuotaMatrix}
+                        />
+                      ) : displayQuotaWindows.length > 0 ? (
+                        displayQuotaWindows.map((window) => {
+                          const windowRemaining = window.remainingPercent;
+                          const windowWidth = Math.max(0, Math.min(100, windowRemaining ?? 0));
+                          const resetLabel =
+                            window.resetLabel && window.resetLabel !== '-' ? window.resetLabel : '';
+                          const resetDisplayLabel = formatQuotaResetDisplay(
+                            window.resetAtMs,
+                            resetLabel,
+                            i18n.language
+                          );
+                          const shortLabel = getQuotaWindowShortLabel(window);
+                          return (
+                            <div
+                              key={window.key}
+                              className={styles.quotaWindowCard}
+                              title={`${window.label}: ${formatPercent(windowRemaining)}`}
+                            >
+                              <div className={styles.quotaWindowPrimaryLine}>
+                                <span className={styles.quotaWindowSummary} title={window.label}>
+                                  {shortLabel}
+                                </span>
+                                <div className={styles.quotaTrack} aria-hidden="true">
+                                  <span
+                                    className={`${styles.quotaBar} ${getRemainingBarClass(row)}`}
+                                    style={{ width: `${windowWidth}%` }}
+                                  />
+                                </div>
+                                <strong className={styles.quotaWindowPercent}>
+                                  {windowRemaining !== null ? formatPercent(windowRemaining) : '-'}
+                                </strong>
                                 <span
-                                  className={`${styles.quotaBar} ${getRemainingBarClass(row)}`}
-                                  style={{ width: `${windowWidth}%` }}
-                                />
+                                  className={styles.quotaResetMeta}
+                                  title={
+                                    resetDisplayLabel !== '-'
+                                      ? `${t('accounts.col_reset')}: ${resetDisplayLabel}`
+                                      : ''
+                                  }
+                                >
+                                  {resetDisplayLabel}
+                                </span>
                               </div>
-                              <strong className={styles.quotaWindowPercent}>
-                                {windowRemaining !== null ? formatPercent(windowRemaining) : '-'}
-                              </strong>
-                              <span
-                                className={styles.quotaResetMeta}
-                                title={
-                                  resetDisplayLabel !== '-'
-                                    ? `${t('accounts.col_reset')}: ${resetDisplayLabel}`
-                                    : ''
-                                }
-                              >
-                                {resetDisplayLabel}
-                              </span>
                             </div>
-                          </div>
-                        );
-                      })
-                    ) : (
-                      <span className={styles.quotaEmptyState} data-account-quota-empty="true">
-                        {t('accounts.quota_source_none')}
-                      </span>
-                    )}
-                    {hiddenQuotaWindowCount > 0 ? (
-                      <button
-                        type="button"
-                        className={styles.quotaMoreButton}
-                        title={t('accounts.quota_more_windows_title', {
-                          count: hiddenQuotaWindowCount,
-                        })}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void openAccountDetail(row, 'quota');
-                        }}
-                      >
-                        {t('accounts.quota_more_windows', {
-                          count: hiddenQuotaWindowCount,
-                        })}
-                      </button>
-                    ) : null}
-                  </div>
-                </div>
+                          );
+                        })
+                      ) : (
+                        <span className={styles.quotaEmptyState} data-account-quota-empty="true">
+                          {t('accounts.quota_source_none')}
+                        </span>
+                      )}
+                    </div>
+                  ),
+                })}
 
                 <div className={styles.accountCardRecommendation}>
                   {renderRowActions(row, item.health.status === 'reauth')}

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -6857,7 +6857,7 @@ export function AccountsPage() {
             });
             const quotaEmptyLabel =
               quotaWindows.length > 0
-                ? t('accounts.quota_standard_none')
+                ? t('accounts.quota_details_only')
                 : t('accounts.quota_source_none');
             const quotaWindowTitle =
               standardQuotaWindows
@@ -7041,7 +7041,10 @@ export function AccountsPage() {
                   isSelectionMode,
                   className: styles.accountCardEvidence,
                   title: accountHistoryTitle,
-                  ariaLabel: `${t('accounts.list_header_historical_usage')}: ${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
+                  ariaLabel: `${t('accounts.list_header_historical_usage')}: ${accountHistoryTitle}. ${t(
+                    'accounts.open_detail',
+                    { name: row.fileName }
+                  )}: ${t('accounts.detail_tab_quota')}`,
                   kind: 'history',
                   onOpen: () => void openAccountDetail(row, 'quota'),
                   children: (
@@ -7097,7 +7100,10 @@ export function AccountsPage() {
                   isSelectionMode,
                   className: styles.accountCardBusiness,
                   title: quotaWindowTitle,
-                  ariaLabel: `${t('accounts.list_header_quota')}: ${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
+                  ariaLabel: `${t('accounts.list_header_quota')}: ${quotaWindowTitle}. ${t(
+                    'accounts.open_detail',
+                    { name: row.fileName }
+                  )}: ${t('accounts.detail_tab_quota')}`,
                   kind: 'quota',
                   onOpen: () => void openAccountDetail(row, 'quota'),
                   children: (

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -165,7 +165,7 @@ import {
 import {
   buildAccountQuotaDisplayWindows,
   getQuotaWindowShortLabel,
-  isStandardAccountQuotaWindow,
+  isStandardAccountQuotaListWindow,
   type AccountQuotaDisplayWindow,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
 import {
@@ -188,7 +188,6 @@ import {
   DETAIL_EVENTS_LIMIT,
   DETAIL_EVENTS_RANGE_MS,
   PAGE_SIZE_OPTIONS,
-  buildAntigravityQuotaMatrix,
   formatHistoryNumber,
   formatHistorySuccessRate,
   formatPercent,
@@ -266,7 +265,6 @@ import {
   AccountModelsTab,
   AccountOverviewTab,
   AccountProviderTabs,
-  AccountQuotaMatrix,
   AccountQuotaTab,
   AccountsBatchDeletePreview,
 } from '@/features/accounts/components';
@@ -6846,7 +6844,7 @@ export function AccountsPage() {
             const accountHistory = accountHistoryByRowKey.get(row.selectionKey) ?? null;
             const quotaWindows =
               quotaDisplayWindowsByRowKey.get(row.selectionKey) ?? buildQuotaDisplayWindows(row);
-            const standardQuotaWindows = quotaWindows.filter(isStandardAccountQuotaWindow);
+            const standardQuotaWindows = quotaWindows.filter(isStandardAccountQuotaListWindow);
             const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
             const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
             const item = buildAccountListItem(row, {
@@ -6857,8 +6855,10 @@ export function AccountsPage() {
               quotaWindows,
               requestEvidence: requestEvidenceBySelectionKey.get(row.selectionKey),
             });
-            const antigravityQuotaMatrix = buildAntigravityQuotaMatrix(row, standardQuotaWindows);
-            const displayQuotaWindows = antigravityQuotaMatrix ? [] : standardQuotaWindows;
+            const quotaEmptyLabel =
+              quotaWindows.length > 0
+                ? t('accounts.quota_standard_none')
+                : t('accounts.quota_source_none');
             const quotaWindowTitle =
               standardQuotaWindows
                 .map((window) => {
@@ -6867,7 +6867,7 @@ export function AccountsPage() {
                     : window.label;
                   return `${label}: ${formatPercent(window.remainingPercent)}`;
                 })
-                .join('\n') || t('accounts.quota_source_none');
+                .join('\n') || quotaEmptyLabel;
             const healthTitle = t(
               item.health.tooltipKey,
               formatQuotaResetTooltipParams(
@@ -7041,13 +7041,13 @@ export function AccountsPage() {
                   isSelectionMode,
                   className: styles.accountCardEvidence,
                   title: accountHistoryTitle,
-                  ariaLabel: `${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
+                  ariaLabel: `${t('accounts.list_header_historical_usage')}: ${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
                   kind: 'history',
                   onOpen: () => void openAccountDetail(row, 'quota'),
                   children: (
                     <>
-                      <div className={styles.accountHistoryGrid}>
-                        <div
+                      <span className={styles.accountHistoryGrid}>
+                        <span
                           className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricRequests}`}
                           aria-label={`${t('accounts.history_requests')}: ${accountHistoryRequestExactValue}`}
                         >
@@ -7055,8 +7055,8 @@ export function AccountsPage() {
                             <IconSend size={13} />
                           </span>
                           <strong>{accountHistoryRequestValue}</strong>
-                        </div>
-                        <div
+                        </span>
+                        <span
                           className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricTokens}`}
                           aria-label={`${t('accounts.history_tokens')}: ${accountHistoryTokenExactValue}`}
                         >
@@ -7064,8 +7064,8 @@ export function AccountsPage() {
                             <IconBinary size={13} />
                           </span>
                           <strong>{accountHistoryTokenValue}</strong>
-                        </div>
-                        <div
+                        </span>
+                        <span
                           className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricCost}`}
                           aria-label={`${t('accounts.history_cost')}: ${accountHistoryCostExactValue}`}
                         >
@@ -7073,8 +7073,8 @@ export function AccountsPage() {
                             <IconDollarSign size={13} />
                           </span>
                           <strong>{accountHistoryCostValue}</strong>
-                        </div>
-                        <div
+                        </span>
+                        <span
                           className={`${styles.accountHistoryMetric} ${styles.accountHistoryMetricSuccess}`}
                           aria-label={`${t('accounts.history_success')}: ${accountHistorySuccessExactValue}`}
                         >
@@ -7082,8 +7082,8 @@ export function AccountsPage() {
                             <IconCheck size={13} />
                           </span>
                           <strong>{accountHistorySuccessValue}</strong>
-                        </div>
-                      </div>
+                        </span>
+                      </span>
                       {accountHistoryFootnote ? (
                         <span className={styles.accountHistoryFootnote}>
                           {accountHistoryFootnote}
@@ -7097,18 +7097,13 @@ export function AccountsPage() {
                   isSelectionMode,
                   className: styles.accountCardBusiness,
                   title: quotaWindowTitle,
-                  ariaLabel: `${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
+                  ariaLabel: `${t('accounts.list_header_quota')}: ${t('accounts.open_detail', { name: row.fileName })}: ${t('accounts.detail_tab_quota')}`,
                   kind: 'quota',
                   onOpen: () => void openAccountDetail(row, 'quota'),
                   children: (
-                    <div className={styles.quotaWindowGrid} title={quotaWindowTitle}>
-                      {antigravityQuotaMatrix ? (
-                        <AccountQuotaMatrix
-                          accountKey={row.selectionKey}
-                          matrix={antigravityQuotaMatrix}
-                        />
-                      ) : displayQuotaWindows.length > 0 ? (
-                        displayQuotaWindows.map((window) => {
+                    <span className={styles.quotaWindowGrid} title={quotaWindowTitle}>
+                      {standardQuotaWindows.length > 0 ? (
+                        standardQuotaWindows.map((window) => {
                           const windowRemaining = window.remainingPercent;
                           const windowWidth = Math.max(0, Math.min(100, windowRemaining ?? 0));
                           const resetLabel =
@@ -7120,21 +7115,21 @@ export function AccountsPage() {
                           );
                           const shortLabel = getQuotaWindowShortLabel(window);
                           return (
-                            <div
+                            <span
                               key={window.key}
                               className={styles.quotaWindowCard}
                               title={`${window.label}: ${formatPercent(windowRemaining)}`}
                             >
-                              <div className={styles.quotaWindowPrimaryLine}>
+                              <span className={styles.quotaWindowPrimaryLine}>
                                 <span className={styles.quotaWindowSummary} title={window.label}>
                                   {shortLabel}
                                 </span>
-                                <div className={styles.quotaTrack} aria-hidden="true">
+                                <span className={styles.quotaTrack} aria-hidden="true">
                                   <span
                                     className={`${styles.quotaBar} ${getRemainingBarClass(row)}`}
                                     style={{ width: `${windowWidth}%` }}
                                   />
-                                </div>
+                                </span>
                                 <strong className={styles.quotaWindowPercent}>
                                   {windowRemaining !== null ? formatPercent(windowRemaining) : '-'}
                                 </strong>
@@ -7148,16 +7143,16 @@ export function AccountsPage() {
                                 >
                                   {resetDisplayLabel}
                                 </span>
-                              </div>
-                            </div>
+                              </span>
+                            </span>
                           );
                         })
                       ) : (
                         <span className={styles.quotaEmptyState} data-account-quota-empty="true">
-                          {t('accounts.quota_source_none')}
+                          {quotaEmptyLabel}
                         </span>
                       )}
-                    </div>
+                    </span>
                   ),
                 })}
 

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
@@ -140,6 +140,24 @@ describe('QuotaWindowCard', () => {
     expect(renderer.root.findAllByProps({ 'data-quota-model-comparison': 'true' })).toHaveLength(0);
   });
 
+  it('keeps a fixed billing interval in standard mode when mode is inferred', () => {
+    const renderer = renderCard(
+      makeWindow({
+        kind: 'billing',
+        windowMode: 'fixed',
+        limitWindowSeconds: 30 * 24 * 60 * 60,
+        cycleStartMs: 1_000,
+        cycleEndMs: 30 * 24 * 60 * 60 * 1_000,
+      })
+    );
+
+    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'standard' })).toHaveLength(1);
+    expect(renderer.root.findAllByProps({ 'data-quota-standard-comparison': 'true' })).toHaveLength(
+      1
+    );
+    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'other' })).toHaveLength(0);
+  });
+
   it('uses semantic colors for the current usage metric icons', () => {
     const renderer = renderCard(makeWindow());
     const current = renderer.root.findByProps({ 'data-quota-usage-period': 'current' });

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
@@ -26,7 +26,6 @@ import {
 import {
   isIntervalAccountQuotaWindow,
   isModelScopedAccountQuotaWindow,
-  isStandardAccountQuotaWindow,
   type AccountQuotaWindowKind,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
 import type { AccountQuotaBoundaryAccuracy } from '@/features/accounts/model/accountQuotaWindowDefinitions';
@@ -151,9 +150,8 @@ const formatObservedAt = (value: number, locale: string): string =>
 
 const inferCardMode = (window: AccountDetailQuotaWindow): QuotaWindowCardMode => {
   if (!isIntervalAccountQuotaWindow(window)) return 'other';
-  if (isStandardAccountQuotaWindow(window)) return 'standard';
   if (isModelScopedAccountQuotaWindow(window)) return 'model';
-  return 'other';
+  return 'standard';
 };
 
 const windowIconForKind = (

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
@@ -23,7 +23,12 @@ import {
   IconChartLine,
   IconCheck,
 } from '@/components/ui/icons';
-import type { AccountQuotaWindowKind } from '@/features/accounts/model/accountQuotaDisplayWindows';
+import {
+  isIntervalAccountQuotaWindow,
+  isModelScopedAccountQuotaWindow,
+  isStandardAccountQuotaWindow,
+  type AccountQuotaWindowKind,
+} from '@/features/accounts/model/accountQuotaDisplayWindows';
 import type { AccountQuotaBoundaryAccuracy } from '@/features/accounts/model/accountQuotaWindowDefinitions';
 import type {
   AccountDetailQuotaWindow,
@@ -31,7 +36,6 @@ import type {
 } from '@/features/accounts/model/accountDetailViewModel';
 import { formatQuotaResetDisplay } from '@/features/accounts/model/accountsPagePresentation';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
-import { isCodexMainQuotaModelScope } from '@/utils/quota/codexQuota';
 import { QuotaProgressBar } from './QuotaProgressBar';
 import styles from './QuotaWindowCard.module.scss';
 
@@ -145,16 +149,11 @@ const formatObservedAt = (value: number, locale: string): string =>
     minute: '2-digit',
   }).format(value);
 
-const isIntervalWindow = (window: AccountDetailQuotaWindow): boolean =>
-  window.windowMode === 'fixed' ||
-  window.windowMode === 'calendar' ||
-  window.windowMode === 'rolling';
-
 const inferCardMode = (window: AccountDetailQuotaWindow): QuotaWindowCardMode => {
-  if (!isIntervalWindow(window)) return 'other';
-  if (window.source === 'codex' && isCodexMainQuotaModelScope(window.modelScope)) return 'standard';
-  if (window.modelScope?.complete === false) return 'model';
-  return window.modelScope?.kind && window.modelScope.kind !== 'all' ? 'model' : 'standard';
+  if (!isIntervalAccountQuotaWindow(window)) return 'other';
+  if (isStandardAccountQuotaWindow(window)) return 'standard';
+  if (isModelScopedAccountQuotaWindow(window)) return 'model';
+  return 'other';
 };
 
 const windowIconForKind = (
@@ -617,7 +616,7 @@ export const QuotaWindowCard = ({
 
   const progress = <QuotaProgress className={styles.bar} percent={q.remainingPercent} />;
 
-  if (resolvedMode === 'other' || !isIntervalWindow(q)) {
+  if (resolvedMode === 'other' || !isIntervalAccountQuotaWindow(q)) {
     return (
       <div
         className={`${styles.card} ${styles.otherCard}`}

--- a/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
@@ -17,7 +17,6 @@ import {
 import {
   isIntervalAccountQuotaWindow,
   isModelScopedAccountQuotaWindow,
-  isStandardAccountQuotaWindow,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import { QuotaWindowCard } from '../QuotaWindowCard';
@@ -116,15 +115,13 @@ export function AccountQuotaTab({
   const { t, i18n } = useTranslation();
   const history = detailView.history;
   const allWindows = detailView.quota.windows;
-  const standardWindows = allWindows.filter(isStandardAccountQuotaWindow);
+  const standardWindows = allWindows.filter(
+    (window) => isIntervalAccountQuotaWindow(window) && !isModelScopedAccountQuotaWindow(window)
+  );
   const modelWindows = allWindows.filter(
     (window) => isIntervalAccountQuotaWindow(window) && isModelScopedAccountQuotaWindow(window)
   );
-  const otherQuotaItems = allWindows.filter(
-    (window) =>
-      !isStandardAccountQuotaWindow(window) &&
-      !(isIntervalAccountQuotaWindow(window) && isModelScopedAccountQuotaWindow(window))
-  );
+  const otherQuotaItems = allWindows.filter((window) => !isIntervalAccountQuotaWindow(window));
 
   const formatNumber = (value: number) => new Intl.NumberFormat(i18n.language).format(value);
   const formatTime = (value: number | null) =>

--- a/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
@@ -9,28 +9,19 @@ import {
   IconDollarSign,
   IconRefreshCw,
 } from '@/components/ui/icons';
-import type {
-  AccountDetailQuotaWindow,
-  AccountDetailViewModel,
-} from '@/features/accounts/model/accountDetailViewModel';
+import type { AccountDetailViewModel } from '@/features/accounts/model/accountDetailViewModel';
 import {
   formatPercent,
   formatQuotaResetTimestamp,
 } from '@/features/accounts/model/accountsPagePresentation';
+import {
+  isIntervalAccountQuotaWindow,
+  isModelScopedAccountQuotaWindow,
+  isStandardAccountQuotaWindow,
+} from '@/features/accounts/model/accountQuotaDisplayWindows';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
-import { isCodexMainQuotaModelScope } from '@/utils/quota/codexQuota';
 import { QuotaWindowCard } from '../QuotaWindowCard';
 import styles from '@/features/accounts/AccountsPage.module.scss';
-
-const isIntervalQuotaWindow = (window: AccountDetailQuotaWindow): boolean =>
-  window.windowMode === 'fixed' ||
-  window.windowMode === 'calendar' ||
-  window.windowMode === 'rolling';
-
-const isModelScopedQuotaWindow = (window: AccountDetailQuotaWindow): boolean =>
-  window.modelScope?.kind !== undefined &&
-  window.modelScope.kind !== 'all' &&
-  !(window.source === 'codex' && isCodexMainQuotaModelScope(window.modelScope));
 
 type MetricTone = 'blue' | 'green' | 'teal' | 'amber';
 
@@ -125,13 +116,15 @@ export function AccountQuotaTab({
   const { t, i18n } = useTranslation();
   const history = detailView.history;
   const allWindows = detailView.quota.windows;
-  const standardWindows = allWindows.filter(
-    (window) => isIntervalQuotaWindow(window) && !isModelScopedQuotaWindow(window)
-  );
+  const standardWindows = allWindows.filter(isStandardAccountQuotaWindow);
   const modelWindows = allWindows.filter(
-    (window) => isIntervalQuotaWindow(window) && isModelScopedQuotaWindow(window)
+    (window) => isIntervalAccountQuotaWindow(window) && isModelScopedAccountQuotaWindow(window)
   );
-  const otherQuotaItems = allWindows.filter((window) => !isIntervalQuotaWindow(window));
+  const otherQuotaItems = allWindows.filter(
+    (window) =>
+      !isStandardAccountQuotaWindow(window) &&
+      !(isIntervalAccountQuotaWindow(window) && isModelScopedAccountQuotaWindow(window))
+  );
 
   const formatNumber = (value: number) => new Intl.NumberFormat(i18n.language).format(value);
   const formatTime = (value: number | null) =>

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
@@ -6,6 +6,9 @@ import {
   buildAccountQuotaDisplayWindow,
   buildAccountQuotaDisplayWindows,
   getQuotaWindowShortLabel,
+  isIntervalAccountQuotaWindow,
+  isModelScopedAccountQuotaWindow,
+  isStandardAccountQuotaWindow,
   parseQuotaResetLabelMs,
   type TranslateQuotaWindowLabel,
 } from './accountQuotaDisplayWindows';
@@ -60,6 +63,85 @@ const buildRow = (file: AuthFileItem, stores: AccountQuotaStores = emptyStores()
 };
 
 describe('accountQuotaDisplayWindows', () => {
+  describe('quota window classification', () => {
+    it.each(['fixed', 'calendar', 'rolling'] as const)(
+      'classifies an account-wide %s window as standard quota',
+      (windowMode) => {
+        const window = {
+          windowMode,
+          source: 'claude' as const,
+          modelScope: { kind: 'all' as const, complete: true },
+        };
+
+        expect(isIntervalAccountQuotaWindow(window)).toBe(true);
+        expect(isModelScopedAccountQuotaWindow(window)).toBe(false);
+        expect(isStandardAccountQuotaWindow(window)).toBe(true);
+      }
+    );
+
+    it.each([
+      { kind: 'models' as const, models: ['gemini-3-pro'], complete: true },
+      { kind: 'family' as const, key: 'gemini', complete: true },
+    ])('classifies an explicitly model-scoped fixed window as model quota', (modelScope) => {
+      const window = { windowMode: 'fixed' as const, source: 'antigravity' as const, modelScope };
+
+      expect(isIntervalAccountQuotaWindow(window)).toBe(true);
+      expect(isModelScopedAccountQuotaWindow(window)).toBe(true);
+      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+    });
+
+    it('keeps the complete Codex main family in standard quota', () => {
+      const window = {
+        windowMode: 'fixed' as const,
+        source: 'codex' as const,
+        modelScope: { kind: 'family' as const, key: 'codex_main', complete: true },
+      };
+
+      expect(isModelScopedAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaWindow(window)).toBe(true);
+    });
+
+    it.each([
+      { kind: 'billing' as const, windowMode: 'non_window' as const },
+      { kind: 'payg' as const, windowMode: 'non_window' as const },
+      { kind: 'product' as const, windowMode: 'non_window' as const },
+      { kind: 'unknown' as const, windowMode: 'unknown' as const },
+    ])('does not classify a $kind $windowMode item as standard quota', ({ kind, windowMode }) => {
+      const window = {
+        kind,
+        windowMode,
+        source: 'xai' as const,
+        modelScope: { kind: 'all' as const, complete: true },
+      };
+
+      expect(isIntervalAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+    });
+
+    it('does not classify a billing item as standard even when it has interval boundaries', () => {
+      const window = {
+        kind: 'billing' as const,
+        windowMode: 'fixed' as const,
+        source: 'xai' as const,
+        modelScope: { kind: 'all' as const, complete: true },
+      };
+
+      expect(isIntervalAccountQuotaWindow(window)).toBe(true);
+      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+    });
+
+    it('fails closed when a provider reports an incomplete account-wide scope', () => {
+      const window = {
+        windowMode: 'fixed' as const,
+        source: 'antigravity' as const,
+        modelScope: { kind: 'all' as const, complete: false },
+      };
+
+      expect(isModelScopedAccountQuotaWindow(window)).toBe(true);
+      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+    });
+  });
+
   it('rolls legacy yearless reset labels into the next calendar year', () => {
     const nowMs = new Date(2026, 11, 31, 23, 0, 0, 0).getTime();
 

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
@@ -8,7 +8,7 @@ import {
   getQuotaWindowShortLabel,
   isIntervalAccountQuotaWindow,
   isModelScopedAccountQuotaWindow,
-  isStandardAccountQuotaWindow,
+  isStandardAccountQuotaListWindow,
   parseQuotaResetLabelMs,
   type TranslateQuotaWindowLabel,
 } from './accountQuotaDisplayWindows';
@@ -75,7 +75,7 @@ describe('accountQuotaDisplayWindows', () => {
 
         expect(isIntervalAccountQuotaWindow(window)).toBe(true);
         expect(isModelScopedAccountQuotaWindow(window)).toBe(false);
-        expect(isStandardAccountQuotaWindow(window)).toBe(true);
+        expect(isStandardAccountQuotaListWindow(window)).toBe(true);
       }
     );
 
@@ -87,7 +87,7 @@ describe('accountQuotaDisplayWindows', () => {
 
       expect(isIntervalAccountQuotaWindow(window)).toBe(true);
       expect(isModelScopedAccountQuotaWindow(window)).toBe(true);
-      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(false);
     });
 
     it('keeps the complete Codex main family in standard quota', () => {
@@ -98,7 +98,7 @@ describe('accountQuotaDisplayWindows', () => {
       };
 
       expect(isModelScopedAccountQuotaWindow(window)).toBe(false);
-      expect(isStandardAccountQuotaWindow(window)).toBe(true);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(true);
     });
 
     it.each([
@@ -115,10 +115,10 @@ describe('accountQuotaDisplayWindows', () => {
       };
 
       expect(isIntervalAccountQuotaWindow(window)).toBe(false);
-      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(false);
     });
 
-    it('does not classify a billing item as standard even when it has interval boundaries', () => {
+    it('keeps a fixed billing interval out of the list while retaining interval semantics', () => {
       const window = {
         kind: 'billing' as const,
         windowMode: 'fixed' as const,
@@ -127,7 +127,7 @@ describe('accountQuotaDisplayWindows', () => {
       };
 
       expect(isIntervalAccountQuotaWindow(window)).toBe(true);
-      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(false);
     });
 
     it('fails closed when a provider reports an incomplete account-wide scope', () => {
@@ -138,7 +138,7 @@ describe('accountQuotaDisplayWindows', () => {
       };
 
       expect(isModelScopedAccountQuotaWindow(window)).toBe(true);
-      expect(isStandardAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(false);
     });
   });
 
@@ -469,6 +469,56 @@ describe('accountQuotaDisplayWindows', () => {
       source: 'xai',
     });
     expect(getQuotaWindowShortLabel(windows[1])).toBe('PAYG');
+  });
+
+  it('keeps a monthly xAI billing period as an interval while hiding it from the list', () => {
+    const periodStartMs = Date.parse('2026-08-01T00:00:00Z');
+    const periodEndMs = Date.parse('2026-09-01T00:00:00Z');
+    const stores = {
+      ...emptyStores(),
+      xaiQuota: {
+        'xai.json': {
+          status: 'success',
+          billing: {
+            periodType: 'monthly',
+            usagePercent: 20,
+            periodStart: '2026-08-01T00:00:00Z',
+            periodEnd: '2026-09-01T00:00:00Z',
+            productUsage: [{ product: 'Grok Code Fast', usagePercent: 20 }],
+            monthlyLimitCents: 10_000,
+            usedCents: 2_000,
+            includedUsedCents: 2_000,
+            onDemandCapCents: null,
+            onDemandUsedCents: null,
+            onDemandUsedPercent: null,
+            billingPeriodStart: '2026-08-01T00:00:00Z',
+            billingPeriodEnd: '2026-09-01T00:00:00Z',
+            usedPercent: 20,
+          },
+        },
+      },
+    } satisfies AccountQuotaStores;
+    const row = buildRow({ name: 'xai.json', type: 'xai' }, stores);
+
+    const windows = buildAccountQuotaDisplayWindows(row, {
+      stores,
+      translateQuotaWindowLabel,
+      t,
+      nowMs: Date.parse('2026-08-15T00:00:00Z'),
+    });
+    const periodWindow = windows.find((window) => window.key === 'credits-period');
+
+    expect(periodWindow).toMatchObject({
+      kind: 'billing',
+      windowMode: 'fixed',
+      cycleStartMs: periodStartMs,
+      cycleEndMs: periodEndMs,
+      modelScope: { kind: 'all', complete: true },
+    });
+    expect(periodWindow).toBeDefined();
+    expect(isIntervalAccountQuotaWindow(periodWindow!)).toBe(true);
+    expect(isModelScopedAccountQuotaWindow(periodWindow!)).toBe(false);
+    expect(isStandardAccountQuotaListWindow(periodWindow!)).toBe(false);
   });
 
   it('shows xAI weekly credits as a separate quota window', () => {

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
@@ -17,7 +17,10 @@ import {
   parseQuotaResetLabelMs,
   resolveAbsoluteQuotaReset,
 } from '@/utils/quota/formatters';
-import { inferCodexQuotaScopeFromProviderWindowId } from '@/utils/quota/codexQuota';
+import {
+  inferCodexQuotaScopeFromProviderWindowId,
+  isCodexMainQuotaModelScope,
+} from '@/utils/quota/codexQuota';
 import type { AccountRow } from './accountRows';
 import type { AccountQuotaStores } from './accountQuotaSummary';
 
@@ -99,6 +102,31 @@ export const remainingPercentFromUsed = (value: number | null | undefined) =>
   typeof value === 'number' && Number.isFinite(value) ? clampDisplayPercent(100 - value) : null;
 
 export { parseQuotaResetLabelMs };
+
+export const isIntervalAccountQuotaWindow = (
+  window: Pick<AccountQuotaDisplayWindow, 'windowMode'>
+): boolean =>
+  window.windowMode === 'fixed' ||
+  window.windowMode === 'calendar' ||
+  window.windowMode === 'rolling';
+
+export const isModelScopedAccountQuotaWindow = (
+  window: Pick<AccountQuotaDisplayWindow, 'modelScope' | 'source'>
+): boolean =>
+  window.modelScope?.complete === false ||
+  (window.modelScope?.kind !== undefined &&
+    window.modelScope.kind !== 'all' &&
+    !(window.source === 'codex' && isCodexMainQuotaModelScope(window.modelScope)));
+
+export const isStandardAccountQuotaWindow = (
+  window: Pick<AccountQuotaDisplayWindow, 'kind' | 'windowMode' | 'modelScope' | 'source'>
+): boolean =>
+  isIntervalAccountQuotaWindow(window) &&
+  !isModelScopedAccountQuotaWindow(window) &&
+  window.kind !== 'billing' &&
+  window.kind !== 'payg' &&
+  window.kind !== 'product' &&
+  window.kind !== 'summary';
 
 const normalizeText = (value: string): string => value.trim().toLowerCase().replace(/\s+/g, ' ');
 

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
@@ -118,7 +118,7 @@ export const isModelScopedAccountQuotaWindow = (
     window.modelScope.kind !== 'all' &&
     !(window.source === 'codex' && isCodexMainQuotaModelScope(window.modelScope)));
 
-export const isStandardAccountQuotaWindow = (
+export const isStandardAccountQuotaListWindow = (
   window: Pick<AccountQuotaDisplayWindow, 'kind' | 'windowMode' | 'modelScope' | 'source'>
 ): boolean =>
   isIntervalAccountQuotaWindow(window) &&

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -993,8 +993,6 @@
     "quota_source_short_cache": "Last check",
     "quota_source_short_observed": "Request record",
     "quota_source_short_none": "No data",
-    "quota_more_windows": "+{{count}}",
-    "quota_more_windows_title": "{{count}} more quota windows. Open details to inspect.",
     "activity_brief": "{{count}} calls · {{rate}} success",
     "activity_empty": "No recent calls",
     "activity_success_failure": "Success {{success}} · Failure {{failure}}",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -988,7 +988,7 @@
     "quota_source_cache": "Previous check result",
     "quota_source_observed_header": "Recent request return data",
     "quota_source_none": "No quota data",
-    "quota_standard_none": "No standard quota",
+    "quota_details_only": "Quota available in details",
     "quota_brief_remaining": "{{percent}} left",
     "quota_brief_unknown": "Unknown quota",
     "quota_source_short_cache": "Last check",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -988,6 +988,7 @@
     "quota_source_cache": "Previous check result",
     "quota_source_observed_header": "Recent request return data",
     "quota_source_none": "No quota data",
+    "quota_standard_none": "No standard quota",
     "quota_brief_remaining": "{{percent}} left",
     "quota_brief_unknown": "Unknown quota",
     "quota_source_short_cache": "Last check",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -992,6 +992,7 @@
     "quota_source_cache": "Результат предыдущей проверки",
     "quota_source_observed_header": "Данные последнего ответа",
     "quota_source_none": "Нет данных квоты",
+    "quota_standard_none": "Нет стандартной квоты",
     "quota_brief_remaining": "Осталось {{percent}}",
     "quota_brief_unknown": "Квота неизвестна",
     "quota_source_short_cache": "Пред. проверка",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -997,8 +997,6 @@
     "quota_source_short_cache": "Пред. проверка",
     "quota_source_short_observed": "Запись запроса",
     "quota_source_short_none": "Нет данных",
-    "quota_more_windows": "+{{count}}",
-    "quota_more_windows_title": "Еще {{count}} окон квоты. Откройте детали для просмотра.",
     "activity_brief": "{{count}} вызовов · успех {{rate}}",
     "activity_empty": "Нет недавних вызовов",
     "activity_success_failure": "Успешно {{success}} · Ошибки {{failure}}",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -992,7 +992,7 @@
     "quota_source_cache": "Результат предыдущей проверки",
     "quota_source_observed_header": "Данные последнего ответа",
     "quota_source_none": "Нет данных квоты",
-    "quota_standard_none": "Нет стандартной квоты",
+    "quota_details_only": "Квота доступна в деталях",
     "quota_brief_remaining": "Осталось {{percent}}",
     "quota_brief_unknown": "Квота неизвестна",
     "quota_source_short_cache": "Пред. проверка",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -991,8 +991,6 @@
     "quota_source_short_cache": "上次查询",
     "quota_source_short_observed": "请求记录",
     "quota_source_short_none": "无数据",
-    "quota_more_windows": "+{{count}} 项",
-    "quota_more_windows_title": "还有 {{count}} 个额度窗口，点击查看详情",
     "activity_brief": "{{count}} 次 · 成功率 {{rate}}",
     "activity_empty": "暂无近期请求",
     "activity_success_failure": "成功 {{success}} · 失败 {{failure}}",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -986,6 +986,7 @@
     "quota_source_cache": "上次查询结果",
     "quota_source_observed_header": "最近请求返回信息",
     "quota_source_none": "暂无额度数据",
+    "quota_standard_none": "无标准额度",
     "quota_brief_remaining": "剩余 {{percent}}",
     "quota_brief_unknown": "额度未知",
     "quota_source_short_cache": "上次查询",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -986,7 +986,7 @@
     "quota_source_cache": "上次查询结果",
     "quota_source_observed_header": "最近请求返回信息",
     "quota_source_none": "暂无额度数据",
-    "quota_standard_none": "无标准额度",
+    "quota_details_only": "额度仅在详情中显示",
     "quota_brief_remaining": "剩余 {{percent}}",
     "quota_brief_unknown": "额度未知",
     "quota_source_short_cache": "上次查询",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -986,6 +986,7 @@
     "quota_source_cache": "上次查詢結果",
     "quota_source_observed_header": "最近請求返回資訊",
     "quota_source_none": "暫無額度資料",
+    "quota_standard_none": "無標準額度",
     "quota_brief_remaining": "剩餘 {{percent}}",
     "quota_brief_unknown": "額度未知",
     "quota_source_short_cache": "上次查詢",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -991,8 +991,6 @@
     "quota_source_short_cache": "上次查詢",
     "quota_source_short_observed": "請求記錄",
     "quota_source_short_none": "無資料",
-    "quota_more_windows": "+{{count}} 項",
-    "quota_more_windows_title": "還有 {{count}} 個額度視窗，點擊查看詳情",
     "activity_brief": "{{count}} 次 · 成功率 {{rate}}",
     "activity_empty": "暫無近期請求",
     "activity_success_failure": "成功 {{success}} · 失敗 {{failure}}",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -986,7 +986,7 @@
     "quota_source_cache": "上次查詢結果",
     "quota_source_observed_header": "最近請求返回資訊",
     "quota_source_none": "暫無額度資料",
-    "quota_standard_none": "無標準額度",
+    "quota_details_only": "額度僅在詳情中顯示",
     "quota_brief_remaining": "剩餘 {{percent}}",
     "quota_brief_unknown": "額度未知",
     "quota_source_short_cache": "上次查詢",


### PR DESCRIPTION
## Summary

Improve the Accounts credential list so historical usage and quota information act as direct, accessible shortcuts to the current credential quota tab. Keep the complete quota inventory in the detail view while making the list focused on standard quota windows.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Make the full historical usage and quota information regions open the existing quota detail route in normal mode.
- Preserve card selection behavior in selection mode and reuse the existing dirty-configuration navigation guard.
- Share interval/model-scope classification helpers while keeping compact-list visibility separate from detail-page quota grouping, including Codex main-scope handling.
- Show every list-visible standard interval window, keep model, billing, PAYG, and other quota available in details, and remove the obsolete +N affordance.
- Exclude model-scoped Antigravity groups from the compact list while retaining them in quota details.
- Distinguish credentials with no quota data from credentials whose quota is available only in the detail view.

## User Impact

Users can click either the historical usage or quota information region to open the selected credential directly on the Quota tab. Empty, loading, or unavailable regions remain openable. The list shows all eligible standard windows directly without a +N control; quota types intentionally excluded from the compact list are identified as available in details.

## Compatibility / Runtime Notes

- CPA panel mode: frontend-only behavior; existing Accounts URL state and navigation are preserved.
- Manager Server mode: no Manager Server source or API changes; the rebuilt panel uses the same behavior.
- Full Docker / native packages: no configuration, database, or packaging behavior changes.

## Data / Security Notes

N/A. No API, database, migration, credential, raw usage, or security behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the merged PR commit to restore the previous Accounts quota-list presentation and interaction.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/features/accounts/AccountsPage.test.tsx
npm test
npm run type-check
npm run lint
npm run build
npm run build:demo
npm run check:demo-isolation
git diff --check
Prettier check: changed AccountsPage, AccountsPage tests, and four locale files
Playwright demo preview checks: 1920px, 1025px, 1024px, 768px, 390px; normal and selection mode; keyboard navigation; light and dark themes
```

## Screenshots / Recordings

Manual Playwright UI validation covered the changed regions and responsive states. No persistent screenshot or recording artifact is included in this frontend-only PR.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a localized Accounts UI interaction and presentation change with no documentation or user-facing configuration changes.

## Related

N/A
