### PR TITLE
🐛 fix(manager-server): tolerate quota rollover boundary jitter

### DIFF
--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1241,6 +1241,9 @@ func cycleBoundaryIsNearScheduledRollover(
 	cycle model.AccountQuotaCycle,
 	snapshot model.AccountQuotaSnapshot,
 ) bool {
+	if isProvisionalZeroAPIBoundary(snapshot) {
+		return false
+	}
 	if cycle.ScheduledEndMS == nil ||
 		cycle.DurationSeconds == nil ||
 		snapshot.CycleStartMS == nil ||

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -1035,20 +1035,28 @@ func reconcileCycle(
 		}
 		return active.ID, 0, false, nil
 	}
-	if activeErr == nil && isReliableLifecycleBoundary(*snapshot) && active.ScheduledEndMS != nil &&
-		*snapshot.CycleStartMS >= *active.ScheduledEndMS {
-		actualEndMS := *active.ScheduledEndMS
-		if actualEndMS < active.ActualStartMS {
-			actualEndMS = active.ActualStartMS
+	if activeErr == nil && isReliableLifecycleBoundary(*snapshot) && active.ScheduledEndMS != nil {
+		strictScheduledRollover := *snapshot.CycleStartMS >= *active.ScheduledEndMS
+		nearScheduledRollover := cycleBoundaryIsNearScheduledRollover(active, *snapshot)
+		if strictScheduledRollover || nearScheduledRollover {
+			actualEndMS := *active.ScheduledEndMS
+			if actualEndMS < active.ActualStartMS {
+				actualEndMS = active.ActualStartMS
+			}
+			if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
+				state = 'closed', actual_end_ms = ?, end_reason = 'scheduled',
+				last_observation_id = ?, updated_at_ms = ? where id = ?`,
+				actualEndMS, observationID, snapshot.CreatedAtMS, active.ID); err != nil {
+				return 0, 0, false, err
+			}
+			var id int64
+			if nearScheduledRollover {
+				id, err = restoreOrInsertCycleAt(ctx, tx, activationID, observationID, &actualEndMS, snapshot)
+			} else {
+				id, err = restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
+			}
+			return id, active.ID, false, err
 		}
-		if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
-			state = 'closed', actual_end_ms = ?, end_reason = 'scheduled',
-			last_observation_id = ?, updated_at_ms = ? where id = ?`,
-			actualEndMS, observationID, snapshot.CreatedAtMS, active.ID); err != nil {
-			return 0, 0, false, err
-		}
-		id, err := restoreOrInsertCycle(ctx, tx, activationID, observationID, snapshot)
-		return id, active.ID, false, err
 	}
 	if isProvisionalZeroAPIBoundary(*snapshot) {
 		// A zero-use Codex API response whose calculated start follows the query
@@ -1221,6 +1229,31 @@ func cycleBoundaryShouldRefreshExpiredCurrent(
 		return false
 	}
 	return snapshot.ObservedAtMS >= *cycle.ScheduledEndMS &&
+		*snapshot.CycleEndMS > snapshot.ObservedAtMS
+}
+
+// cycleBoundaryIsNearScheduledRollover reports whether a reliable incoming
+// boundary is just before the active scheduled end because of provider timing
+// jitter. The observation must already be at the old end, while the incoming
+// boundary must still cover that observation, so material overlaps continue to
+// use the expired-boundary refresh path.
+func cycleBoundaryIsNearScheduledRollover(
+	cycle model.AccountQuotaCycle,
+	snapshot model.AccountQuotaSnapshot,
+) bool {
+	if cycle.ScheduledEndMS == nil ||
+		cycle.DurationSeconds == nil ||
+		snapshot.CycleStartMS == nil ||
+		snapshot.CycleEndMS == nil ||
+		snapshot.DurationSeconds == nil {
+		return false
+	}
+	if *cycle.DurationSeconds != *snapshot.DurationSeconds ||
+		*snapshot.CycleStartMS >= *cycle.ScheduledEndMS {
+		return false
+	}
+	return *cycle.ScheduledEndMS-*snapshot.CycleStartMS <= quotaBoundaryJitterMS &&
+		snapshot.ObservedAtMS >= *cycle.ScheduledEndMS &&
 		*snapshot.CycleEndMS > snapshot.ObservedAtMS
 }
 
@@ -1405,16 +1438,40 @@ func restoreOrInsertCycle(
 	activationID, observationID int64,
 	snapshot *model.AccountQuotaSnapshot,
 ) (int64, error) {
+	return restoreOrInsertCycleAt(ctx, tx, activationID, observationID, nil, snapshot)
+}
+
+func restoreOrInsertCycleAt(
+	ctx context.Context,
+	tx *sql.Tx,
+	activationID, observationID int64,
+	actualStartMS *int64,
+	snapshot *model.AccountQuotaSnapshot,
+) (int64, error) {
 	closed, err := matchingClosedCycle(ctx, tx, activationID, *snapshot)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, err
 	}
 	if errors.Is(err, sql.ErrNoRows) {
-		return insertCycle(ctx, tx, activationID, observationID, *snapshot)
+		if actualStartMS == nil {
+			return insertCycle(ctx, tx, activationID, observationID, *snapshot)
+		}
+		return insertCycleWithKey(
+			ctx,
+			tx,
+			activationID,
+			observationID,
+			*actualStartMS,
+			providerCycleKey(*snapshot),
+			*snapshot,
+		)
 	}
 
 	if !cycleBoundaryShouldUpgrade(closed, *snapshot) {
 		applyActiveCycleBoundary(snapshot, closed)
+	}
+	if actualStartMS == nil {
+		actualStartMS = snapshot.CycleStartMS
 	}
 	if _, err := tx.ExecContext(ctx, `update account_quota_cycles set
 		state = 'active', scheduled_start_ms = ?, scheduled_end_ms = ?, actual_start_ms = ?,
@@ -1422,7 +1479,7 @@ func restoreOrInsertCycle(
 		last_observation_id = ?, updated_at_ms = ? where id = ?`,
 		snapshot.CycleStartMS,
 		snapshot.CycleEndMS,
-		*snapshot.CycleStartMS,
+		*actualStartMS,
 		snapshot.DurationSeconds,
 		snapshot.BoundaryAccuracy,
 		observationID,

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3545,6 +3545,114 @@ func TestQuotaLifecycleScheduledRolloverUsesScheduledBoundaryAfterIdleGap(t *tes
 	}
 }
 
+func TestQuotaLifecycleTreatsNegativeBoundaryJitterAsScheduledRollover(t *testing.T) {
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	oldStartMS := quotaLifecycleBaseMS
+	oldEndMS := oldStartMS + durationSeconds*1000
+	nextStartMS := oldEndMS - 5*1000
+	nextEndMS := nextStartMS + durationSeconds*1000
+	observedAtMS := oldEndMS + 5*60*1000
+	service := newQuotaSnapshotTestService(t, observedAtMS+quotaLifecycleHourMS)
+
+	first := quotaLifecycleFixedWindow("weekly", "weekly", oldStartMS, durationSeconds, 20)
+	writeQuotaLifecycleObservation(t, service, "complete", oldStartMS+quotaLifecycleHourMS, []WindowInput{first})
+
+	next := quotaLifecycleFixedWindow("weekly", "weekly", nextStartMS, durationSeconds, 8)
+	next.Source = "api_query"
+	next.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-negative-jitter", "codex:quota-windows",
+			observedAtMS, []WindowInput{next},
+		),
+	}}); err != nil {
+		t.Fatalf("write negative-jitter observation: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.PreviousCycle == nil {
+		t.Fatalf("negative-jitter rollover did not expose both cycles: %#v", window)
+	}
+	if window.CurrentCycle.ID == window.PreviousCycle.ID {
+		t.Fatalf("negative-jitter rollover reused the active cycle: %#v", window)
+	}
+	if window.PreviousCycle.State != "closed" || window.PreviousCycle.EndReason != "scheduled" ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != oldEndMS {
+		t.Fatalf("negative-jitter previous cycle = %#v", window.PreviousCycle)
+	}
+	if window.CurrentCycle.ActualStartMS != oldEndMS ||
+		window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != nextStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != nextEndMS {
+		t.Fatalf("negative-jitter current cycle = %#v", window.CurrentCycle)
+	}
+	if window.CurrentCycle.ActualStartMS != *window.PreviousCycle.ActualEndMS {
+		t.Fatalf("negative-jitter transition has overlap or gap: %#v", window)
+	}
+}
+
+func TestQuotaLifecycleNegativeBoundaryJitterCanonicalizesIndependentActualTransition(t *testing.T) {
+	const durationSeconds = int64(5 * 60 * 60)
+	oldStartMS := quotaLifecycleBaseMS
+	oldEndMS := oldStartMS + durationSeconds*1000
+	actualTransitionMS := oldStartMS + 4*quotaLifecycleHourMS
+	nextStartMS := oldEndMS - 5*1000
+	nextEndMS := nextStartMS + durationSeconds*1000
+	observedAtMS := oldEndMS + 5*60*1000
+	service := newQuotaSnapshotTestService(t, observedAtMS+quotaLifecycleHourMS)
+
+	initial := quotaLifecycleFixedWindow("five-hour", "five_hour", oldStartMS, durationSeconds, 75)
+	writeQuotaLifecycleObservation(t, service, "complete", oldStartMS+quotaLifecycleHourMS, []WindowInput{initial})
+
+	reset := quotaLifecycleFixedWindow("five-hour", "five_hour", oldStartMS, durationSeconds, 1)
+	reset.Source = "response_header"
+	reset.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "response_header", "header-early-reset", "codex:quota-windows",
+			actualTransitionMS, []WindowInput{reset},
+		),
+	}}); err != nil {
+		t.Fatalf("write independent actual transition: %v", err)
+	}
+
+	resetted := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if resetted.CurrentCycle == nil || resetted.CurrentCycle.ActualStartMS != actualTransitionMS ||
+		resetted.CurrentCycle.ScheduledStartMS == nil || *resetted.CurrentCycle.ScheduledStartMS != oldStartMS {
+		t.Fatalf("independent actual transition was not established: %#v", resetted)
+	}
+	oldCycleID := resetted.CurrentCycle.ID
+
+	next := quotaLifecycleFixedWindow("five-hour", "five_hour", nextStartMS, durationSeconds, 8)
+	next.Source = "api_query"
+	next.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-negative-jitter-after-reset", "codex:quota-windows",
+			observedAtMS, []WindowInput{next},
+		),
+	}}); err != nil {
+		t.Fatalf("write negative-jitter observation after actual transition: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["five-hour"]
+	if window.CurrentCycle == nil || window.PreviousCycle == nil || window.PreviousCycle.ID != oldCycleID {
+		t.Fatalf("negative-jitter rollover lost the independent transition cycle: %#v", window)
+	}
+	if window.PreviousCycle.ActualStartMS != actualTransitionMS ||
+		window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != oldEndMS ||
+		window.PreviousCycle.EndReason != "scheduled" {
+		t.Fatalf("negative-jitter closed cycle crossed the provider reset: %#v", window.PreviousCycle)
+	}
+	if window.CurrentCycle.ActualStartMS != oldEndMS ||
+		window.CurrentCycle.ScheduledStartMS == nil || *window.CurrentCycle.ScheduledStartMS != nextStartMS ||
+		window.CurrentCycle.ScheduledEndMS == nil || *window.CurrentCycle.ScheduledEndMS != nextEndMS {
+		t.Fatalf("negative-jitter next cycle did not use the canonical transition: %#v", window.CurrentCycle)
+	}
+	if window.CurrentCycle.ActualStartMS != *window.PreviousCycle.ActualEndMS {
+		t.Fatalf("negative-jitter transition has overlap or gap after actual reset: %#v", window)
+	}
+}
+
 func TestQuotaLifecycleExposesFiveHourAndWeeklyScheduledGapsAsPrevious(t *testing.T) {
 	const gapMS = int64(8 * 60 * 1000)
 	weeklyStartMS := quotaLifecycleBaseMS
@@ -3570,16 +3678,17 @@ func TestQuotaLifecycleExposesFiveHourAndWeeklyScheduledGapsAsPrevious(t *testin
 	})
 
 	windows := queryQuotaLifecycleWindows(t, service, false)
-	for id, bounds := range map[string][2]int64{
-		"five-hour": {fiveHourStartMS, fiveHourEndMS},
-		"weekly":    {weeklyStartMS, weeklyEndMS},
+	for id, bounds := range map[string][3]int64{
+		"five-hour": {fiveHourStartMS, fiveHourEndMS, fiveHourNextStartMS},
+		"weekly":    {weeklyStartMS, weeklyEndMS, weeklyNextStartMS},
 	} {
-		wantStart, wantEnd := bounds[0], bounds[1]
+		wantStart, wantEnd, wantCurrentStart := bounds[0], bounds[1], bounds[2]
 		window := windows[id]
 		if window.CurrentCycle == nil || window.PreviousCycle == nil ||
 			window.PreviousCycle.ActualStartMS != wantStart || window.PreviousCycle.ActualEndMS == nil ||
 			*window.PreviousCycle.ActualEndMS != wantEnd || window.PreviousCycle.EndReason != "scheduled" ||
-			window.PreviousCycle.ActivationID != window.CurrentCycle.ActivationID {
+			window.PreviousCycle.ActivationID != window.CurrentCycle.ActivationID ||
+			window.CurrentCycle.ActualStartMS != wantCurrentStart {
 			t.Fatalf("%s scheduled gap previous lifecycle = %#v", id, window)
 		}
 	}

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -3653,6 +3653,58 @@ func TestQuotaLifecycleNegativeBoundaryJitterCanonicalizesIndependentActualTrans
 	}
 }
 
+func TestQuotaLifecycleDoesNotUseProvisionalZeroAPINegativeJitterForScheduledRollover(t *testing.T) {
+	const durationSeconds = int64(7 * 24 * 60 * 60)
+	oldStartMS := quotaLifecycleBaseMS
+	oldEndMS := oldStartMS + durationSeconds*1000
+	provisionalStartMS := oldEndMS - 5*1000
+	observedAtMS := oldEndMS + 30*1000
+	service, path := newQuotaSnapshotTestServiceWithPath(t, observedAtMS+quotaLifecycleHourMS)
+
+	oldCycle := quotaLifecycleFixedWindow("weekly", "weekly", oldStartMS, durationSeconds, 65)
+	writeQuotaLifecycleObservation(t, service, "complete", oldStartMS+quotaLifecycleHourMS, []WindowInput{oldCycle})
+	initial := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if initial.CurrentCycle == nil {
+		t.Fatalf("initial provisional-zero lifecycle = %#v", initial)
+	}
+	oldCycleID := initial.CurrentCycle.ID
+
+	provisional := quotaLifecycleFixedWindow("weekly", "weekly", provisionalStartMS, durationSeconds, 0)
+	provisional.BoundaryAccuracy = "derived"
+	if _, err := service.Write(context.Background(), WriteRequest{Entries: []WriteEntry{
+		quotaLifecycleWriteEntryWithObservation(
+			"complete", "api_query", "api-negative-jitter-provisional", "codex:quota-windows",
+			observedAtMS, []WindowInput{provisional},
+		),
+	}}); err != nil {
+		t.Fatalf("write provisional negative-jitter API boundary: %v", err)
+	}
+
+	window := queryQuotaLifecycleWindows(t, service, false)["weekly"]
+	if window.CurrentCycle == nil || window.CurrentCycle.ID != oldCycleID ||
+		window.CurrentCycle.State != "active" || window.PreviousCycle != nil {
+		t.Fatalf("provisional negative-jitter API boundary changed lifecycle = %#v", window)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open provisional lifecycle database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var cycleCount, provisionalSnapshotCount int
+	if err := db.QueryRow(`select count(*) from account_quota_cycles`).Scan(&cycleCount); err != nil {
+		t.Fatalf("count provisional lifecycle cycles: %v", err)
+	}
+	if err := db.QueryRow(`select count(*) from account_quota_snapshots
+		where source_observation_id = 'api-negative-jitter-provisional'
+			and cycle_id is null and boundary_accuracy = 'unknown'`).Scan(&provisionalSnapshotCount); err != nil {
+		t.Fatalf("count unassigned provisional snapshot: %v", err)
+	}
+	if cycleCount != 1 || provisionalSnapshotCount != 1 {
+		t.Fatalf("cycle_count=%d provisional_snapshot_count=%d, want 1 and 1", cycleCount, provisionalSnapshotCount)
+	}
+}
+
 func TestQuotaLifecycleExposesFiveHourAndWeeklyScheduledGapsAsPrevious(t *testing.T) {
 	const gapMS = int64(8 * 60 * 1000)
 	weeklyStartMS := quotaLifecycleBaseMS


### PR DESCRIPTION
## Summary

Fix Manager Server fixed/calendar quota rollovers when a reliable API-derived cycle start is up to 60 seconds before an expired scheduled end because of observation jitter. Canonicalize the actual attribution transition at the previous scheduled end while preserving the provider's observed scheduled geometry.

Follow up by preventing Codex provisional-zero API evidence from using the new near-jitter rollover path.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Detect only same-duration, reliable negative boundary jitter that is observed after the old scheduled end and whose incoming boundary still covers the observation.
- Close the previous cycle at its scheduled end and create or restore the next cycle with that end as its canonical actual start, preventing usage overlap or reset-crossing attribution.
- Exclude Codex `api_query` provisional-zero snapshots from near-jitter rollover so they remain unassigned with `boundary_accuracy = 'unknown'`.
- Preserve strict observation gaps, material-overlap expired-boundary refresh (#654), counter-reset thresholds, and historical previous-cycle fallback (#630).

## User Impact

Manual API quota refreshes near a scheduled fixed/calendar reset retain distinct previous and current cycles with non-overlapping usage attribution. Provisional zero-use API observations no longer create a premature cycle. No change to ordinary rollover or observation-gap behavior.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; no panel or API contract changes.
- Manager Server mode: Applies to fixed/calendar quota lifecycle reconciliation; existing #630 and #654 behavior is preserved.
- Full Docker / native packages: No configuration, packaging, or runtime artifact changes.

## Data / Security Notes

No schema, migration, usage SQL, raw usage event, credential, or security changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commits f1502d66 and e0447cca to roll back this PR; no schema or migration rollback is required.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
cd apps/manager-server && go test ./internal/service/quotasnapshot -run 'TestQuotaLifecycle' -count=1
cd apps/manager-server && go test ./internal/service/quotasnapshot -run 'TestQuotaLifecycle(DoesNotUseProvisionalZeroAPINegativeJitterForScheduledRollover|ActivatesCodexCycleFromConfirmedCallAfterProvisionalAPI|TreatsNegativeBoundaryJitterAsScheduledRollover|NegativeBoundaryJitterCanonicalizesIndependentActualTransition|AcceptsZeroUseAPIBoundaryAtScheduledRollover|TreatsZeroUseResponseHeaderAsConfirmedCallEvidence|RefreshesExpiredBoundaryFromFreshOverlappingObservation|RefreshesExpiredCalendarBoundaryFromFreshOverlappingObservation|KeepsExpiredBoundaryGuardBeforeScheduledEnd|ExpiredBoundaryRefreshPreservesConfirmedResetTransition|StaleBoundaryAfterActiveExpiryCannotResetLifecycle|AllowsHigherAccuracyCorrectionWithinBoundaryJitter)' -count=1
cd apps/manager-server && go test ./...
cd apps/manager-server && go test -race ./internal/service/quotasnapshot -run 'TestQuotaLifecycle' -count=1
gofmt -d apps/manager-server/internal/repository/quotasnapshot/lifecycle.go apps/manager-server/internal/service/quotasnapshot/service_test.go
git diff --check
```

All listed commands passed on final commit f1502d66, based on origin/dev e4785bd6. A full `go test -race ./...` was also attempted; it timed out in the existing SQLite long-table test `TestUsageRollupLongContextUpgradeParksLargeTables` after 10 minutes while creating large-table indexes, outside the changed scope.

## Screenshots / Recordings

N/A — backend-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — backend correctness fix with no new user-facing capability

Docs decision:

No documentation changes are needed for this scoped lifecycle correctness fix.

## Related

N/A
