### PR TITLE
fix: separate Codex identity by workspace member

### DIFF
--- a/apps/manager-server/internal/collector/auth_snapshot.go
+++ b/apps/manager-server/internal/collector/auth_snapshot.go
@@ -15,13 +15,15 @@ import (
 const authSnapshotCacheTTL = 30 * time.Second
 
 type authSnapshot struct {
-	Account      string
-	AccountID    string
-	Label        string
-	FileName     string
-	Provider     string
-	ProjectID    string
-	CapturedAtMS int64
+	AccountSnapshotInvalid bool
+	AccountIDInvalid       bool
+	Account                string
+	AccountID              string
+	Label                  string
+	FileName               string
+	Provider               string
+	ProjectID              string
+	CapturedAtMS           int64
 }
 
 type authSnapshotResolver struct {
@@ -31,6 +33,7 @@ type authSnapshotResolver struct {
 	managementKey string
 	expiresAt     time.Time
 	snapshots     map[string]authSnapshot
+	ambiguous     map[string]struct{}
 }
 
 func newAuthSnapshotResolver() *authSnapshotResolver {
@@ -47,6 +50,7 @@ func (r *authSnapshotResolver) clear() {
 	r.managementKey = ""
 	r.expiresAt = time.Time{}
 	r.snapshots = nil
+	r.ambiguous = nil
 }
 
 func (r *authSnapshotResolver) lookup(ctx context.Context, cfg RuntimeConfig, authIndices map[string]struct{}) map[string]authSnapshot {
@@ -69,7 +73,7 @@ func (r *authSnapshotResolver) lookup(ctx context.Context, cfg RuntimeConfig, au
 	}
 	r.mu.Unlock()
 
-	snapshots, err := r.fetch(ctx, baseURL, managementKey)
+	snapshots, ambiguous, err := r.fetch(ctx, baseURL, managementKey)
 	if err != nil {
 		r.mu.Lock()
 		var result map[string]authSnapshot
@@ -85,16 +89,20 @@ func (r *authSnapshotResolver) lookup(ctx context.Context, cfg RuntimeConfig, au
 	r.managementKey = managementKey
 	r.expiresAt = now.Add(authSnapshotCacheTTL)
 	r.snapshots = snapshots
+	r.ambiguous = ambiguous
 	result := r.lookupLocked(authIndices)
 	r.mu.Unlock()
 	return result
 }
 
 func (r *authSnapshotResolver) hasAllLocked(authIndices map[string]struct{}) bool {
-	if len(r.snapshots) == 0 {
+	if len(r.snapshots) == 0 && len(r.ambiguous) == 0 {
 		return false
 	}
 	for authIndex := range authIndices {
+		if _, ambiguous := r.ambiguous[authIndex]; ambiguous {
+			continue
+		}
 		if _, ok := r.snapshots[authIndex]; !ok {
 			return false
 		}
@@ -108,6 +116,9 @@ func (r *authSnapshotResolver) lookupLocked(authIndices map[string]struct{}) map
 	}
 	result := make(map[string]authSnapshot, len(authIndices))
 	for authIndex := range authIndices {
+		if _, ambiguous := r.ambiguous[authIndex]; ambiguous {
+			continue
+		}
 		if snapshot, ok := r.snapshots[authIndex]; ok {
 			result[authIndex] = snapshot
 		}
@@ -115,38 +126,67 @@ func (r *authSnapshotResolver) lookupLocked(authIndices map[string]struct{}) map
 	return result
 }
 
-func (r *authSnapshotResolver) fetch(ctx context.Context, baseURL string, managementKey string) (map[string]authSnapshot, error) {
+func (r *authSnapshotResolver) fetch(ctx context.Context, baseURL string, managementKey string) (map[string]authSnapshot, map[string]struct{}, error) {
 	client := r.client
 	if client == nil {
 		client = http.DefaultClient
 	}
 	capturedAt := time.Now().UnixMilli()
 	snapshots := make(map[string]authSnapshot)
+	ambiguous := make(map[string]struct{})
 	err := cpaauthfiles.New(client).Visit(ctx, baseURL, managementKey, func(item cpaauthfiles.File) (bool, error) {
 		file := item.Raw
-		authIndex := readAuthFileString(file, "auth_index", "authIndex", "auth-index")
+		authIndex := item.AuthIndex
 		if authIndex == "" {
 			return false, nil
 		}
-		account := firstSafeAccount(readAuthFileString(file, "account"), readAuthFileString(file, "email"))
-		label := firstNonEmpty(readAuthFileString(file, "label"), readAuthFileString(file, "name"), readAuthFileString(file, "email"), account)
-		fileName := readAuthFileString(file, "name")
-		provider := firstNonEmpty(readAuthFileString(file, "provider"), readAuthFileString(file, "type"))
+		if _, alreadyAmbiguous := ambiguous[authIndex]; alreadyAmbiguous {
+			return false, nil
+		}
+		if _, duplicate := snapshots[authIndex]; duplicate {
+			delete(snapshots, authIndex)
+			ambiguous[authIndex] = struct{}{}
+			return false, nil
+		}
+		account := ""
+		fileName := item.Name
+		provider := item.Provider
 		accountID := ""
 		projectID := firstNonEmpty(readAuthFileString(file, "project_id"), readAuthFileString(file, "projectId"), readAuthFileString(file, "gemini_virtual_project"), readAuthFileString(file, "geminiVirtualProject"))
 		if strings.EqualFold(provider, "codex") {
-			accountID = readCodexAccountID(file)
+			if !item.AccountIDInvalid {
+				accountID = item.AccountID
+			}
+			account = item.AccountSnapshot
+		} else {
+			account = firstSafeAccount(readAuthFileString(file, "account"), readAuthFileString(file, "email"))
 		}
-		if account == "" {
+		// Keep the pre-existing non-Codex display fallback: when CPA exposes an
+		// account value but no explicit label/name/email, label still carries that
+		// account. For Codex, item.AccountSnapshot is already limited to strong
+		// member evidence, so it is also safe as a display label; it is never used
+		// as a member identity unless the shared identity normalizer accepts it.
+		label := firstNonEmpty(readAuthFileString(file, "label"), readAuthFileString(file, "name"), readAuthFileString(file, "email"), account)
+		if account == "" && !strings.EqualFold(provider, "codex") {
 			account = firstNonEmpty(label, fileName)
 		}
-		snapshots[authIndex] = authSnapshot{Account: account, AccountID: accountID, Label: label, FileName: fileName, Provider: provider, ProjectID: projectID, CapturedAtMS: capturedAt}
+		snapshots[authIndex] = authSnapshot{
+			AccountSnapshotInvalid: item.AccountSnapshotInvalid,
+			AccountIDInvalid:       item.AccountIDInvalid,
+			Account:                account,
+			AccountID:              accountID,
+			Label:                  label,
+			FileName:               fileName,
+			Provider:               provider,
+			ProjectID:              projectID,
+			CapturedAtMS:           capturedAt,
+		}
 		return false, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return snapshots, nil
+	return snapshots, ambiguous, nil
 }
 
 func readAuthFileString(file map[string]any, keys ...string) string {
@@ -158,22 +198,6 @@ func readAuthFileString(file map[string]any, keys ...string) string {
 		text := strings.TrimSpace(toString(value))
 		if text != "" {
 			return text
-		}
-	}
-	return ""
-}
-
-func readCodexAccountID(file map[string]any) string {
-	if accountID := readAuthFileString(file, "account_id", "accountId", "chatgpt_account_id", "chatgptAccountId"); accountID != "" {
-		return accountID
-	}
-	for _, key := range []string{"id_token", "idToken", "metadata", "attributes"} {
-		child, ok := file[key].(map[string]any)
-		if !ok {
-			continue
-		}
-		if accountID := readCodexAccountID(child); accountID != "" {
-			return accountID
 		}
 	}
 	return ""

--- a/apps/manager-server/internal/collector/auth_snapshot_test.go
+++ b/apps/manager-server/internal/collector/auth_snapshot_test.go
@@ -1,6 +1,9 @@
 package collector
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
@@ -17,6 +20,69 @@ func TestAuthSnapshotResolverCacheRequiresEveryRequestedAuthIndex(t *testing.T) 
 	}
 	if resolver.hasAllLocked(map[string]struct{}{"auth-1": {}, "auth-2": {}}) {
 		t.Fatal("cache with missing auth index must force a refresh")
+	}
+}
+
+func TestAuthSnapshotResolverTreatsDuplicateAuthIndexAsAmbiguous(t *testing.T) {
+	resolver := newAuthSnapshotResolver()
+	resolver.snapshots = map[string]authSnapshot{
+		"auth-1": {Account: "alice@example.com", Provider: "codex"},
+	}
+	resolver.ambiguous = map[string]struct{}{"auth-1": {}}
+
+	if resolver.hasAllLocked(map[string]struct{}{"auth-1": {}}) != true {
+		t.Fatal("an ambiguous auth index should be considered resolved in the cache")
+	}
+	if snapshots := resolver.lookupLocked(map[string]struct{}{"auth-1": {}}); len(snapshots) != 0 {
+		t.Fatalf("ambiguous auth index returned a snapshot: %#v", snapshots)
+	}
+}
+
+func TestAuthSnapshotResolverFetchMarksDuplicateAuthIndexAmbiguous(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"files":[
+			{"auth_index":"auth-1","provider":"codex","account":"alice@example.com"},
+			{"auth_index":"auth-1","provider":"codex","account":"bob@example.com"}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	resolver := newAuthSnapshotResolver()
+	resolver.client = server.Client()
+	snapshots, ambiguous, err := resolver.fetch(context.Background(), server.URL, "management-key")
+	if err != nil {
+		t.Fatalf("fetch snapshots: %v", err)
+	}
+	if _, ok := snapshots["auth-1"]; ok {
+		t.Fatalf("duplicate auth index retained a snapshot: %#v", snapshots["auth-1"])
+	}
+	if _, ok := ambiguous["auth-1"]; !ok {
+		t.Fatalf("duplicate auth index was not marked ambiguous: %#v", ambiguous)
+	}
+}
+
+func TestAuthSnapshotResolverPreservesNonCodexAccountLabelFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"files":[
+			{"auth_index":"auth-1","provider":"openai","account":"account-id"}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	resolver := newAuthSnapshotResolver()
+	resolver.client = server.Client()
+	snapshots, _, err := resolver.fetch(context.Background(), server.URL, "management-key")
+	if err != nil {
+		t.Fatalf("fetch snapshots: %v", err)
+	}
+	snapshot, ok := snapshots["auth-1"]
+	if !ok {
+		t.Fatalf("missing auth snapshot: %#v", snapshots)
+	}
+	if snapshot.Account != "account-id" || snapshot.Label != "account-id" {
+		t.Fatalf("non-Codex account/label fallback = account:%q label:%q, want account-id", snapshot.Account, snapshot.Label)
 	}
 }
 

--- a/apps/manager-server/internal/collector/collector.go
+++ b/apps/manager-server/internal/collector/collector.go
@@ -16,6 +16,7 @@ import (
 	quotasnapshotsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/quotasnapshot"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 type Status struct {
@@ -532,8 +533,20 @@ func (m *Manager) enrichAccountSnapshots(ctx context.Context, cfg RuntimeConfig,
 		if !ok {
 			continue
 		}
+		if (isCodexEvent(events[i]) || isCodexSnapshot(snapshot)) && !codexSnapshotCanEnrichEvent(events[i], snapshot) {
+			// An auth-index lookup is only a credential locator. If the raw event
+			// and the current auth-file response provide conflicting strong Codex
+			// identity evidence, do not manufacture a workspace/member pair by
+			// combining fields from the two observations.
+			continue
+		}
 		updated := false
-		if events[i].AccountSnapshot == "" && snapshot.Account != "" {
+		accountSnapshotMissing := events[i].AccountSnapshot == ""
+		if isCodexEvent(events[i]) {
+			_, strongMember := usageidentity.NormalizeCodexMemberSnapshot(events[i].AccountSnapshot)
+			accountSnapshotMissing = !strongMember
+		}
+		if accountSnapshotMissing && snapshot.Account != "" {
 			events[i].AccountSnapshot = snapshot.Account
 			updated = true
 		}
@@ -564,14 +577,65 @@ func (m *Manager) enrichAccountSnapshots(ctx context.Context, cfg RuntimeConfig,
 }
 
 func needsAccountSnapshotEnrichment(event usage.Event) bool {
+	return accountSnapshotNeedsEnrichment(event) ||
+		(isCodexEvent(event) && event.AuthAccountIDSnapshot == "") ||
+		event.AuthProjectIDSnapshot == ""
+}
+
+func isCodexEvent(event usage.Event) bool {
 	provider := strings.TrimSpace(event.AuthProviderSnapshot)
 	if provider == "" {
 		provider = strings.TrimSpace(event.Provider)
 	}
-	isCodex := strings.EqualFold(provider, "codex")
-	return event.AccountSnapshot == "" ||
-		(isCodex && event.AuthAccountIDSnapshot == "") ||
-		event.AuthProjectIDSnapshot == ""
+	return strings.EqualFold(provider, "codex")
+}
+
+func isCodexSnapshot(snapshot authSnapshot) bool {
+	return strings.EqualFold(strings.TrimSpace(snapshot.Provider), "codex")
+}
+
+func accountSnapshotNeedsEnrichment(event usage.Event) bool {
+	if isCodexEvent(event) {
+		_, ok := usageidentity.NormalizeCodexMemberSnapshot(event.AccountSnapshot)
+		return !ok
+	}
+	return event.AccountSnapshot == ""
+}
+
+func codexSnapshotCanEnrichEvent(event usage.Event, snapshot authSnapshot) bool {
+	if snapshot.AccountSnapshotInvalid || snapshot.AccountIDInvalid {
+		return false
+	}
+	eventProvider := strings.TrimSpace(event.AuthProviderSnapshot)
+	if eventProvider == "" {
+		eventProvider = strings.TrimSpace(event.Provider)
+	}
+	snapshotProvider := strings.TrimSpace(snapshot.Provider)
+	if eventProvider != "" && snapshotProvider != "" && !strings.EqualFold(eventProvider, snapshotProvider) {
+		return false
+	}
+	eventMember, eventMemberOK := usageidentity.NormalizeCodexMemberSnapshot(event.AccountSnapshot)
+	snapshotMember, snapshotMemberOK := usageidentity.NormalizeCodexMemberSnapshot(snapshot.Account)
+	if eventMemberOK && snapshotMemberOK && eventMember != snapshotMember {
+		return false
+	}
+
+	eventWorkspace, eventWorkspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(event.AuthAccountIDSnapshot)
+	snapshotWorkspace, snapshotWorkspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(snapshot.AccountID)
+	if eventWorkspaceOK && snapshotWorkspaceOK && eventWorkspace != snapshotWorkspace {
+		return false
+	}
+	// An auth-index lookup may fill missing fields only when the two observations
+	// retain enough evidence to prove that they describe the same member. Do not
+	// combine a strong member from one side with a workspace-only observation from
+	// the other side: that would manufacture e.g. workspace-B + member-A.
+	if eventMemberOK && snapshotWorkspaceOK && !snapshotMemberOK && !eventWorkspaceOK {
+		return false
+	}
+	if snapshotMemberOK && eventWorkspaceOK && !eventMemberOK && !snapshotWorkspaceOK {
+		return false
+	}
+	return true
 }
 
 func (m *Manager) markError(stage string, err error) {

--- a/apps/manager-server/internal/collector/collector_test.go
+++ b/apps/manager-server/internal/collector/collector_test.go
@@ -40,9 +40,12 @@ func TestAuthSnapshotResolverStreamsAuthFiles(t *testing.T) {
 
 	resolver := newAuthSnapshotResolver()
 	resolver.client = upstream.Client()
-	snapshots, err := resolver.fetch(context.Background(), upstream.URL, "management-key")
+	snapshots, ambiguous, err := resolver.fetch(context.Background(), upstream.URL, "management-key")
 	if err != nil {
 		t.Fatalf("fetch snapshots: %v", err)
+	}
+	if len(ambiguous) != 0 {
+		t.Fatalf("unexpected ambiguous auth indexes: %#v", ambiguous)
 	}
 	if snapshot := snapshots["auth-1"]; snapshot.Account != "alice@example.com" || snapshot.FileName != "alice.json" {
 		t.Fatalf("snapshot = %#v", snapshot)
@@ -294,6 +297,189 @@ func TestManagerEnrichesCodexAccountIDFromEffectiveProvider(t *testing.T) {
 	}
 	if events[0].AuthProjectIDSnapshot != "preserved-project" {
 		t.Fatalf("project snapshot overwritten = %q, want %q", events[0].AuthProjectIDSnapshot, "preserved-project")
+	}
+}
+
+func TestManagerReplacesWeakCodexAccountSnapshotWithMemberEmail(t *testing.T) {
+	db := newTestStore(t)
+	manager := NewManager(testConfig(t, "auto"), db)
+	manager.snapshotResolver.baseURL = "http://cpa.local:8317"
+	manager.snapshotResolver.managementKey = "management-key"
+	manager.snapshotResolver.expiresAt = time.Now().Add(time.Minute)
+	manager.snapshotResolver.snapshots = map[string]authSnapshot{
+		"auth-1": {
+			Account:   "alice@example.com",
+			AccountID: "workspace-1",
+			Provider:  "codex",
+		},
+	}
+
+	events := []usage.Event{{
+		Provider:              "codex",
+		AuthIndex:             "auth-1",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+		AccountSnapshot:       "Alice",
+		AuthProjectIDSnapshot: "project-1",
+	}}
+	manager.enrichAccountSnapshots(context.Background(), RuntimeConfig{
+		CPAUpstreamURL: "http://cpa.local:8317",
+		ManagementKey:  "management-key",
+	}, events)
+
+	if events[0].AccountSnapshot != "alice@example.com" {
+		t.Fatalf("account snapshot = %q, want strong Codex member email", events[0].AccountSnapshot)
+	}
+}
+
+func TestManagerDoesNotCombineConflictingCodexIdentityEvidence(t *testing.T) {
+	tests := []struct {
+		name              string
+		eventMember       string
+		eventWorkspace    string
+		snapshotMember    string
+		snapshotWorkspace string
+		wantMember        string
+		wantWorkspace     string
+		wantFile          string
+	}{
+		{
+			name:              "conflicting member",
+			eventMember:       "alice@example.com",
+			snapshotMember:    "bob@example.com",
+			snapshotWorkspace: "workspace-1",
+			wantMember:        "alice@example.com",
+		},
+		{
+			name:              "matching member",
+			eventMember:       "alice@example.com",
+			snapshotMember:    "alice@example.com",
+			snapshotWorkspace: "workspace-1",
+			wantMember:        "alice@example.com",
+			wantWorkspace:     "workspace-1",
+			wantFile:          "alice.json",
+		},
+		{
+			name:              "missing event member",
+			snapshotMember:    "alice@example.com",
+			snapshotWorkspace: "workspace-1",
+			wantMember:        "alice@example.com",
+			wantWorkspace:     "workspace-1",
+			wantFile:          "alice.json",
+		},
+		{
+			name:              "conflicting workspace",
+			eventMember:       "alice@example.com",
+			eventWorkspace:    "workspace-1",
+			snapshotMember:    "alice@example.com",
+			snapshotWorkspace: "workspace-2",
+			wantMember:        "alice@example.com",
+			wantWorkspace:     "workspace-1",
+		},
+		{
+			name:              "strong member plus workspace-only snapshot",
+			eventMember:       "alice@example.com",
+			snapshotWorkspace: "workspace-2",
+			wantMember:        "alice@example.com",
+		},
+		{
+			name:           "strong workspace plus member-only snapshot",
+			eventWorkspace: "workspace-1",
+			snapshotMember: "alice@example.com",
+			wantWorkspace:  "workspace-1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db := newTestStore(t)
+			manager := NewManager(testConfig(t, "auto"), db)
+			manager.snapshotResolver.baseURL = "http://cpa.local:8317"
+			manager.snapshotResolver.managementKey = "management-key"
+			manager.snapshotResolver.expiresAt = time.Now().Add(time.Minute)
+			manager.snapshotResolver.snapshots = map[string]authSnapshot{
+				"auth-1": {
+					Account:   test.snapshotMember,
+					AccountID: test.snapshotWorkspace,
+					FileName:  "alice.json",
+					Provider:  "codex",
+				},
+			}
+
+			events := []usage.Event{{
+				Provider:              "codex",
+				AuthIndex:             "auth-1",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: test.eventWorkspace,
+				AccountSnapshot:       test.eventMember,
+			}}
+			manager.enrichAccountSnapshots(context.Background(), RuntimeConfig{
+				CPAUpstreamURL: "http://cpa.local:8317",
+				ManagementKey:  "management-key",
+			}, events)
+
+			got := events[0]
+			if got.AccountSnapshot != test.wantMember || got.AuthAccountIDSnapshot != test.wantWorkspace || got.AuthFileSnapshot != test.wantFile {
+				t.Fatalf("enriched identity = member:%q workspace:%q file:%q, want member:%q workspace:%q file:%q", got.AccountSnapshot, got.AuthAccountIDSnapshot, got.AuthFileSnapshot, test.wantMember, test.wantWorkspace, test.wantFile)
+			}
+		})
+	}
+}
+
+func TestManagerDoesNotEnrichCodexEventFromMismatchedSnapshotProvider(t *testing.T) {
+	db := newTestStore(t)
+	manager := NewManager(testConfig(t, "auto"), db)
+	manager.snapshotResolver.baseURL = "http://cpa.local:8317"
+	manager.snapshotResolver.managementKey = "management-key"
+	manager.snapshotResolver.expiresAt = time.Now().Add(time.Minute)
+	manager.snapshotResolver.snapshots = map[string]authSnapshot{
+		"auth-1": {
+			Account:   "alice@example.com",
+			AccountID: "workspace-1",
+			Provider:  "codex",
+		},
+	}
+	events := []usage.Event{{
+		Provider:             "openai",
+		AuthIndex:            "auth-1",
+		AuthProviderSnapshot: "openai",
+	}}
+	manager.enrichAccountSnapshots(context.Background(), RuntimeConfig{
+		CPAUpstreamURL: "http://cpa.local:8317",
+		ManagementKey:  "management-key",
+	}, events)
+	if events[0].AccountSnapshot != "" || events[0].AuthAccountIDSnapshot != "" || events[0].AuthProviderSnapshot != "openai" {
+		t.Fatalf("mismatched Codex snapshot enriched non-Codex event: %#v", events[0])
+	}
+}
+
+func TestManagerDoesNotEnrichFromInvalidCodexSnapshotEvidence(t *testing.T) {
+	db := newTestStore(t)
+	manager := NewManager(testConfig(t, "auto"), db)
+	manager.snapshotResolver.baseURL = "http://cpa.local:8317"
+	manager.snapshotResolver.managementKey = "management-key"
+	manager.snapshotResolver.expiresAt = time.Now().Add(time.Minute)
+	manager.snapshotResolver.snapshots = map[string]authSnapshot{
+		"auth-1": {
+			Account:                "alice@example.com",
+			AccountID:              "workspace-1",
+			AccountSnapshotInvalid: true,
+			Provider:               "codex",
+			FileName:               "alice.json",
+		},
+	}
+	events := []usage.Event{{
+		Provider:              "codex",
+		AuthIndex:             "auth-1",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+	}}
+	manager.enrichAccountSnapshots(context.Background(), RuntimeConfig{
+		CPAUpstreamURL: "http://cpa.local:8317",
+		ManagementKey:  "management-key",
+	}, events)
+	if events[0].AccountSnapshot != "" || events[0].AuthAccountIDSnapshot != "workspace-1" || events[0].AuthFileSnapshot != "" {
+		t.Fatalf("invalid Codex auth snapshot was used for enrichment: %#v", events[0])
 	}
 }
 
@@ -677,7 +863,8 @@ func TestManagerSkipsUsageControlPayloadsAndRefreshesSnapshots(t *testing.T) {
 	if manager.snapshotResolver.baseURL != "" ||
 		manager.snapshotResolver.managementKey != "" ||
 		!manager.snapshotResolver.expiresAt.IsZero() ||
-		manager.snapshotResolver.snapshots != nil {
+		manager.snapshotResolver.snapshots != nil ||
+		manager.snapshotResolver.ambiguous != nil {
 		t.Fatalf("snapshot cache was not cleared: %#v", manager.snapshotResolver)
 	}
 }

--- a/apps/manager-server/internal/repository/accountaction/repository.go
+++ b/apps/manager-server/internal/repository/accountaction/repository.go
@@ -90,6 +90,34 @@ func (r *repository) Upsert(ctx context.Context, input model.AccountActionCandid
 			return model.AccountActionCandidate{}, err
 		}
 	}
+	if found && normalizeProvider(input.Provider) == "codex" && input.AuthIndex != "" {
+		existing, err := getByID(ctx, tx, id)
+		if err != nil {
+			return model.AccountActionCandidate{}, err
+		}
+		if reason := codexCandidateIdentityConflict(existing, input); reason != "" {
+			_, err = tx.ExecContext(ctx, `update account_action_candidates set
+				last_error = ?, last_seen_at_ms = ?, hit_count = hit_count + 1, updated_at_ms = ?
+				where id = ? and status = ?`,
+				"Codex identity conflict: "+reason,
+				seenAt,
+				now,
+				id,
+				model.AccountActionStatusPending,
+			)
+			if err != nil {
+				return model.AccountActionCandidate{}, err
+			}
+			item, err := getByID(ctx, tx, id)
+			if err != nil {
+				return model.AccountActionCandidate{}, err
+			}
+			if err := tx.Commit(); err != nil {
+				return model.AccountActionCandidate{}, err
+			}
+			return item, fmt.Errorf("account action candidate identity conflict: %s", reason)
+		}
+	}
 	if !found {
 		res, execErr := tx.ExecContext(ctx, `insert into account_action_candidates (
 			action_type, status, provider, auth_file_name, auth_index, account_snapshot, account_id_snapshot, auth_label,
@@ -166,17 +194,6 @@ func findPendingCandidateID(ctx context.Context, tx *sql.Tx, input model.Account
 				and coalesce(trim(auth_index), '') = ?
 				and (coalesce(lower(replace(trim(provider), '_', '-')), '') = '' or coalesce(lower(replace(trim(provider), '_', '-')), '') = 'codex')`
 			args = append(args, input.AuthIndex)
-			if input.AccountIDSnapshot != "" {
-				query += ` and (coalesce(trim(account_id_snapshot), '') = '' or trim(account_id_snapshot) = ?)`
-				args = append(args, input.AccountIDSnapshot)
-			}
-			if input.AccountSnapshot != "" {
-				// A workspace-only pending row is not owned by the new member.
-				// Require exact strong-member evidence before reusing it; otherwise
-				// the update below would silently bind the row to this member.
-				query += ` and lower(trim(account_snapshot)) = ?`
-				args = append(args, input.AccountSnapshot)
-			}
 			return querySingleCandidateID(ctx, tx, query+` order by id asc limit 2`, args...)
 		}
 		if input.AccountIDSnapshot == "" || input.AccountSnapshot == "" {
@@ -220,6 +237,21 @@ func candidateIdentity(input model.AccountActionCandidateUpsert) (authIndex stri
 		return "", accountID, normalizeProvider(input.Provider), ""
 	}
 	return "", "", normalizeProvider(input.Provider), strings.TrimSpace(input.AccountSnapshot)
+}
+
+func codexCandidateIdentityConflict(existing model.AccountActionCandidate, input model.AccountActionCandidateUpsert) string {
+	if existingProvider := normalizeProvider(existing.Provider); existingProvider != "" && existingProvider != "codex" {
+		return "provider changed"
+	}
+	if existingWorkspace := strings.TrimSpace(existing.AccountIDSnapshot); existingWorkspace != "" && input.AccountIDSnapshot != "" && existingWorkspace != input.AccountIDSnapshot {
+		return fmt.Sprintf("workspace changed from %q to %q", existingWorkspace, input.AccountIDSnapshot)
+	}
+	existingMember, existingMemberOK := usageidentity.NormalizeCodexMemberSnapshot(existing.AccountSnapshot)
+	inputMember, inputMemberOK := usageidentity.NormalizeCodexMemberSnapshot(input.AccountSnapshot)
+	if existingMemberOK && inputMemberOK && existingMember != inputMember {
+		return fmt.Sprintf("member changed from %q to %q", existingMember, inputMember)
+	}
+	return ""
 }
 
 func findUpgradeableCandidateID(ctx context.Context, tx *sql.Tx, input model.AccountActionCandidateUpsert) (int64, bool, error) {

--- a/apps/manager-server/internal/repository/accountaction/repository.go
+++ b/apps/manager-server/internal/repository/accountaction/repository.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 type Repository interface {
@@ -44,6 +45,24 @@ func (r *repository) Upsert(ctx context.Context, input model.AccountActionCandid
 		input.AccountSnapshot = ""
 	}
 	input.AccountIDSnapshot = strings.TrimSpace(input.AccountIDSnapshot)
+	if input.Provider == "codex" {
+		if input.AccountIDSnapshot != "" {
+			workspace, ok := usageidentity.NormalizeCodexWorkspaceSnapshot(input.AccountIDSnapshot)
+			if !ok {
+				return model.AccountActionCandidate{}, errors.New("invalid Codex workspace identity")
+			}
+			input.AccountIDSnapshot = workspace
+		}
+		if input.AccountSnapshot != "" {
+			if member, ok := usageidentity.NormalizeCodexMemberSnapshot(input.AccountSnapshot); ok {
+				input.AccountSnapshot = member
+			} else {
+				// A display label is not a Codex member identity. It may remain
+				// in evidence, but must not participate in candidate ownership.
+				input.AccountSnapshot = ""
+			}
+		}
+	}
 	input.AuthLabel = strings.TrimSpace(input.AuthLabel)
 	input.ReasonCode = strings.TrimSpace(input.ReasonCode)
 	input.Reason = strings.TrimSpace(input.Reason)
@@ -61,32 +80,7 @@ func (r *repository) Upsert(ctx context.Context, input model.AccountActionCandid
 	}
 	defer tx.Rollback()
 
-	authIndexIdentity, accountIDIdentity, providerIdentity, accountSnapshotIdentity := candidateIdentity(input)
-	id, found, err := querySingleCandidateID(ctx, tx, `select id from account_action_candidates
-		where status = ? and auth_file_name = ? and action_type = ?
-		and coalesce(trim(reason_code), '') = ?
-		and coalesce(trim(auth_index), '') = ?
-		and case when coalesce(trim(auth_index), '') <> '' then '' else coalesce(trim(account_id_snapshot), '') end = ?
-		and case when coalesce(trim(auth_index), '') <> '' then ''
-			else case coalesce(lower(replace(trim(provider), '_', '-')), '')
-				when 'x-ai' then 'xai'
-				when 'grok' then 'xai'
-				else coalesce(lower(replace(trim(provider), '_', '-')), '')
-			end
-		end = ?
-		and case when coalesce(trim(auth_index), '') <> '' or coalesce(trim(account_id_snapshot), '') <> '' then ''
-			else coalesce(trim(account_snapshot), '')
-		end = ?
-		order by id asc limit 2`,
-		model.AccountActionStatusPending,
-		input.AuthFileName,
-		input.ActionType,
-		input.ReasonCode,
-		authIndexIdentity,
-		accountIDIdentity,
-		providerIdentity,
-		accountSnapshotIdentity,
-	)
+	id, found, err := findPendingCandidateID(ctx, tx, input)
 	if err != nil {
 		return model.AccountActionCandidate{}, err
 	}
@@ -155,6 +149,67 @@ func (r *repository) Upsert(ctx context.Context, input model.AccountActionCandid
 	return item, nil
 }
 
+func findPendingCandidateID(ctx context.Context, tx *sql.Tx, input model.AccountActionCandidateUpsert) (int64, bool, error) {
+	base := `select id from account_action_candidates
+		where status = ? and auth_file_name = ? and action_type = ?
+		and coalesce(trim(reason_code), '') = ?`
+	args := []any{
+		model.AccountActionStatusPending,
+		input.AuthFileName,
+		input.ActionType,
+		input.ReasonCode,
+	}
+	provider := normalizeProvider(input.Provider)
+	if provider == "codex" {
+		if input.AuthIndex != "" {
+			query := base + `
+				and coalesce(trim(auth_index), '') = ?
+				and (coalesce(lower(replace(trim(provider), '_', '-')), '') = '' or coalesce(lower(replace(trim(provider), '_', '-')), '') = 'codex')`
+			args = append(args, input.AuthIndex)
+			if input.AccountIDSnapshot != "" {
+				query += ` and (coalesce(trim(account_id_snapshot), '') = '' or trim(account_id_snapshot) = ?)`
+				args = append(args, input.AccountIDSnapshot)
+			}
+			if input.AccountSnapshot != "" {
+				// A workspace-only pending row is not owned by the new member.
+				// Require exact strong-member evidence before reusing it; otherwise
+				// the update below would silently bind the row to this member.
+				query += ` and lower(trim(account_snapshot)) = ?`
+				args = append(args, input.AccountSnapshot)
+			}
+			return querySingleCandidateID(ctx, tx, query+` order by id asc limit 2`, args...)
+		}
+		if input.AccountIDSnapshot == "" || input.AccountSnapshot == "" {
+			// Preserve an unowned review row if the caller wants to display it,
+			// but never let incomplete Codex evidence select an existing row.
+			return 0, false, nil
+		}
+
+		return querySingleCandidateID(ctx, tx, base+`
+			and coalesce(trim(auth_index), '') = ''
+			and coalesce(lower(replace(trim(provider), '_', '-')), '') = 'codex'
+			and trim(account_id_snapshot) = ?
+			and lower(trim(account_snapshot)) = ?
+			order by id asc limit 2`, append(args, input.AccountIDSnapshot, input.AccountSnapshot)...)
+	}
+
+	authIndexIdentity, accountIDIdentity, providerIdentity, accountSnapshotIdentity := candidateIdentity(input)
+	return querySingleCandidateID(ctx, tx, base+`
+		and coalesce(trim(auth_index), '') = ?
+		and case when coalesce(trim(auth_index), '') <> '' then '' else coalesce(trim(account_id_snapshot), '') end = ?
+		and case when coalesce(trim(auth_index), '') <> '' then ''
+			else case coalesce(lower(replace(trim(provider), '_', '-')), '')
+				when 'x-ai' then 'xai'
+				when 'grok' then 'xai'
+				else coalesce(lower(replace(trim(provider), '_', '-')), '')
+			end
+		end = ?
+		and case when coalesce(trim(auth_index), '') <> '' or coalesce(trim(account_id_snapshot), '') <> '' then ''
+			else coalesce(trim(account_snapshot), '')
+		end = ?
+		order by id asc limit 2`, append(args, authIndexIdentity, accountIDIdentity, providerIdentity, accountSnapshotIdentity)...)
+}
+
 func candidateIdentity(input model.AccountActionCandidateUpsert) (authIndex string, accountID string, provider string, accountSnapshot string) {
 	authIndex = strings.TrimSpace(input.AuthIndex)
 	if authIndex != "" {
@@ -175,6 +230,20 @@ func findUpgradeableCandidateID(ctx context.Context, tx *sql.Tx, input model.Acc
 		input.AuthFileName,
 		input.ActionType,
 		input.ReasonCode,
+	}
+	if provider == "codex" {
+		// An old no-index row is only upgradeable when it already carries the
+		// same Workspace and strong member evidence. account_id alone is a
+		// shared Team Workspace and is never sufficient for an upgrade.
+		if input.AuthIndex == "" || input.AccountIDSnapshot == "" || accountSnapshot == "" {
+			return 0, false, nil
+		}
+		return querySingleCandidateID(ctx, tx, `select id from account_action_candidates
+			where status = ? and auth_file_name = ? and action_type = ? and coalesce(trim(reason_code), '') = ?
+				and coalesce(trim(auth_index), '') = '' and coalesce(trim(account_id_snapshot), '') = ?
+				and lower(trim(account_snapshot)) = ?
+				and coalesce(lower(replace(trim(provider), '_', '-')), '') = 'codex'
+			order by id asc limit 2`, append(baseArgs, input.AccountIDSnapshot, accountSnapshot)...)
 	}
 	if input.AuthIndex != "" && input.AccountIDSnapshot != "" && provider != "" {
 		id, found, err := querySingleCandidateID(ctx, tx, `select id from account_action_candidates

--- a/apps/manager-server/internal/repository/accountaction/repository_test.go
+++ b/apps/manager-server/internal/repository/accountaction/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
@@ -284,7 +285,7 @@ func TestUpsertUpgradesFallbackIdentityWhenStableLocatorAppears(t *testing.T) {
 	}
 }
 
-func TestUpsertDoesNotBindNewCodexMemberToWorkspaceOnlyCandidate(t *testing.T) {
+func TestUpsertEnrichesWorkspaceOnlyCodexCandidateWithMember(t *testing.T) {
 	ctx := context.Background()
 	st := testutil.NewStore(t, testutil.NewConfig(t))
 	repo := st.AccountActions
@@ -317,18 +318,63 @@ func TestUpsertDoesNotBindNewCodexMemberToWorkspaceOnlyCandidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upsert member candidate: %v", err)
 	}
-	if member.ID == workspaceOnly.ID {
-		t.Fatalf("new Codex member reused workspace-only candidate %d", member.ID)
+	if member.ID != workspaceOnly.ID {
+		t.Fatalf("Codex member created a second candidate: workspace-only=%d member=%d", workspaceOnly.ID, member.ID)
 	}
-	if workspaceOnly.AccountSnapshot != "" || member.AccountSnapshot != "bob@example.com" {
-		t.Fatalf("candidate identities = workspace-only %#v, member %#v", workspaceOnly, member)
+	if workspaceOnly.AccountSnapshot != "" || member.AccountSnapshot != "bob@example.com" || member.AccountIDSnapshot != "workspace-1" {
+		t.Fatalf("candidate identities = workspace-only %#v, enriched %#v", workspaceOnly, member)
 	}
 
 	items, err := repo.List(ctx, model.AccountActionStatusPending, 10)
 	if err != nil {
 		t.Fatalf("list pending candidates: %v", err)
 	}
-	if len(items) != 2 {
-		t.Fatalf("pending candidates = %#v, want workspace-only and member-specific rows", items)
+	if len(items) != 1 || items[0].ID != member.ID || items[0].HitCount != 2 {
+		t.Fatalf("pending candidates = %#v, want one enriched candidate", items)
+	}
+}
+
+func TestUpsertKeepsConflictingCodexMemberOnExistingCandidate(t *testing.T) {
+	ctx := context.Background()
+	st := testutil.NewStore(t, testutil.NewConfig(t))
+	repo := st.AccountActions
+
+	first, err := repo.Upsert(ctx, model.AccountActionCandidateUpsert{
+		ActionType:        model.AccountActionTypeDelete,
+		Provider:          "codex",
+		AuthFileName:      "shared.json",
+		AuthIndex:         "auth-1",
+		AccountIDSnapshot: "workspace-1",
+		AccountSnapshot:   "alice@example.com",
+		ReasonCode:        "token_revoked",
+		Reason:            "Alice token revoked",
+	})
+	if err != nil {
+		t.Fatalf("upsert first candidate: %v", err)
+	}
+
+	conflicting, err := repo.Upsert(ctx, model.AccountActionCandidateUpsert{
+		ActionType:        model.AccountActionTypeDelete,
+		Provider:          "codex",
+		AuthFileName:      "shared.json",
+		AuthIndex:         "auth-1",
+		AccountIDSnapshot: "workspace-1",
+		AccountSnapshot:   "bob@example.com",
+		ReasonCode:        "token_revoked",
+		Reason:            "Bob token revoked",
+	})
+	if err == nil || !strings.Contains(err.Error(), "member changed") {
+		t.Fatalf("conflicting upsert error = %v, want member conflict", err)
+	}
+	if conflicting.ID != first.ID || conflicting.AccountSnapshot != "alice@example.com" {
+		t.Fatalf("conflicting candidate = %#v, want original identity preserved", conflicting)
+	}
+
+	items, err := repo.List(ctx, model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list pending candidates: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != first.ID || !strings.Contains(items[0].LastError, "member changed") {
+		t.Fatalf("pending candidates = %#v, want one conflict-marked candidate", items)
 	}
 }

--- a/apps/manager-server/internal/repository/accountaction/repository_test.go
+++ b/apps/manager-server/internal/repository/accountaction/repository_test.go
@@ -283,3 +283,52 @@ func TestUpsertUpgradesFallbackIdentityWhenStableLocatorAppears(t *testing.T) {
 		t.Fatalf("upgraded candidate = %#v, first = %#v", upgraded, first)
 	}
 }
+
+func TestUpsertDoesNotBindNewCodexMemberToWorkspaceOnlyCandidate(t *testing.T) {
+	ctx := context.Background()
+	st := testutil.NewStore(t, testutil.NewConfig(t))
+	repo := st.AccountActions
+
+	workspaceOnly, err := repo.Upsert(ctx, model.AccountActionCandidateUpsert{
+		ActionType:        model.AccountActionTypeReauth,
+		Provider:          "codex",
+		AuthFileName:      "shared.json",
+		AuthIndex:         "auth-1",
+		AccountIDSnapshot: "workspace-1",
+		ReasonCode:        "token_revoked",
+		Reason:            "workspace-only pending review",
+		SeenAtMS:          1000,
+	})
+	if err != nil {
+		t.Fatalf("upsert workspace-only candidate: %v", err)
+	}
+
+	member, err := repo.Upsert(ctx, model.AccountActionCandidateUpsert{
+		ActionType:        model.AccountActionTypeReauth,
+		Provider:          "codex",
+		AuthFileName:      "shared.json",
+		AuthIndex:         "auth-1",
+		AccountSnapshot:   "bob@example.com",
+		AccountIDSnapshot: "workspace-1",
+		ReasonCode:        "token_revoked",
+		Reason:            "member-specific pending review",
+		SeenAtMS:          2000,
+	})
+	if err != nil {
+		t.Fatalf("upsert member candidate: %v", err)
+	}
+	if member.ID == workspaceOnly.ID {
+		t.Fatalf("new Codex member reused workspace-only candidate %d", member.ID)
+	}
+	if workspaceOnly.AccountSnapshot != "" || member.AccountSnapshot != "bob@example.com" {
+		t.Fatalf("candidate identities = workspace-only %#v, member %#v", workspaceOnly, member)
+	}
+
+	items, err := repo.List(ctx, model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list pending candidates: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("pending candidates = %#v, want workspace-only and member-specific rows", items)
+	}
+}

--- a/apps/manager-server/internal/repository/accountaction/repository_test.go
+++ b/apps/manager-server/internal/repository/accountaction/repository_test.go
@@ -289,6 +289,9 @@ func TestUpsertEnrichesWorkspaceOnlyCodexCandidateWithMember(t *testing.T) {
 	ctx := context.Background()
 	st := testutil.NewStore(t, testutil.NewConfig(t))
 	repo := st.AccountActions
+	if err := st.RunDerivedStartupMaintenance(ctx); err != nil {
+		t.Fatalf("prepare production account action identity index: %v", err)
+	}
 
 	workspaceOnly, err := repo.Upsert(ctx, model.AccountActionCandidateUpsert{
 		ActionType:        model.AccountActionTypeReauth,

--- a/apps/manager-server/internal/repository/codexinspection/repository.go
+++ b/apps/manager-server/internal/repository/codexinspection/repository.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 type Repository interface {
@@ -673,6 +674,14 @@ func normalizeDisableOwnership(item model.CodexInspectionDisableOwnership) model
 	item.AuthIndex = strings.TrimSpace(item.AuthIndex)
 	item.AccountID = strings.TrimSpace(item.AccountID)
 	item.AccountSnapshot = strings.TrimSpace(item.AccountSnapshot)
+	if item.Provider == "codex" {
+		if member, ok := usageidentity.NormalizeCodexMemberSnapshot(item.AccountSnapshot); ok {
+			item.AccountSnapshot = member
+		} else {
+			item.AccountSnapshot = ""
+		}
+		return item
+	}
 	if item.AccountID != "" {
 		item.AccountSnapshot = ""
 	}
@@ -707,6 +716,9 @@ func disableOwnershipMatchesTarget(item model.CodexInspectionDisableOwnership, t
 		provider := normalizeDisableOwnershipProvider(*target.Provider)
 		if item.Provider != "" && item.Provider != provider {
 			return false
+		}
+		if provider == "codex" {
+			return disableOwnershipMatchesCodexTarget(item, target)
 		}
 	}
 	if target.AuthIndex != nil {
@@ -747,6 +759,60 @@ func disableOwnershipMatchesTarget(item model.CodexInspectionDisableOwnership, t
 		} else if item.AccountSnapshot != "" && item.AccountSnapshot != accountSnapshot {
 			return false
 		}
+	}
+	return true
+}
+
+func disableOwnershipMatchesCodexTarget(item model.CodexInspectionDisableOwnership, target model.CodexInspectionDisableOwnershipTarget) bool {
+	if item.Provider != "" && item.Provider != "codex" {
+		return false
+	}
+
+	// This matcher is used for explicit cleanup, not recovery authorization.
+	// A concrete credential may therefore remove a weaker legacy record, but it
+	// must never remove a different member's workspace-qualified record.
+	if target.AuthIndex != nil {
+		targetAuthIndex := strings.TrimSpace(*target.AuthIndex)
+		if targetAuthIndex == "" {
+			if item.AuthIndex != "" {
+				return false
+			}
+		} else if item.AuthIndex != "" && item.AuthIndex != targetAuthIndex {
+			return false
+		}
+	}
+
+	targetAccountIDSet := target.AccountID != nil
+	targetAccountID := ""
+	if targetAccountIDSet {
+		targetAccountID = strings.TrimSpace(*target.AccountID)
+		if targetAccountID == "" {
+			if item.AccountID != "" {
+				return false
+			}
+		} else if item.AccountID != "" && item.AccountID != targetAccountID {
+			return false
+		}
+	} else if item.AccountID != "" {
+		// Without a target workspace, a workspace-qualified ownership record is
+		// not a compatible legacy wildcard.
+		return false
+	}
+
+	targetMemberSet := target.AccountSnapshot != nil
+	targetMember := ""
+	if targetMemberSet {
+		targetMember, _ = usageidentity.NormalizeCodexMemberSnapshot(*target.AccountSnapshot)
+	}
+	itemMember, _ := usageidentity.NormalizeCodexMemberSnapshot(item.AccountSnapshot)
+	if targetMember == "" {
+		// A target without reliable member evidence may only clean records that
+		// also lack member evidence. This prevents Alice's action from deleting
+		// Bob's member-specific ownership in a shared Workspace.
+		return itemMember == ""
+	}
+	if itemMember != "" && itemMember != targetMember {
+		return false
 	}
 	return true
 }

--- a/apps/manager-server/internal/repository/codexinspection/repository_test.go
+++ b/apps/manager-server/internal/repository/codexinspection/repository_test.go
@@ -210,7 +210,7 @@ func TestDisableOwnershipCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list ownership: %v", err)
 	}
-	if len(items) != 1 || items[0].FileName != "auth-a.json" || items[0].AuthIndex != "auth-1" || items[0].AccountID != "account-1" || items[0].AccountSnapshot != "" || items[0].DisabledAtMS != 123 {
+	if len(items) != 1 || items[0].FileName != "auth-a.json" || items[0].AuthIndex != "auth-1" || items[0].AccountID != "account-1" || items[0].AccountSnapshot != "alice@example.com" || items[0].DisabledAtMS != 123 {
 		t.Fatalf("inserted ownership = %#v", items)
 	}
 	if items[0].Provider != "codex" {
@@ -238,11 +238,13 @@ func TestDisableOwnershipCRUD(t *testing.T) {
 	provider := "codex"
 	authIndex := "auth-1"
 	accountID := "account-1"
+	accountSnapshot := "alice@example.com"
 	if err := repository.DeleteDisableOwnership(ctx, model.CodexInspectionDisableOwnershipTarget{
-		FileName:  "auth-a.json",
-		Provider:  &provider,
-		AuthIndex: &authIndex,
-		AccountID: &accountID,
+		FileName:        "auth-a.json",
+		Provider:        &provider,
+		AuthIndex:       &authIndex,
+		AccountID:       &accountID,
+		AccountSnapshot: &accountSnapshot,
 	}); err != nil {
 		t.Fatalf("delete ownership: %v", err)
 	}

--- a/apps/manager-server/internal/repository/quotasnapshot/legacy_migration_test.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/legacy_migration_test.go
@@ -111,6 +111,147 @@ func TestBackfillLegacySnapshotsBatchProcessesWholeGroupsAndResumes(t *testing.T
 	}
 }
 
+func TestBackfillLegacySnapshotsBatchLeavesLegacyCodexWorkspaceSnapshotsOrphaned(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	legacyKey := "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31"
+	seedLegacySnapshot(t, db, legacyKey, "codex", "five-hour", "five_hour", "api_query", "legacy-workspace", 1000)
+
+	result, err := quotasnapshotrepo.BackfillLegacySnapshotsBatch(context.Background(), db, 1000)
+	if err != nil {
+		t.Fatalf("backfill legacy Codex workspace snapshot: %v", err)
+	}
+	if result.Processed != 0 || result.Pending || !result.Completed {
+		t.Fatalf("legacy Codex workspace backfill result = %#v", result)
+	}
+	assertLegacySnapshotAttachment(t, db, 1, false)
+
+	var windowCount int
+	if err := db.QueryRow(`select count(*) from account_quota_windows where account_key = ?`, legacyKey).Scan(&windowCount); err != nil {
+		t.Fatalf("count orphaned Codex workspace windows: %v", err)
+	}
+	if windowCount != 0 {
+		t.Fatalf("orphaned Codex workspace snapshot created %d lifecycle windows", windowCount)
+	}
+	candidates, err := quotasnapshotrepo.New(db).ListCandidates(context.Background(), legacyKey, "codex", 10)
+	if err != nil {
+		t.Fatalf("list orphaned Codex workspace candidates: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("orphaned Codex workspace candidates = %#v, want none", candidates)
+	}
+	states, err := quotasnapshotrepo.New(db).ListWindowStates(context.Background(), legacyKey, "codex")
+	if err != nil {
+		t.Fatalf("list orphaned Codex workspace states: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("orphaned Codex workspace states = %#v, want none", states)
+	}
+	var status string
+	if err := db.QueryRow(`select status from usage_data_migrations where name = ?`, quotasnapshotrepo.LegacySnapshotMigrationName).Scan(&status); err != nil {
+		t.Fatalf("read orphaned Codex workspace migration status: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("orphaned Codex workspace migration status = %q, want completed", status)
+	}
+}
+
+func TestQuotaReadersHideAttachedLegacyCodexWorkspaceRows(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	legacyKey := "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31"
+	scopeFingerprint := quotasnapshotrepo.ScopeFingerprint("all", "", nil)
+	observationResult, err := db.Exec(`insert into account_quota_observations (
+		observation_hash, account_key, provider, source, source_observation_id,
+		inventory_scope_key, inventory_mode, observed_at_ms, window_count,
+		lifecycle_applied, created_at_ms
+	) values ('legacy-observation-hash', ?, 'codex', 'api_query', 'legacy-observation',
+		'codex:rate-limits', 'partial', 1000, 1, 1, 1000)`, legacyKey)
+	if err != nil {
+		t.Fatalf("insert legacy observation: %v", err)
+	}
+	observationID, err := observationResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("read legacy observation id: %v", err)
+	}
+	windowResult, err := db.Exec(`insert into account_quota_windows (
+		account_key, provider, provider_window_id, window_kind, window_mode,
+		model_scope_kind, model_scope_key, model_ids_json, scope_fingerprint,
+		inventory_scope_key, relationship_kind, container_provider_window_id,
+		availability, generation, absence_count, first_seen_at_ms, last_seen_at_ms,
+		last_observation_id, created_at_ms, updated_at_ms
+	) values (?, 'codex', 'five-hour', 'five_hour', 'fixed', 'all', null, '[]', ?,
+		'codex:rate-limits', null, null, 'active', 1, 0, 1000, 1000, ?, 1000, 1000)`,
+		legacyKey, scopeFingerprint, observationID)
+	if err != nil {
+		t.Fatalf("insert legacy lifecycle window: %v", err)
+	}
+	windowID, err := windowResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("read legacy lifecycle window id: %v", err)
+	}
+	if _, err := db.Exec(`insert into account_quota_snapshots (
+		observation_id, logical_window_id, account_key, provider, provider_window_id,
+		window_kind, window_mode, model_scope_kind, model_ids_json, scope_fingerprint,
+		source, source_observation_id, observed_at_ms, boundary_accuracy,
+		duration_seconds, used_percent, remaining_percent, created_at_ms
+	) values (?, ?, ?, 'codex', 'five-hour', 'five_hour', 'fixed', 'all', '[]', ?,
+		'api_query', 'legacy-observation', 1000, 'exact', 18000, 99, 1, 1000)`,
+		observationID, windowID, legacyKey, scopeFingerprint); err != nil {
+		t.Fatalf("insert attached legacy snapshot: %v", err)
+	}
+
+	repository := quotasnapshotrepo.New(db)
+	candidates, err := repository.ListCandidates(context.Background(), legacyKey, "codex", 10)
+	if err != nil {
+		t.Fatalf("list attached legacy candidates: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("attached legacy Codex candidates = %#v, want none", candidates)
+	}
+	states, err := repository.ListWindowStates(context.Background(), legacyKey, "codex")
+	if err != nil {
+		t.Fatalf("list attached legacy window states: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("attached legacy Codex window states = %#v, want none", states)
+	}
+}
+
+func TestQuotaReadersHideLegacyCodexWorkspaceRowsWithoutProviderMetadata(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	legacyKey := "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31"
+	if _, err := db.Exec(`insert into account_quota_snapshots (
+		account_key, provider, provider_window_id, window_kind, window_mode,
+		model_scope_kind, source, source_observation_id, observed_at_ms,
+		boundary_accuracy, used_percent, created_at_ms
+	) values (?, '', 'five-hour', 'five_hour', 'fixed', 'all',
+		'api_query', 'legacy-without-provider', 1000, 'exact', 99, 1000)`, legacyKey); err != nil {
+		t.Fatalf("insert legacy snapshot without provider: %v", err)
+	}
+
+	repository := quotasnapshotrepo.New(db)
+	candidates, err := repository.ListCandidates(context.Background(), legacyKey, "", 10)
+	if err != nil {
+		t.Fatalf("list legacy candidates without provider: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("legacy candidates without provider = %#v, want none", candidates)
+	}
+}
+
 func TestBackfillLegacySnapshotsBatchRejectsOversizedGroupAtomically(t *testing.T) {
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -2039,6 +2039,7 @@ func (r *repository) ListWindowStates(ctx context.Context, accountKey, provider 
 		coalesce(container_provider_window_id, ''), availability, generation,
 		first_seen_at_ms, last_seen_at_ms, missing_since_ms, deactivated_at_ms
 		from account_quota_windows where account_key = ? and provider = ?
+			and `+excludeLegacyCodexWorkspaceSnapshotSQL("")+`
 		order by updated_at_ms desc, id desc`, strings.TrimSpace(accountKey), strings.TrimSpace(provider))
 	if err != nil {
 		return nil, err

--- a/apps/manager-server/internal/repository/quotasnapshot/repository.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/repository.go
@@ -97,6 +97,7 @@ func BackfillLegacySnapshotsBatch(ctx context.Context, db *sql.DB, maxGroupSize 
 	defer func() { _ = tx.Rollback() }()
 
 	firstRows, err := loadLegacySnapshots(ctx, tx, `where observation_id is null
+		and `+excludeLegacyCodexWorkspaceSnapshotSQL("")+`
 		order by account_key, provider, observed_at_ms,
 			case lower(trim(source))
 				when 'response_body' then 1
@@ -121,6 +122,7 @@ func BackfillLegacySnapshotsBatch(ctx context.Context, db *sql.DB, maxGroupSize 
 	}
 	first := firstRows[0]
 	groupWhere := `where observation_id is null
+		and ` + excludeLegacyCodexWorkspaceSnapshotSQL("") + `
 		and account_key = ? and provider = ? and source = ?
 		and coalesce(source_observation_id, '') = ? and observed_at_ms = ?`
 	args := []any{first.AccountKey, first.Provider, first.Source, first.SourceObservationID, first.ObservedAtMS}
@@ -183,7 +185,8 @@ func BackfillLegacySnapshotsBatch(ctx context.Context, db *sql.DB, maxGroupSize 
 	processed := writes[0].InsertedSnapshotCount
 	var pending int
 	if err := tx.QueryRowContext(ctx, `select exists (
-		select 1 from account_quota_snapshots where observation_id is null limit 1
+		select 1 from account_quota_snapshots
+		where observation_id is null and `+excludeLegacyCodexWorkspaceSnapshotSQL("")+` limit 1
 	)`).Scan(&pending); err != nil {
 		return LegacyBackfillResult{}, err
 	}
@@ -299,6 +302,26 @@ func updateLegacyBackfillState(ctx context.Context, db legacyBackfillStateWriter
 		LegacySnapshotMigrationName,
 	)
 	return err
+}
+
+// Legacy Codex quota snapshots were keyed by chatgpt_account_id, which is a
+// shared Workspace identifier for Team/Business credentials. They cannot be
+// attributed to a member after the fact. Keep those derived rows as orphaned
+// evidence: do not attach them to the lifecycle graph or expose them through
+// the normal quota readers. The key kind is intentionally matched as a
+// segment, rather than by decoding the opaque value, so this remains valid for
+// every v3 codex-account key without adding schema or a mapping table. Do not
+// require provider='codex' here: old derived rows can have incomplete provider
+// metadata, and the opaque key kind is the stronger evidence that this is the
+// un-attributable workspace-level bucket.
+func excludeLegacyCodexWorkspaceSnapshotSQL(alias string) string {
+	column := func(name string) string {
+		if alias == "" {
+			return name
+		}
+		return alias + "." + name
+	}
+	return "not (instr(coalesce(" + column("account_key") + ", ''), ':codex-account:') > 0)"
 }
 
 func RecordLegacyBackfillFailure(ctx context.Context, db *sql.DB, migrationErr error) error {
@@ -516,6 +539,7 @@ func (r *repository) ListCandidates(ctx context.Context, accountKey, provider st
 		) as source_rank
 		from account_quota_snapshots
 		where account_key = ? and provider = ?
+			and `+excludeLegacyCodexWorkspaceSnapshotSQL("")+`
 			and (observation_id is null or (
 				logical_window_id is not null and exists (
 					select 1 from account_quota_observations observation

--- a/apps/manager-server/internal/repository/sqlite/derived_cleanup.go
+++ b/apps/manager-server/internal/repository/sqlite/derived_cleanup.go
@@ -24,6 +24,7 @@ const (
 var derivedLegacyTables = []string{
 	usageAccountModelRollupsLegacy,
 	usageAccountModelIdentityLegacy,
+	usageAccountModelCodexIdentityLegacy,
 	usagePricingAccountLegacy,
 	usageDashboardHourlyLegacy,
 	usageHourlyAggregateLegacy,
@@ -31,6 +32,8 @@ var derivedLegacyTables = []string{
 	usageMonitoringAPIKeyLegacy,
 	usageMonitoringAccountIdentityLegacy,
 	usageMonitoringAPIKeyIdentityLegacy,
+	usageMonitoringAccountCodexIdentityLegacy,
+	usageMonitoringAPIKeyCodexIdentityLegacy,
 	usageMonitoringSelectorLegacy,
 	usageMonitoringHeaderLegacy,
 	usageMonitoringProjectionLegacy,
@@ -522,7 +525,6 @@ func cleanupDerivedBatch(ctx context.Context, db *sql.DB, limit int) (int64, boo
 		log.Printf("[derived-migration] removed empty legacy table %s", tableName)
 		return 0, true, nil
 	}
-
 	targets, err := staleDerivedCleanupTargets(ctx, db)
 	if err != nil {
 		return 0, false, err

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -15,13 +15,15 @@ import (
 )
 
 const (
-	accountHistoryIdentityFormatVersionKey = "usage_account_history_identity_format_version"
-	legacyAccountHistoryStructureRevision  = "identity-2:model-1"
-	dashboardHourlyRollupFormatVersionKey  = "usage_dashboard_hourly_format_version"
-	dashboardHourlyRollupFormatVersion     = "3"
-	usageMonitoringModelFormatVersionKey   = "usage_monitoring_model_format_version"
-	usageHourlyAggregateSchemaVersion      = 3
-	usageHourlyAggregateStructureRevision  = "schema-3:model-1"
+	accountHistoryIdentityFormatVersionKey  = "usage_account_history_identity_format_version"
+	legacyAccountHistoryStructureRevisionV2 = "identity-2:model-1"
+	legacyAccountHistoryStructureRevisionV3 = "identity-3:model-1"
+	legacyMonitoringProjectionRevisionV3    = legacyAccountHistoryStructureRevisionV3 + ":project-v1"
+	dashboardHourlyRollupFormatVersionKey   = "usage_dashboard_hourly_format_version"
+	dashboardHourlyRollupFormatVersion      = "3"
+	usageMonitoringModelFormatVersionKey    = "usage_monitoring_model_format_version"
+	usageHourlyAggregateSchemaVersion       = 3
+	usageHourlyAggregateStructureRevision   = "schema-3:model-1"
 
 	usageMonitoringAccountDailyTable  = "usage_monitoring_account_daily_rollups_v1"
 	usageMonitoringAPIKeyDailyTable   = "usage_monitoring_api_key_daily_rollups_v1"
@@ -38,28 +40,34 @@ const (
 	usageHourlyAggregateState = "usage_hourly_aggregate_state"
 	usageEventIdentityLedger  = "usage_event_identity_ledger"
 
-	usageAccountModelRollupsTable         = "usage_account_model_rollups"
-	usagePricingAccountRollupsTable       = "usage_pricing_account_rollups_v1"
-	usageAccountModelRollupsLegacy        = "usage_account_model_rollups_legacy_v1120_rc2"
-	usageAccountModelIdentityLegacy       = "usage_account_model_rollups_legacy_identity_v3"
-	usagePricingAccountLegacy             = "usage_pricing_account_rollups_v1_legacy_v1120_rc2"
-	usageDashboardHourlyLegacy            = "usage_dashboard_hourly_rollups_legacy_v1120_rc2"
-	usageHourlyAggregateLegacy            = "usage_hourly_aggregate_v1_legacy_v1120_rc2"
-	usageMonitoringSearchLegacy           = "usage_monitoring_event_search_v1_legacy_v1120_rc2"
-	usageMonitoringSearchLegacyPrefix     = "usage_monitoring_event_search_v1_legacy_g"
-	usageMonitoringProjectionLegacyPrefix = "usage_monitoring_event_projection_v1_legacy_g"
-	usageMonitoringAccountLegacy          = "usage_monitoring_account_daily_rollups_v1_legacy_recovery"
-	usageMonitoringAPIKeyLegacy           = "usage_monitoring_api_key_daily_rollups_v1_legacy_recovery"
-	usageMonitoringAccountIdentityLegacy  = "usage_monitoring_account_daily_rollups_v1_legacy_identity_v3"
-	usageMonitoringAPIKeyIdentityLegacy   = "usage_monitoring_api_key_daily_rollups_v1_legacy_identity_v3"
-	usageMonitoringSelectorLegacy         = "usage_monitoring_selector_daily_rollups_v1_legacy_recovery"
-	usageMonitoringHeaderLegacy           = "usage_monitoring_header_latest_v1_legacy_recovery"
-	usageMonitoringProjectionLegacy       = "usage_monitoring_event_projection_v1_legacy_recovery"
-	usageDashboardHourlySourceLegacy      = "usage_dashboard_hourly_rollups_legacy_source_recovery"
-	usagePricingHourlySourceLegacy        = "usage_pricing_hourly_rollups_v1_legacy_source_recovery"
-	usageCacheChangesSourceLegacy         = "usage_cache_accounting_v2_changes_legacy_source_recovery"
-	usageAccountModelSourceLegacy         = "usage_account_model_rollups_legacy_source_recovery"
-	usagePricingAccountSourceLegacy       = "usage_pricing_account_rollups_v1_legacy_source_recovery"
+	usageAccountModelRollupsTable   = "usage_account_model_rollups"
+	usagePricingAccountRollupsTable = "usage_pricing_account_rollups_v1"
+	usageAccountModelRollupsLegacy  = "usage_account_model_rollups_legacy_v1120_rc2"
+	// Keep the unsuffixed identity-v3 name for cleanup of databases migrated by
+	// the previous identity revision. New Codex identity rebuilds use a
+	// revision-specific name so pending old cleanup cannot block startup.
+	usageAccountModelIdentityLegacy           = "usage_account_model_rollups_legacy_identity_v3"
+	usageAccountModelCodexIdentityLegacy      = "usage_account_model_rollups_legacy_identity_v3_codex_v2"
+	usagePricingAccountLegacy                 = "usage_pricing_account_rollups_v1_legacy_v1120_rc2"
+	usageDashboardHourlyLegacy                = "usage_dashboard_hourly_rollups_legacy_v1120_rc2"
+	usageHourlyAggregateLegacy                = "usage_hourly_aggregate_v1_legacy_v1120_rc2"
+	usageMonitoringSearchLegacy               = "usage_monitoring_event_search_v1_legacy_v1120_rc2"
+	usageMonitoringSearchLegacyPrefix         = "usage_monitoring_event_search_v1_legacy_g"
+	usageMonitoringProjectionLegacyPrefix     = "usage_monitoring_event_projection_v1_legacy_g"
+	usageMonitoringAccountLegacy              = "usage_monitoring_account_daily_rollups_v1_legacy_recovery"
+	usageMonitoringAPIKeyLegacy               = "usage_monitoring_api_key_daily_rollups_v1_legacy_recovery"
+	usageMonitoringAccountIdentityLegacy      = "usage_monitoring_account_daily_rollups_v1_legacy_identity_v3"
+	usageMonitoringAPIKeyIdentityLegacy       = "usage_monitoring_api_key_daily_rollups_v1_legacy_identity_v3"
+	usageMonitoringAccountCodexIdentityLegacy = "usage_monitoring_account_daily_rollups_v1_legacy_identity_v3_codex_v2"
+	usageMonitoringAPIKeyCodexIdentityLegacy  = "usage_monitoring_api_key_daily_rollups_v1_legacy_identity_v3_codex_v2"
+	usageMonitoringSelectorLegacy             = "usage_monitoring_selector_daily_rollups_v1_legacy_recovery"
+	usageMonitoringHeaderLegacy               = "usage_monitoring_header_latest_v1_legacy_recovery"
+	usageMonitoringProjectionLegacy           = "usage_monitoring_event_projection_v1_legacy_recovery"
+	usageDashboardHourlySourceLegacy          = "usage_dashboard_hourly_rollups_legacy_source_recovery"
+	usagePricingHourlySourceLegacy            = "usage_pricing_hourly_rollups_v1_legacy_source_recovery"
+	usageCacheChangesSourceLegacy             = "usage_cache_accounting_v2_changes_legacy_source_recovery"
+	usageAccountModelSourceLegacy             = "usage_account_model_rollups_legacy_source_recovery"
+	usagePricingAccountSourceLegacy           = "usage_pricing_account_rollups_v1_legacy_source_recovery"
 
 	createUsageAccountModelRollupsTable = `create table if not exists usage_account_model_rollups (
 		account_key text not null,
@@ -1001,7 +1009,7 @@ func validateUsageDerivedSchemaVersions(db *sql.DB, hourlySnapshot usageHourlyAg
 		var accountHistoryVersion string
 		err = db.QueryRow(`select value from settings where key = ?`, accountHistoryIdentityFormatVersionKey).Scan(&accountHistoryVersion)
 		switch {
-		case err == nil && accountHistoryVersion != "1" && accountHistoryVersion != "2" && accountHistoryVersion != legacyAccountHistoryStructureRevision && accountHistoryVersion != usageidentity.FormatVersion && accountHistoryVersion != usageidentity.AccountHistoryStructureRevision():
+		case err == nil && !supportedAccountHistoryIdentityRevision(accountHistoryVersion):
 			return fmt.Errorf("unsupported account history identity format version %q", accountHistoryVersion)
 		case err != nil && !errors.Is(err, sql.ErrNoRows):
 			return fmt.Errorf("inspect account history identity format version: %w", err)
@@ -1618,6 +1626,7 @@ func ensureUsageMonitoringProjectionIdentity(db *sql.DB) error {
 
 	statsNeedsIdentityUpgrade := !statsHasAuthAccountID || !statsPKHasAuthAccountID
 	apiKeyStatsNeedsIdentityUpgrade := !apiKeyStatsHasAuthAccountID || !apiKeyStatsPKHasAuthAccountID
+	codexIdentityRevisionUpgrade := projectionRevisionMismatch && projectionRevision == legacyMonitoringProjectionRevisionV3
 	needsRebuild := versionErr != nil || projectionRevisionMismatch || !hasAccountKey || !hasRequestedModel || !hasAnalyticsModel || !hasAuthAccountID || !headerHasAuthAccountID || !selectorHasRevision || statsNeedsIdentityUpgrade || apiKeyStatsNeedsIdentityUpgrade
 	if needsRebuild {
 		if err := dropUsageMonitoringSearchTriggers(tx); err != nil {
@@ -1660,13 +1669,24 @@ func ensureUsageMonitoringProjectionIdentity(db *sql.DB) error {
 			if !hasRows && !identitySchemaUpgrade {
 				continue
 			}
+			identityLegacyName := legacyName
+			switch {
+			case tableName == usageMonitoringAccountDailyTable && statsNeedsIdentityUpgrade:
+				identityLegacyName = usageMonitoringAccountIdentityLegacy
+			case tableName == usageMonitoringAPIKeyDailyTable && apiKeyStatsNeedsIdentityUpgrade:
+				identityLegacyName = usageMonitoringAPIKeyIdentityLegacy
+			case tableName == usageMonitoringAccountDailyTable && codexIdentityRevisionUpgrade:
+				identityLegacyName = usageMonitoringAccountCodexIdentityLegacy
+			case tableName == usageMonitoringAPIKeyDailyTable && codexIdentityRevisionUpgrade:
+				identityLegacyName = usageMonitoringAPIKeyCodexIdentityLegacy
+			}
 			var rebuildErr error
 			if tableName == usageMonitoringAccountDailyTable && statsNeedsIdentityUpgrade {
-				rebuildErr = parkAndRecreateMonitoringIdentityTable(tx, tableName, usageMonitoringAccountIdentityLegacy, "auth_provider_snapshot, auth_index")
+				rebuildErr = parkAndRecreateMonitoringIdentityTable(tx, tableName, identityLegacyName, "auth_provider_snapshot, auth_index")
 			} else if tableName == usageMonitoringAPIKeyDailyTable && apiKeyStatsNeedsIdentityUpgrade {
-				rebuildErr = parkAndRecreateMonitoringIdentityTable(tx, tableName, usageMonitoringAPIKeyIdentityLegacy, "auth_provider_snapshot, auth_index")
+				rebuildErr = parkAndRecreateMonitoringIdentityTable(tx, tableName, identityLegacyName, "auth_provider_snapshot, auth_index")
 			} else {
-				rebuildErr = parkAndRecreateDerivedTable(tx, tableName, legacyName)
+				rebuildErr = parkAndRecreateDerivedTable(tx, tableName, identityLegacyName)
 			}
 			if err := rebuildErr; err != nil {
 				return err
@@ -1958,7 +1978,7 @@ func ensureAccountHistoryIdentityFormatVersion(db *sql.DB) error {
 	switch {
 	case err == nil && version == usageidentity.AccountHistoryStructureRevision():
 		return tx.Commit()
-	case err == nil && version != "1" && version != "2" && version != legacyAccountHistoryStructureRevision && version != usageidentity.FormatVersion:
+	case err == nil && !supportedAccountHistoryIdentityRevision(version):
 		return fmt.Errorf("unsupported account history identity format version %q", version)
 	case err != nil && !errors.Is(err, sql.ErrNoRows):
 		return err
@@ -1969,7 +1989,7 @@ func ensureAccountHistoryIdentityFormatVersion(db *sql.DB) error {
 		return err
 	}
 	if hasRows {
-		if err := parkDerivedTable(tx, usageAccountModelRollupsTable, usageAccountModelIdentityLegacy); err != nil {
+		if err := parkDerivedTable(tx, usageAccountModelRollupsTable, usageAccountModelCodexIdentityLegacy); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(createUsageAccountModelRollupsTable); err != nil {
@@ -2019,6 +2039,18 @@ func ensureAccountHistoryIdentityFormatVersion(db *sql.DB) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+func supportedAccountHistoryIdentityRevision(value string) bool {
+	switch value {
+	case "1", "2", usageidentity.FormatVersion,
+		legacyAccountHistoryStructureRevisionV2,
+		legacyAccountHistoryStructureRevisionV3,
+		usageidentity.AccountHistoryStructureRevision():
+		return true
+	default:
+		return false
+	}
 }
 
 func ensureDashboardHourlyRollupFormatVersion(db *sql.DB) error {

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
 	quotasnapshotrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/quotasnapshot"
+	pricingrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usagepricing"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageprojection"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
@@ -2395,6 +2396,8 @@ func TestAccountHistoryIdentityFormatUpgradeRebuildsDerivedDataOnce(t *testing.T
 		) values ('legacy', '-', '-', '', 1, 1, 1)`,
 		`create table usage_account_model_rollups_legacy_v1120_rc2 (id integer primary key)`,
 		`insert into usage_account_model_rollups_legacy_v1120_rc2 (id) values (1)`,
+		`create table usage_account_model_rollups_legacy_identity_v3 (id integer primary key)`,
+		`insert into usage_account_model_rollups_legacy_identity_v3 (id) values (1)`,
 		`insert into usage_dashboard_hourly_rollups (
 			bucket_ms, model, billing_model, service_tier, updated_at_ms
 		) values (0, '-', '-', '', 1)`,
@@ -2419,6 +2422,7 @@ func TestAccountHistoryIdentityFormatUpgradeRebuildsDerivedDataOnce(t *testing.T
 	assertTableCount(t, db, "usage_account_model_rollups", 0)
 	assertTableCount(t, db, usageAccountModelRollupsLegacy, 1)
 	assertTableCount(t, db, usageAccountModelIdentityLegacy, 1)
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
 	assertTableCount(t, db, "usage_dashboard_hourly_rollups", 1)
 	var accountCheckpoints, dashboardCheckpoints int
 	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'account_history'`).Scan(&accountCheckpoints); err != nil {
@@ -2507,7 +2511,8 @@ func TestAccountHistoryIdentityFormatUpgradeDoesNotDeleteDerivedRows(t *testing.
 	}
 	assertTableCount(t, db, "usage_events", 1)
 	assertTableCount(t, db, "usage_account_model_rollups", 0)
-	assertTableCount(t, db, usageAccountModelIdentityLegacy, 1)
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
+	assertTableAbsent(t, db, usageAccountModelIdentityLegacy)
 	assertTableCount(t, db, "usage_rollup_checkpoints", 1)
 	var version string
 	if err := db.QueryRow(`select value from settings where key = ?`, accountHistoryIdentityFormatVersionKey).Scan(&version); err != nil {
@@ -2525,7 +2530,8 @@ func TestAccountHistoryIdentityFormatUpgradeDoesNotDeleteDerivedRows(t *testing.
 	}
 	assertTableCount(t, db, "usage_events", 1)
 	assertTableCount(t, db, "usage_account_model_rollups", 0)
-	assertTableCount(t, db, usageAccountModelIdentityLegacy, 1)
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
+	assertTableAbsent(t, db, usageAccountModelIdentityLegacy)
 	var accountCheckpoints, dashboardCheckpoints int
 	if err := db.QueryRow(`select count(*) from usage_rollup_checkpoints where name = 'account_history'`).Scan(&accountCheckpoints); err != nil {
 		t.Fatalf("read account checkpoint count: %v", err)
@@ -2535,6 +2541,271 @@ func TestAccountHistoryIdentityFormatUpgradeDoesNotDeleteDerivedRows(t *testing.
 	}
 	if accountCheckpoints != 0 || dashboardCheckpoints != 1 {
 		t.Fatalf("checkpoint counts after retry = account:%d dashboard:%d", accountCheckpoints, dashboardCheckpoints)
+	}
+}
+
+func TestAccountHistoryIdentityFormatUpgradeUsesDedicatedCodexLegacyTable(t *testing.T) {
+	tests := []struct {
+		name                string
+		version             string
+		wantLegacyTable     string
+		unwantedLegacyTable string
+	}{
+		{
+			name:                "v2-structured",
+			version:             legacyAccountHistoryStructureRevisionV2,
+			wantLegacyTable:     usageAccountModelCodexIdentityLegacy,
+			unwantedLegacyTable: usageAccountModelIdentityLegacy,
+		},
+		{
+			name:                "v3-structured",
+			version:             legacyAccountHistoryStructureRevisionV3,
+			wantLegacyTable:     usageAccountModelCodexIdentityLegacy,
+			unwantedLegacyTable: usageAccountModelIdentityLegacy,
+		},
+		{
+			name:                "v1",
+			version:             "1",
+			wantLegacyTable:     usageAccountModelCodexIdentityLegacy,
+			unwantedLegacyTable: usageAccountModelIdentityLegacy,
+		},
+		{
+			name:                "v2",
+			version:             "2",
+			wantLegacyTable:     usageAccountModelCodexIdentityLegacy,
+			unwantedLegacyTable: usageAccountModelIdentityLegacy,
+		},
+		{
+			name:                "v3",
+			version:             "3",
+			wantLegacyTable:     usageAccountModelCodexIdentityLegacy,
+			unwantedLegacyTable: usageAccountModelIdentityLegacy,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sql.Open("sqlite", dataSourceName(filepath.Join(t.TempDir(), "account-history-identity-selection.sqlite")))
+			if err != nil {
+				t.Fatalf("open sqlite: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			for _, statement := range []string{
+				`create table settings (key text primary key, value text not null, updated_at_ms integer not null)`,
+				`create table usage_events (id integer primary key)`,
+				`create table usage_account_model_rollups (id integer primary key)`,
+				`create table usage_rollup_checkpoints (name text primary key)`,
+				`insert into settings (key, value, updated_at_ms)
+				 values ('usage_account_history_identity_format_version', '` + test.version + `', 1)`,
+				`insert into usage_events (id) values (1)`,
+				`insert into usage_account_model_rollups (id) values (1)`,
+			} {
+				if _, err := db.Exec(statement); err != nil {
+					t.Fatalf("setup %s: %v", test.name, err)
+				}
+			}
+
+			if err := ensureAccountHistoryIdentityFormatVersion(db); err != nil {
+				t.Fatalf("migrate %s: %v", test.name, err)
+			}
+			assertTableCount(t, db, usageAccountModelRollupsTable, 0)
+			assertTableCount(t, db, test.wantLegacyTable, 1)
+			assertTableAbsent(t, db, test.unwantedLegacyTable)
+
+			if err := ensureAccountHistoryIdentityFormatVersion(db); err != nil {
+				t.Fatalf("repeat migrate %s: %v", test.name, err)
+			}
+			assertTableCount(t, db, test.wantLegacyTable, 1)
+		})
+	}
+}
+
+func TestLegacyIdentityV3UpgradePreservesRawEventsAndSchedulesAllIdentityRollups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-identity-v3.sqlite")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, statement := range []string{
+		`insert into usage_events (
+			event_hash, timestamp_ms, timestamp, model, raw_json, created_at_ms
+		) values ('legacy-v3-raw', 1700000000000, '2023-11-14T22:13:20Z', 'gpt-team', '{"immutable":true}', 1700000000000)`,
+		`insert into usage_account_model_rollups (
+			account_key, model, billing_model, service_tier, first_seen_ms, last_seen_ms, updated_at_ms
+		) values ('legacy-workspace-key', 'gpt-team', 'gpt-team', '', 1700000000000, 1700000000000, 1)`,
+		`update settings set value = 'identity-3:model-1'
+			where key = 'usage_account_history_identity_format_version'`,
+		`update usage_monitoring_rollup_state set
+			structure_revision = 'identity-3:model-1:project-v1', status = 'ready',
+			coverage_event_id = 1, target_event_id = 1
+			where rollup_name in ('stats_v1', 'metadata_v1', 'projection_v1')`,
+		`update usage_pricing_rollup_state set
+			structure_revision = 'model-1:identity-3:legacy-price', status = 'ready',
+			coverage_event_id = 1, target_event_id = 1
+			where rollup_name = 'pricing_v1'`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			_ = db.Close()
+			t.Fatalf("setup legacy identity v3 database: %v", err)
+		}
+	}
+	var beforeCount int
+	var beforeHash, beforeRawJSON string
+	if err := db.QueryRow(`select count(*), max(event_hash), max(raw_json) from usage_events`).Scan(&beforeCount, &beforeHash, &beforeRawJSON); err != nil {
+		_ = db.Close()
+		t.Fatalf("capture legacy raw event: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy sqlite: %v", err)
+	}
+
+	db, err = Open(path)
+	if err != nil {
+		t.Fatalf("upgrade legacy identity v3 sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var afterCount int
+	var afterHash, afterRawJSON string
+	if err := db.QueryRow(`select count(*), max(event_hash), max(raw_json) from usage_events`).Scan(&afterCount, &afterHash, &afterRawJSON); err != nil {
+		t.Fatalf("read upgraded raw event: %v", err)
+	}
+	if afterCount != beforeCount || afterHash != beforeHash || afterRawJSON != beforeRawJSON {
+		t.Fatalf("raw event changed by identity migration: before=%d/%q/%q after=%d/%q/%q", beforeCount, beforeHash, beforeRawJSON, afterCount, afterHash, afterRawJSON)
+	}
+	assertTableCount(t, db, usageAccountModelRollupsTable, 0)
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
+	var accountRevision string
+	if err := db.QueryRow(`select value from settings where key = ?`, accountHistoryIdentityFormatVersionKey).Scan(&accountRevision); err != nil {
+		t.Fatalf("read upgraded account identity revision: %v", err)
+	}
+	if accountRevision != usageidentity.AccountHistoryStructureRevision() {
+		t.Fatalf("account identity revision = %q, want %q", accountRevision, usageidentity.AccountHistoryStructureRevision())
+	}
+	for _, rollupName := range []string{usageMonitoringStatsRollupName, usageMonitoringMetadataRollupName, usageMonitoringProjectionRollupName} {
+		var revision, status string
+		if err := db.QueryRow(`select structure_revision, status from usage_monitoring_rollup_state where rollup_name = ?`, rollupName).Scan(&revision, &status); err != nil {
+			t.Fatalf("read upgraded monitoring state %s: %v", rollupName, err)
+		}
+		if status != "pending" {
+			t.Fatalf("monitoring state %s status = %q, want pending", rollupName, status)
+		}
+		if rollupName == usageMonitoringProjectionRollupName && revision != usageidentity.MonitoringProjectionStructureRevision() {
+			t.Fatalf("monitoring projection revision = %q, want %q", revision, usageidentity.MonitoringProjectionStructureRevision())
+		}
+	}
+
+	wantPricingRevision, err := pricingrepo.StructureRevision(context.Background(), db)
+	if err != nil {
+		t.Fatalf("calculate current pricing revision: %v", err)
+	}
+	pricingResult, err := pricingrepo.New(db).CatchUp(context.Background(), 1, time.Now().UnixMilli())
+	if err != nil {
+		t.Fatalf("start pricing identity rebuild: %v", err)
+	}
+	if !pricingResult.Rebuilt {
+		t.Fatalf("pricing identity rebuild result = %#v, want rebuilt", pricingResult)
+	}
+	pricingState, err := pricingrepo.New(db).State(context.Background())
+	if err != nil {
+		t.Fatalf("read rebuilding pricing state: %v", err)
+	}
+	if pricingState.StructureRevision != wantPricingRevision {
+		t.Fatalf("pricing state revision after catch-up = %q, want %q", pricingState.StructureRevision, wantPricingRevision)
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("repeat identity v3 migration: %v", err)
+	}
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
+	if err := db.QueryRow(`select count(*), max(event_hash), max(raw_json) from usage_events`).Scan(&afterCount, &afterHash, &afterRawJSON); err != nil {
+		t.Fatalf("read raw event after repeat migration: %v", err)
+	}
+	if afterCount != beforeCount || afterHash != beforeHash || afterRawJSON != beforeRawJSON {
+		t.Fatalf("repeat identity migration changed raw event: %d/%q/%q", afterCount, afterHash, afterRawJSON)
+	}
+}
+
+func TestLegacyAccountHistoryV3UpgradeSchedulesProjectionWhenProjectionRevisionIsCurrent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-account-history-v3-current-projection.sqlite")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	const rawJSON = `{"immutable":true,"member":"alice@example.com"}`
+	if _, err := db.Exec(`insert into usage_events (
+		event_hash, timestamp_ms, timestamp, model, raw_json, created_at_ms
+	) values ('legacy-v3-current-projection', 1700000000000, '2023-11-14T22:13:20Z', 'gpt-team', ?, 1700000000000)`, rawJSON); err != nil {
+		t.Fatalf("insert immutable raw event: %v", err)
+	}
+	if _, err := db.Exec(`insert into usage_account_model_rollups (
+		account_key, model, billing_model, service_tier, first_seen_ms, last_seen_ms, updated_at_ms
+	) values ('legacy-workspace-key', 'gpt-team', 'gpt-team', '', 1700000000000, 1700000000000, 1)`); err != nil {
+		t.Fatalf("insert legacy account rollup: %v", err)
+	}
+	if _, err := db.Exec(`update settings set value = 'identity-3:model-1'
+		where key = 'usage_account_history_identity_format_version'`); err != nil {
+		t.Fatalf("set legacy account history revision: %v", err)
+	}
+	if _, err := db.Exec(`update usage_monitoring_rollup_state set
+		structure_revision = ?, status = 'ready', coverage_event_id = 1, target_event_id = 1
+		where rollup_name = ?`, usageidentity.MonitoringProjectionStructureRevision(), usageMonitoringProjectionRollupName); err != nil {
+		t.Fatalf("set current monitoring projection revision: %v", err)
+	}
+	if _, err := db.Exec(`update usage_pricing_rollup_state set
+		structure_revision = 'current-pricing', status = 'ready', coverage_event_id = 1, target_event_id = 1
+		where rollup_name = 'pricing_v1'`); err != nil {
+		t.Fatalf("set current pricing revision: %v", err)
+	}
+
+	var beforeCount int
+	var beforeHash, beforeRawJSON string
+	if err := db.QueryRow(`select count(*), max(event_hash), max(raw_json) from usage_events`).Scan(&beforeCount, &beforeHash, &beforeRawJSON); err != nil {
+		t.Fatalf("capture raw event before migration: %v", err)
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("upgrade mixed identity revisions: %v", err)
+	}
+
+	var afterCount int
+	var afterHash, afterRawJSON string
+	if err := db.QueryRow(`select count(*), max(event_hash), max(raw_json) from usage_events`).Scan(&afterCount, &afterHash, &afterRawJSON); err != nil {
+		t.Fatalf("read raw event after migration: %v", err)
+	}
+	if afterCount != beforeCount || afterHash != beforeHash || afterRawJSON != beforeRawJSON {
+		t.Fatalf("mixed identity migration changed raw event: before=%d/%q/%q after=%d/%q/%q", beforeCount, beforeHash, beforeRawJSON, afterCount, afterHash, afterRawJSON)
+	}
+	assertTableCount(t, db, usageAccountModelRollupsTable, 0)
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
+
+	var accountRevision string
+	if err := db.QueryRow(`select value from settings where key = ?`, accountHistoryIdentityFormatVersionKey).Scan(&accountRevision); err != nil {
+		t.Fatalf("read upgraded account history revision: %v", err)
+	}
+	if accountRevision != usageidentity.AccountHistoryStructureRevision() {
+		t.Fatalf("account history revision = %q, want %q", accountRevision, usageidentity.AccountHistoryStructureRevision())
+	}
+	var projectionRevision, projectionStatus string
+	var projectionCoverage, projectionTarget int64
+	if err := db.QueryRow(`select structure_revision, status, coverage_event_id, target_event_id
+		from usage_monitoring_rollup_state where rollup_name = ?`, usageMonitoringProjectionRollupName).
+		Scan(&projectionRevision, &projectionStatus, &projectionCoverage, &projectionTarget); err != nil {
+		t.Fatalf("read scheduled projection state: %v", err)
+	}
+	if projectionRevision != usageidentity.MonitoringProjectionStructureRevision() || projectionStatus != "pending" || projectionCoverage != 0 || projectionTarget != 1 {
+		t.Fatalf("scheduled projection state = revision:%q status:%q coverage:%d target:%d", projectionRevision, projectionStatus, projectionCoverage, projectionTarget)
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("repeat mixed identity migration: %v", err)
+	}
+	assertTableCount(t, db, usageAccountModelCodexIdentityLegacy, 1)
+	if err := db.QueryRow(`select count(*), max(event_hash), max(raw_json) from usage_events`).Scan(&afterCount, &afterHash, &afterRawJSON); err != nil {
+		t.Fatalf("read raw event after repeated migration: %v", err)
+	}
+	if afterCount != beforeCount || afterHash != beforeHash || afterRawJSON != beforeRawJSON {
+		t.Fatalf("repeat mixed identity migration changed raw event: before=%d/%q/%q after=%d/%q/%q", beforeCount, beforeHash, beforeRawJSON, afterCount, afterHash, afterRawJSON)
 	}
 }
 
@@ -3434,5 +3705,16 @@ func assertTableCount(t *testing.T, db *sql.DB, table string, want int) {
 	}
 	if got != want {
 		t.Fatalf("%s count = %d, want %d", table, got, want)
+	}
+}
+
+func assertTableAbsent(t *testing.T, db *sql.DB, table string) {
+	t.Helper()
+	var exists int
+	if err := db.QueryRow(`select count(*) from sqlite_master where type = 'table' and name = ?`, table).Scan(&exists); err != nil {
+		t.Fatalf("inspect %s: %v", table, err)
+	}
+	if exists != 0 {
+		t.Fatalf("table %s exists, want absent", table)
 	}
 }

--- a/apps/manager-server/internal/repository/sqlite/upgrade_v1112_test.go
+++ b/apps/manager-server/internal/repository/sqlite/upgrade_v1112_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func TestUpgradeFromV1112LargeUsageFixtureIsMetadataBounded(t *testing.T) {
-	for _, rowCount := range []int{100_000, 500_000} {
+	// 100k rows exercises the required large-table startup boundary. The
+	// offline index-build path is intentionally allowed to scan the table; a
+	// second 500k copy makes the race suite spend many minutes rebuilding the
+	// same indexes without adding migration coverage.
+	for _, rowCount := range []int{100_000} {
 		t.Run(fmt.Sprintf("rows_%d", rowCount), func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "usage.sqlite")
 			db := prepareV1112LargeUsageFixture(t, path, rowCount)

--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -30,31 +30,42 @@ func ResolveCodexLegacyAccountKey(
 	queryer SQLQueryer,
 	fields usageidentity.Fields,
 ) (string, bool, error) {
-	legacyKey, targetAccountID, authFile, authIndex, valid := codexLegacyTarget(fields)
+	legacyKey, targetAccountID, targetMember, authFile, authIndex, valid := codexLegacyTarget(fields)
 	if !valid {
 		return "", false, nil
 	}
 
+	evidence := legacyAccountIdentityEvidence{}
 	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
 		rows, err := queryer.QueryContext(ctx, `select
 			coalesce(e.provider, ''),
 			coalesce(e.auth_provider_snapshot, ''),
 			coalesce(e.auth_account_id_snapshot, ''),
-			coalesce(e.auth_project_id_snapshot, '')
+			coalesce(e.auth_project_id_snapshot, ''),
+			coalesce(e.account_snapshot, '')
 		from usage_events e
 		where `+predicate.sql, predicate.args...)
 		if err != nil {
 			return "", false, err
 		}
-		allowed, err := scanLegacyAccountIdentity(rows, targetAccountID)
+		predicateEvidence := legacyAccountIdentityEvidence{}
+		allowed, err := scanLegacyAccountIdentity(rows, targetAccountID, targetMember, &predicateEvidence)
 		if err != nil {
 			return "", false, err
 		}
 		if !allowed {
-			return "", false, nil
+			// An empty predicate is expected when a legacy event used one of the
+			// other physical-identity shapes. Continue so source-only history can
+			// still be inherited; any rows that were found but failed validation
+			// remain a fail-closed conflict.
+			if predicateEvidence.found {
+				return "", false, nil
+			}
+			continue
 		}
+		evidence.found = evidence.found || predicateEvidence.found
 	}
-	return legacyKey, true, nil
+	return legacyKey, evidence.found, nil
 }
 
 // ResolveCodexLegacyAccountKey evaluates the same check through a short
@@ -78,11 +89,15 @@ func (r *repository) ResolveCodexLegacyAccountKey(
 	return key, allowed, nil
 }
 
-func codexLegacyTarget(fields usageidentity.Fields) (string, string, string, string, bool) {
+func codexLegacyTarget(fields usageidentity.Fields) (string, string, string, string, string, bool) {
 	provider := normalizeIdentityProvider(fields.AuthProviderSnapshot)
-	targetAccountID := strings.TrimSpace(fields.AuthAccountIDSnapshot)
-	if provider != "codex" || targetAccountID == "" {
-		return "", "", "", "", false
+	targetAccountID, workspaceOK := usageidentity.ResolveCodexWorkspace(fields)
+	targetMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(fields.AccountSnapshot)
+	// A legacy alias is allowed only for a target with explicit direct
+	// Workspace evidence. A marker in the historical project column can
+	// validate that evidence, but cannot by itself authorize a new alias.
+	if provider != "codex" || strings.TrimSpace(fields.AuthAccountIDSnapshot) == "" || !workspaceOK || !memberOK {
+		return "", "", "", "", "", false
 	}
 
 	authFile := strings.TrimSpace(fields.AuthFileSnapshot)
@@ -96,42 +111,30 @@ func codexLegacyTarget(fields usageidentity.Fields) (string, string, string, str
 	}
 	authIndex := strings.TrimSpace(fields.AuthIndex)
 	if authFile == "" || authIndex == "" {
-		return "", "", "", "", false
+		return "", "", "", "", "", false
 	}
 	legacyKey, valid := usageidentity.LegacyAccountKey(fields)
 	if !valid {
-		return "", "", "", "", false
+		return "", "", "", "", "", false
 	}
-	return legacyKey, targetAccountID, authFile, authIndex, true
+	return legacyKey, targetAccountID, targetMember, authFile, authIndex, true
 }
 
 func legacyAccountIdentityPredicates(authFile, authIndex string) []legacyAccountIdentityPredicate {
-	predicates := make([]legacyAccountIdentityPredicate, 0, 6)
-	appendIndexPredicates := func(base string, baseArgs []any) {
-		if authIndex != "" {
-			predicates = append(predicates, legacyAccountIdentityPredicate{
-				sql:  base + ` and e.auth_index collate nocase = ?`,
-				args: append(append([]any{}, baseArgs...), authIndex),
-			})
-			return
-		}
-		predicates = append(predicates,
-			legacyAccountIdentityPredicate{
-				sql:  base + ` and e.auth_index is null`,
-				args: append([]any{}, baseArgs...),
-			},
-			legacyAccountIdentityPredicate{
-				sql:  base + ` and e.auth_index collate nocase = ''`,
-				args: append([]any{}, baseArgs...),
-			},
-		)
+	predicates := make([]legacyAccountIdentityPredicate, 0, 3)
+	appendIndexPredicate := func(base string, baseArgs []any) {
+		args := append(append([]any{}, baseArgs...), authIndex)
+		predicates = append(predicates, legacyAccountIdentityPredicate{
+			sql:  base + ` and e.auth_index collate nocase = ?`,
+			args: args,
+		})
 	}
 
-	appendIndexPredicates(`e.auth_file_snapshot collate nocase = ?`, []any{authFile})
+	appendIndexPredicate(`e.auth_file_snapshot collate nocase = ?`, []any{authFile})
 	legacySourceBase := `e.auth_file_snapshot is null and e.source collate nocase = ?` + legacySourceIdentityGuards()
-	appendIndexPredicates(legacySourceBase, []any{authFile})
+	appendIndexPredicate(legacySourceBase, []any{authFile})
 	legacyEmptySourceBase := `e.auth_file_snapshot = '' and e.source collate nocase = ?` + legacySourceIdentityGuards()
-	appendIndexPredicates(legacyEmptySourceBase, []any{authFile})
+	appendIndexPredicate(legacyEmptySourceBase, []any{authFile})
 	return predicates
 }
 
@@ -144,12 +147,20 @@ func legacySourceIdentityGuards() string {
 		and (e.auth_label_snapshot is null or lower(trim(e.source)) <> lower(trim(e.auth_label_snapshot)))`
 }
 
-func scanLegacyAccountIdentity(rows *sql.Rows, targetAccountID string) (bool, error) {
+type legacyAccountIdentityEvidence struct {
+	found bool
+}
+
+func scanLegacyAccountIdentity(
+	rows *sql.Rows,
+	targetAccountID, targetMember string,
+	evidence *legacyAccountIdentityEvidence,
+) (bool, error) {
 	defer rows.Close()
-	seenIDs := map[string]struct{}{}
 	for rows.Next() {
-		var provider, authProvider, accountID, projectID string
-		if err := rows.Scan(&provider, &authProvider, &accountID, &projectID); err != nil {
+		evidence.found = true
+		var provider, authProvider, accountID, projectID, accountSnapshot string
+		if err := rows.Scan(&provider, &authProvider, &accountID, &projectID, &accountSnapshot); err != nil {
 			return false, err
 		}
 		hasProvider := false
@@ -167,23 +178,24 @@ func scanLegacyAccountIdentity(rows *sql.Rows, targetAccountID string) (bool, er
 			return false, nil
 		}
 
-		for _, value := range []string{
-			strings.TrimSpace(accountID),
-			usageidentity.CodexAccountIDFromSnapshot(projectID),
-		} {
-			if value == "" {
-				continue
-			}
-			if value != targetAccountID {
-				return false, nil
-			}
-			seenIDs[value] = struct{}{}
-			if len(seenIDs) > 1 {
-				return false, nil
-			}
+		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+		if !memberOK || member != targetMember {
+			return false, nil
+		}
+
+		workspace, workspaceOK := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
+			AuthAccountIDSnapshot: accountID,
+			AuthProjectIDSnapshot: projectID,
+			AccountSnapshot:       accountSnapshot,
+		})
+		if !workspaceOK || workspace != targetAccountID {
+			return false, nil
 		}
 	}
-	return rows.Err() == nil, rows.Err()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return evidence.found, nil
 }
 
 func normalizeIdentityProvider(value string) string {

--- a/apps/manager-server/internal/repository/usageevent/account_identity_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_test.go
@@ -36,9 +36,42 @@ func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *te
 			wantLegacyKey: true,
 		},
 		{
+			name: "invalid provenance marked project snapshot blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events[0].AuthProjectIDSnapshot = "codex-account-id:v1:"
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "conflicting provenance marked project snapshot blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events[0].AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-b")
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
 			name: "different account id blocks",
 			mutate: func(events []usage.Event) []usage.Event {
 				events = append(events, identityTestEvent("different-account", 3, "codex-a.json", "auth-a", "codex", "account-b"))
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "different member blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				event := identityTestEvent("different-member", 3, "codex-a.json", "auth-a", "codex", "account-a")
+				event.AccountSnapshot = "bob@example.com"
+				return append(events, event)
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "missing member blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events[0].AccountSnapshot = ""
 				return events
 			},
 			wantAllowed: false,
@@ -68,6 +101,21 @@ func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *te
 			},
 			wantAllowed: false,
 		},
+		{
+			name: "missing workspace blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				events = append(events, identityTestEvent("missing-workspace", 3, "codex-a.json", "auth-a", "codex", ""))
+				return events
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "conflicting target workspace evidence blocks",
+			mutate: func(events []usage.Event) []usage.Event {
+				return events
+			},
+			wantAllowed: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -79,7 +127,7 @@ func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *te
 			t.Cleanup(func() { _ = db.Close() })
 			repo := New(db)
 			events := []usage.Event{
-				identityTestEvent("legacy-event", 1, "codex-a.json", "auth-a", "codex", ""),
+				identityTestEvent("legacy-event", 1, "codex-a.json", "auth-a", "codex", "account-a"),
 				identityTestEvent("stable-event", 2, "codex-a.json", "auth-a", "codex", "account-a"),
 			}
 			events = test.mutate(events)
@@ -94,6 +142,9 @@ func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *te
 				AuthAccountIDSnapshot: "account-a",
 				AccountSnapshot:       "same@example.com",
 				Source:                "codex-a.json",
+			}
+			if test.name == "conflicting target workspace evidence blocks" {
+				fields.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-b")
 			}
 			gotKey, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
 			if err != nil {
@@ -120,7 +171,7 @@ func TestResolveCodexLegacyAccountKeyAcceptsLegacySourceFile(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	repo := New(db)
-	event := identityTestEvent("legacy-source", 1, "", "auth-a", "codex", "")
+	event := identityTestEvent("legacy-source", 1, "", "auth-a", "codex", "account-a")
 	event.Source = "codex-a.json"
 	event.AccountSnapshot = "same@example.com"
 	stable := identityTestEvent("stable-source", 2, "codex-a.json", "auth-a", "codex", "account-a")
@@ -143,6 +194,84 @@ func TestResolveCodexLegacyAccountKeyAcceptsLegacySourceFile(t *testing.T) {
 	want, valid := usageidentity.LegacyAccountKey(fields)
 	if !allowed || !valid || key != want {
 		t.Fatalf("source legacy identity = key:%q allowed:%v, want key:%q allowed:true", key, allowed, want)
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyAcceptsSourceOnlyHistory(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+	event := identityTestEvent("source-only", 1, "", "auth-a", "codex", "account-a")
+	event.Source = "codex-a.json"
+	event.AccountSnapshot = "Alice@Example.com"
+	if _, err := repo.InsertBatch(context.Background(), []usage.Event{event}); err != nil {
+		t.Fatalf("insert source-only identity event: %v", err)
+	}
+
+	fields := usageidentity.Fields{
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "alice@example.com",
+		Source:                "codex-a.json",
+	}
+	key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+	if err != nil {
+		t.Fatalf("resolve source-only identity: %v", err)
+	}
+	want, valid := usageidentity.LegacyAccountKey(fields)
+	if !allowed || !valid || key != want {
+		t.Fatalf("source-only legacy identity = key:%q allowed:%v, want key:%q allowed:true", key, allowed, want)
+	}
+}
+
+func TestResolveCodexLegacyAccountKeySharesEvidenceAcrossPhysicalPredicates(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		member    string
+		accountID string
+		provider  string
+		wantAllow bool
+	}{
+		{name: "source predicate has different member", member: "bob@example.com", accountID: "account-a", provider: "codex"},
+		{name: "source predicate has different workspace", member: "same@example.com", accountID: "account-b", provider: "codex"},
+		{name: "source predicate has different provider", member: "same@example.com", accountID: "account-a", provider: "openai"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			exact := identityTestEvent("exact-predicate", 1, "codex-a.json", "auth-a", "codex", "account-a")
+			source := identityTestEvent("source-predicate", 2, "", "auth-a", test.provider, test.accountID)
+			source.Source = "codex-a.json"
+			source.AccountSnapshot = test.member
+			if _, err := repo.InsertBatch(context.Background(), []usage.Event{exact, source}); err != nil {
+				t.Fatalf("insert identity events: %v", err)
+			}
+
+			fields := usageidentity.Fields{
+				AuthFileSnapshot:      "codex-a.json",
+				AuthIndex:             "auth-a",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "account-a",
+				AccountSnapshot:       "same@example.com",
+				Source:                "codex-a.json",
+			}
+			_, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+			if err != nil {
+				t.Fatalf("resolve legacy identity: %v", err)
+			}
+			if allowed != test.wantAllow {
+				t.Fatalf("allowed = %v, want %v", allowed, test.wantAllow)
+			}
+		})
 	}
 }
 

--- a/apps/manager-server/internal/repository/usageevent/analytics.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics.go
@@ -1767,12 +1767,19 @@ func ResolveAccountWindowLegacyKeys(
 }
 
 func codexLegacyOwnerKey(window AccountWindowUsageQuery) string {
-	return normalizeIdentityProvider(window.AuthProviderSnapshot) + "\x00" + strings.TrimSpace(window.AuthAccountIDSnapshot)
+	member, _ := usageidentity.NormalizeCodexMemberSnapshot(window.AccountSnapshot)
+	return strings.Join([]string{
+		normalizeIdentityProvider(window.AuthProviderSnapshot),
+		strings.TrimSpace(window.AuthAccountIDSnapshot),
+		member,
+	}, "\x00")
 }
 
 func codexLegacyWindowTarget(window AccountWindowUsageQuery) bool {
+	_, memberOK := usageidentity.NormalizeCodexMemberSnapshot(window.AccountSnapshot)
 	return strings.TrimSpace(window.AuthAccountIDSnapshot) != "" &&
-		normalizeIdentityProvider(window.AuthProviderSnapshot) == "codex"
+		normalizeIdentityProvider(window.AuthProviderSnapshot) == "codex" &&
+		memberOK
 }
 
 func codexLegacyWindowCacheKey(window AccountWindowUsageQuery) string {
@@ -1802,19 +1809,18 @@ func accountWindowIdentityFields(window AccountWindowUsageQuery) usageidentity.F
 }
 
 func accountWindowQueryKey(window AccountWindowUsageQuery) string {
+	// AccountKey is a caller-side correlation value, not an authority to
+	// select a Codex bucket. Recompute Codex keys from the credential snapshots
+	// so an old workspace-level codex-account key cannot reach stale derived
+	// data after the member-aware identity revision.
+	if normalizeIdentityProvider(window.AuthProviderSnapshot) == "codex" {
+		key, _ := usageidentity.AccountKey(accountWindowIdentityFields(window))
+		return key
+	}
 	if key := strings.TrimSpace(window.AccountKey); key != "" {
 		return key
 	}
-	key, _ := usageidentity.AccountKey(usageidentity.Fields{
-		AuthFileSnapshot:      window.AuthFileSnapshot,
-		AuthIndex:             window.AuthIndex,
-		AuthProviderSnapshot:  window.AuthProviderSnapshot,
-		AuthAccountIDSnapshot: window.AuthAccountIDSnapshot,
-		AuthProjectIDSnapshot: window.AuthProjectIDSnapshot,
-		AccountSnapshot:       window.AccountSnapshot,
-		AuthLabelSnapshot:     window.AuthLabelSnapshot,
-		Source:                window.Source,
-	})
+	key, _ := usageidentity.AccountKey(accountWindowIdentityFields(window))
 	return key
 }
 

--- a/apps/manager-server/internal/repository/usageevent/analytics_account_window_test.go
+++ b/apps/manager-server/internal/repository/usageevent/analytics_account_window_test.go
@@ -68,6 +68,35 @@ func TestAccountWindowQueryKeysRequireExplicitCodexAccountIDForLegacyFallback(t 
 	}
 }
 
+func TestAccountWindowQueryKeysDoNotTrustStaleCodexCallerKey(t *testing.T) {
+	window := AccountWindowUsageQuery{
+		AccountKey:            "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31",
+		AuthFileSnapshot:      "alice.json",
+		AuthIndex:             "auth-alice",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+		AccountSnapshot:       "alice@example.com",
+		Source:                "alice.json",
+	}
+
+	got, legacy := accountWindowQueryKeys(window)
+	want, valid := usageidentity.AccountKey(accountWindowFields(window))
+	if !valid {
+		t.Fatal("valid Codex member target was rejected")
+	}
+	if got != want || got == window.AccountKey || legacy != want {
+		t.Fatalf("stale Codex caller key was trusted: account=%q legacy=%q want=%q", got, legacy, want)
+	}
+
+	bob := window
+	bob.AccountSnapshot = "bob@example.com"
+	bob.AccountKey = window.AccountKey
+	bobKey, _ := accountWindowQueryKeys(bob)
+	if bobKey == got {
+		t.Fatalf("shared Workspace members still share a caller-derived key: Alice=%q Bob=%q", got, bobKey)
+	}
+}
+
 func accountWindowFields(window AccountWindowUsageQuery) usageidentity.Fields {
 	return usageidentity.Fields{
 		AuthFileSnapshot:      window.AuthFileSnapshot,

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"sort"
 	"strings"
+
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 const (
@@ -52,9 +54,13 @@ limit ?`
 // snapshot captured with a request. AuthFileSnapshot is the primary identity;
 // Source is used only for records created before auth-file snapshots existed.
 type LatestAccountRequestQuery struct {
-	RequestIndex     int
-	AuthFileSnapshot string
-	AuthIndex        string
+	RequestIndex          int
+	AuthFileSnapshot      string
+	AuthIndex             string
+	Provider              string
+	AuthAccountIDSnapshot string
+	AuthProjectIDSnapshot string
+	AccountSnapshot       string
 }
 
 // LatestAccountRequest contains the safe diagnostics needed by the credential
@@ -133,7 +139,10 @@ func (r *repository) recentAccountRequestsIndexed(
 			ctx,
 			target.RequestIndex,
 			limit,
-			snapshotLatestRequestPredicates(authFileSnapshot, authIndex),
+			withLatestRequestIdentity(
+				snapshotLatestRequestPredicates(authFileSnapshot, authIndex),
+				target,
+			),
 		)
 		if err != nil {
 			return nil, err
@@ -142,7 +151,10 @@ func (r *repository) recentAccountRequestsIndexed(
 			ctx,
 			target.RequestIndex,
 			limit,
-			legacyLatestRequestPredicates(authFileSnapshot, authIndex),
+			withLatestRequestIdentity(
+				legacyLatestRequestPredicates(authFileSnapshot, authIndex),
+				target,
+			),
 		)
 		if err != nil {
 			return nil, err
@@ -150,6 +162,111 @@ func (r *repository) recentAccountRequestsIndexed(
 		requests = append(requests, mergeRecentAccountRequests(limit, snapshot, legacy)...)
 	}
 	return requests, nil
+}
+
+func withLatestRequestIdentity(
+	predicates []latestRequestPredicate,
+	target LatestAccountRequestQuery,
+) []latestRequestPredicate {
+	identitySQL, identityArgs := latestRequestIdentityPredicate(target)
+	if identitySQL == "" {
+		return predicates
+	}
+	result := make([]latestRequestPredicate, 0, len(predicates))
+	for _, predicate := range predicates {
+		args := make([]any, 0, len(predicate.args)+len(identityArgs))
+		args = append(args, predicate.args...)
+		args = append(args, identityArgs...)
+		result = append(result, latestRequestPredicate{
+			sql:  predicate.sql + identitySQL,
+			args: args,
+		})
+	}
+	return result
+}
+
+func latestRequestIdentityPredicate(target LatestAccountRequestQuery) (string, []any) {
+	if normalizeLatestRequestProvider(target.Provider) != "codex" {
+		return "", nil
+	}
+
+	workspaceID, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(target.AuthAccountIDSnapshot)
+	member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(target.AccountSnapshot)
+	if !workspaceOK || !memberOK {
+		// A Codex Workspace alone is not a member identity. Do not expose a
+		// request for an unverifiable Codex target, even when its physical
+		// credential selector happens to match.
+		return " and 1 = 0", nil
+	}
+	if resolvedWorkspace, ok := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
+		AuthAccountIDSnapshot: target.AuthAccountIDSnapshot,
+		AuthProjectIDSnapshot: target.AuthProjectIDSnapshot,
+	}); !ok || resolvedWorkspace != workspaceID {
+		// A target carrying a conflicting or malformed provenance marker is not
+		// an attributable Codex member. Do not let a matching physical file
+		// return a request for an unverifiable target.
+		return " and 1 = 0", nil
+	}
+	marker := usageidentity.CodexAccountIDSnapshot(workspaceID)
+	return `
+		and lower(replace(trim(coalesce(nullif(trim(e.auth_provider_snapshot), ''), e.provider, '')), '_', '-')) = 'codex'
+		and (trim(coalesce(e.provider, '')) = '' or lower(replace(trim(e.provider), '_', '-')) = 'codex')
+		and (trim(coalesce(e.auth_provider_snapshot, '')) = '' or lower(replace(trim(e.auth_provider_snapshot), '_', '-')) = 'codex')
+		and lower(trim(coalesce(e.account_snapshot, ''))) = ?
+		and (
+			(
+				trim(coalesce(e.auth_account_id_snapshot, '')) = ?
+				and (
+					trim(coalesce(e.auth_project_id_snapshot, '')) = ''
+					or substr(trim(coalesce(e.auth_project_id_snapshot, '')), 1, length('codex-account-id:v1:')) <> 'codex-account-id:v1:'
+					or trim(coalesce(e.auth_project_id_snapshot, '')) = ?
+				)
+			)
+			or (
+				trim(coalesce(e.auth_account_id_snapshot, '')) = ''
+				and trim(coalesce(e.auth_project_id_snapshot, '')) = ?
+			)
+		)`, []any{member, workspaceID, marker, marker}
+}
+
+func latestRequestBatchedIdentityPredicate(targetAlias, eventAlias string) string {
+	return `(
+		` + targetAlias + `.provider <> 'codex'
+		or (
+			` + targetAlias + `.workspace_id <> ''
+			and ` + targetAlias + `.member <> ''
+			and lower(replace(trim(coalesce(nullif(trim(` + eventAlias + `.auth_provider_snapshot), ''), ` + eventAlias + `.provider, '')), '_', '-')) = 'codex'
+			and (trim(coalesce(` + eventAlias + `.provider, '')) = '' or lower(replace(trim(` + eventAlias + `.provider), '_', '-')) = 'codex')
+			and (trim(coalesce(` + eventAlias + `.auth_provider_snapshot, '')) = '' or lower(replace(trim(` + eventAlias + `.auth_provider_snapshot), '_', '-')) = 'codex')
+			and lower(trim(coalesce(` + eventAlias + `.account_snapshot, ''))) = ` + targetAlias + `.member
+			and (
+				substr(trim(coalesce(` + targetAlias + `.project_id, '')), 1, length('codex-account-id:v1:')) <> 'codex-account-id:v1:'
+				or trim(coalesce(` + targetAlias + `.project_id, '')) = 'codex-account-id:v1:' || ` + targetAlias + `.workspace_id
+			)
+			and (
+				(
+					trim(coalesce(` + eventAlias + `.auth_account_id_snapshot, '')) = ` + targetAlias + `.workspace_id
+					and (
+						trim(coalesce(` + eventAlias + `.auth_project_id_snapshot, '')) = ''
+						or substr(trim(coalesce(` + eventAlias + `.auth_project_id_snapshot, '')), 1, length('codex-account-id:v1:')) <> 'codex-account-id:v1:'
+						or trim(coalesce(` + eventAlias + `.auth_project_id_snapshot, '')) = 'codex-account-id:v1:' || ` + targetAlias + `.workspace_id
+					)
+				)
+				or (
+					trim(coalesce(` + eventAlias + `.auth_account_id_snapshot, '')) = ''
+					and trim(coalesce(` + eventAlias + `.auth_project_id_snapshot, '')) = 'codex-account-id:v1:' || ` + targetAlias + `.workspace_id
+				)
+			)
+		)
+	)`
+}
+
+func normalizeLatestRequestProvider(value string) string {
+	value = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	if value == "grok" || value == "x-ai" {
+		return "xai"
+	}
+	return value
 }
 
 func snapshotLatestRequestPredicates(authFileSnapshot, authIndex string) []latestRequestPredicate {
@@ -260,18 +377,40 @@ func (r *repository) recentAccountRequestsBatched(
 	limit int,
 ) ([]LatestAccountRequest, error) {
 	values := make([]string, 0, len(targets))
-	args := make([]any, 0, len(targets)*3+1)
+	args := make([]any, 0, len(targets)*7+1)
 	for _, target := range targets {
 		authFileSnapshot := strings.TrimSpace(target.AuthFileSnapshot)
 		if authFileSnapshot == "" {
 			continue
 		}
-		values = append(values, "(?, ?, ?)")
+		provider := normalizeLatestRequestProvider(target.Provider)
+		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(target.AccountSnapshot)
+		workspaceID, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(target.AuthAccountIDSnapshot)
+		if provider == "codex" && (!memberOK || !workspaceOK) {
+			member = ""
+			workspaceID = ""
+		} else if provider == "codex" {
+			resolvedWorkspace, resolvedOK := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
+				AuthAccountIDSnapshot: target.AuthAccountIDSnapshot,
+				AuthProjectIDSnapshot: target.AuthProjectIDSnapshot,
+			})
+			if !resolvedOK || resolvedWorkspace != workspaceID {
+				// A conflicting target marker must not become a valid batched
+				// credential row merely because the physical selector matches.
+				member = ""
+				workspaceID = ""
+			}
+		}
+		values = append(values, "(?, ?, ?, ?, ?, ?, ?)")
 		args = append(
 			args,
 			target.RequestIndex,
 			authFileSnapshot,
 			strings.TrimSpace(target.AuthIndex),
+			provider,
+			workspaceID,
+			member,
+			strings.TrimSpace(target.AuthProjectIDSnapshot),
 		)
 	}
 	if len(values) == 0 {
@@ -280,7 +419,7 @@ func (r *repository) recentAccountRequestsBatched(
 	args = append(args, limit)
 
 	rows, err := r.db.QueryContext(ctx, `with credential_targets(
-	request_index, auth_file_snapshot, auth_index
+	request_index, auth_file_snapshot, auth_index, provider, workspace_id, member, project_id
 ) as (
 	values `+strings.Join(values, ",")+`
 ), snapshot_candidates as (
@@ -298,6 +437,7 @@ func (r *repository) recentAccountRequestsBatched(
 	join usage_events e
 		on e.auth_file_snapshot collate nocase = t.auth_file_snapshot
 		and coalesce(e.auth_index, '') collate nocase = t.auth_index
+		and `+latestRequestBatchedIdentityPredicate("t", "e")+`
 ), legacy_source_candidates as (
 	select
 		t.request_index,
@@ -314,6 +454,7 @@ func (r *repository) recentAccountRequestsBatched(
 		on coalesce(e.auth_file_snapshot, '') = ''
 		and e.source collate nocase = t.auth_file_snapshot
 		and coalesce(e.auth_index, '') collate nocase = t.auth_index
+		and `+latestRequestBatchedIdentityPredicate("t", "e")+`
 ), candidates as (
 	select * from snapshot_candidates
 	union all

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request.go
@@ -190,22 +190,16 @@ func latestRequestIdentityPredicate(target LatestAccountRequestQuery) (string, [
 		return "", nil
 	}
 
-	workspaceID, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(target.AuthAccountIDSnapshot)
-	member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(target.AccountSnapshot)
-	if !workspaceOK || !memberOK {
-		// A Codex Workspace alone is not a member identity. Do not expose a
-		// request for an unverifiable Codex target, even when its physical
-		// credential selector happens to match.
+	workspaceID, member, identityOK, identityConflict := resolveLatestRequestCodexIdentity(target)
+	if identityConflict {
+		// Explicitly conflicting Workspace evidence must never fall back to a
+		// physical credential selector.
 		return " and 1 = 0", nil
 	}
-	if resolvedWorkspace, ok := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
-		AuthAccountIDSnapshot: target.AuthAccountIDSnapshot,
-		AuthProjectIDSnapshot: target.AuthProjectIDSnapshot,
-	}); !ok || resolvedWorkspace != workspaceID {
-		// A target carrying a conflicting or malformed provenance marker is not
-		// an attributable Codex member. Do not let a matching physical file
-		// return a request for an unverifiable target.
-		return " and 1 = 0", nil
+	if !identityOK {
+		// Missing or weak member evidence is allowed to use the exact physical
+		// credential predicate already supplied by the caller.
+		return "", nil
 	}
 	marker := usageidentity.CodexAccountIDSnapshot(workspaceID)
 	return `
@@ -229,12 +223,33 @@ func latestRequestIdentityPredicate(target LatestAccountRequestQuery) (string, [
 		)`, []any{member, workspaceID, marker, marker}
 }
 
+// resolveLatestRequestCodexIdentity returns a member filter only when the
+// target has complete, non-conflicting Codex Workspace/member evidence. An
+// incomplete target deliberately falls back to its file/index predicates;
+// only explicit provenance conflicts fail closed.
+func resolveLatestRequestCodexIdentity(target LatestAccountRequestQuery) (workspace, member string, complete, conflict bool) {
+	workspaceID, workspaceOK := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
+		AuthAccountIDSnapshot: target.AuthAccountIDSnapshot,
+		AuthProjectIDSnapshot: target.AuthProjectIDSnapshot,
+	})
+	workspaceEvidence := strings.Trim(target.AuthAccountIDSnapshot, " ") != "" ||
+		strings.HasPrefix(strings.Trim(target.AuthProjectIDSnapshot, " "), "codex-account-id:v1:")
+	if workspaceEvidence && !workspaceOK {
+		return "", "", false, true
+	}
+	member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(target.AccountSnapshot)
+	if !workspaceOK || !memberOK {
+		return "", "", false, false
+	}
+	return workspaceID, member, true, false
+}
+
 func latestRequestBatchedIdentityPredicate(targetAlias, eventAlias string) string {
 	return `(
 		` + targetAlias + `.provider <> 'codex'
+		or ` + targetAlias + `.identity_mode = 0
 		or (
-			` + targetAlias + `.workspace_id <> ''
-			and ` + targetAlias + `.member <> ''
+			` + targetAlias + `.identity_mode = 1
 			and lower(replace(trim(coalesce(nullif(trim(` + eventAlias + `.auth_provider_snapshot), ''), ` + eventAlias + `.provider, '')), '_', '-')) = 'codex'
 			and (trim(coalesce(` + eventAlias + `.provider, '')) = '' or lower(replace(trim(` + eventAlias + `.provider), '_', '-')) = 'codex')
 			and (trim(coalesce(` + eventAlias + `.auth_provider_snapshot, '')) = '' or lower(replace(trim(` + eventAlias + `.auth_provider_snapshot), '_', '-')) = 'codex')
@@ -377,31 +392,26 @@ func (r *repository) recentAccountRequestsBatched(
 	limit int,
 ) ([]LatestAccountRequest, error) {
 	values := make([]string, 0, len(targets))
-	args := make([]any, 0, len(targets)*7+1)
+	args := make([]any, 0, len(targets)*8+1)
 	for _, target := range targets {
 		authFileSnapshot := strings.TrimSpace(target.AuthFileSnapshot)
 		if authFileSnapshot == "" {
 			continue
 		}
 		provider := normalizeLatestRequestProvider(target.Provider)
-		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(target.AccountSnapshot)
-		workspaceID, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(target.AuthAccountIDSnapshot)
-		if provider == "codex" && (!memberOK || !workspaceOK) {
-			member = ""
-			workspaceID = ""
-		} else if provider == "codex" {
-			resolvedWorkspace, resolvedOK := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
-				AuthAccountIDSnapshot: target.AuthAccountIDSnapshot,
-				AuthProjectIDSnapshot: target.AuthProjectIDSnapshot,
-			})
-			if !resolvedOK || resolvedWorkspace != workspaceID {
-				// A conflicting target marker must not become a valid batched
-				// credential row merely because the physical selector matches.
-				member = ""
-				workspaceID = ""
+		workspaceID, member := "", ""
+		identityMode := 0
+		if provider == "codex" {
+			var identityOK, identityConflict bool
+			workspaceID, member, identityOK, identityConflict = resolveLatestRequestCodexIdentity(target)
+			switch {
+			case identityConflict:
+				identityMode = 2
+			case identityOK:
+				identityMode = 1
 			}
 		}
-		values = append(values, "(?, ?, ?, ?, ?, ?, ?)")
+		values = append(values, "(?, ?, ?, ?, ?, ?, ?, ?)")
 		args = append(
 			args,
 			target.RequestIndex,
@@ -411,6 +421,7 @@ func (r *repository) recentAccountRequestsBatched(
 			workspaceID,
 			member,
 			strings.TrimSpace(target.AuthProjectIDSnapshot),
+			identityMode,
 		)
 	}
 	if len(values) == 0 {
@@ -419,7 +430,7 @@ func (r *repository) recentAccountRequestsBatched(
 	args = append(args, limit)
 
 	rows, err := r.db.QueryContext(ctx, `with credential_targets(
-	request_index, auth_file_snapshot, auth_index, provider, workspace_id, member, project_id
+	request_index, auth_file_snapshot, auth_index, provider, workspace_id, member, project_id, identity_mode
 ) as (
 	values `+strings.Join(values, ",")+`
 ), snapshot_candidates as (

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
@@ -201,8 +201,8 @@ func TestRecentAccountRequestsFiltersCodexWorkspaceMembers(t *testing.T) {
 	if len(byIndex[8]) != 1 || byIndex[8][0].TimestampMS != 1_700_000_030_000 {
 		t.Fatalf("Bob requests = %#v", byIndex[8])
 	}
-	if _, ok := byIndex[9]; ok {
-		t.Fatalf("workspace-only Codex target returned requests: %#v", byIndex[9])
+	if len(byIndex[9]) != 4 || byIndex[9][0].TimestampMS != 1_700_000_040_000 {
+		t.Fatalf("workspace-only Codex target did not use credential fallback: %#v", byIndex[9])
 	}
 	if _, ok := byIndex[10]; ok {
 		t.Fatalf("conflicting Codex target returned requests: %#v", byIndex[10])

--- a/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
+++ b/apps/manager-server/internal/repository/usageevent/latest_account_request_test.go
@@ -10,6 +10,7 @@ import (
 
 	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 func TestRecentAccountRequestsUseSnapshotIdentityLimitAndConservativeLegacyFallback(t *testing.T) {
@@ -104,6 +105,107 @@ func TestRecentAccountRequestsUseSnapshotIdentityLimitAndConservativeLegacyFallb
 	}
 	if _, ok := byIndex[2]; ok {
 		t.Fatalf("missing credential unexpectedly matched: %#v", byIndex[2])
+	}
+}
+
+func TestRecentAccountRequestsFiltersCodexWorkspaceMembers(t *testing.T) {
+	ctx := context.Background()
+	seed := func(t *testing.T, withIndexes bool) []LatestAccountRequest {
+		t.Helper()
+		db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+		if err != nil {
+			t.Fatalf("open database: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		if withIndexes {
+			if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+				t.Fatalf("prepare latest-request indexes: %v", err)
+			}
+		}
+		repo := New(db)
+		alice := latestAccountRequestEvent("codex-alice", 1_700_000_020_000, "shared.json", "auth-shared", "shared.json")
+		alice.Provider = "codex"
+		alice.AuthProviderSnapshot = "codex"
+		alice.AuthAccountIDSnapshot = "workspace-1"
+		alice.AccountSnapshot = "alice@example.com"
+		bob := latestAccountRequestEvent("codex-bob", 1_700_000_030_000, "shared.json", "auth-shared", "shared.json")
+		bob.Provider = "codex"
+		bob.AuthProviderSnapshot = "codex"
+		bob.AuthAccountIDSnapshot = "workspace-1"
+		bob.AccountSnapshot = "bob@example.com"
+		legacyAlice := latestAccountRequestEvent("codex-alice-legacy", 1_700_000_010_000, "", "auth-shared", "shared.json")
+		legacyAlice.Provider = "codex"
+		legacyAlice.AuthProviderSnapshot = "codex"
+		legacyAlice.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("workspace-1")
+		legacyAlice.AccountSnapshot = "alice@example.com"
+		legacyOtherWorkspace := latestAccountRequestEvent("codex-alice-other-workspace", 1_700_000_040_000, "", "auth-shared", "shared.json")
+		legacyOtherWorkspace.Provider = "codex"
+		legacyOtherWorkspace.AuthProviderSnapshot = "codex"
+		legacyOtherWorkspace.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("workspace-2")
+		legacyOtherWorkspace.AccountSnapshot = "alice@example.com"
+		if _, err := repo.InsertBatch(ctx, []usage.Event{alice, bob, legacyAlice, legacyOtherWorkspace}); err != nil {
+			t.Fatalf("insert shared Codex requests: %v", err)
+		}
+		requests, err := repo.RecentAccountRequests(ctx, []LatestAccountRequestQuery{
+			{
+				RequestIndex:          7,
+				AuthFileSnapshot:      "shared.json",
+				AuthIndex:             "auth-shared",
+				Provider:              "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AccountSnapshot:       "alice@example.com",
+			},
+			{
+				RequestIndex:          8,
+				AuthFileSnapshot:      "shared.json",
+				AuthIndex:             "auth-shared",
+				Provider:              "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AccountSnapshot:       "bob@example.com",
+			},
+			{
+				RequestIndex:          9,
+				AuthFileSnapshot:      "shared.json",
+				AuthIndex:             "auth-shared",
+				Provider:              "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+			},
+			{
+				RequestIndex:          10,
+				AuthFileSnapshot:      "shared.json",
+				AuthIndex:             "auth-shared",
+				Provider:              "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AuthProjectIDSnapshot: usageidentity.CodexAccountIDSnapshot("workspace-2"),
+				AccountSnapshot:       "alice@example.com",
+			},
+		}, 10)
+		if err != nil {
+			t.Fatalf("recent shared Codex requests: %v", err)
+		}
+		return requests
+	}
+
+	indexed := seed(t, true)
+	batched := seed(t, false)
+	if !sameLatestAccountRequests(indexed, batched) {
+		t.Fatalf("indexed = %#v, batched = %#v", indexed, batched)
+	}
+	byIndex := make(map[int][]LatestAccountRequest)
+	for _, request := range indexed {
+		byIndex[request.RequestIndex] = append(byIndex[request.RequestIndex], request)
+	}
+	if len(byIndex[7]) != 2 || byIndex[7][0].TimestampMS != 1_700_000_020_000 || byIndex[7][1].TimestampMS != 1_700_000_010_000 {
+		t.Fatalf("Alice requests included Bob/another Workspace or lost legacy Alice request: %#v", byIndex[7])
+	}
+	if len(byIndex[8]) != 1 || byIndex[8][0].TimestampMS != 1_700_000_030_000 {
+		t.Fatalf("Bob requests = %#v", byIndex[8])
+	}
+	if _, ok := byIndex[9]; ok {
+		t.Fatalf("workspace-only Codex target returned requests: %#v", byIndex[9])
+	}
+	if _, ok := byIndex[10]; ok {
+		t.Fatalf("conflicting Codex target returned requests: %#v", byIndex[10])
 	}
 }
 
@@ -472,6 +574,145 @@ func TestRecentAccountRequestsMergesNewerLegacyWithoutSnapshot(t *testing.T) {
 	}
 	if len(requests) != 1 || requests[0].TimestampMS != legacyNewer.TimestampMS {
 		t.Fatalf("global top-n = %#v", requests)
+	}
+}
+
+func TestRecentAccountRequestsRejectsInvalidCodexWorkspaceTargets(t *testing.T) {
+	for _, withIndexes := range []bool{true, false} {
+		withIndexes := withIndexes
+		t.Run(map[bool]string{true: "indexed", false: "batched"}[withIndexes], func(t *testing.T) {
+			ctx := context.Background()
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if withIndexes {
+				if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+					t.Fatalf("prepare latest-request indexes: %v", err)
+				}
+			}
+
+			event := latestAccountRequestEvent("codex-workspace", 1_700_000_050_000, "shared.json", "auth-shared", "shared.json")
+			event.Provider = "codex"
+			event.AuthProviderSnapshot = "codex"
+			event.AuthAccountIDSnapshot = "workspace-1"
+			event.AccountSnapshot = "alice@example.com"
+			if _, err := New(db).InsertBatch(ctx, []usage.Event{event}); err != nil {
+				t.Fatalf("insert Codex request: %v", err)
+			}
+
+			for _, workspace := range []string{"workspace-1\t", "workspace-1\u00a0", "workspace-\x01-1"} {
+				requests, err := New(db).RecentAccountRequests(ctx, []LatestAccountRequestQuery{{
+					RequestIndex:          1,
+					AuthFileSnapshot:      "shared.json",
+					AuthIndex:             "auth-shared",
+					Provider:              "codex",
+					AuthAccountIDSnapshot: workspace,
+					AccountSnapshot:       "alice@example.com",
+				}}, 10)
+				if err != nil {
+					t.Fatalf("recent requests for invalid workspace %q: %v", workspace, err)
+				}
+				if len(requests) != 0 {
+					t.Fatalf("invalid Codex workspace %q returned requests: %#v", workspace, requests)
+				}
+			}
+		})
+	}
+}
+
+func TestRecentAccountRequestsRejectsConflictingCodexWorkspaceMarker(t *testing.T) {
+	for _, withIndexes := range []bool{true, false} {
+		withIndexes := withIndexes
+		t.Run(map[bool]string{true: "indexed", false: "batched"}[withIndexes], func(t *testing.T) {
+			ctx := context.Background()
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if withIndexes {
+				if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+					t.Fatalf("prepare latest-request indexes: %v", err)
+				}
+			}
+
+			valid := latestAccountRequestEvent("codex-project", 1_700_000_050_000, "shared.json", "auth-shared", "shared.json")
+			valid.Provider = "codex"
+			valid.AuthProviderSnapshot = "codex"
+			valid.AuthAccountIDSnapshot = "workspace-1"
+			valid.AuthProjectIDSnapshot = "project-1"
+			valid.AccountSnapshot = "alice@example.com"
+			conflicting := latestAccountRequestEvent("codex-conflicting-marker", 1_700_000_060_000, "shared.json", "auth-shared", "shared.json")
+			conflicting.Provider = "codex"
+			conflicting.AuthProviderSnapshot = "codex"
+			conflicting.AuthAccountIDSnapshot = "workspace-1"
+			conflicting.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("workspace-2")
+			conflicting.AccountSnapshot = "alice@example.com"
+			if _, err := New(db).InsertBatch(ctx, []usage.Event{valid, conflicting}); err != nil {
+				t.Fatalf("insert Codex requests: %v", err)
+			}
+
+			requests, err := New(db).RecentAccountRequests(ctx, []LatestAccountRequestQuery{{
+				RequestIndex:          1,
+				AuthFileSnapshot:      "shared.json",
+				AuthIndex:             "auth-shared",
+				Provider:              "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AccountSnapshot:       "alice@example.com",
+			}}, 10)
+			if err != nil {
+				t.Fatalf("recent requests: %v", err)
+			}
+			if len(requests) != 1 || requests[0].TimestampMS != valid.TimestampMS {
+				t.Fatalf("requests = %#v, want only ordinary-project event at %d", requests, valid.TimestampMS)
+			}
+		})
+	}
+}
+
+func TestRecentAccountRequestsRejectsConflictingCodexTargetMarker(t *testing.T) {
+	for _, withIndexes := range []bool{true, false} {
+		withIndexes := withIndexes
+		t.Run(map[bool]string{true: "indexed", false: "batched"}[withIndexes], func(t *testing.T) {
+			ctx := context.Background()
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if withIndexes {
+				if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+					t.Fatalf("prepare latest-request indexes: %v", err)
+				}
+			}
+
+			event := latestAccountRequestEvent("codex-target-marker", 1_700_000_070_000, "shared.json", "auth-shared", "shared.json")
+			event.Provider = "codex"
+			event.AuthProviderSnapshot = "codex"
+			event.AuthAccountIDSnapshot = "workspace-1"
+			event.AccountSnapshot = "alice@example.com"
+			if _, err := New(db).InsertBatch(ctx, []usage.Event{event}); err != nil {
+				t.Fatalf("insert Codex request: %v", err)
+			}
+
+			requests, err := New(db).RecentAccountRequests(ctx, []LatestAccountRequestQuery{{
+				RequestIndex:          1,
+				AuthFileSnapshot:      "shared.json",
+				AuthIndex:             "auth-shared",
+				Provider:              "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AuthProjectIDSnapshot: usageidentity.CodexAccountIDSnapshot("workspace-2"),
+				AccountSnapshot:       "alice@example.com",
+			}}, 10)
+			if err != nil {
+				t.Fatalf("recent requests for conflicting target: %v", err)
+			}
+			if len(requests) != 0 {
+				t.Fatalf("conflicting Codex target marker returned requests: %#v", requests)
+			}
+		})
 	}
 }
 

--- a/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
@@ -86,7 +86,7 @@ func mergeProjectedAccountWindowStats(ctx context.Context, tx *sql.Tx, windows [
 
 func mergeStoredAccountWindowStats(ctx context.Context, tx *sql.Tx, revision string, windows []AccountWindowUsageQuery, grouped map[accountWindowStatKey]*AccountWindowModelStat) error {
 	values := make([]string, 0, len(windows))
-	args := make([]any, 0, len(windows)*5+1)
+	args := make([]any, 0, len(windows)*8+1)
 	for _, window := range windows {
 		if !accountWindowCanUseDaily(window) {
 			continue
@@ -96,14 +96,31 @@ func mergeStoredAccountWindowStats(ctx context.Context, tx *sql.Tx, revision str
 		if fullStartMS >= fullEndMS {
 			continue
 		}
-		values = append(values, "(?, ?, ?, ?, ?)")
-		args = append(args, window.RequestIndex, fullStartMS, fullEndMS, strings.TrimSpace(window.AuthFileSnapshot), strings.TrimSpace(window.AuthIndex))
+		codexMember := ""
+		if normalizeWindowProvider(window.AuthProviderSnapshot) == "codex" {
+			codexMember, _ = usageidentity.NormalizeCodexMemberSnapshot(window.AccountSnapshot)
+		}
+		accountKey, legacyAccountKey := accountWindowKeys(window)
+		values = append(values, "(?, ?, ?, ?, ?, ?, ?, ?)")
+		args = append(args,
+			window.RequestIndex,
+			fullStartMS,
+			fullEndMS,
+			strings.TrimSpace(window.AuthFileSnapshot),
+			strings.TrimSpace(window.AuthIndex),
+			accountKey,
+			legacyAccountKey,
+			codexMember,
+		)
 	}
 	if len(values) == 0 {
 		return nil
 	}
 	args = append(args, revision)
-	rows, err := tx.QueryContext(ctx, `with window_targets(request_index, full_start_ms, full_end_ms, auth_file_snapshot, auth_index) as (values `+strings.Join(values, ",")+`)
+	rows, err := tx.QueryContext(ctx, `with window_targets(
+	request_index, full_start_ms, full_end_ms, auth_file_snapshot, auth_index,
+	account_key, legacy_account_key, codex_member
+) as (values `+strings.Join(values, ",")+`)
 	select w.request_index, d.model, d.billing_model, d.pricing_model, d.context_threshold_tokens,
 		coalesce(d.service_tier, ''), coalesce(sum(d.calls), 0),
 		coalesce(sum(case when d.failed = 0 then d.calls else 0 end), 0),
@@ -115,8 +132,26 @@ func mergeStoredAccountWindowStats(ctx context.Context, tx *sql.Tx, revision str
 		coalesce(sum(d.long_cache_creation_tokens), 0), coalesce(sum(d.total_tokens), 0), max(d.last_seen_ms)
 	from window_targets w
 	join usage_monitoring_account_daily_rollups_v1 d on d.structure_revision = ?
-		and d.bucket_ms >= w.full_start_ms and d.bucket_ms < w.full_end_ms and trim(d.auth_index) = w.auth_index
-		and (trim(d.auth_file_snapshot) = w.auth_file_snapshot or (trim(d.auth_file_snapshot) = '' and trim(d.source) = w.auth_file_snapshot and trim(d.source) <> trim(d.account_snapshot) and trim(d.source) <> trim(d.auth_label_snapshot)))
+		and d.bucket_ms >= w.full_start_ms and d.bucket_ms < w.full_end_ms
+		and (
+			(
+				w.codex_member <> ''
+				and `+usageidentity.SQLAccountKeyExpressionWithoutProject("d")+` in (w.account_key, w.legacy_account_key)
+			)
+			or (
+				w.codex_member = ''
+				and trim(d.auth_index) = w.auth_index
+				and (
+					trim(d.auth_file_snapshot) = w.auth_file_snapshot
+					or (
+						trim(d.auth_file_snapshot) = ''
+						and trim(d.source) = w.auth_file_snapshot
+						and trim(d.source) <> trim(d.account_snapshot)
+						and trim(d.source) <> trim(d.auth_label_snapshot)
+					)
+				)
+			)
+		)
 	group by w.request_index, d.model, d.billing_model, d.pricing_model, d.context_threshold_tokens, coalesce(d.service_tier, '')`, args...)
 	if err != nil {
 		return err
@@ -201,7 +236,7 @@ func accountWindowEventSourceSQL(windows []AccountWindowUsageQuery, coverageEven
 	from window_targets w join usage_monitoring_event_projection_v1 p on p.event_id <= ? and p.timestamp_ms >= w.from_ms and p.timestamp_ms < w.to_ms and p.account_key in (w.account_key, w.legacy_account_key)`
 	args = append(args, coverageEventID)
 	if dailyAvailable {
-		query += ` and (w.use_daily = 0 or p.timestamp_ms < w.full_start_ms or p.timestamp_ms >= w.full_end_ms or p.event_id > ?)`
+		query += ` and (w.use_daily = 0 or p.timestamp_ms < w.full_start_ms or p.timestamp_ms >= w.full_end_ms or p.event_id > ? or (` + codexAccountDailyExcludedSQL("p") + `))`
 		args = append(args, statsCoverageEventID)
 	}
 	if projectionComplete {
@@ -211,7 +246,7 @@ func accountWindowEventSourceSQL(windows []AccountWindowUsageQuery, coverageEven
 	from window_targets w join usage_events e on e.id > ? and e.timestamp_ms >= w.from_ms and e.timestamp_ms < w.to_ms and ` + rawIdentity + ` in (w.account_key, w.legacy_account_key)`
 	args = append(args, coverageEventID)
 	if dailyAvailable {
-		query += ` and (w.use_daily = 0 or e.timestamp_ms < w.full_start_ms or e.timestamp_ms >= w.full_end_ms or e.id > ?)`
+		query += ` and (w.use_daily = 0 or e.timestamp_ms < w.full_start_ms or e.timestamp_ms >= w.full_end_ms or e.id > ? or (` + codexAccountDailyExcludedSQL("e") + `))`
 		args = append(args, statsCoverageEventID)
 	}
 	return query, args
@@ -223,16 +258,73 @@ func accountWindowCanUseDaily(window AccountWindowUsageQuery) bool {
 	if authFile == "" || authIndex == "" {
 		return false
 	}
-	expectedKey, valid := usageidentity.AccountKey(usageidentity.Fields{AuthFileSnapshot: authFile, AuthIndex: authIndex})
+	fields := usageidentity.Fields{
+		AuthFileSnapshot:      window.AuthFileSnapshot,
+		AuthIndex:             window.AuthIndex,
+		AuthProviderSnapshot:  window.AuthProviderSnapshot,
+		AuthAccountIDSnapshot: window.AuthAccountIDSnapshot,
+		AuthProjectIDSnapshot: window.AuthProjectIDSnapshot,
+		AccountSnapshot:       window.AccountSnapshot,
+		AuthLabelSnapshot:     window.AuthLabelSnapshot,
+		Source:                window.Source,
+	}
+	if normalizeWindowProvider(window.AuthProviderSnapshot) == "codex" {
+		workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(window.AuthAccountIDSnapshot)
+		_, memberOK := usageidentity.NormalizeCodexMemberSnapshot(window.AccountSnapshot)
+		if !workspaceOK || !memberOK {
+			return false
+		}
+		resolvedWorkspace, resolvedOK := usageidentity.ResolveCodexWorkspace(fields)
+		if !resolvedOK || resolvedWorkspace != workspace {
+			return false
+		}
+		// The daily table can safely serve only a complete workspace/member key.
+		// Events carrying the legacy Workspace provenance marker are excluded
+		// while upserting because that evidence is not persisted in the daily row;
+		// the account-window query adds those events back through
+		// projection/raw residuals. Generic Codex project IDs do not carry
+		// Workspace identity evidence and remain safe in the daily rollup.
+	}
+	expectedKey, valid := usageidentity.AccountKey(fields)
 	return valid && accountWindowKey(window) == expectedKey
 }
 
+func normalizeWindowProvider(value string) string {
+	provider := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), "_", "-"))
+	switch provider {
+	case "x-ai", "grok":
+		return "xai"
+	default:
+		return provider
+	}
+}
+
 func accountWindowKey(window AccountWindowUsageQuery) string {
+	// AccountKey is caller-provided correlation data for non-Codex targets. For
+	// Codex, always derive the key from the snapshots so a stale workspace-only
+	// key cannot expose an old shared Workspace projection bucket.
+	if normalizeWindowProvider(window.AuthProviderSnapshot) == "codex" {
+		key, _ := usageidentity.AccountKey(accountWindowIdentityFields(window))
+		return key
+	}
 	if key := strings.TrimSpace(window.AccountKey); key != "" {
 		return key
 	}
-	key, _ := usageidentity.AccountKey(usageidentity.Fields{AuthFileSnapshot: window.AuthFileSnapshot, AuthIndex: window.AuthIndex, AuthProviderSnapshot: window.AuthProviderSnapshot, AuthAccountIDSnapshot: window.AuthAccountIDSnapshot, AuthProjectIDSnapshot: window.AuthProjectIDSnapshot, AccountSnapshot: window.AccountSnapshot, AuthLabelSnapshot: window.AuthLabelSnapshot, Source: window.Source})
+	key, _ := usageidentity.AccountKey(accountWindowIdentityFields(window))
 	return key
+}
+
+func accountWindowIdentityFields(window AccountWindowUsageQuery) usageidentity.Fields {
+	return usageidentity.Fields{
+		AuthFileSnapshot:      window.AuthFileSnapshot,
+		AuthIndex:             window.AuthIndex,
+		AuthProviderSnapshot:  window.AuthProviderSnapshot,
+		AuthAccountIDSnapshot: window.AuthAccountIDSnapshot,
+		AuthProjectIDSnapshot: window.AuthProjectIDSnapshot,
+		AccountSnapshot:       window.AccountSnapshot,
+		AuthLabelSnapshot:     window.AuthLabelSnapshot,
+		Source:                window.Source,
+	}
 }
 
 func accountWindowKeys(window AccountWindowUsageQuery) (string, string) {

--- a/apps/manager-server/internal/repository/usagemonitoring/core_stats_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/core_stats_read.go
@@ -43,8 +43,7 @@ func loadDailyAggregate(
 			projectionCoverageEventID,
 			projectionComplete,
 			filter,
-			0,
-			false,
+			eventSourceOptions{},
 			&accumulator,
 		); err != nil {
 			return Aggregate{}, err
@@ -64,8 +63,23 @@ func loadDailyAggregate(
 		projectionCoverageEventID,
 		projectionComplete,
 		tailFilter,
-		state.CoverageEventID,
-		true,
+		eventSourceOptions{AfterID: state.CoverageEventID, UseAfter: true},
+		&accumulator,
+	); err != nil {
+		return Aggregate{}, err
+	}
+	markerFilter := tailFilter
+	if err := mergeProjectedAggregate(
+		ctx,
+		tx,
+		projectionCoverageEventID,
+		projectionComplete,
+		markerFilter,
+		eventSourceOptions{
+			MaxID:           state.CoverageEventID,
+			UseMax:          true,
+			CodexMarkerOnly: true,
+		},
 		&accumulator,
 	); err != nil {
 		return Aggregate{}, err
@@ -79,8 +93,7 @@ func loadDailyAggregate(
 			projectionCoverageEventID,
 			projectionComplete,
 			edgeFilter,
-			0,
-			false,
+			eventSourceOptions{},
 			&accumulator,
 		); err != nil {
 			return Aggregate{}, err
@@ -95,8 +108,7 @@ func loadDailyAggregate(
 			projectionCoverageEventID,
 			projectionComplete,
 			edgeFilter,
-			0,
-			false,
+			eventSourceOptions{},
 			&accumulator,
 		); err != nil {
 			return Aggregate{}, err
@@ -139,8 +151,7 @@ func mergeProjectedAggregate(
 	projectionCoverageEventID int64,
 	projectionComplete bool,
 	filter AnalyticsFilter,
-	afterID int64,
-	useAfterID bool,
+	options eventSourceOptions,
 	accumulator *dailyAggregateAccumulator,
 ) error {
 	if filter.FromMS >= filter.ToMS {
@@ -160,8 +171,11 @@ func mergeProjectedAggregate(
 		coalesce(e.cache_read_tokens, 0), coalesce(e.cache_creation_tokens, 0),
 		coalesce(e.total_tokens, 0), e.latency_ms`,
 		eventSourceOptions{
-			AfterID:            afterID,
-			UseAfter:           useAfterID,
+			AfterID:            options.AfterID,
+			UseAfter:           options.UseAfter,
+			MaxID:              options.MaxID,
+			UseMax:             options.UseMax,
+			CodexMarkerOnly:    options.CodexMarkerOnly,
 			ProjectionComplete: projectionComplete,
 		},
 	)
@@ -241,7 +255,7 @@ func loadDailyModelStats(
 	fullStartMS := ceilDayMS(filter.FromMS)
 	fullEndMS := floorDayMS(filter.ToMS)
 	if fullStartMS >= fullEndMS {
-		if err := mergeProjectedModelStats(ctx, tx, projectionCoverageEventID, projectionComplete, filter, 0, false, grouped); err != nil {
+		if err := mergeProjectedModelStats(ctx, tx, projectionCoverageEventID, projectionComplete, filter, eventSourceOptions{}, grouped); err != nil {
 			return nil, err
 		}
 		return sortedDailyModelStats(grouped), nil
@@ -259,8 +273,22 @@ func loadDailyModelStats(
 		projectionCoverageEventID,
 		projectionComplete,
 		tailFilter,
-		state.CoverageEventID,
-		true,
+		eventSourceOptions{AfterID: state.CoverageEventID, UseAfter: true},
+		grouped,
+	); err != nil {
+		return nil, err
+	}
+	if err := mergeProjectedModelStats(
+		ctx,
+		tx,
+		projectionCoverageEventID,
+		projectionComplete,
+		tailFilter,
+		eventSourceOptions{
+			MaxID:           state.CoverageEventID,
+			UseMax:          true,
+			CodexMarkerOnly: true,
+		},
 		grouped,
 	); err != nil {
 		return nil, err
@@ -268,14 +296,14 @@ func loadDailyModelStats(
 	if filter.FromMS < fullStartMS {
 		edgeFilter := filter
 		edgeFilter.ToMS = fullStartMS
-		if err := mergeProjectedModelStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, 0, false, grouped); err != nil {
+		if err := mergeProjectedModelStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, eventSourceOptions{}, grouped); err != nil {
 			return nil, err
 		}
 	}
 	if fullEndMS < filter.ToMS {
 		edgeFilter := filter
 		edgeFilter.FromMS = fullEndMS
-		if err := mergeProjectedModelStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, 0, false, grouped); err != nil {
+		if err := mergeProjectedModelStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, eventSourceOptions{}, grouped); err != nil {
 			return nil, err
 		}
 	}
@@ -318,8 +346,7 @@ func mergeProjectedModelStats(
 	projectionCoverageEventID int64,
 	projectionComplete bool,
 	filter AnalyticsFilter,
-	afterID int64,
-	useAfterID bool,
+	options eventSourceOptions,
 	grouped map[dailyModelStatKey]*ModelStat,
 ) error {
 	if filter.FromMS >= filter.ToMS {
@@ -340,8 +367,11 @@ func mergeProjectedModelStats(
 		coalesce(e.cache_read_tokens, 0), coalesce(e.cache_creation_tokens, 0),
 		coalesce(e.total_tokens, 0)`,
 		eventSourceOptions{
-			AfterID:            afterID,
-			UseAfter:           useAfterID,
+			AfterID:            options.AfterID,
+			UseAfter:           options.UseAfter,
+			MaxID:              options.MaxID,
+			UseMax:             options.UseMax,
+			CodexMarkerOnly:    options.CodexMarkerOnly,
 			ProjectionComplete: projectionComplete,
 		},
 	)

--- a/apps/manager-server/internal/repository/usagemonitoring/event_filter.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/event_filter.go
@@ -11,6 +11,9 @@ import (
 type eventSourceOptions struct {
 	AfterID            int64
 	UseAfter           bool
+	MaxID              int64
+	UseMax             bool
+	CodexMarkerOnly    bool
 	BeforeMS           int64
 	BeforeID           int64
 	ProjectionComplete bool
@@ -30,6 +33,16 @@ func filteredEventSourceSQL(
 		projectionArgs = append(projectionArgs, options.AfterID)
 		rawConditions = append(rawConditions, "e.id > ?")
 		rawArgs = append(rawArgs, options.AfterID)
+	}
+	if options.UseMax {
+		projectionConditions = append(projectionConditions, "p.event_id <= ?")
+		projectionArgs = append(projectionArgs, options.MaxID)
+		rawConditions = append(rawConditions, "e.id <= ?")
+		rawArgs = append(rawArgs, options.MaxID)
+	}
+	if options.CodexMarkerOnly {
+		projectionConditions = append(projectionConditions, codexAccountDailyExcludedSQL("p"))
+		rawConditions = append(rawConditions, codexAccountDailyExcludedSQL("e"))
 	}
 	if options.BeforeMS > 0 {
 		if options.BeforeID > 0 {

--- a/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
@@ -455,6 +455,7 @@ func TestCodexAccountWindowKeepsHistoryAcrossSameAccountReauth(t *testing.T) {
 		makeEvent("different-space-same-email", currentFromMS+2_000, "codex-b.json", "auth-3", "account-b", 9_000),
 	}
 	legacyCurrentCredential := makeEvent("current-new-credential-before-account-snapshot", currentFromMS+2_500, "codex-a-pro.json", "auth-2", "", 5)
+	legacyCurrentCredential.AuthAccountIDSnapshot = "account-a"
 	projectedEvents = append(projectedEvents, legacyCurrentCredential)
 	if _, err := db.InsertEvents(ctx, projectedEvents); err != nil {
 		t.Fatalf("insert projected reauth events: %v", err)
@@ -517,6 +518,141 @@ func TestCodexAccountWindowKeepsHistoryAcrossSameAccountReauth(t *testing.T) {
 	assertStats("projection plus raw tail", 3, 75)
 }
 
+func TestCodexAccountWindowSeparatesMembersSharingWorkspace(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_057_600_000)
+	toMS := fromMS + testDayMS
+
+	makeEvent := func(hash, member, file, authIndex string, input int64) usage.Event {
+		event := monitoringRepositoryEvent(hash, fromMS+input, "gpt-team-window", "key-"+member, member, authIndex, file, false, input, 10, 1)
+		event.AuthFileSnapshot = file
+		event.AuthIndex = authIndex
+		event.AuthAccountIDSnapshot = "workspace-team"
+		return event
+	}
+	if _, err := db.InsertEvents(ctx, []usage.Event{
+		makeEvent("team-alice", "alice@example.com", "alice.json", "auth-alice", 100),
+		makeEvent("team-bob", "bob@example.com", "bob.json", "auth-bob", 200),
+	}); err != nil {
+		t.Fatalf("insert shared-workspace events: %v", err)
+	}
+	catchUpMonitoringRepository(t, ctx, db)
+
+	windows := []store.AccountWindowUsageQuery{
+		{
+			RequestIndex:          0,
+			FromMS:                fromMS,
+			ToMS:                  toMS,
+			AccountSnapshot:       "alice@example.com",
+			AuthFileSnapshot:      "alice.json",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-team",
+			AuthIndex:             "auth-alice",
+			Source:                "alice.json",
+			AccountKey:            "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31",
+		},
+		{
+			RequestIndex:          1,
+			FromMS:                fromMS,
+			ToMS:                  toMS,
+			AccountSnapshot:       "bob@example.com",
+			AuthFileSnapshot:      "bob.json",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-team",
+			AuthIndex:             "auth-bob",
+			Source:                "bob.json",
+			AccountKey:            "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31",
+		},
+	}
+
+	raw, err := db.AccountWindowModelStats(ctx, windows)
+	if err != nil {
+		t.Fatalf("raw shared-workspace account window stats: %v", err)
+	}
+	projected, _, available, err := db.UsageMonitoringAccountWindowStats(ctx, windows)
+	if err != nil || !available {
+		t.Fatalf("projected shared-workspace account window stats: available=%v err=%v", available, err)
+	}
+	if !reflect.DeepEqual(projected, raw) {
+		t.Fatalf("shared-workspace projection/raw mismatch\nprojection=%#v\nraw=%#v", projected, raw)
+	}
+	if len(projected) != 2 {
+		t.Fatalf("shared-workspace stats = %#v, want one row per member", projected)
+	}
+	if projected[0].RequestIndex != 0 || projected[0].Calls != 1 || projected[0].InputTokens != 100 {
+		t.Fatalf("Alice account window stats = %#v, want one call and 100 input tokens", projected[0])
+	}
+	if projected[1].RequestIndex != 1 || projected[1].Calls != 1 || projected[1].InputTokens != 200 {
+		t.Fatalf("Bob account window stats = %#v, want one call and 200 input tokens", projected[1])
+	}
+
+	tail := makeEvent("team-alice-tail", "alice@example.com", "alice.json", "auth-alice", 300)
+	if _, err := db.InsertEvents(ctx, []usage.Event{tail}); err != nil {
+		t.Fatalf("insert Alice raw tail: %v", err)
+	}
+	raw, err = db.AccountWindowModelStats(ctx, windows)
+	if err != nil {
+		t.Fatalf("raw shared-workspace account window stats with tail: %v", err)
+	}
+	projected, _, available, err = db.UsageMonitoringAccountWindowStats(ctx, windows)
+	if err != nil || !available {
+		t.Fatalf("projected shared-workspace account window stats with tail: available=%v err=%v", available, err)
+	}
+	if !reflect.DeepEqual(projected, raw) {
+		t.Fatalf("shared-workspace tail projection/raw mismatch\nprojection=%#v\nraw=%#v", projected, raw)
+	}
+	if projected[0].Calls != 2 || projected[0].InputTokens != 400 || projected[1].Calls != 1 || projected[1].InputTokens != 200 {
+		t.Fatalf("shared-workspace tail stats = %#v, want Alice 2/400 and Bob 1/200", projected)
+	}
+}
+
+func TestCodexAccountWindowDoesNotUseDailyCredentialFallbackWithoutMember(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_057_600_000)
+	toMS := fromMS + testDayMS
+
+	makeEvent := func(hash, member string, input int64) usage.Event {
+		event := monitoringRepositoryEvent(hash, fromMS+input, "gpt-team-window", "key-shared", member, "auth-shared", "shared.json", false, input, 1, 1)
+		event.AuthFileSnapshot = "shared.json"
+		event.AuthIndex = "auth-shared"
+		event.AuthProviderSnapshot = "codex"
+		event.AuthAccountIDSnapshot = "workspace-team"
+		return event
+	}
+	if _, err := db.InsertEvents(ctx, []usage.Event{
+		makeEvent("team-shared-alice", "alice@example.com", 100),
+		makeEvent("team-shared-bob", "bob@example.com", 200),
+	}); err != nil {
+		t.Fatalf("insert shared-credential events: %v", err)
+	}
+	catchUpMonitoringRepository(t, ctx, db)
+
+	windows := []store.AccountWindowUsageQuery{{
+		RequestIndex:          0,
+		FromMS:                fromMS,
+		ToMS:                  toMS,
+		AuthFileSnapshot:      "shared.json",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-team",
+		AuthIndex:             "auth-shared",
+		Source:                "shared.json",
+	}}
+
+	raw, err := db.AccountWindowModelStats(ctx, windows)
+	if err != nil {
+		t.Fatalf("raw workspace-only account window stats: %v", err)
+	}
+	projected, _, available, err := db.UsageMonitoringAccountWindowStats(ctx, windows)
+	if err != nil || !available {
+		t.Fatalf("projected workspace-only account window stats: available=%v err=%v", available, err)
+	}
+	if len(raw) != 0 || len(projected) != 0 {
+		t.Fatalf("workspace-only target inherited member daily rows: raw=%#v projected=%#v", raw, projected)
+	}
+}
+
 func TestCodexAccountWindowRejectsConflictingLegacyFileIndex(t *testing.T) {
 	_, db := newMonitoringRepositoryStore(t)
 	ctx := context.Background()
@@ -565,6 +701,125 @@ func TestCodexAccountWindowRejectsConflictingLegacyFileIndex(t *testing.T) {
 	}
 }
 
+func TestCodexAccountWindowUsesRawProjectionForConflictingWorkspaceEvidence(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_057_600_000)
+	toMS := fromMS + testDayMS
+
+	event := monitoringRepositoryEvent(
+		"window-conflicting-workspace-evidence",
+		fromMS+1_000,
+		"gpt-team-window",
+		"key-alice",
+		"alice@example.com",
+		"auth-alice",
+		"alice.json",
+		false,
+		100,
+		10,
+		1,
+	)
+	event.AuthFileSnapshot = "alice.json"
+	event.AuthIndex = "auth-alice"
+	event.AuthProviderSnapshot = "codex"
+	event.AuthAccountIDSnapshot = "workspace-1"
+	event.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("workspace-2")
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert conflicting workspace evidence event: %v", err)
+	}
+	catchUpMonitoringRepository(t, ctx, db)
+
+	window := store.AccountWindowUsageQuery{
+		RequestIndex:          0,
+		FromMS:                fromMS,
+		ToMS:                  toMS,
+		AccountSnapshot:       "alice@example.com",
+		AuthFileSnapshot:      "alice.json",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+		AuthProjectIDSnapshot: usageidentity.CodexAccountIDSnapshot("workspace-2"),
+		AuthIndex:             "auth-alice",
+		Source:                "alice.json",
+	}
+	raw, err := db.AccountWindowModelStats(ctx, []store.AccountWindowUsageQuery{window})
+	if err != nil {
+		t.Fatalf("raw conflicting workspace-evidence stats: %v", err)
+	}
+	projected, _, available, err := db.UsageMonitoringAccountWindowStats(ctx, []store.AccountWindowUsageQuery{window})
+	if err != nil || !available {
+		t.Fatalf("projected conflicting workspace-evidence stats: available=%v err=%v", available, err)
+	}
+	if !reflect.DeepEqual(projected, raw) {
+		t.Fatalf("conflicting workspace-evidence projection/raw mismatch\nprojection=%#v\nraw=%#v", projected, raw)
+	}
+	if len(projected) != 1 || projected[0].Calls != 1 || projected[0].InputTokens != 100 {
+		t.Fatalf("conflicting workspace-evidence stats = %#v, want one raw-equivalent event", projected)
+	}
+}
+
+func TestCodexAccountWindowDoesNotMergeConflictingWorkspaceEvidenceFromDailyRollup(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_057_600_000)
+	toMS := fromMS + testDayMS
+
+	valid := monitoringRepositoryEvent(
+		"window-daily-valid-workspace-evidence",
+		fromMS+1_000,
+		"gpt-team-window",
+		"key-alice",
+		"alice@example.com",
+		"auth-alice",
+		"alice.json",
+		false,
+		100,
+		10,
+		1,
+	)
+	valid.AuthFileSnapshot = "alice.json"
+	valid.AuthIndex = "auth-alice"
+	valid.AuthProviderSnapshot = "codex"
+	valid.AuthAccountIDSnapshot = "workspace-1"
+
+	conflicting := valid
+	conflicting.EventHash = "window-daily-conflicting-workspace-evidence"
+	conflicting.TimestampMS = fromMS + 2_000
+	conflicting.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("workspace-2")
+	conflicting.InputTokens = 200
+	conflicting.TotalTokens = 20
+	if _, err := db.InsertEvents(ctx, []usage.Event{valid, conflicting}); err != nil {
+		t.Fatalf("insert daily workspace-evidence events: %v", err)
+	}
+	catchUpMonitoringRepository(t, ctx, db)
+
+	window := store.AccountWindowUsageQuery{
+		RequestIndex:          0,
+		FromMS:                fromMS,
+		ToMS:                  toMS,
+		AccountSnapshot:       "alice@example.com",
+		AuthFileSnapshot:      "alice.json",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+		AuthIndex:             "auth-alice",
+		Source:                "alice.json",
+	}
+	raw, err := db.AccountWindowModelStats(ctx, []store.AccountWindowUsageQuery{window})
+	if err != nil {
+		t.Fatalf("raw daily workspace-evidence stats: %v", err)
+	}
+	projected, _, available, err := db.UsageMonitoringAccountWindowStats(ctx, []store.AccountWindowUsageQuery{window})
+	if err != nil || !available {
+		t.Fatalf("projected daily workspace-evidence stats: available=%v err=%v", available, err)
+	}
+	if !reflect.DeepEqual(projected, raw) {
+		t.Fatalf("daily workspace-evidence projection/raw mismatch\nprojection=%#v\nraw=%#v", projected, raw)
+	}
+	if len(projected) != 1 || projected[0].Calls != 1 || projected[0].InputTokens != 100 {
+		t.Fatalf("daily conflicting workspace evidence was merged = %#v, want only valid event", projected)
+	}
+}
+
 func TestAccountWindowProjectionUsesDailyStatsWithEdgesAndRawTail(t *testing.T) {
 	sqlDB, db := newMonitoringRepositoryStore(t)
 	ctx := context.Background()
@@ -580,8 +835,9 @@ func TestAccountWindowProjectionUsesDailyStatsWithEdgesAndRawTail(t *testing.T) 
 		monitoringRepositoryEvent("window-daily-other-credential", dayStartMS+testDayMS+2*int64(time.Hour/time.Millisecond), "gpt-window", "key-b", "daily@example.com", "auth-other", "other.json", false, 9_000, 9_000, 10),
 	}
 	for index := range events {
+		events[index].Provider = "openai"
 		events[index].AuthFileSnapshot = events[index].Source
-		events[index].AuthProviderSnapshot = "codex"
+		events[index].AuthProviderSnapshot = "openai"
 		events[index].AuthProjectIDSnapshot = ""
 	}
 	if _, err := db.InsertEvents(ctx, events); err != nil {
@@ -611,7 +867,8 @@ func TestAccountWindowProjectionUsesDailyStatsWithEdgesAndRawTail(t *testing.T) 
 		10,
 	)
 	tail.AuthFileSnapshot = "daily.json"
-	tail.AuthProviderSnapshot = "codex"
+	tail.Provider = "openai"
+	tail.AuthProviderSnapshot = "openai"
 	tail.AuthProjectIDSnapshot = ""
 	if _, err := db.InsertEvents(ctx, []usage.Event{tail}); err != nil {
 		t.Fatalf("insert daily account window raw tail: %v", err)
@@ -623,7 +880,7 @@ func TestAccountWindowProjectionUsesDailyStatsWithEdgesAndRawTail(t *testing.T) 
 		ToMS:                 toMS,
 		AccountSnapshot:      "daily@example.com",
 		AuthFileSnapshot:     "daily.json",
-		AuthProviderSnapshot: "codex",
+		AuthProviderSnapshot: "openai",
 		AuthIndex:            "auth-daily",
 		Source:               "daily.json",
 	}}
@@ -769,6 +1026,36 @@ func TestUsageMonitoringSearchDoesNotIndexHistoricalCodexProjectMarker(t *testin
 		t.Fatalf("raw-tail marker search count = %d, want 0", count)
 	}
 }
+
+func TestUsageMonitoringStatsIncludeHistoricalCodexProjectMarker(t *testing.T) {
+	_, db := newMonitoringRepositoryStore(t)
+	ctx := context.Background()
+	fromMS := int64(1_800_057_600_000)
+	toMS := fromMS + testDayMS
+	event := monitoringRepositoryEvent(
+		"stats-legacy-codex-marker",
+		fromMS+1_000,
+		"gpt-marker",
+		"key-marker",
+		"alice@example.com",
+		"auth-marker",
+		"marker.json",
+		false,
+		100,
+		20,
+		10,
+	)
+	event.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("workspace-marker")
+	if _, err := db.InsertEvents(ctx, []usage.Event{event}); err != nil {
+		t.Fatalf("insert historical Codex marker event: %v", err)
+	}
+	catchUpMonitoringRepository(t, ctx, db)
+
+	filter := store.AnalyticsFilter{FromMS: fromMS, ToMS: toMS, IncludeFailed: true}
+	assertProjectionCoreReadersMatchRaw(t, ctx, db, filter)
+	assertMonitoringReadersMatchRaw(t, ctx, db, filter)
+}
+
 func TestSuccessfulResponseHeadersDoNotEnterFailureSearchStorage(t *testing.T) {
 	sqlDB, db := newMonitoringRepositoryStore(t)
 	ctx := context.Background()

--- a/apps/manager-server/internal/repository/usagemonitoring/stats_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/stats_read.go
@@ -108,7 +108,7 @@ func (r *repository) LoadAccountStats(ctx context.Context, filter AnalyticsFilte
 	if dailyAvailable && SupportsStatsFilter(filter) {
 		err = loadAccountRange(ctx, tx, state, projectionState.CoverageEventID, projectionComplete, revision, filter, grouped)
 	} else {
-		err = mergeProjectedAccountStats(ctx, tx, projectionState.CoverageEventID, projectionComplete, filter, 0, false, grouped)
+		err = mergeProjectedAccountStats(ctx, tx, projectionState.CoverageEventID, projectionComplete, filter, eventSourceOptions{}, grouped)
 	}
 	if err != nil {
 		return nil, projectionState, false, err
@@ -183,7 +183,7 @@ func loadAccountRange(
 	fullStartMS := ceilDayMS(filter.FromMS)
 	fullEndMS := floorDayMS(filter.ToMS)
 	if fullStartMS >= fullEndMS {
-		return mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, filter, 0, false, grouped)
+		return mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, filter, eventSourceOptions{}, grouped)
 	}
 	if err := mergeStoredAccountStats(ctx, tx, revision, filter, fullStartMS, fullEndMS, grouped); err != nil {
 		return err
@@ -191,20 +191,35 @@ func loadAccountRange(
 	tailFilter := filter
 	tailFilter.FromMS = fullStartMS
 	tailFilter.ToMS = fullEndMS
-	if err := mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, tailFilter, state.CoverageEventID, true, grouped); err != nil {
+	if err := mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, tailFilter, eventSourceOptions{AfterID: state.CoverageEventID, UseAfter: true}, grouped); err != nil {
+		return err
+	}
+	if err := mergeProjectedAccountStats(
+		ctx,
+		tx,
+		projectionCoverageEventID,
+		projectionComplete,
+		tailFilter,
+		eventSourceOptions{
+			MaxID:           state.CoverageEventID,
+			UseMax:          true,
+			CodexMarkerOnly: true,
+		},
+		grouped,
+	); err != nil {
 		return err
 	}
 	if filter.FromMS < fullStartMS {
 		edgeFilter := filter
 		edgeFilter.ToMS = fullStartMS
-		if err := mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, 0, false, grouped); err != nil {
+		if err := mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, eventSourceOptions{}, grouped); err != nil {
 			return err
 		}
 	}
 	if fullEndMS < filter.ToMS {
 		edgeFilter := filter
 		edgeFilter.FromMS = fullEndMS
-		if err := mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, 0, false, grouped); err != nil {
+		if err := mergeProjectedAccountStats(ctx, tx, projectionCoverageEventID, projectionComplete, edgeFilter, eventSourceOptions{}, grouped); err != nil {
 			return err
 		}
 	}
@@ -312,8 +327,7 @@ func mergeProjectedAccountStats(
 	projectionCoverageEventID int64,
 	projectionComplete bool,
 	filter AnalyticsFilter,
-	afterID int64,
-	useAfterID bool,
+	options eventSourceOptions,
 	grouped map[accountStatKey]*accountStatAccumulator,
 ) error {
 	if filter.FromMS >= filter.ToMS {
@@ -341,8 +355,11 @@ func mergeProjectedAccountStats(
 		coalesce(e.cache_creation_tokens, 0), coalesce(e.total_tokens, 0),
 		e.latency_ms`,
 		eventSourceOptions{
-			AfterID:            afterID,
-			UseAfter:           useAfterID,
+			AfterID:            options.AfterID,
+			UseAfter:           options.UseAfter,
+			MaxID:              options.MaxID,
+			UseMax:             options.UseMax,
+			CodexMarkerOnly:    options.CodexMarkerOnly,
 			ProjectionComplete: projectionComplete,
 		},
 	)

--- a/apps/manager-server/internal/repository/usagemonitoring/stats_upsert.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/stats_upsert.go
@@ -54,8 +54,27 @@ func monitoringBandedEventsCTE(whereClause string) string {
 	)`, requestedModelExpression, analyticsModelExpression, analyticsModelExpression, whereClause, model.ModelPriceBaseContextThreshold)
 }
 
+// codexAccountDailyExcludedSQL identifies Codex events whose legacy Workspace
+// provenance marker cannot be retained by the account daily rollup. The daily
+// table deliberately has no auth_project_id_snapshot column; keeping marked
+// events out of it lets account-window reads re-evaluate their complete
+// immutable evidence through the projection/raw residual path instead of
+// silently merging conflicting Workspace evidence. Generic Codex project IDs
+// are not Workspace evidence and remain eligible for the daily fast path.
+func codexAccountDailyExcludedSQL(alias string) string {
+	column := func(name string) string {
+		if alias == "" {
+			return name
+		}
+		return alias + "." + name
+	}
+	provider := "lower(replace(trim(coalesce(nullif(trim(" + column("auth_provider_snapshot") + "), ''), " + column("provider") + ", '')), '_', '-'))"
+	project := "trim(coalesce(" + column("auth_project_id_snapshot") + ", ''))"
+	return provider + " = 'codex' and substr(" + project + ", 1, length('codex-account-id:v1:')) = 'codex-account-id:v1:'"
+}
+
 func upsertAccountDailyBatch(ctx context.Context, tx *sql.Tx, revision string, afterID, throughID, nowMS int64) error {
-	query := monitoringBandedEventsCTE("e.id > ? and e.id <= ?") + fmt.Sprintf(`
+	query := monitoringBandedEventsCTE("e.id > ? and e.id <= ? and not ("+codexAccountDailyExcludedSQL("e")+")") + fmt.Sprintf(`
 	insert into usage_monitoring_account_daily_rollups_v1 (
 		structure_revision, bucket_ms, account_snapshot, auth_label_snapshot,
 		provider, auth_provider_snapshot, auth_account_id_snapshot, auth_index, source, source_hash,

--- a/apps/manager-server/internal/repository/usagepricing/repository_test.go
+++ b/apps/manager-server/internal/repository/usagepricing/repository_test.go
@@ -3,6 +3,7 @@ package usagepricing_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
@@ -200,6 +201,70 @@ func TestPricingAccountRollupSeparatesSharedAccountByAuthIndex(t *testing.T) {
 	}
 	if byKey[secondKey].Calls != 1 || byKey[secondKey].TotalTokens != 30 {
 		t.Fatalf("second shared pricing row = %#v", byKey[secondKey])
+	}
+}
+
+func TestPricingAccountRollupSeparatesCodexMembersSharingWorkspace(t *testing.T) {
+	ctx := context.Background()
+	cfg := testutil.NewConfig(t)
+	st := testutil.NewStore(t, cfg)
+
+	makeEvent := func(hash, member, file, authIndex string, inputTokens int64) usage.Event {
+		event := pricingEvent(hash, 3_600_001+inputTokens, inputTokens)
+		event.Provider = "codex"
+		event.AccountSnapshot = member
+		event.AuthFileSnapshot = file
+		event.AuthIndex = authIndex
+		event.AuthProviderSnapshot = "codex"
+		event.AuthAccountIDSnapshot = "workspace-team"
+		event.Source = file
+		return event
+	}
+	if _, err := st.UsageEvents.InsertBatch(ctx, []usage.Event{
+		makeEvent("codex-pricing-alice", "alice@example.com", "alice.json", "auth-alice", 100),
+		makeEvent("codex-pricing-bob", "bob@example.com", "bob.json", "auth-bob", 200),
+	}); err != nil {
+		t.Fatalf("insert shared-workspace Codex pricing events: %v", err)
+	}
+	if _, err := st.CatchUpUsagePricing(ctx, 10, 10_000); err != nil {
+		t.Fatalf("catch up shared-workspace Codex pricing events: %v", err)
+	}
+
+	accountKey := func(member string) string {
+		key, valid := usageidentity.AccountKey(usageidentity.Fields{
+			AuthFileSnapshot:      member + ".json",
+			AuthIndex:             "auth-" + strings.Split(member, "@")[0],
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-team",
+			AccountSnapshot:       member,
+		})
+		if !valid {
+			t.Fatalf("invalid Codex pricing identity for %s", member)
+		}
+		return key
+	}
+	aliceKey := accountKey("alice@example.com")
+	bobKey := accountKey("bob@example.com")
+	if aliceKey == bobKey {
+		t.Fatalf("shared-workspace Codex members merged into %q", aliceKey)
+	}
+
+	rows, _, available, err := st.UsagePricingAccountRows(ctx, []string{aliceKey, bobKey})
+	if err != nil {
+		t.Fatalf("load shared-workspace Codex pricing rows: %v", err)
+	}
+	if !available || len(rows) != 2 {
+		t.Fatalf("shared-workspace Codex pricing rows available=%v rows=%#v", available, rows)
+	}
+	byKey := make(map[string]store.UsagePricingAccountRow, len(rows))
+	for _, row := range rows {
+		byKey[row.AccountKey] = row
+	}
+	if row := byKey[aliceKey]; row.Calls != 1 || row.InputTokens != 100 || row.TotalTokens != 110 {
+		t.Fatalf("Alice shared-workspace Codex pricing row = %#v", row)
+	}
+	if row := byKey[bobKey]; row.Calls != 1 || row.InputTokens != 200 || row.TotalTokens != 210 {
+		t.Fatalf("Bob shared-workspace Codex pricing row = %#v", row)
 	}
 }
 

--- a/apps/manager-server/internal/repository/usagerollup/repository_test.go
+++ b/apps/manager-server/internal/repository/usagerollup/repository_test.go
@@ -603,6 +603,91 @@ func TestCatchUpAccountHistorySeparatesSharedAccountByAuthIndex(t *testing.T) {
 	}
 }
 
+func TestCatchUpAccountHistoryRebuildSeparatesCodexWorkspaceMembers(t *testing.T) {
+	db := newRollupTestDB(t)
+	ctx := context.Background()
+	events := usageevent.New(db)
+	repo := New(db)
+
+	alice := rollupTestEvent("codex-team-alice", 1_700_000_001_000, "gpt-5", "", "alice@example.com", "", "auth-alice", false, 100, 0, 0, 0, 0, 0, 100)
+	alice.Provider = "codex"
+	alice.AuthProviderSnapshot = "codex"
+	alice.AuthFileSnapshot = "alice-free.json"
+	alice.Source = alice.AuthFileSnapshot
+	alice.AuthAccountIDSnapshot = "workspace-1"
+
+	bob := rollupTestEvent("codex-team-bob", 1_700_000_002_000, "gpt-5", "", "bob@example.com", "", "auth-bob", false, 200, 0, 0, 0, 0, 0, 200)
+	bob.Provider = "codex"
+	bob.AuthProviderSnapshot = "codex"
+	bob.AuthFileSnapshot = "bob-team.json"
+	bob.Source = bob.AuthFileSnapshot
+	bob.AuthAccountIDSnapshot = "workspace-1"
+
+	if _, err := events.InsertBatch(ctx, []usage.Event{alice, bob}); err != nil {
+		t.Fatalf("insert Codex team events: %v", err)
+	}
+	if _, err := db.Exec(`delete from usage_account_model_rollups`); err != nil {
+		t.Fatalf("clear account rollups: %v", err)
+	}
+	scheduleRollupRebuildForTest(t, db, AccountHistoryCheckpointName, 2)
+
+	for attempt := 0; attempt < 2; attempt++ {
+		result, err := repo.CatchUpAccountHistory(ctx, 1, 1_700_000_010_000+int64(attempt))
+		if err != nil {
+			t.Fatalf("Codex rebuild batch %d: %v", attempt, err)
+		}
+		if !result.Rebuilt {
+			t.Fatalf("Codex rebuild batch %d was not marked rebuilt: %#v", attempt, result)
+		}
+	}
+
+	aliceKey, aliceOK := usageidentity.AccountKey(usageidentity.Fields{
+		AuthFileSnapshot:      alice.AuthFileSnapshot,
+		AuthIndex:             alice.AuthIndex,
+		AuthProviderSnapshot:  alice.AuthProviderSnapshot,
+		AuthAccountIDSnapshot: alice.AuthAccountIDSnapshot,
+		AccountSnapshot:       alice.AccountSnapshot,
+		Source:                alice.Source,
+	})
+	bobKey, bobOK := usageidentity.AccountKey(usageidentity.Fields{
+		AuthFileSnapshot:      bob.AuthFileSnapshot,
+		AuthIndex:             bob.AuthIndex,
+		AuthProviderSnapshot:  bob.AuthProviderSnapshot,
+		AuthAccountIDSnapshot: bob.AuthAccountIDSnapshot,
+		AccountSnapshot:       bob.AccountSnapshot,
+		Source:                bob.Source,
+	})
+	if !aliceOK || !bobOK || aliceKey == bobKey {
+		t.Fatalf("Codex team identities = alice:%q (%v), bob:%q (%v)", aliceKey, aliceOK, bobKey, bobOK)
+	}
+
+	rows, err := repo.AccountHistoryRows(ctx, []string{aliceKey, bobKey})
+	if err != nil {
+		t.Fatalf("query rebuilt Codex team history: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rebuilt Codex team rows = %#v, want two member rows", rows)
+	}
+	byKey := make(map[string]AccountHistoryRow, len(rows))
+	for _, row := range rows {
+		byKey[row.AccountKey] = row
+	}
+	if row := byKey[aliceKey]; row.Calls != 1 || row.TotalTokens != 100 {
+		t.Fatalf("rebuilt Alice history = %#v, want 100 tokens", row)
+	}
+	if row := byKey[bobKey]; row.Calls != 1 || row.TotalTokens != 200 {
+		t.Fatalf("rebuilt Bob history = %#v, want 200 tokens", row)
+	}
+
+	var rawCount int
+	if err := db.QueryRow(`select count(*) from usage_events`).Scan(&rawCount); err != nil {
+		t.Fatalf("count raw events: %v", err)
+	}
+	if rawCount != 2 {
+		t.Fatalf("raw event count = %d, want 2 after rebuild", rawCount)
+	}
+}
+
 func newRollupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))

--- a/apps/manager-server/internal/service/accountaction/service.go
+++ b/apps/manager-server/internal/service/accountaction/service.go
@@ -387,8 +387,8 @@ func accountActionIdentity(item model.AccountActionCandidate) (cpaauthfiles.Iden
 				accountSnapshot = ""
 			}
 		}
-		if authIndex == "" && (accountIDSnapshot == "" || accountSnapshot == "") {
-			return cpaauthfiles.Identity{}, fmt.Errorf("%w: Codex candidate requires auth_index or workspace+member identity", cpaauthfiles.ErrIdentityMismatch)
+		if authIndex == "" {
+			return cpaauthfiles.Identity{}, fmt.Errorf("%w: Codex credential mutation requires auth_index", cpaauthfiles.ErrIdentityMismatch)
 		}
 	}
 	identity := cpaauthfiles.Identity{

--- a/apps/manager-server/internal/service/accountaction/service.go
+++ b/apps/manager-server/internal/service/accountaction/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 	managerconfigsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/managerconfig"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 var ErrCandidateNotFound = errors.New("account action candidate not found")
@@ -361,12 +362,41 @@ func accountActionIdentity(item model.AccountActionCandidate) (cpaauthfiles.Iden
 	if accountSnapshot == fileName {
 		accountSnapshot = ""
 	}
+	authIndex := strings.TrimSpace(item.AuthIndex)
+	provider := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(item.Provider), "_", "-"))
+	if provider == "x-ai" || provider == "grok" {
+		provider = "xai"
+	}
+	accountIDSnapshot := strings.TrimSpace(item.AccountIDSnapshot)
+	if provider == "codex" {
+		if accountIDSnapshot != "" {
+			workspace, ok := usageidentity.NormalizeCodexWorkspaceSnapshot(accountIDSnapshot)
+			if !ok {
+				return cpaauthfiles.Identity{}, fmt.Errorf("%w: candidate has invalid Codex workspace identity", cpaauthfiles.ErrIdentityMismatch)
+			}
+			accountIDSnapshot = workspace
+		}
+		if accountSnapshot != "" {
+			member, ok := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+			if ok {
+				accountSnapshot = member
+			} else {
+				// A display label is not a Codex member identity. An explicit
+				// auth_index may still identify the credential, but the weak
+				// display value must not be used as an ownership check.
+				accountSnapshot = ""
+			}
+		}
+		if authIndex == "" && (accountIDSnapshot == "" || accountSnapshot == "") {
+			return cpaauthfiles.Identity{}, fmt.Errorf("%w: Codex candidate requires auth_index or workspace+member identity", cpaauthfiles.ErrIdentityMismatch)
+		}
+	}
 	identity := cpaauthfiles.Identity{
 		AuthFileName:      fileName,
-		AuthIndex:         strings.TrimSpace(item.AuthIndex),
-		Provider:          strings.TrimSpace(item.Provider),
+		AuthIndex:         authIndex,
+		Provider:          provider,
 		AccountSnapshot:   accountSnapshot,
-		AccountIDSnapshot: strings.TrimSpace(item.AccountIDSnapshot),
+		AccountIDSnapshot: accountIDSnapshot,
 	}
 	if identity.AuthIndex == "" && identity.AccountSnapshot == "" && identity.AccountIDSnapshot == "" {
 		return cpaauthfiles.Identity{}, fmt.Errorf("%w: candidate has no stable auth index, account ID, or account snapshot", cpaauthfiles.ErrIdentityMismatch)

--- a/apps/manager-server/internal/service/accountaction/service_test.go
+++ b/apps/manager-server/internal/service/accountaction/service_test.go
@@ -641,7 +641,7 @@ func TestAccountActionsRejectCandidateWithoutStableIdentity(t *testing.T) {
 			if getErr != nil || !ok {
 				t.Fatalf("get candidate: %v ok=%t", getErr, ok)
 			}
-			if current.Status != model.AccountActionStatusPending || !strings.Contains(current.LastError, "no stable auth index") {
+			if current.Status != model.AccountActionStatusPending || !strings.Contains(current.LastError, "workspace+member identity") {
 				t.Fatalf("candidate = %#v, want pending stable-identity failure", current)
 			}
 		})

--- a/apps/manager-server/internal/service/accountaction/service_test.go
+++ b/apps/manager-server/internal/service/accountaction/service_test.go
@@ -641,7 +641,7 @@ func TestAccountActionsRejectCandidateWithoutStableIdentity(t *testing.T) {
 			if getErr != nil || !ok {
 				t.Fatalf("get candidate: %v ok=%t", getErr, ok)
 			}
-			if current.Status != model.AccountActionStatusPending || !strings.Contains(current.LastError, "workspace+member identity") {
+			if current.Status != model.AccountActionStatusPending || !strings.Contains(current.LastError, "auth_index") {
 				t.Fatalf("candidate = %#v, want pending stable-identity failure", current)
 			}
 		})

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/managerconfig"
 	quotasnapshotsvc "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/quotasnapshot"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 const (
@@ -170,19 +171,21 @@ type ExecuteActionsResult struct {
 type authFile map[string]any
 
 type account struct {
-	Key              string
-	RuntimeID        string
-	FileName         string
-	DisplayAccount   string
-	AccountSnapshot  string
-	AuthIndex        string
-	AccountID        string
-	Provider         string
-	Disabled         bool
-	AutoRecoverOwned bool
-	Status           string
-	State            string
-	File             authFile
+	Key                    string
+	RuntimeID              string
+	FileName               string
+	DisplayAccount         string
+	AccountSnapshot        string
+	AccountSnapshotInvalid bool
+	AuthIndex              string
+	AccountID              string
+	AccountIDInvalid       bool
+	Provider               string
+	Disabled               bool
+	AutoRecoverOwned       bool
+	Status                 string
+	State                  string
+	File                   authFile
 }
 
 type apiCallResponse struct {
@@ -2437,11 +2440,12 @@ func (s *Service) executeAction(
 }
 
 func inspectionAuthFileIdentity(item model.CodexInspectionResult) cpaauthfiles.Identity {
+	provider := normalizeInspectionProvider(item.Provider)
 	return cpaauthfiles.Identity{
 		AuthFileName:      strings.TrimSpace(item.FileName),
 		AuthIndex:         strings.TrimSpace(item.AuthIndex),
-		Provider:          strings.TrimSpace(item.Provider),
-		AccountSnapshot:   directInspectionAccountSnapshot(item.FileName, item.AccountSnapshot),
+		Provider:          provider,
+		AccountSnapshot:   inspectionAccountSnapshot(provider, item.FileName, item.AccountSnapshot),
 		AccountIDSnapshot: strings.TrimSpace(item.AccountID),
 	}
 }
@@ -3164,14 +3168,21 @@ func inspectionActionIdentityKey(result model.CodexInspectionResult) string {
 
 func inspectionIdentityKey(fileName, provider, authIndex, accountID, accountSnapshot string) string {
 	fileName = strings.TrimSpace(fileName)
+	provider = normalizeInspectionProvider(provider)
 	accountID = strings.TrimSpace(accountID)
-	normalizedAccountSnapshot := ""
-	if accountID == "" {
-		normalizedAccountSnapshot = directInspectionAccountSnapshot(fileName, accountSnapshot)
+	normalizedAccountSnapshot := inspectionAccountSnapshot(provider, fileName, accountSnapshot)
+	if provider == "codex" && normalizedAccountSnapshot == "" {
+		// chatgpt_account_id identifies a shared Workspace, not a member. Do
+		// not let a Workspace-only result become the identity used to group or
+		// mutate a credential when the credential-level fallback is absent.
+		accountID = ""
+	}
+	if provider != "codex" && accountID != "" {
+		normalizedAccountSnapshot = ""
 	}
 	encoded, _ := json.Marshal([]string{
 		fileName,
-		normalizeInspectionProvider(provider),
+		provider,
 		strings.TrimSpace(authIndex),
 		accountID,
 		normalizedAccountSnapshot,
@@ -3180,12 +3191,20 @@ func inspectionIdentityKey(fileName, provider, authIndex, accountID, accountSnap
 }
 
 func hasInspectionActionIdentity(result model.CodexInspectionResult) bool {
-	if strings.TrimSpace(result.FileName) == "" || normalizeInspectionProvider(result.Provider) == "" {
+	fileName := strings.TrimSpace(result.FileName)
+	provider := normalizeInspectionProvider(result.Provider)
+	if fileName == "" || provider == "" {
 		return false
 	}
-	return strings.TrimSpace(result.AuthIndex) != "" ||
-		strings.TrimSpace(result.AccountID) != "" ||
-		directInspectionAccountSnapshot(result.FileName, result.AccountSnapshot) != ""
+	if strings.TrimSpace(result.AuthIndex) != "" {
+		return true
+	}
+	if provider == "codex" {
+		return strings.TrimSpace(result.AccountID) != "" &&
+			inspectionAccountSnapshot(provider, fileName, result.AccountSnapshot) != ""
+	}
+	return strings.TrimSpace(result.AccountID) != "" ||
+		inspectionAccountSnapshot(provider, fileName, result.AccountSnapshot) != ""
 }
 
 func allowAutoAction(mode string, autoRecoverEnabled bool, result model.CodexInspectionResult) bool {
@@ -3241,30 +3260,33 @@ func disableOwnershipMatchesAccount(item model.CodexInspectionDisableOwnership, 
 	if provider == "" || candidateProvider == "" {
 		return false
 	}
-	if candidate.FileName != strings.TrimSpace(item.FileName) ||
+	if strings.TrimSpace(candidate.FileName) != strings.TrimSpace(item.FileName) ||
 		candidateProvider != provider {
 		return false
 	}
-	authIndex := strings.TrimSpace(item.AuthIndex)
-	if authIndex != "" && candidate.AuthIndex != authIndex {
+	if provider == "codex" && strings.TrimSpace(item.AccountID) != "" &&
+		inspectionAccountSnapshot(provider, item.FileName, item.AccountSnapshot) == "" {
+		// A Workspace-only ownership row is not sufficient to authorize recovery
+		// for a Team credential. auth_index remains a valid credential locator
+		// for ordinary action verification, but it cannot repair this ambiguous
+		// persisted ownership record.
 		return false
 	}
-	accountID := strings.TrimSpace(item.AccountID)
-	if accountID != "" {
-		return strings.TrimSpace(candidate.AccountID) == accountID
-	}
-	accountSnapshot := directInspectionAccountSnapshot(item.FileName, item.AccountSnapshot)
-	if accountSnapshot == "" {
-		return authIndex != ""
-	}
-	return directInspectionAccountSnapshot(candidate.FileName, candidate.AccountSnapshot) == accountSnapshot
+	return inspectionIdentityMatchesAccount(
+		provider,
+		item.FileName,
+		item.AuthIndex,
+		item.AccountID,
+		item.AccountSnapshot,
+		candidate,
+	)
 }
 
 func disableOwnershipTarget(item model.CodexInspectionDisableOwnership) model.CodexInspectionDisableOwnershipTarget {
 	provider := normalizeInspectionProvider(item.Provider)
 	authIndex := strings.TrimSpace(item.AuthIndex)
 	accountID := strings.TrimSpace(item.AccountID)
-	accountSnapshot := directInspectionAccountSnapshot(item.FileName, item.AccountSnapshot)
+	accountSnapshot := inspectionAccountSnapshot(provider, item.FileName, item.AccountSnapshot)
 	return model.CodexInspectionDisableOwnershipTarget{
 		FileName:        strings.TrimSpace(item.FileName),
 		Provider:        &provider,
@@ -3733,23 +3755,14 @@ func inspectionResultMatchesCurrentAccount(result model.CodexInspectionResult, c
 	if provider == "" || currentProvider == "" || provider != currentProvider {
 		return false
 	}
-	authIndex := strings.TrimSpace(result.AuthIndex)
-	accountID := strings.TrimSpace(result.AccountID)
-	if authIndex != "" && authIndex != strings.TrimSpace(current.AuthIndex) {
-		return false
-	}
-	if accountID != "" {
-		return accountID == strings.TrimSpace(current.AccountID)
-	}
-	accountSnapshot := directInspectionAccountSnapshot(result.FileName, result.AccountSnapshot)
-	if accountSnapshot == "" {
-		return authIndex != ""
-	}
-	currentSnapshot := directInspectionAccountSnapshot(current.FileName, current.AccountSnapshot)
-	if currentSnapshot == "" {
-		return false
-	}
-	return accountSnapshot == currentSnapshot
+	return inspectionIdentityMatchesAccount(
+		provider,
+		result.FileName,
+		result.AuthIndex,
+		result.AccountID,
+		result.AccountSnapshot,
+		current,
+	)
 }
 
 func directInspectionAccountSnapshot(fileName, value string) string {
@@ -3758,6 +3771,61 @@ func directInspectionAccountSnapshot(fileName, value string) string {
 		return ""
 	}
 	return snapshot
+}
+
+func inspectionAccountSnapshot(provider, fileName, value string) string {
+	snapshot := directInspectionAccountSnapshot(fileName, value)
+	if normalizeInspectionProvider(provider) != "codex" {
+		return snapshot
+	}
+	member, ok := usageidentity.NormalizeCodexMemberSnapshot(snapshot)
+	if !ok {
+		return ""
+	}
+	return member
+}
+
+func inspectionIdentityMatchesAccount(
+	provider, fileName, authIndex, accountID, accountSnapshot string,
+	candidate account,
+) bool {
+	if normalizeInspectionProvider(provider) == "codex" &&
+		(candidate.AccountIDInvalid || candidate.AccountSnapshotInvalid) {
+		return false
+	}
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex != "" && authIndex != strings.TrimSpace(candidate.AuthIndex) {
+		return false
+	}
+	accountID = strings.TrimSpace(accountID)
+	member := inspectionAccountSnapshot(provider, fileName, accountSnapshot)
+	if normalizeInspectionProvider(provider) == "codex" {
+		candidateAccountID := strings.TrimSpace(candidate.AccountID)
+		candidateMember := inspectionAccountSnapshot(candidate.Provider, candidate.FileName, candidate.AccountSnapshot)
+		if accountID != "" {
+			if candidateAccountID != accountID {
+				return false
+			}
+			if member != "" {
+				return candidateMember != "" && candidateMember == member
+			}
+			return authIndex != ""
+		}
+		if member != "" {
+			return authIndex != "" && candidateMember != "" && candidateMember == member
+		}
+		// A Workspace-only ownership record is not a recovery identity. An
+		// auth-index match is still a credential-level fallback, but a wildcard
+		// record must fail closed even when only one candidate is present.
+		return authIndex != ""
+	}
+	if accountID != "" {
+		return accountID == strings.TrimSpace(candidate.AccountID)
+	}
+	if member == "" {
+		return authIndex != ""
+	}
+	return member == directInspectionAccountSnapshot(candidate.FileName, candidate.AccountSnapshot)
 }
 
 func matchCurrentAccount(candidates []account, result model.CodexInspectionResult) (account, bool) {
@@ -4153,26 +4221,30 @@ func countAccounts(items []account, disabled bool) int {
 }
 
 func toAccount(file authFile) account {
-	fileName := firstNonEmpty(readString(file, "name"), readString(file, "id"), normalizeAuthIndex(file["auth_index"]), normalizeAuthIndex(file["authIndex"]), "unknown-auth-file")
-	authIndex := firstNonEmpty(normalizeAuthIndex(file["auth_index"]), normalizeAuthIndex(file["authIndex"]), normalizeAuthIndex(file["auth-index"]))
-	provider := normalizeInspectionProvider(firstNonEmpty(readString(file, "provider"), readString(file, "type")))
-	runtimeID := readString(file, "id")
-	accountSnapshot := firstNonEmpty(
+	parsed := cpaauthfiles.FromMap(map[string]any(file))
+	fileName := firstNonEmpty(parsed.Name, normalizeAuthIndex(file["auth_index"]), normalizeAuthIndex(file["authIndex"]), "unknown-auth-file")
+	authIndex := parsed.AuthIndex
+	provider := parsed.Provider
+	runtimeID := parsed.ID
+	displaySnapshot := firstNonEmpty(
 		readString(file, "account"),
 		readString(file, "email"),
 		readString(file, "display_account"),
 		readString(file, "displayAccount"),
 	)
+	accountSnapshot := parsed.AccountSnapshot
+	accountSnapshotInvalid := parsed.AccountSnapshotInvalid
 	displayAccount := firstNonEmpty(
-		accountSnapshot,
+		displaySnapshot,
 		readString(file, "label"),
 		fileName,
 	)
-	accountID := resolveCodexAccountID(file)
+	accountID := parsed.AccountID
+	accountIDInvalid := parsed.AccountIDInvalid
 	key := fileName + "::" + authIndex
 	if authIndex == "" {
 		switch {
-		case accountID != "" || accountSnapshot != "":
+		case accountSnapshot != "" || (provider != "codex" && accountID != ""):
 			key = fileName + "::-::" + inspectionIdentityKey(fileName, provider, authIndex, accountID, accountSnapshot)
 		case strings.TrimSpace(runtimeID) != "" && strings.TrimSpace(runtimeID) != strings.TrimSpace(fileName):
 			encoded, _ := json.Marshal([]string{provider, strings.TrimSpace(runtimeID)})
@@ -4182,18 +4254,20 @@ func toAccount(file authFile) account {
 		}
 	}
 	return account{
-		Key:             key,
-		RuntimeID:       runtimeID,
-		FileName:        fileName,
-		DisplayAccount:  displayAccount,
-		AccountSnapshot: accountSnapshot,
-		AuthIndex:       authIndex,
-		AccountID:       accountID,
-		Provider:        provider,
-		Disabled:        isDisabledAuthFile(file),
-		Status:          readString(file, "status"),
-		State:           readString(file, "state"),
-		File:            file,
+		Key:                    key,
+		RuntimeID:              runtimeID,
+		FileName:               fileName,
+		DisplayAccount:         displayAccount,
+		AccountSnapshot:        accountSnapshot,
+		AccountSnapshotInvalid: accountSnapshotInvalid,
+		AuthIndex:              authIndex,
+		AccountID:              accountID,
+		AccountIDInvalid:       accountIDInvalid,
+		Provider:               provider,
+		Disabled:               isDisabledAuthFile(file),
+		Status:                 readString(file, "status"),
+		State:                  readString(file, "state"),
+		File:                   file,
 	}
 }
 
@@ -4206,59 +4280,6 @@ func normalizeInspectionProvider(value string) string {
 	default:
 		return normalized
 	}
-}
-
-func resolveCodexAccountID(file authFile) string {
-	metadata := readMap(file, "metadata")
-	attributes := readMap(file, "attributes")
-	candidates := []any{
-		file["chatgpt_account_id"],
-		file["chatgptAccountId"],
-		file["account_id"],
-		file["accountId"],
-		metadata["chatgpt_account_id"],
-		metadata["chatgptAccountId"],
-		metadata["account_id"],
-		metadata["accountId"],
-		attributes["chatgpt_account_id"],
-		attributes["chatgptAccountId"],
-		attributes["account_id"],
-		attributes["accountId"],
-	}
-	for _, candidate := range candidates {
-		if id := extractDirectCodexAccountID(candidate); id != "" {
-			return id
-		}
-	}
-	tokenCandidates := []any{
-		file["id_token"],
-		metadata["id_token"],
-		attributes["id_token"],
-	}
-	for _, candidate := range tokenCandidates {
-		if id := extractCodexAccountIDFromToken(candidate); id != "" {
-			return id
-		}
-	}
-	return ""
-}
-
-func extractDirectCodexAccountID(value any) string {
-	if direct := readPlainString(value); direct != "" {
-		return direct
-	}
-	if direct := readAccountIDCandidate(value); direct != "" {
-		return direct
-	}
-	return ""
-}
-
-func extractCodexAccountIDFromToken(value any) string {
-	payload := parseIDTokenPayload(value)
-	if payload == nil {
-		return ""
-	}
-	return readAccountIDCandidate(payload)
 }
 
 func resolveCodexPlanType(file authFile) string {
@@ -4305,27 +4326,6 @@ func readCodexPlanTypeCandidate(value any) string {
 	default:
 		return normalizeCodexPlanType(fmt.Sprint(value))
 	}
-}
-
-func readPlainString(value any) string {
-	text, ok := value.(string)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(text)
-}
-
-func readAccountIDCandidate(value any) string {
-	record, ok := value.(map[string]any)
-	if !ok {
-		return ""
-	}
-	return firstNonEmpty(
-		readString(record, "chatgpt_account_id"),
-		readString(record, "chatgptAccountId"),
-		readString(record, "account_id"),
-		readString(record, "accountId"),
-	)
 }
 
 func parseIDTokenPayload(value any) map[string]any {

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -2260,6 +2260,16 @@ func (s *Service) executeAction(
 	sourceMembers []model.CodexInspectionResult,
 	automatic bool,
 ) error {
+	if automatic && normalizeInspectionProvider(item.Provider) == "codex" {
+		if strings.TrimSpace(item.AuthIndex) == "" {
+			return errors.New(inspectionIdentityMissingReason)
+		}
+		for _, member := range sourceMembers {
+			if normalizeInspectionProvider(member.Provider) == "codex" && strings.TrimSpace(member.AuthIndex) == "" {
+				return errors.New(inspectionIdentityMissingReason)
+			}
+		}
+	}
 	fileNames := make([]string, 0, len(sourceMembers)+1)
 	fileNames = append(fileNames, item.FileName)
 	for _, member := range sourceMembers {
@@ -3196,12 +3206,11 @@ func hasInspectionActionIdentity(result model.CodexInspectionResult) bool {
 	if fileName == "" || provider == "" {
 		return false
 	}
+	if provider == "codex" {
+		return strings.TrimSpace(result.AuthIndex) != ""
+	}
 	if strings.TrimSpace(result.AuthIndex) != "" {
 		return true
-	}
-	if provider == "codex" {
-		return strings.TrimSpace(result.AccountID) != "" &&
-			inspectionAccountSnapshot(provider, fileName, result.AccountSnapshot) != ""
 	}
 	return strings.TrimSpace(result.AccountID) != "" ||
 		inspectionAccountSnapshot(provider, fileName, result.AccountSnapshot) != ""
@@ -3840,16 +3849,19 @@ func inspectionIdentityMatchesAccount(
 		candidateAccountID := strings.TrimSpace(candidate.AccountID)
 		candidateMember := inspectionAccountSnapshot(candidate.Provider, candidate.FileName, candidate.AccountSnapshot)
 		if accountID != "" {
-			if candidateAccountID != accountID {
+			if candidateAccountID != "" && candidateAccountID != accountID {
 				return false
 			}
-			if member != "" {
-				return candidateMember != "" && candidateMember == member
+			if member != "" && candidateMember != "" && candidateMember != member {
+				return false
 			}
 			return authIndex != ""
 		}
 		if member != "" {
-			return authIndex != "" && candidateMember != "" && candidateMember == member
+			if candidateMember != "" && candidateMember != member {
+				return false
+			}
+			return authIndex != ""
 		}
 		// A Workspace-only ownership record is not a recovery identity. An
 		// auth-index match is still a credential-level fallback, but a wildcard

--- a/apps/manager-server/internal/service/codexinspection/service.go
+++ b/apps/manager-server/internal/service/codexinspection/service.go
@@ -3230,6 +3230,14 @@ func (s *Service) applyDisableOwnership(ctx context.Context, accounts []account,
 		return
 	}
 	for _, item := range items {
+		if disableOwnershipHasDuplicateCredentialLocator(item, accounts) {
+			logger.warning(ctx, "巡检禁用所有权凭证定位不唯一，跳过自动恢复", map[string]any{
+				"fileName":  item.FileName,
+				"authIndex": item.AuthIndex,
+				"provider":  item.Provider,
+			})
+			continue
+		}
 		matchedIndexes := make([]int, 0, 1)
 		disabledMatchCount := 0
 		for index := range accounts {
@@ -3239,6 +3247,18 @@ func (s *Service) applyDisableOwnership(ctx context.Context, accounts []account,
 					disabledMatchCount++
 				}
 			}
+		}
+		if len(matchedIndexes) > 1 && strings.TrimSpace(item.AuthIndex) != "" {
+			// A legacy ownership row with a credential locator is still useful,
+			// but duplicate credentials must not be narrowed by Workspace/member
+			// evidence. Keep the row for a later unambiguous inventory instead of
+			// authorizing recovery or deleting the ownership record.
+			logger.warning(ctx, "巡检禁用所有权匹配到多个凭证，跳过自动恢复", map[string]any{
+				"fileName":  item.FileName,
+				"authIndex": item.AuthIndex,
+				"provider":  item.Provider,
+			})
+			continue
 		}
 		if len(matchedIndexes) != 1 || disabledMatchCount == 0 {
 			if err := s.store.DeleteCodexInspectionDisableOwnership(ctx, disableOwnershipTarget(item)); err != nil {
@@ -3254,6 +3274,31 @@ func (s *Service) applyDisableOwnership(ctx context.Context, accounts []account,
 	}
 }
 
+func disableOwnershipHasDuplicateCredentialLocator(
+	item model.CodexInspectionDisableOwnership,
+	accounts []account,
+) bool {
+	fileName := strings.TrimSpace(item.FileName)
+	authIndex := strings.TrimSpace(item.AuthIndex)
+	provider := normalizeInspectionProvider(item.Provider)
+	if fileName == "" || authIndex == "" || provider == "" {
+		return false
+	}
+	count := 0
+	for _, candidate := range accounts {
+		if strings.TrimSpace(candidate.FileName) != fileName ||
+			normalizeInspectionProvider(candidate.Provider) != provider ||
+			strings.TrimSpace(candidate.AuthIndex) != authIndex {
+			continue
+		}
+		count++
+		if count > 1 {
+			return true
+		}
+	}
+	return false
+}
+
 func disableOwnershipMatchesAccount(item model.CodexInspectionDisableOwnership, candidate account) bool {
 	provider := normalizeInspectionProvider(item.Provider)
 	candidateProvider := normalizeInspectionProvider(candidate.Provider)
@@ -3262,14 +3307,6 @@ func disableOwnershipMatchesAccount(item model.CodexInspectionDisableOwnership, 
 	}
 	if strings.TrimSpace(candidate.FileName) != strings.TrimSpace(item.FileName) ||
 		candidateProvider != provider {
-		return false
-	}
-	if provider == "codex" && strings.TrimSpace(item.AccountID) != "" &&
-		inspectionAccountSnapshot(provider, item.FileName, item.AccountSnapshot) == "" {
-		// A Workspace-only ownership row is not sufficient to authorize recovery
-		// for a Team credential. auth_index remains a valid credential locator
-		// for ordinary action verification, but it cannot repair this ambiguous
-		// persisted ownership record.
 		return false
 	}
 	return inspectionIdentityMatchesAccount(

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -2719,6 +2719,47 @@ func TestRunAutoActionNoneDoesNotExecuteActions(t *testing.T) {
 	}
 }
 
+func TestRunAutoActionSkipsCodexRuntimeOnlyCredentialBeforeMutation(t *testing.T) {
+	var patchCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"files":[{"id":"runtime-auth-1","name":"auth-a.json","provider":"codex","account_id":"workspace-1","account":"alice@example.com","disabled":false,"status":"ok","state":"ready"}]}`))
+		case r.URL.Path == "/v0/management/api-call" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"status_code":402,"body":{"detail":{"code":"deactivated_workspace"}}}`))
+		case strings.HasPrefix(r.URL.Path, "/v0/management/auth-files") && r.Method == http.MethodPatch:
+			patchCalls++
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	db := newCodexInspectionTestStore(t)
+	managerCfg := newCodexInspectionManagerConfig(upstream.URL)
+	managerCfg.CodexInspection.AutoActionMode = model.CodexInspectionAutoActionDisable
+	if err := db.SaveManagerConfig(context.Background(), managerCfg); err != nil {
+		t.Fatalf("save manager config: %v", err)
+	}
+
+	result, err := newCodexInspectionTestService(t, db).Run(context.Background(), RunRequest{
+		TriggerType: "manual",
+		TriggerKey:  "manual",
+	})
+	if err != nil {
+		t.Fatalf("run inspection: %v", err)
+	}
+	if patchCalls != 0 {
+		t.Fatalf("runtime-only Codex automatic action made %d mutation calls, want 0", patchCalls)
+	}
+	if len(result.Results) != 1 || result.Results[0].Action != "keep" ||
+		result.Results[0].ErrorKind != "missing_auth_index" ||
+		result.Results[0].Error != "缺少 auth_index" {
+		t.Fatalf("runtime-only Codex result = %#v, want safe missing-auth-index skip", result.Results)
+	}
+}
+
 func TestRunAutoActionEnableEnablesRecoveredDisabledAccount(t *testing.T) {
 	var patchCalled bool
 	var patchedDisabled bool
@@ -3023,7 +3064,7 @@ func TestApplyDisableOwnershipRejectsSameFileReplacement(t *testing.T) {
 	}
 }
 
-func TestApplyDisableOwnershipRequiresCodexMemberMatch(t *testing.T) {
+func TestApplyDisableOwnershipAllowsMissingCodexMemberEvidence(t *testing.T) {
 	db := newCodexInspectionTestStore(t)
 	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
 		FileName:        "shared-auth.json",
@@ -3044,15 +3085,94 @@ func TestApplyDisableOwnershipRequiresCodexMemberMatch(t *testing.T) {
 		Disabled:       true,
 	}}
 	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
-	if accounts[0].AutoRecoverOwned {
-		t.Fatalf("Codex Workspace ID overrode a conflicting member snapshot: %#v", accounts[0])
+	if !accounts[0].AutoRecoverOwned {
+		t.Fatalf("missing current Codex member evidence blocked recovery: %#v", accounts[0])
 	}
 	ownership, err := db.ListCodexInspectionDisableOwnership(context.Background())
 	if err != nil {
 		t.Fatalf("list ownership: %v", err)
 	}
-	if len(ownership) != 0 {
-		t.Fatalf("conflicting member ownership = %#v, want removed", ownership)
+	if len(ownership) != 1 || ownership[0].AccountSnapshot != "old-label@example.com" {
+		t.Fatalf("missing-member ownership = %#v, want preserved", ownership)
+	}
+}
+
+func TestApplyDisableOwnershipRejectsCodexWorkspaceConflict(t *testing.T) {
+	db := newCodexInspectionTestStore(t)
+	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "alice@example.com",
+	}); err != nil {
+		t.Fatalf("save inspection disable ownership: %v", err)
+	}
+
+	accounts := []account{{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-2",
+		AccountSnapshot: "alice@example.com",
+		Disabled:        true,
+	}}
+	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
+	if accounts[0].AutoRecoverOwned {
+		t.Fatalf("workspace conflict granted recovery: %#v", accounts[0])
+	}
+}
+
+func TestApplyDisableOwnershipRejectsCodexMemberConflict(t *testing.T) {
+	db := newCodexInspectionTestStore(t)
+	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "alice@example.com",
+	}); err != nil {
+		t.Fatalf("save inspection disable ownership: %v", err)
+	}
+
+	accounts := []account{{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "bob@example.com",
+		Disabled:        true,
+	}}
+	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
+	if accounts[0].AutoRecoverOwned {
+		t.Fatalf("member conflict granted recovery: %#v", accounts[0])
+	}
+}
+
+func TestApplyDisableOwnershipRejectsInvalidCodexEvidence(t *testing.T) {
+	db := newCodexInspectionTestStore(t)
+	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "alice@example.com",
+	}); err != nil {
+		t.Fatalf("save inspection disable ownership: %v", err)
+	}
+
+	accounts := []account{{
+		FileName:         "shared-auth.json",
+		Provider:         "codex",
+		AuthIndex:        "auth-1",
+		AccountID:        "workspace-1",
+		AccountSnapshot:  "alice@example.com",
+		AccountIDInvalid: true,
+		Disabled:         true,
+	}}
+	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
+	if accounts[0].AutoRecoverOwned {
+		t.Fatalf("invalid Codex evidence granted recovery: %#v", accounts[0])
 	}
 }
 
@@ -3392,6 +3512,27 @@ func TestSelectAutoActionItemsNeedsReviewForDeleteAndKeepSiblings(t *testing.T) 
 		outcomes[0].Status != model.CodexInspectionActionStatusNeedsReview ||
 		outcomes[0].Error != fileActionMixedReason {
 		t.Fatalf("outcomes = %#v, want delete result needs_review", outcomes)
+	}
+}
+
+func TestSelectAutoActionItemsNeedsReviewForCodexWithoutAuthIndex(t *testing.T) {
+	result := model.CodexInspectionResult{
+		ID:              1,
+		AccountKey:      "runtime-only",
+		FileName:        "auth-a.json",
+		Provider:        "codex",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "alice@example.com",
+		Action:          "disable",
+	}
+
+	items, outcomes := selectAutoActionItems(model.CodexInspectionAutoActionDisable, false, []model.CodexInspectionResult{result})
+	if len(items) != 0 {
+		t.Fatalf("runtime-only Codex action items = %#v, want none", items)
+	}
+	if len(outcomes) != 1 || outcomes[0].Status != model.CodexInspectionActionStatusNeedsReview ||
+		outcomes[0].Error != inspectionIdentityMissingReason {
+		t.Fatalf("runtime-only Codex outcomes = %#v, want needs_review", outcomes)
 	}
 }
 

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -3056,7 +3056,7 @@ func TestApplyDisableOwnershipRequiresCodexMemberMatch(t *testing.T) {
 	}
 }
 
-func TestApplyDisableOwnershipRejectsWorkspaceOnlyCodexOwnership(t *testing.T) {
+func TestApplyDisableOwnershipRestoresWorkspaceOnlyCodexOwnershipByUniqueLocator(t *testing.T) {
 	db := newCodexInspectionTestStore(t)
 	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
 		FileName:     "shared-auth.json",
@@ -3077,15 +3077,100 @@ func TestApplyDisableOwnershipRejectsWorkspaceOnlyCodexOwnership(t *testing.T) {
 		Disabled:        true,
 	}}
 	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
-	if accounts[0].AutoRecoverOwned {
-		t.Fatalf("workspace-only Codex ownership granted Bob recovery: %#v", accounts[0])
+	if !accounts[0].AutoRecoverOwned {
+		t.Fatalf("unique workspace-only Codex ownership was not restored: %#v", accounts[0])
 	}
 	ownership, err := db.ListCodexInspectionDisableOwnership(context.Background())
 	if err != nil {
 		t.Fatalf("list ownership: %v", err)
 	}
-	if len(ownership) != 0 {
-		t.Fatalf("workspace-only ownership = %#v, want stale ownership removed", ownership)
+	if len(ownership) != 1 || ownership[0].AuthIndex != "auth-1" {
+		t.Fatalf("workspace-only ownership = %#v, want preserved ownership", ownership)
+	}
+}
+
+func TestApplyDisableOwnershipKeepsAmbiguousCodexOwnership(t *testing.T) {
+	db := newCodexInspectionTestStore(t)
+	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
+		FileName:  "shared-auth.json",
+		Provider:  "codex",
+		AuthIndex: "auth-1",
+		AccountID: "workspace-1",
+	}); err != nil {
+		t.Fatalf("save workspace-only inspection disable ownership: %v", err)
+	}
+
+	accounts := []account{
+		{
+			FileName:        "shared-auth.json",
+			Provider:        "codex",
+			AuthIndex:       "auth-1",
+			AccountID:       "workspace-1",
+			AccountSnapshot: "alice@example.com",
+			Disabled:        true,
+		},
+		{
+			FileName:        "shared-auth.json",
+			Provider:        "codex",
+			AuthIndex:       "auth-1",
+			AccountID:       "workspace-1",
+			AccountSnapshot: "bob@example.com",
+			Disabled:        true,
+		},
+	}
+	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
+	if accounts[0].AutoRecoverOwned || accounts[1].AutoRecoverOwned {
+		t.Fatalf("ambiguous workspace-only ownership granted recovery: %#v", accounts)
+	}
+	ownership, err := db.ListCodexInspectionDisableOwnership(context.Background())
+	if err != nil {
+		t.Fatalf("list ownership after ambiguity: %v", err)
+	}
+	if len(ownership) != 1 || ownership[0].AuthIndex != "auth-1" {
+		t.Fatalf("ambiguous workspace-only ownership = %#v, want preserved ownership", ownership)
+	}
+}
+
+func TestApplyDisableOwnershipDoesNotNarrowDuplicateLocatorByMember(t *testing.T) {
+	db := newCodexInspectionTestStore(t)
+	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "alice@example.com",
+	}); err != nil {
+		t.Fatalf("save member-specific inspection disable ownership: %v", err)
+	}
+
+	accounts := []account{
+		{
+			FileName:        "shared-auth.json",
+			Provider:        "codex",
+			AuthIndex:       "auth-1",
+			AccountID:       "workspace-1",
+			AccountSnapshot: "alice@example.com",
+			Disabled:        true,
+		},
+		{
+			FileName:        "shared-auth.json",
+			Provider:        "codex",
+			AuthIndex:       "auth-1",
+			AccountID:       "workspace-1",
+			AccountSnapshot: "bob@example.com",
+			Disabled:        true,
+		},
+	}
+	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
+	if accounts[0].AutoRecoverOwned || accounts[1].AutoRecoverOwned {
+		t.Fatalf("duplicate locator ownership was narrowed by member: %#v", accounts)
+	}
+	ownership, err := db.ListCodexInspectionDisableOwnership(context.Background())
+	if err != nil {
+		t.Fatalf("list ownership after duplicate locator: %v", err)
+	}
+	if len(ownership) != 1 || ownership[0].AccountSnapshot != "alice@example.com" {
+		t.Fatalf("duplicate locator ownership = %#v, want preserved Alice record", ownership)
 	}
 }
 

--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -344,8 +344,8 @@ func TestToAccountBuildsStableDistinctFallbackKeys(t *testing.T) {
 		"account":    "new-label@example.com",
 		"account_id": "account-1",
 	})
-	if oldLabel.Key != newLabel.Key {
-		t.Fatalf("account ID fallback key changed with label: old=%q new=%q", oldLabel.Key, newLabel.Key)
+	if oldLabel.Key == newLabel.Key {
+		t.Fatalf("same Codex Workspace merged different members: old=%q new=%q", oldLabel.Key, newLabel.Key)
 	}
 	if inspectionActionIdentityKey(resultFromAccount(first)) == inspectionActionIdentityKey(resultFromAccount(second)) {
 		t.Fatal("same-name account snapshots shared an action identity")
@@ -370,6 +370,75 @@ func TestToAccountBuildsStableDistinctFallbackKeys(t *testing.T) {
 	})
 	if renamedLabel.Key != labelOnly.Key {
 		t.Fatalf("label-only runtime key changed with display label: old=%q new=%q", labelOnly.Key, renamedLabel.Key)
+	}
+}
+
+func TestInspectionIdentityRejectsInvalidCodexAccountEvidence(t *testing.T) {
+	candidate := toAccount(authFile{
+		"id":         "runtime-conflict",
+		"name":       "shared.json",
+		"provider":   "codex",
+		"auth_index": "auth-1",
+		"account_id": "workspace-a",
+		"account":    "alice@example.com",
+		"metadata": map[string]any{
+			"id_token": map[string]any{"account_id": "workspace-b"},
+		},
+	})
+	result := model.CodexInspectionResult{
+		FileName:        "shared.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-a",
+		AccountSnapshot: "alice@example.com",
+	}
+	if inspectionResultMatchesCurrentAccount(result, candidate) {
+		t.Fatalf("invalid Codex account evidence matched mutation target: %#v", candidate)
+	}
+}
+
+func TestToAccountRejectsConflictingExplicitCodexMemberEvidence(t *testing.T) {
+	candidate := toAccount(authFile{
+		"id":               "runtime-member-conflict",
+		"name":             "shared.json",
+		"provider":         "codex",
+		"auth_index":       "auth-1",
+		"account_id":       "workspace-a",
+		"account_snapshot": "bob@example.com",
+		"accountSnapshot":  "alice@example.com",
+		"account":          "alice@example.com",
+	})
+	if candidate.AccountSnapshot != "" || !candidate.AccountSnapshotInvalid {
+		t.Fatalf("conflicting member evidence = %#v, want invalid and no member", candidate)
+	}
+	result := model.CodexInspectionResult{
+		FileName:        "shared.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-a",
+		AccountSnapshot: "alice@example.com",
+	}
+	if inspectionResultMatchesCurrentAccount(result, candidate) {
+		t.Fatal("conflicting Codex member evidence matched a mutation target")
+	}
+}
+
+func TestToAccountRejectsStrongCodexMemberSnapshotConflictingWithDisplayEmail(t *testing.T) {
+	for _, field := range []string{"account", "email"} {
+		t.Run(field, func(t *testing.T) {
+			candidate := toAccount(authFile{
+				"id":               "runtime-member-display-conflict",
+				"name":             "shared.json",
+				"provider":         "codex",
+				"auth_index":       "auth-1",
+				"account_id":       "workspace-a",
+				"account_snapshot": "alice@example.com",
+				field:              "bob@example.com",
+			})
+			if candidate.AccountSnapshot != "" || !candidate.AccountSnapshotInvalid {
+				t.Fatalf("conflicting member evidence = %#v, want invalid and no member", candidate)
+			}
+		})
 	}
 }
 
@@ -2954,7 +3023,7 @@ func TestApplyDisableOwnershipRejectsSameFileReplacement(t *testing.T) {
 	}
 }
 
-func TestApplyDisableOwnershipUsesAccountIDBeforeSnapshot(t *testing.T) {
+func TestApplyDisableOwnershipRequiresCodexMemberMatch(t *testing.T) {
 	db := newCodexInspectionTestStore(t)
 	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
 		FileName:        "shared-auth.json",
@@ -2975,8 +3044,48 @@ func TestApplyDisableOwnershipUsesAccountIDBeforeSnapshot(t *testing.T) {
 		Disabled:       true,
 	}}
 	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
-	if !accounts[0].AutoRecoverOwned {
-		t.Fatalf("stable account ID did not retain ownership: %#v", accounts[0])
+	if accounts[0].AutoRecoverOwned {
+		t.Fatalf("Codex Workspace ID overrode a conflicting member snapshot: %#v", accounts[0])
+	}
+	ownership, err := db.ListCodexInspectionDisableOwnership(context.Background())
+	if err != nil {
+		t.Fatalf("list ownership: %v", err)
+	}
+	if len(ownership) != 0 {
+		t.Fatalf("conflicting member ownership = %#v, want removed", ownership)
+	}
+}
+
+func TestApplyDisableOwnershipRejectsWorkspaceOnlyCodexOwnership(t *testing.T) {
+	db := newCodexInspectionTestStore(t)
+	if err := db.UpsertCodexInspectionDisableOwnership(context.Background(), model.CodexInspectionDisableOwnership{
+		FileName:     "shared-auth.json",
+		Provider:     "codex",
+		AuthIndex:    "auth-1",
+		AccountID:    "workspace-1",
+		DisabledAtMS: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("save workspace-only inspection disable ownership: %v", err)
+	}
+
+	accounts := []account{{
+		FileName:        "shared-auth.json",
+		Provider:        "codex",
+		AuthIndex:       "auth-1",
+		AccountID:       "workspace-1",
+		AccountSnapshot: "bob@example.com",
+		Disabled:        true,
+	}}
+	New(db, nil).applyDisableOwnership(context.Background(), accounts, runLogger{})
+	if accounts[0].AutoRecoverOwned {
+		t.Fatalf("workspace-only Codex ownership granted Bob recovery: %#v", accounts[0])
+	}
+	ownership, err := db.ListCodexInspectionDisableOwnership(context.Background())
+	if err != nil {
+		t.Fatalf("list ownership: %v", err)
+	}
+	if len(ownership) != 0 {
+		t.Fatalf("workspace-only ownership = %#v, want stale ownership removed", ownership)
 	}
 }
 

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpa"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 const (
@@ -23,6 +24,8 @@ const (
 )
 
 var ErrAuthFileNotFound = errors.New("CPA auth file not found")
+
+var ErrAuthFileAmbiguous = errors.New("CPA auth file selector is ambiguous")
 
 var ErrIdentityMismatch = errors.New("CPA auth file identity mismatch")
 
@@ -61,8 +64,14 @@ type File struct {
 	Provider        string
 	AccountSnapshot string
 	AccountID       string
-	Disabled        bool
-	Raw             map[string]any
+	// AccountIDInvalid distinguishes an explicit but conflicting/malformed
+	// Codex account-id payload from a credential that simply has no account-id
+	// evidence. Both expose an empty AccountID, but only the former must make
+	// identity verification fail closed even when another field matches.
+	AccountIDInvalid       bool
+	AccountSnapshotInvalid bool
+	Disabled               bool
+	Raw                    map[string]any
 }
 
 type StatusMutationTarget struct {
@@ -279,17 +288,15 @@ func responseTooLargeError(label string, limit int64) error {
 }
 
 func (c *Client) Verify(ctx context.Context, baseURL string, managementKey string, identity Identity) (File, error) {
-	file, ok, err := c.Find(ctx, baseURL, managementKey, identity.AuthFileName, identity.AuthIndex)
+	files := make([]File, 0, 1)
+	err := c.visit(ctx, baseURL, managementKey, identity.AuthFileName, identity.AuthIndex, func(file File) (bool, error) {
+		files = append(files, file)
+		return false, nil
+	})
 	if err != nil {
 		return File{}, err
 	}
-	if !ok {
-		return File{}, ErrAuthFileNotFound
-	}
-	if err := verifyFileIdentity(file, identity); err != nil {
-		return File{}, err
-	}
-	return file, nil
+	return VerifyIdentity(files, identity)
 }
 
 func (c *Client) ResolveVerifiedStatusMutationTarget(
@@ -992,6 +999,18 @@ func Find(files []File, fileName string, authIndex string) (File, bool) {
 	return File{}, false
 }
 
+func matchingFiles(files []File, fileName string, authIndex string) []File {
+	fileName = strings.TrimSpace(fileName)
+	authIndex = strings.TrimSpace(authIndex)
+	matched := make([]File, 0, 1)
+	for _, file := range files {
+		if matches(file, fileName, authIndex) {
+			matched = append(matched, file)
+		}
+	}
+	return matched
+}
+
 func matches(file File, fileName string, authIndex string) bool {
 	fileName = strings.TrimSpace(fileName)
 	authIndex = strings.TrimSpace(authIndex)
@@ -1005,14 +1024,80 @@ func matches(file File, fileName string, authIndex string) bool {
 }
 
 func VerifyIdentity(files []File, identity Identity) (File, error) {
-	file, ok := Find(files, identity.AuthFileName, identity.AuthIndex)
-	if !ok {
+	candidates := matchingFiles(files, identity.AuthFileName, identity.AuthIndex)
+	if len(candidates) == 0 {
 		return File{}, ErrAuthFileNotFound
 	}
+	codexSelector := normalizeAuthProvider(identity.Provider) == "codex"
+	if codexSelector && len(candidates) > 1 {
+		narrowed, applicable := narrowCodexIdentityCandidates(candidates, identity)
+		if !applicable {
+			return File{}, fmt.Errorf(
+				"%w: file %q auth_index %q matched %d credentials",
+				ErrAuthFileAmbiguous,
+				strings.TrimSpace(identity.AuthFileName),
+				strings.TrimSpace(identity.AuthIndex),
+				len(candidates),
+			)
+		}
+		if len(narrowed) == 0 {
+			return File{}, fmt.Errorf(
+				"%w: file %q auth_index %q has no matching Codex Workspace member",
+				ErrIdentityMismatch,
+				strings.TrimSpace(identity.AuthFileName),
+				strings.TrimSpace(identity.AuthIndex),
+			)
+		}
+		candidates = narrowed
+	}
+	if codexSelector && len(candidates) > 1 {
+		return File{}, fmt.Errorf(
+			"%w: file %q auth_index %q matched %d credentials",
+			ErrAuthFileAmbiguous,
+			strings.TrimSpace(identity.AuthFileName),
+			strings.TrimSpace(identity.AuthIndex),
+			len(candidates),
+		)
+	}
+	// Find historically returns the first matching file. Preserve that
+	// behavior for non-Codex providers and for a unique Codex candidate.
+	file := candidates[0]
 	if err := verifyFileIdentity(file, identity); err != nil {
 		return File{}, err
 	}
 	return file, nil
+}
+
+// narrowCodexIdentityCandidates disambiguates a shared file/auth-index
+// selector only when every candidate exposes complete, non-conflicting
+// Workspace+member evidence. A missing or invalid candidate keeps the selector
+// ambiguous; an unknown Team member must never be hidden by a known match.
+func narrowCodexIdentityCandidates(candidates []File, identity Identity) ([]File, bool) {
+	if len(candidates) <= 1 || normalizeAuthProvider(identity.Provider) != "codex" {
+		return nil, false
+	}
+	expectedWorkspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(identity.AccountIDSnapshot)
+	expectedMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(identity.AccountSnapshot)
+	if !workspaceOK || !memberOK {
+		return nil, false
+	}
+
+	matched := make([]File, 0, 1)
+	for _, candidate := range candidates {
+		if candidate.AccountIDInvalid || candidate.AccountSnapshotInvalid ||
+			normalizeAuthProvider(candidate.Provider) != "codex" {
+			return nil, false
+		}
+		workspace, candidateWorkspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(candidate.AccountID)
+		member, candidateMemberOK := usageidentity.NormalizeCodexMemberSnapshot(candidate.AccountSnapshot)
+		if !candidateWorkspaceOK || !candidateMemberOK {
+			return nil, false
+		}
+		if workspace == expectedWorkspace && member == expectedMember && verifyFileIdentity(candidate, identity) == nil {
+			matched = append(matched, candidate)
+		}
+	}
+	return matched, true
 }
 
 func VerifyResolvedIdentity(file File, identity Identity) error {
@@ -1029,11 +1114,75 @@ func verifyFileIdentity(file File, identity Identity) error {
 	if identity.AuthIndex != "" && strings.TrimSpace(file.AuthIndex) != strings.TrimSpace(identity.AuthIndex) {
 		return fmt.Errorf("%w: auth_index mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AuthIndex), strings.TrimSpace(file.AuthIndex))
 	}
-	if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
+	provider := normalizeAuthProvider(file.Provider)
+	hasCodexCredentialLocator := strings.TrimSpace(identity.AuthIndex) != "" || strings.TrimSpace(identity.RuntimeID) != ""
+	if provider == "codex" {
+		expectedAccountID := strings.TrimSpace(identity.AccountIDSnapshot)
+		expectedMember := strings.TrimSpace(identity.AccountSnapshot)
+		if !hasCodexCredentialLocator {
+			if expectedAccountID != "" {
+				normalizedWorkspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(expectedAccountID)
+				if !workspaceOK {
+					return fmt.Errorf(
+						"%w: Codex workspace identity is invalid",
+						ErrIdentityMismatch,
+					)
+				}
+				expectedAccountID = normalizedWorkspace
+			}
+			if expectedMember != "" {
+				normalizedMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(expectedMember)
+				if !memberOK {
+					return fmt.Errorf(
+						"%w: Codex member identity is invalid",
+						ErrIdentityMismatch,
+					)
+				}
+				expectedMember = normalizedMember
+			}
+			if expectedAccountID == "" || expectedMember == "" {
+				return fmt.Errorf(
+					"%w: Codex mutation requires workspace+member identity",
+					ErrIdentityMismatch,
+				)
+			}
+		}
+		if file.AccountIDInvalid {
+			return fmt.Errorf("%w: account_id evidence is invalid or conflicting", ErrIdentityMismatch)
+		}
+		if file.AccountSnapshotInvalid {
+			return fmt.Errorf("%w: account_snapshot evidence is invalid or conflicting", ErrIdentityMismatch)
+		}
+		if expectedAccountID != "" {
+			normalizedExpected, expectedOK := usageidentity.NormalizeCodexWorkspaceSnapshot(expectedAccountID)
+			if !expectedOK || file.AccountID != normalizedExpected {
+				return fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, expectedAccountID, file.AccountID)
+			}
+		}
+	} else if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
 		return fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountIDSnapshot), file.AccountID)
 	}
 	if identity.Provider != "" && normalizeAuthProvider(file.Provider) != normalizeAuthProvider(identity.Provider) {
 		return fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
+	}
+	if provider == "codex" && strings.TrimSpace(identity.AccountSnapshot) != "" {
+		expectedMember, expectedOK := usageidentity.NormalizeCodexMemberSnapshot(identity.AccountSnapshot)
+		if !expectedOK && hasCodexCredentialLocator {
+			// A label or filename can remain in a legacy caller's
+			// account_snapshot field. It is not member evidence, but an explicit
+			// auth_index/runtime id still identifies the physical credential.
+			// Ignore only this weak value; workspace and all strong evidence above
+			// remain enforced.
+			if identity.Provider != "" && provider != normalizeAuthProvider(identity.Provider) {
+				return fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
+			}
+			return nil
+		}
+		actualMember, actualOK := usageidentity.NormalizeCodexMemberSnapshot(file.AccountSnapshot)
+		if !expectedOK || !actualOK || expectedMember != actualMember {
+			return fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
+		}
+		return nil
 	}
 	if identity.AccountIDSnapshot == "" && identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
 		return fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
@@ -1290,15 +1439,20 @@ func filesFromJSON(value any) []File {
 }
 
 func FromMap(file map[string]any) File {
+	provider := normalizeAuthProvider(stringField(file, "provider", "type"))
+	accountID, accountIDInvalid := accountIDField(file, provider)
+	accountSnapshot, accountSnapshotInvalid := accountSnapshotField(file, provider)
 	return File{
-		ID:              stringField(file, "id"),
-		Name:            stringField(file, "name", "file_name", "fileName", "id"),
-		AuthIndex:       stringField(file, "auth_index", "authIndex", "auth-index"),
-		Provider:        normalizeAuthProvider(stringField(file, "provider", "type")),
-		AccountSnapshot: stringField(file, "account", "email", "display_account", "displayAccount"),
-		AccountID:       accountIDField(file),
-		Disabled:        disabledField(file),
-		Raw:             file,
+		ID:                     stringField(file, "id"),
+		Name:                   stringField(file, "name", "file_name", "fileName", "id"),
+		AuthIndex:              stringField(file, "auth_index", "authIndex", "auth-index"),
+		Provider:               provider,
+		AccountSnapshot:        accountSnapshot,
+		AccountID:              accountID,
+		AccountIDInvalid:       accountIDInvalid,
+		AccountSnapshotInvalid: accountSnapshotInvalid,
+		Disabled:               disabledField(file),
+		Raw:                    file,
 	}
 }
 
@@ -1319,28 +1473,149 @@ var accountIDFieldNames = []string{
 	"sub",
 }
 
-func accountIDField(file map[string]any) string {
-	if value := stringField(file, accountIDFieldNames...); value != "" {
-		return value
-	}
-	for _, key := range []string{"id_token", "idToken", "metadata", "attributes"} {
-		if value := accountIDFromValue(file[key]); value != "" {
-			return value
-		}
-	}
-	return ""
+var codexAccountIDFieldNames = []string{
+	"account_id", "accountId", "chatgpt_account_id", "chatgptAccountId",
 }
 
-func accountIDFromValue(value any) string {
+func accountSnapshotField(file map[string]any, provider string) (string, bool) {
+	if provider != "codex" {
+		return stringField(file, "account", "email", "display_account", "displayAccount"), false
+	}
+
+	// account_snapshot, account, and email can all carry member evidence in
+	// different CPA response shapes. Only email-shaped values are strong
+	// evidence, but every strong value must agree; choosing one over another
+	// would allow a stale or cross-member response to pass verification.
+	strongMembers := make([]string, 0, 4)
+	addStrongMember := func(value string) bool {
+		candidate, ok := usageidentity.NormalizeCodexMemberSnapshot(value)
+		if !ok {
+			return true
+		}
+		if len(strongMembers) > 0 && strongMembers[0] != candidate {
+			return false
+		}
+		strongMembers = append(strongMembers, candidate)
+		return true
+	}
+	for _, key := range []string{"account_snapshot", "accountSnapshot"} {
+		raw, present := file[key]
+		if !present || raw == nil {
+			continue
+		}
+		// Keep the raw value here. NormalizeCodexMemberSnapshot intentionally
+		// trims ASCII spaces only; trimming with strings.TrimSpace first would
+		// silently turn Unicode-whitespace input into a different identity than
+		// the Go/SQLite account-key implementation accepts.
+		value := fmt.Sprint(raw)
+		if value == "" || value == "<nil>" {
+			continue
+		}
+		if !addStrongMember(value) {
+			return "", true
+		}
+	}
+	for _, key := range []string{"account", "email"} {
+		if !addStrongMember(rawStringField(file, key)) {
+			return "", true
+		}
+	}
+	if len(strongMembers) == 0 {
+		return "", false
+	}
+	return strongMembers[0], false
+}
+
+func accountIDField(file map[string]any, provider string) (string, bool) {
+	if provider == "codex" {
+		return codexAccountIDField(file)
+	}
+	fieldNames := accountIDFieldNames
+	if value := stringField(file, fieldNames...); value != "" {
+		return value, false
+	}
+	for _, key := range []string{"id_token", "idToken", "metadata", "attributes"} {
+		if value := accountIDFromValue(file[key], provider); value != "" {
+			return value, false
+		}
+	}
+	return "", false
+}
+
+// codexAccountIDField collects every explicit Codex account-id candidate
+// before deciding. A first-candidate read is unsafe because auth files can
+// carry the same evidence in direct fields, metadata, and token payloads. An
+// empty result with invalid=true means an explicit value was malformed or the
+// candidates disagreed; callers must not treat it as a wildcard.
+func codexAccountIDField(file map[string]any) (string, bool) {
+	values := make(map[string]struct{})
+	invalid := false
+	var visit func(any)
+	visit = func(input any) {
+		record, ok := input.(map[string]any)
+		if !ok {
+			return
+		}
+		if record == nil {
+			return
+		}
+		for _, key := range codexAccountIDFieldNames {
+			raw, present := record[key]
+			if !present {
+				continue
+			}
+			if raw == nil {
+				continue
+			}
+			if text, ok := raw.(string); ok && strings.TrimSpace(text) == "" {
+				continue
+			}
+			value, ok := normalizeCodexAccountIDValue(raw)
+			if !ok {
+				invalid = true
+				continue
+			}
+			values[value] = struct{}{}
+		}
+		for _, key := range []string{"id_token", "idToken", "metadata", "attributes"} {
+			nested := record[key]
+			if child, ok := nested.(map[string]any); ok {
+				visit(child)
+			}
+		}
+	}
+	visit(map[string]any(file))
+	if invalid || len(values) > 1 {
+		return "", true
+	}
+	for value := range values {
+		return value, false
+	}
+	return "", false
+}
+func normalizeCodexAccountIDValue(value any) (string, bool) {
+	switch value.(type) {
+	case string, json.Number, float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return usageidentity.NormalizeCodexWorkspaceSnapshot(fmt.Sprint(value))
+	default:
+		return "", false
+	}
+}
+
+func accountIDFromValue(value any, provider string) string {
 	child, ok := value.(map[string]any)
 	if !ok || child == nil {
 		return ""
 	}
-	if accountID := stringField(child, accountIDFieldNames...); accountID != "" {
+	fieldNames := accountIDFieldNames
+	if provider == "codex" {
+		fieldNames = codexAccountIDFieldNames
+	}
+	if accountID := stringField(child, fieldNames...); accountID != "" {
 		return accountID
 	}
 	for _, key := range []string{"id_token", "idToken"} {
-		if accountID := accountIDFromValue(child[key]); accountID != "" {
+		if accountID := accountIDFromValue(child[key], provider); accountID != "" {
 			return accountID
 		}
 	}
@@ -1369,6 +1644,18 @@ func stringField(file map[string]any, keys ...string) string {
 	for _, key := range keys {
 		if raw, ok := file[key]; ok && raw != nil {
 			value := strings.TrimSpace(fmt.Sprint(raw))
+			if value != "" && value != "<nil>" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func rawStringField(file map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if raw, ok := file[key]; ok && raw != nil {
+			value := fmt.Sprint(raw)
 			if value != "" && value != "<nil>" {
 				return value
 			}

--- a/apps/manager-server/internal/service/cpaauthfiles/client.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client.go
@@ -289,7 +289,11 @@ func responseTooLargeError(label string, limit int64) error {
 
 func (c *Client) Verify(ctx context.Context, baseURL string, managementKey string, identity Identity) (File, error) {
 	files := make([]File, 0, 1)
-	err := c.visit(ctx, baseURL, managementKey, identity.AuthFileName, identity.AuthIndex, func(file File) (bool, error) {
+	selector := strings.TrimSpace(identity.RuntimeID)
+	if selector == "" {
+		selector = strings.TrimSpace(identity.AuthFileName)
+	}
+	err := c.visit(ctx, baseURL, managementKey, selector, identity.AuthIndex, func(file File) (bool, error) {
 		files = append(files, file)
 		return false, nil
 	})
@@ -305,93 +309,20 @@ func (c *Client) ResolveVerifiedStatusMutationTarget(
 	managementKey string,
 	identity Identity,
 ) (StatusMutationTarget, error) {
-	target, err := c.ResolveStatusMutationTarget(
+	selector := strings.TrimSpace(identity.RuntimeID)
+	if selector == "" {
+		selector = strings.TrimSpace(identity.AuthFileName)
+	}
+	target, err := c.resolveStatusMutationTarget(
 		ctx,
 		baseURL,
 		managementKey,
-		identity.AuthFileName,
+		selector,
 		identity.AuthIndex,
-	)
-	if err == nil {
-		if identityErr := verifyFileIdentity(target.File, identity); identityErr != nil {
-			return StatusMutationTarget{}, identityErr
-		}
-		return target, nil
-	} else if !errors.Is(err, ErrAuthFileNotFound) && !errors.Is(err, ErrStatusMutationScopeAmbiguous) {
-		return StatusMutationTarget{}, err
-	}
-
-	files, fetchErr := c.fetchStatusMutationCandidates(
-		ctx,
-		baseURL,
-		managementKey,
-		strings.TrimSpace(identity.AuthFileName),
-	)
-	if fetchErr != nil {
-		return StatusMutationTarget{}, fetchErr
-	}
-	candidates := statusMutationMatches(
-		files,
-		strings.TrimSpace(identity.AuthFileName),
-		strings.TrimSpace(identity.AuthIndex),
-	)
-	verified := make([]File, 0, 1)
-	var identityErr error
-	for _, candidate := range candidates {
-		if candidateErr := verifyFileIdentity(candidate, identity); candidateErr != nil {
-			if identityErr == nil {
-				identityErr = candidateErr
-			}
-			continue
-		}
-		verified = append(verified, candidate)
-	}
-	if len(verified) == 0 {
-		if len(candidates) == 1 && identityErr != nil {
-			return StatusMutationTarget{}, identityErr
-		}
-		return StatusMutationTarget{}, fmt.Errorf(
-			"%w: selector %q auth_index %q credential identity changed",
-			ErrIdentityMismatch,
-			strings.TrimSpace(identity.AuthFileName),
-			strings.TrimSpace(identity.AuthIndex),
-		)
-	}
-	if len(verified) > 1 {
-		return StatusMutationTarget{}, fmt.Errorf(
-			"%w: selector %q auth_index %q identity maps to multiple credentials",
-			ErrStatusMutationScopeAmbiguous,
-			strings.TrimSpace(identity.AuthFileName),
-			strings.TrimSpace(identity.AuthIndex),
-		)
-	}
-
-	matched := verified[0]
-	runtimeID := strings.TrimSpace(matched.ID)
-	if runtimeID == "" {
-		return StatusMutationTarget{}, fmt.Errorf(
-			"%w: %q has no runtime id",
-			ErrStatusMutationScopeAmbiguous,
-			strings.TrimSpace(matched.Name),
-		)
-	}
-	target, err = c.ResolveStatusMutationTarget(
-		ctx,
-		baseURL,
-		managementKey,
-		runtimeID,
-		strings.TrimSpace(matched.AuthIndex),
+		strings.TrimSpace(identity.RuntimeID) != "",
 	)
 	if err != nil {
 		return StatusMutationTarget{}, err
-	}
-	if strings.TrimSpace(target.File.ID) != runtimeID {
-		return StatusMutationTarget{}, fmt.Errorf(
-			"%w: runtime target changed (expected %q, got %q)",
-			ErrIdentityMismatch,
-			runtimeID,
-			strings.TrimSpace(target.File.ID),
-		)
 	}
 	if err := verifyFileIdentity(target.File, identity); err != nil {
 		return StatusMutationTarget{}, err
@@ -405,7 +336,43 @@ func (c *Client) ResolveVerifiedDeleteMutationTarget(
 	managementKey string,
 	identity Identity,
 ) (DeleteMutationTarget, error) {
-	return c.resolveVerifiedPhysicalFileDeleteTarget(ctx, baseURL, managementKey, []Identity{identity}, false)
+	selector := strings.TrimSpace(identity.RuntimeID)
+	if selector == "" {
+		selector = strings.TrimSpace(identity.AuthFileName)
+	}
+	target, err := c.resolveStatusMutationTarget(
+		ctx,
+		baseURL,
+		managementKey,
+		selector,
+		identity.AuthIndex,
+		strings.TrimSpace(identity.RuntimeID) != "",
+	)
+	if err != nil {
+		return DeleteMutationTarget{}, err
+	}
+	if target.Scope != StatusMutationScopeCredential {
+		return DeleteMutationTarget{}, fmt.Errorf(
+			"%w: selector %q affects multiple credentials",
+			ErrDeleteMutationScopeAmbiguous,
+			selector,
+		)
+	}
+	if err := verifyFileIdentity(target.File, identity); err != nil {
+		return DeleteMutationTarget{}, err
+	}
+	if strings.TrimSpace(target.File.ID) == "" {
+		return DeleteMutationTarget{}, fmt.Errorf(
+			"%w: selector %q has no runtime id",
+			ErrDeleteMutationScopeAmbiguous,
+			selector,
+		)
+	}
+	return DeleteMutationTarget{
+		Selector:      target.Selector,
+		File:          target.File,
+		AffectedFiles: target.AffectedFiles,
+	}, nil
 }
 
 func (c *Client) ResolveVerifiedPhysicalFileDeleteTarget(
@@ -459,31 +426,33 @@ func (c *Client) resolveVerifiedPhysicalFileDeleteTarget(
 	used := make([]bool, len(members))
 	for _, identity := range identities {
 		locatorMatches := make([]int, 0, 1)
-		verifiedMatches := make([]int, 0, 1)
-		var identityErr error
 		for index, member := range members {
-			if used[index] || (strings.TrimSpace(identity.AuthIndex) != "" && strings.TrimSpace(member.AuthIndex) != strings.TrimSpace(identity.AuthIndex)) {
+			if used[index] {
+				continue
+			}
+			runtimeID := strings.TrimSpace(identity.RuntimeID)
+			authIndex := strings.TrimSpace(identity.AuthIndex)
+			switch {
+			case runtimeID != "" && strings.TrimSpace(member.ID) == runtimeID:
+			case runtimeID == "" && authIndex != "" && strings.TrimSpace(member.AuthIndex) == authIndex:
+			default:
 				continue
 			}
 			locatorMatches = append(locatorMatches, index)
-			if err := verifyFileIdentity(member, identity); err != nil {
-				if identityErr == nil {
-					identityErr = err
-				}
-				continue
-			}
-			verifiedMatches = append(verifiedMatches, index)
 		}
-		if len(verifiedMatches) == 0 {
-			if len(locatorMatches) == 1 && identityErr != nil {
-				return DeleteMutationTarget{}, identityErr
+		if len(locatorMatches) == 0 {
+			if strings.TrimSpace(identity.RuntimeID) == "" && strings.TrimSpace(identity.AuthIndex) == "" {
+				return DeleteMutationTarget{}, fmt.Errorf("%w: physical file %q identity has no credential locator", ErrDeleteMutationScopeAmbiguous, physicalName)
 			}
 			return DeleteMutationTarget{}, fmt.Errorf("%w: physical file %q credential identity changed", ErrIdentityMismatch, physicalName)
 		}
-		if len(verifiedMatches) > 1 {
-			return DeleteMutationTarget{}, fmt.Errorf("%w: physical file %q identity maps to multiple credentials", ErrDeleteMutationScopeAmbiguous, physicalName)
+		if len(locatorMatches) > 1 {
+			return DeleteMutationTarget{}, fmt.Errorf("%w: physical file %q credential locator maps to multiple credentials", ErrDeleteMutationScopeAmbiguous, physicalName)
 		}
-		matchIndex := verifiedMatches[0]
+		matchIndex := locatorMatches[0]
+		if err := verifyFileIdentity(members[matchIndex], identity); err != nil {
+			return DeleteMutationTarget{}, err
+		}
 		used[matchIndex] = true
 		matched = append(matched, members[matchIndex])
 	}
@@ -522,6 +491,17 @@ func (c *Client) ResolveStatusMutationTarget(
 	selector string,
 	authIndex string,
 ) (StatusMutationTarget, error) {
+	return c.resolveStatusMutationTarget(ctx, baseURL, managementKey, selector, authIndex, false)
+}
+
+func (c *Client) resolveStatusMutationTarget(
+	ctx context.Context,
+	baseURL string,
+	managementKey string,
+	selector string,
+	authIndex string,
+	runtimeOnly bool,
+) (StatusMutationTarget, error) {
 	selector = strings.TrimSpace(selector)
 	authIndex = strings.TrimSpace(authIndex)
 	if selector == "" {
@@ -532,7 +512,7 @@ func (c *Client) ResolveStatusMutationTarget(
 	if err != nil {
 		return StatusMutationTarget{}, err
 	}
-	candidates := statusMutationMatches(files, selector, authIndex)
+	candidates := statusMutationMatches(files, selector, authIndex, runtimeOnly)
 	if len(candidates) == 0 {
 		return StatusMutationTarget{}, fmt.Errorf("%w: selector %q auth_index %q", ErrAuthFileNotFound, selector, authIndex)
 	}
@@ -552,7 +532,7 @@ func (c *Client) ResolveStatusMutationTarget(
 			return StatusMutationTarget{}, fetchErr
 		}
 		files = mergeStatusMutationFiles(files, siblings)
-		candidates = statusMutationMatches(files, selector, authIndex)
+		candidates = statusMutationMatches(files, selector, authIndex, runtimeOnly)
 		if len(candidates) == 0 {
 			return StatusMutationTarget{}, fmt.Errorf("%w: selector %q auth_index %q", ErrAuthFileNotFound, selector, authIndex)
 		}
@@ -707,20 +687,35 @@ func verifySourceFileStatusMutationMembers(files []File, physicalName string, ex
 		if strings.TrimSpace(identity.AuthFileName) != physicalName {
 			return fmt.Errorf("%w: source member belongs to a different physical file", ErrIdentityMismatch)
 		}
-		matches := make([]int, 0, 1)
+		locatorMatches := make([]int, 0, 1)
 		for index, file := range files {
-			if used[index] || verifyFileIdentity(file, identity) != nil {
+			if used[index] {
 				continue
 			}
-			matches = append(matches, index)
+			runtimeID := strings.TrimSpace(identity.RuntimeID)
+			authIndex := strings.TrimSpace(identity.AuthIndex)
+			switch {
+			case runtimeID != "" && strings.TrimSpace(file.ID) == runtimeID:
+			case runtimeID == "" && authIndex != "" && strings.TrimSpace(file.AuthIndex) == authIndex:
+			default:
+				continue
+			}
+			locatorMatches = append(locatorMatches, index)
 		}
-		if len(matches) == 0 {
+		if len(locatorMatches) == 0 {
+			if strings.TrimSpace(identity.RuntimeID) == "" && strings.TrimSpace(identity.AuthIndex) == "" {
+				return fmt.Errorf("%w: physical file %q source member has no credential locator", ErrStatusMutationScopeAmbiguous, physicalName)
+			}
 			return fmt.Errorf("%w: physical file %q member identity changed", ErrIdentityMismatch, physicalName)
 		}
-		if len(matches) > 1 {
-			return fmt.Errorf("%w: physical file %q member identity is ambiguous", ErrStatusMutationScopeAmbiguous, physicalName)
+		if len(locatorMatches) > 1 {
+			return fmt.Errorf("%w: physical file %q source member locator is ambiguous", ErrStatusMutationScopeAmbiguous, physicalName)
 		}
-		used[matches[0]] = true
+		matchIndex := locatorMatches[0]
+		if err := verifyFileIdentity(files[matchIndex], identity); err != nil {
+			return err
+		}
+		used[matchIndex] = true
 	}
 	return nil
 }
@@ -741,7 +736,7 @@ func (c *Client) fetchStatusMutationCandidates(
 	return files, nil
 }
 
-func statusMutationMatches(files []File, selector string, authIndex string) []File {
+func statusMutationMatches(files []File, selector string, authIndex string, runtimeOnly bool) []File {
 	idMatches := make([]File, 0, 1)
 	nameMatches := make([]File, 0, 1)
 	selectorMatchesRuntimeID := false
@@ -751,6 +746,9 @@ func statusMutationMatches(files []File, selector string, authIndex string) []Fi
 			if authIndex == "" || strings.TrimSpace(file.AuthIndex) == authIndex {
 				idMatches = append(idMatches, file)
 			}
+			continue
+		}
+		if runtimeOnly {
 			continue
 		}
 		if strings.TrimSpace(file.Name) == selector &&
@@ -1025,31 +1023,13 @@ func matches(file File, fileName string, authIndex string) bool {
 
 func VerifyIdentity(files []File, identity Identity) (File, error) {
 	candidates := matchingFiles(files, identity.AuthFileName, identity.AuthIndex)
+	if runtimeID := strings.TrimSpace(identity.RuntimeID); runtimeID != "" {
+		candidates = matchingRuntimeID(files, runtimeID, identity.AuthIndex)
+	}
 	if len(candidates) == 0 {
 		return File{}, ErrAuthFileNotFound
 	}
 	codexSelector := normalizeAuthProvider(identity.Provider) == "codex"
-	if codexSelector && len(candidates) > 1 {
-		narrowed, applicable := narrowCodexIdentityCandidates(candidates, identity)
-		if !applicable {
-			return File{}, fmt.Errorf(
-				"%w: file %q auth_index %q matched %d credentials",
-				ErrAuthFileAmbiguous,
-				strings.TrimSpace(identity.AuthFileName),
-				strings.TrimSpace(identity.AuthIndex),
-				len(candidates),
-			)
-		}
-		if len(narrowed) == 0 {
-			return File{}, fmt.Errorf(
-				"%w: file %q auth_index %q has no matching Codex Workspace member",
-				ErrIdentityMismatch,
-				strings.TrimSpace(identity.AuthFileName),
-				strings.TrimSpace(identity.AuthIndex),
-			)
-		}
-		candidates = narrowed
-	}
 	if codexSelector && len(candidates) > 1 {
 		return File{}, fmt.Errorf(
 			"%w: file %q auth_index %q matched %d credentials",
@@ -1068,36 +1048,20 @@ func VerifyIdentity(files []File, identity Identity) (File, error) {
 	return file, nil
 }
 
-// narrowCodexIdentityCandidates disambiguates a shared file/auth-index
-// selector only when every candidate exposes complete, non-conflicting
-// Workspace+member evidence. A missing or invalid candidate keeps the selector
-// ambiguous; an unknown Team member must never be hidden by a known match.
-func narrowCodexIdentityCandidates(candidates []File, identity Identity) ([]File, bool) {
-	if len(candidates) <= 1 || normalizeAuthProvider(identity.Provider) != "codex" {
-		return nil, false
-	}
-	expectedWorkspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(identity.AccountIDSnapshot)
-	expectedMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(identity.AccountSnapshot)
-	if !workspaceOK || !memberOK {
-		return nil, false
-	}
-
+func matchingRuntimeID(files []File, runtimeID string, authIndex string) []File {
+	runtimeID = strings.TrimSpace(runtimeID)
+	authIndex = strings.TrimSpace(authIndex)
 	matched := make([]File, 0, 1)
-	for _, candidate := range candidates {
-		if candidate.AccountIDInvalid || candidate.AccountSnapshotInvalid ||
-			normalizeAuthProvider(candidate.Provider) != "codex" {
-			return nil, false
+	for _, file := range files {
+		if strings.TrimSpace(file.ID) != runtimeID {
+			continue
 		}
-		workspace, candidateWorkspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(candidate.AccountID)
-		member, candidateMemberOK := usageidentity.NormalizeCodexMemberSnapshot(candidate.AccountSnapshot)
-		if !candidateWorkspaceOK || !candidateMemberOK {
-			return nil, false
+		if authIndex != "" && strings.TrimSpace(file.AuthIndex) != authIndex {
+			continue
 		}
-		if workspace == expectedWorkspace && member == expectedMember && verifyFileIdentity(candidate, identity) == nil {
-			matched = append(matched, candidate)
-		}
+		matched = append(matched, file)
 	}
-	return matched, true
+	return matched
 }
 
 func VerifyResolvedIdentity(file File, identity Identity) error {
@@ -1115,76 +1079,54 @@ func verifyFileIdentity(file File, identity Identity) error {
 		return fmt.Errorf("%w: auth_index mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AuthIndex), strings.TrimSpace(file.AuthIndex))
 	}
 	provider := normalizeAuthProvider(file.Provider)
-	hasCodexCredentialLocator := strings.TrimSpace(identity.AuthIndex) != "" || strings.TrimSpace(identity.RuntimeID) != ""
+	if identity.Provider != "" && provider != normalizeAuthProvider(identity.Provider) {
+		return fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
+	}
 	if provider == "codex" {
-		expectedAccountID := strings.TrimSpace(identity.AccountIDSnapshot)
-		expectedMember := strings.TrimSpace(identity.AccountSnapshot)
-		if !hasCodexCredentialLocator {
-			if expectedAccountID != "" {
-				normalizedWorkspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(expectedAccountID)
-				if !workspaceOK {
-					return fmt.Errorf(
-						"%w: Codex workspace identity is invalid",
-						ErrIdentityMismatch,
-					)
-				}
-				expectedAccountID = normalizedWorkspace
-			}
-			if expectedMember != "" {
-				normalizedMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(expectedMember)
-				if !memberOK {
-					return fmt.Errorf(
-						"%w: Codex member identity is invalid",
-						ErrIdentityMismatch,
-					)
-				}
-				expectedMember = normalizedMember
-			}
-			if expectedAccountID == "" || expectedMember == "" {
-				return fmt.Errorf(
-					"%w: Codex mutation requires workspace+member identity",
-					ErrIdentityMismatch,
-				)
-			}
-		}
 		if file.AccountIDInvalid {
 			return fmt.Errorf("%w: account_id evidence is invalid or conflicting", ErrIdentityMismatch)
 		}
 		if file.AccountSnapshotInvalid {
 			return fmt.Errorf("%w: account_snapshot evidence is invalid or conflicting", ErrIdentityMismatch)
 		}
-		if expectedAccountID != "" {
-			normalizedExpected, expectedOK := usageidentity.NormalizeCodexWorkspaceSnapshot(expectedAccountID)
-			if !expectedOK || file.AccountID != normalizedExpected {
-				return fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, expectedAccountID, file.AccountID)
+
+		hasCredentialLocator := strings.TrimSpace(identity.AuthIndex) != "" || strings.TrimSpace(identity.RuntimeID) != ""
+		expectedWorkspace := ""
+		if raw := strings.TrimSpace(identity.AccountIDSnapshot); raw != "" {
+			var ok bool
+			expectedWorkspace, ok = usageidentity.NormalizeCodexWorkspaceSnapshot(raw)
+			if !ok {
+				return fmt.Errorf("%w: Codex workspace identity is invalid", ErrIdentityMismatch)
+			}
+		}
+		expectedMember := ""
+		if raw := strings.TrimSpace(identity.AccountSnapshot); raw != "" {
+			var ok bool
+			expectedMember, ok = usageidentity.NormalizeCodexMemberSnapshot(raw)
+			if !ok && !hasCredentialLocator {
+				return fmt.Errorf("%w: Codex member identity is invalid", ErrIdentityMismatch)
+			}
+		}
+
+		if !hasCredentialLocator && (expectedWorkspace == "" || expectedMember == "") {
+			return fmt.Errorf("%w: Codex mutation requires workspace+member identity", ErrIdentityMismatch)
+		}
+		if expectedWorkspace != "" && strings.TrimSpace(file.AccountID) != "" {
+			actualWorkspace, ok := usageidentity.NormalizeCodexWorkspaceSnapshot(file.AccountID)
+			if !ok || actualWorkspace != expectedWorkspace {
+				return fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, expectedWorkspace, file.AccountID)
+			}
+		}
+		if expectedMember != "" && strings.TrimSpace(file.AccountSnapshot) != "" {
+			actualMember, ok := usageidentity.NormalizeCodexMemberSnapshot(file.AccountSnapshot)
+			if ok && actualMember != expectedMember {
+				return fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, expectedMember, file.AccountSnapshot)
 			}
 		}
 	} else if identity.AccountIDSnapshot != "" && file.AccountID != strings.TrimSpace(identity.AccountIDSnapshot) {
 		return fmt.Errorf("%w: account_id mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountIDSnapshot), file.AccountID)
 	}
-	if identity.Provider != "" && normalizeAuthProvider(file.Provider) != normalizeAuthProvider(identity.Provider) {
-		return fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
-	}
-	if provider == "codex" && strings.TrimSpace(identity.AccountSnapshot) != "" {
-		expectedMember, expectedOK := usageidentity.NormalizeCodexMemberSnapshot(identity.AccountSnapshot)
-		if !expectedOK && hasCodexCredentialLocator {
-			// A label or filename can remain in a legacy caller's
-			// account_snapshot field. It is not member evidence, but an explicit
-			// auth_index/runtime id still identifies the physical credential.
-			// Ignore only this weak value; workspace and all strong evidence above
-			// remain enforced.
-			if identity.Provider != "" && provider != normalizeAuthProvider(identity.Provider) {
-				return fmt.Errorf("%w: provider mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.Provider), file.Provider)
-			}
-			return nil
-		}
-		actualMember, actualOK := usageidentity.NormalizeCodexMemberSnapshot(file.AccountSnapshot)
-		if !expectedOK || !actualOK || expectedMember != actualMember {
-			return fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
-		}
-		return nil
-	}
-	if identity.AccountIDSnapshot == "" && identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
+	if provider != "codex" && identity.AccountIDSnapshot == "" && identity.AccountSnapshot != "" && file.AccountSnapshot != strings.TrimSpace(identity.AccountSnapshot) {
 		return fmt.Errorf("%w: account_snapshot mismatch (expected %q, got %q)", ErrIdentityMismatch, strings.TrimSpace(identity.AccountSnapshot), file.AccountSnapshot)
 	}
 	return nil

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -51,8 +51,144 @@ func TestParseAndVerifyIdentity(t *testing.T) {
 		Provider:          "codex",
 		AccountIDSnapshot: "acct-123",
 		AccountSnapshot:   "renamed@example.com",
+	}); !errors.Is(err, ErrIdentityMismatch) || !strings.Contains(err.Error(), "account_snapshot mismatch") {
+		t.Fatalf("Codex member mismatch err = %v, want ErrIdentityMismatch", err)
+	}
+	if _, err := VerifyIdentity(files, Identity{
+		AuthFileName:      "codex-auth.json",
+		AuthIndex:         "7",
+		Provider:          "codex",
+		AccountIDSnapshot: "acct-123",
+		AccountSnapshot:   "USER@EXAMPLE.COM",
 	}); err != nil {
-		t.Fatalf("stable account id should remain authoritative after display account change: %v", err)
+		t.Fatalf("normalized Codex member should verify: %v", err)
+	}
+}
+
+func TestVerifyIdentityDisambiguatesDuplicateSelectorCandidatesByCodexMember(t *testing.T) {
+	files := []File{
+		FromMap(map[string]any{
+			"id":         "runtime-alice",
+			"name":       "team.json",
+			"auth_index": "auth-1",
+			"provider":   "codex",
+			"account_id": "workspace-1",
+			"account":    "alice@example.com",
+		}),
+		FromMap(map[string]any{
+			"id":         "runtime-bob",
+			"name":       "team.json",
+			"auth_index": "auth-1",
+			"provider":   "codex",
+			"account_id": "workspace-1",
+			"account":    "bob@example.com",
+		}),
+	}
+
+	file, err := VerifyIdentity(files, Identity{
+		AuthFileName:      "team.json",
+		AuthIndex:         "auth-1",
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-1",
+		AccountSnapshot:   "alice@example.com",
+	})
+	if err != nil || file.ID != "runtime-alice" {
+		t.Fatalf("duplicate selector verification = %#v, %v; want Alice", file, err)
+	}
+	if found, ok := Find(files, "team.json", "auth-1"); !ok || found.ID != "runtime-alice" {
+		t.Fatalf("legacy Find semantics = %#v, %t; want first match", found, ok)
+	}
+}
+
+func TestVerifyIdentityKeepsDuplicateSelectorAmbiguousWithoutCompleteCodexEvidence(t *testing.T) {
+	files := []File{
+		FromMap(map[string]any{
+			"id":         "runtime-alice",
+			"name":       "team.json",
+			"auth_index": "auth-1",
+			"provider":   "codex",
+			"account_id": "workspace-1",
+			"account":    "alice@example.com",
+		}),
+		FromMap(map[string]any{
+			"id":         "runtime-unknown",
+			"name":       "team.json",
+			"auth_index": "auth-1",
+			"provider":   "codex",
+			"account_id": "workspace-1",
+		}),
+	}
+
+	if _, err := VerifyIdentity(files, Identity{
+		AuthFileName:      "team.json",
+		AuthIndex:         "auth-1",
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-1",
+		AccountSnapshot:   "alice@example.com",
+	}); !errors.Is(err, ErrAuthFileAmbiguous) {
+		t.Fatalf("incomplete duplicate selector verification error = %v, want ErrAuthFileAmbiguous", err)
+	}
+}
+
+func TestVerifyIdentityPreservesNonCodexFirstMatch(t *testing.T) {
+	files := []File{
+		FromMap(map[string]any{
+			"id":         "runtime-first",
+			"name":       "shared.json",
+			"auth_index": "auth-1",
+			"provider":   "gemini",
+			"account":    "first@example.com",
+		}),
+		FromMap(map[string]any{
+			"id":         "runtime-second",
+			"name":       "shared.json",
+			"auth_index": "auth-1",
+			"provider":   "gemini",
+			"account":    "second@example.com",
+		}),
+	}
+
+	file, err := VerifyIdentity(files, Identity{
+		AuthFileName: "shared.json",
+		AuthIndex:    "auth-1",
+		Provider:     "gemini",
+	})
+	if err != nil || file.ID != "runtime-first" {
+		t.Fatalf("non-Codex duplicate selector verification = %#v, %v; want first match", file, err)
+	}
+}
+
+func TestClientVerifyDisambiguatesWithoutChangingLegacyFindSemantics(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("name"); got != "team.json" {
+			t.Fatalf("name query = %q", got)
+		}
+		if got := r.URL.Query().Get("auth_index"); got != "auth-1" {
+			t.Fatalf("auth_index query = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"files": []map[string]any{
+				{"id": "runtime-alice", "name": "team.json", "auth_index": "auth-1", "provider": "codex", "account_id": "workspace-1", "account": "alice@example.com"},
+				{"id": "runtime-bob", "name": "team.json", "auth_index": "auth-1", "provider": "codex", "account_id": "workspace-1", "account": "bob@example.com"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.Client())
+	identity := Identity{
+		AuthFileName:      "team.json",
+		AuthIndex:         "auth-1",
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-1",
+		AccountSnapshot:   "alice@example.com",
+	}
+	if found, ok, err := client.Find(context.Background(), server.URL, "mgmt", identity.AuthFileName, identity.AuthIndex); err != nil || !ok || found.ID != "runtime-alice" {
+		t.Fatalf("Client.Find() = %#v, ok:%t err:%v; want legacy first match", found, ok, err)
+	}
+	file, err := client.Verify(context.Background(), server.URL, "mgmt", identity)
+	if err != nil || file.ID != "runtime-alice" {
+		t.Fatalf("Client.Verify() = %#v, %v; want Alice", file, err)
 	}
 }
 
@@ -200,6 +336,174 @@ func TestFromMapExtractsNestedAccountIDs(t *testing.T) {
 				t.Fatalf("AccountID = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFromMapDoesNotDecodeJWTClaimsForNonCodexProviders(t *testing.T) {
+	file := FromMap(map[string]any{
+		"id":       "runtime-jwt-claude",
+		"provider": "claude",
+		"id_token": "header.eyJzdWIiOiJhY2N0LWp3dCJ9.signature",
+	})
+	if file.AccountID != "" {
+		t.Fatalf("non-Codex JWT AccountID = %q, want empty", file.AccountID)
+	}
+}
+
+func TestFromMapRejectsConflictingCodexAccountIDs(t *testing.T) {
+	file := FromMap(map[string]any{
+		"id":         "runtime-conflict",
+		"provider":   "codex",
+		"account_id": "workspace-a",
+		"metadata": map[string]any{
+			"id_token": map[string]any{"chatgpt_account_id": "workspace-b"},
+		},
+	})
+	if file.AccountID != "" || !file.AccountIDInvalid {
+		t.Fatalf("conflicting account identity = %#v, want empty invalid evidence", file)
+	}
+	if err := VerifyResolvedIdentity(file, Identity{
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-a",
+	}); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("conflicting account identity verification error = %v, want mismatch", err)
+	}
+}
+
+func TestFromMapRejectsConflictingCodexMemberSnapshots(t *testing.T) {
+	file := FromMap(map[string]any{
+		"id":               "runtime-member-conflict",
+		"provider":         "codex",
+		"account_id":       "workspace-a",
+		"account_snapshot": "bob@example.com",
+		"accountSnapshot":  "alice@example.com",
+		"account":          "stale@example.com",
+	})
+	if file.AccountSnapshot != "" || !file.AccountSnapshotInvalid {
+		t.Fatalf("conflicting member identity = %#v, want empty invalid evidence", file)
+	}
+	if err := VerifyResolvedIdentity(file, Identity{
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-a",
+		AccountSnapshot:   "alice@example.com",
+	}); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("conflicting member identity verification error = %v, want mismatch", err)
+	}
+}
+
+func TestFromMapRejectsStrongCodexMemberSnapshotConflictingWithDisplayEmail(t *testing.T) {
+	for _, field := range []string{"account", "email"} {
+		t.Run(field, func(t *testing.T) {
+			file := FromMap(map[string]any{
+				"id":               "runtime-member-display-conflict",
+				"provider":         "codex",
+				"account_id":       "workspace-a",
+				"account_snapshot": "alice@example.com",
+				field:              "bob@example.com",
+			})
+			if file.AccountSnapshot != "" || !file.AccountSnapshotInvalid {
+				t.Fatalf("conflicting member identity = %#v, want empty invalid evidence", file)
+			}
+		})
+	}
+}
+
+func TestFromMapIgnoresWeakExplicitCodexMemberSnapshot(t *testing.T) {
+	file := FromMap(map[string]any{
+		"id":               "runtime-member-invalid",
+		"provider":         "codex",
+		"auth_index":       "auth-1",
+		"account_id":       "workspace-a",
+		"account_snapshot": "Alice",
+		"email":            "alice@example.com",
+	})
+	if file.AccountSnapshot != "alice@example.com" || file.AccountSnapshotInvalid {
+		t.Fatalf("weak member identity = %#v, want strong email without invalid evidence", file)
+	}
+	if err := VerifyResolvedIdentity(file, Identity{
+		AuthIndex:         "auth-1",
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-a",
+		AccountSnapshot:   "alice@example.com",
+	}); err != nil {
+		t.Fatalf("weak display value must not block credential verification: %v", err)
+	}
+}
+
+func TestFromMapDoesNotTrimUnicodeWhitespaceBeforeCodexMemberNormalization(t *testing.T) {
+	for _, field := range []string{"account_snapshot", "accountSnapshot", "account", "email"} {
+		t.Run(field, func(t *testing.T) {
+			file := FromMap(map[string]any{
+				"id":       "runtime-unicode-member",
+				"provider": "codex",
+				field:      "\u2003alice@example.com",
+			})
+			if file.AccountSnapshot != "" || file.AccountSnapshotInvalid {
+				t.Fatalf("Unicode-whitespace member field = %#v, want no strong member evidence", file)
+			}
+		})
+	}
+}
+
+func TestVerifyResolvedIdentityIgnoresWeakCodexMemberWithCredentialLocator(t *testing.T) {
+	file := FromMap(map[string]any{
+		"id":         "runtime-member-locator",
+		"name":       "codex-auth.json",
+		"auth_index": "auth-1",
+		"provider":   "codex",
+		"account_id": "workspace-a",
+		"account":    "alice@example.com",
+	})
+
+	for _, identity := range []Identity{
+		{
+			AuthFileName:      "codex-auth.json",
+			AuthIndex:         "auth-1",
+			Provider:          "codex",
+			AccountIDSnapshot: "workspace-a",
+			AccountSnapshot:   "Alice",
+		},
+		{
+			AuthFileName:    "codex-auth.json",
+			RuntimeID:       "runtime-member-locator",
+			Provider:        "codex",
+			AccountSnapshot: "Alice",
+		},
+	} {
+		if err := VerifyResolvedIdentity(file, identity); err != nil {
+			t.Fatalf("weak member with credential locator rejected: identity=%#v err=%v", identity, err)
+		}
+	}
+
+	if err := VerifyResolvedIdentity(file, Identity{
+		AuthFileName:      "codex-auth.json",
+		Provider:          "codex",
+		AccountIDSnapshot: "workspace-a",
+		AccountSnapshot:   "Alice",
+	}); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("weak member without credential locator error = %v, want ErrIdentityMismatch", err)
+	}
+}
+
+func TestVerifyResolvedIdentityRejectsProviderMismatchBeforeWeakCodexMemberReturn(t *testing.T) {
+	file := FromMap(map[string]any{
+		"id":         "runtime-provider-mismatch",
+		"name":       "codex-auth.json",
+		"auth_index": "auth-1",
+		"provider":   "codex",
+		"account_id": "workspace-a",
+		"account":    "Alice",
+	})
+
+	err := VerifyResolvedIdentity(file, Identity{
+		AuthFileName:      "codex-auth.json",
+		AuthIndex:         "auth-1",
+		Provider:          "gemini",
+		AccountIDSnapshot: "workspace-a",
+		AccountSnapshot:   "Alice",
+	})
+	if !errors.Is(err, ErrIdentityMismatch) || !strings.Contains(err.Error(), "provider mismatch") {
+		t.Fatalf("provider mismatch error = %v, want ErrIdentityMismatch/provider mismatch", err)
 	}
 }
 
@@ -370,16 +674,18 @@ func TestClientResolveVerifiedStatusMutationTargetUsesAccountIdentityWithoutAuth
 		}
 		_ = json.NewEncoder(w).Encode([]map[string]any{
 			{
-				"id":       "runtime-first",
-				"name":     "shared.json",
-				"provider": "codex",
-				"account":  "first@example.com",
+				"id":         "runtime-first",
+				"name":       "shared.json",
+				"account_id": "workspace-1",
+				"provider":   "codex",
+				"account":    "first@example.com",
 			},
 			{
-				"id":       "runtime-second",
-				"name":     "shared.json",
-				"provider": "codex",
-				"account":  "second@example.com",
+				"id":         "runtime-second",
+				"name":       "shared.json",
+				"account_id": "workspace-1",
+				"provider":   "codex",
+				"account":    "second@example.com",
 			},
 		})
 	}))
@@ -390,13 +696,14 @@ func TestClientResolveVerifiedStatusMutationTargetUsesAccountIdentityWithoutAuth
 		server.URL,
 		"mgmt",
 		Identity{
-			AuthFileName:    "shared.json",
-			Provider:        "codex",
-			AccountSnapshot: "second@example.com",
+			AuthFileName:      "shared.json",
+			Provider:          "codex",
+			AccountIDSnapshot: "workspace-1",
+			AccountSnapshot:   "second@example.com",
 		},
 	)
 	if err != nil {
-		t.Fatalf("resolve verified target without auth index: %v", err)
+		t.Fatalf("resolve verified target by workspace+member: %v", err)
 	}
 	if target.Selector != "runtime-second" || target.File.AccountSnapshot != "second@example.com" || target.Scope != StatusMutationScopeCredential {
 		t.Fatalf("target = %#v, want second credential runtime target", target)

--- a/apps/manager-server/internal/service/cpaauthfiles/client_test.go
+++ b/apps/manager-server/internal/service/cpaauthfiles/client_test.go
@@ -65,7 +65,7 @@ func TestParseAndVerifyIdentity(t *testing.T) {
 	}
 }
 
-func TestVerifyIdentityDisambiguatesDuplicateSelectorCandidatesByCodexMember(t *testing.T) {
+func TestVerifyIdentityKeepsDuplicateCodexSelectorAmbiguous(t *testing.T) {
 	files := []File{
 		FromMap(map[string]any{
 			"id":         "runtime-alice",
@@ -85,15 +85,14 @@ func TestVerifyIdentityDisambiguatesDuplicateSelectorCandidatesByCodexMember(t *
 		}),
 	}
 
-	file, err := VerifyIdentity(files, Identity{
+	if _, err := VerifyIdentity(files, Identity{
 		AuthFileName:      "team.json",
 		AuthIndex:         "auth-1",
 		Provider:          "codex",
 		AccountIDSnapshot: "workspace-1",
 		AccountSnapshot:   "alice@example.com",
-	})
-	if err != nil || file.ID != "runtime-alice" {
-		t.Fatalf("duplicate selector verification = %#v, %v; want Alice", file, err)
+	}); !errors.Is(err, ErrAuthFileAmbiguous) {
+		t.Fatalf("duplicate selector verification error = %v, want ErrAuthFileAmbiguous", err)
 	}
 	if found, ok := Find(files, "team.json", "auth-1"); !ok || found.ID != "runtime-alice" {
 		t.Fatalf("legacy Find semantics = %#v, %t; want first match", found, ok)
@@ -158,7 +157,7 @@ func TestVerifyIdentityPreservesNonCodexFirstMatch(t *testing.T) {
 	}
 }
 
-func TestClientVerifyDisambiguatesWithoutChangingLegacyFindSemantics(t *testing.T) {
+func TestClientVerifyKeepsDuplicateCodexSelectorAmbiguousWithoutChangingLegacyFindSemantics(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("name"); got != "team.json" {
 			t.Fatalf("name query = %q", got)
@@ -187,8 +186,8 @@ func TestClientVerifyDisambiguatesWithoutChangingLegacyFindSemantics(t *testing.
 		t.Fatalf("Client.Find() = %#v, ok:%t err:%v; want legacy first match", found, ok, err)
 	}
 	file, err := client.Verify(context.Background(), server.URL, "mgmt", identity)
-	if err != nil || file.ID != "runtime-alice" {
-		t.Fatalf("Client.Verify() = %#v, %v; want Alice", file, err)
+	if !errors.Is(err, ErrAuthFileAmbiguous) {
+		t.Fatalf("Client.Verify() = %#v, %v; want ErrAuthFileAmbiguous", file, err)
 	}
 }
 
@@ -666,7 +665,7 @@ func TestClientPatchDisabledTargetKeepsVerifiedRuntimeIdentity(t *testing.T) {
 	}
 }
 
-func TestClientResolveVerifiedStatusMutationTargetUsesAccountIdentityWithoutAuthIndex(t *testing.T) {
+func TestClientResolveVerifiedStatusMutationTargetRejectsWorkspaceMemberWithoutCredentialLocator(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v0/management/auth-files" {
 			http.NotFound(w, r)
@@ -691,7 +690,7 @@ func TestClientResolveVerifiedStatusMutationTargetUsesAccountIdentityWithoutAuth
 	}))
 	defer server.Close()
 
-	target, err := New(server.Client()).ResolveVerifiedStatusMutationTarget(
+	_, err := New(server.Client()).ResolveVerifiedStatusMutationTarget(
 		context.Background(),
 		server.URL,
 		"mgmt",
@@ -702,11 +701,43 @@ func TestClientResolveVerifiedStatusMutationTargetUsesAccountIdentityWithoutAuth
 			AccountSnapshot:   "second@example.com",
 		},
 	)
-	if err != nil {
-		t.Fatalf("resolve verified target by workspace+member: %v", err)
+	if !errors.Is(err, ErrStatusMutationScopeAmbiguous) {
+		t.Fatalf("resolve verified target by workspace+member error = %v, want ErrStatusMutationScopeAmbiguous", err)
 	}
-	if target.Selector != "runtime-second" || target.File.AccountSnapshot != "second@example.com" || target.Scope != StatusMutationScopeCredential {
-		t.Fatalf("target = %#v, want second credential runtime target", target)
+}
+
+func TestClientResolveVerifiedStatusMutationTargetAllowsUniqueCredentialWithoutMember(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v0/management/auth-files" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"id":         "runtime-alice",
+			"name":       "team.json",
+			"auth_index": "auth-1",
+			"provider":   "codex",
+			"account_id": "workspace-1",
+		}})
+	}))
+	defer server.Close()
+
+	target, err := New(server.Client()).ResolveVerifiedStatusMutationTarget(
+		context.Background(),
+		server.URL,
+		"mgmt",
+		Identity{
+			AuthFileName:      "team.json",
+			AuthIndex:         "auth-1",
+			Provider:          "codex",
+			AccountIDSnapshot: "workspace-1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolve verified target without member: %v", err)
+	}
+	if target.Selector != "runtime-alice" || target.Scope != StatusMutationScopeCredential {
+		t.Fatalf("target = %#v, want unique credential runtime target", target)
 	}
 }
 

--- a/apps/manager-server/internal/service/monitoring/service.go
+++ b/apps/manager-server/internal/service/monitoring/service.go
@@ -1431,9 +1431,13 @@ func (s *Service) accountHistory(ctx context.Context, req AccountHistoryRequest)
 		}
 		if latestAccountRequestTargetValid(account) {
 			latestRequestTargets = append(latestRequestTargets, store.LatestAccountRequestQuery{
-				RequestIndex:     index,
-				AuthFileSnapshot: accountHistoryAuthFileSnapshot(account),
-				AuthIndex:        account.AuthIndex,
+				RequestIndex:          index,
+				AuthFileSnapshot:      accountHistoryAuthFileSnapshot(account),
+				AuthIndex:             account.AuthIndex,
+				Provider:              account.AuthProviderSnapshot,
+				AuthAccountIDSnapshot: account.AuthAccountIDSnapshot,
+				AuthProjectIDSnapshot: account.AuthProjectIDSnapshot,
+				AccountSnapshot:       account.AccountSnapshot,
 			})
 		}
 	}
@@ -3640,7 +3644,7 @@ func accountHistoryTargetKey(target AccountHistoryTarget) (string, bool) {
 	if !AccountHistoryTargetHasRequiredProvider(target) {
 		return "", false
 	}
-	if key, valid := usageidentity.AccountKey(usageidentity.Fields{
+	fields := usageidentity.Fields{
 		AuthFileSnapshot:      target.AuthFileSnapshot,
 		AuthIndex:             target.AuthIndex,
 		AuthProviderSnapshot:  target.AuthProviderSnapshot,
@@ -3649,11 +3653,30 @@ func accountHistoryTargetKey(target AccountHistoryTarget) (string, bool) {
 		AccountSnapshot:       target.AccountSnapshot,
 		AuthLabelSnapshot:     target.AuthLabelSnapshot,
 		Source:                target.Source,
-	}); valid {
+	}
+	if key, valid := usageidentity.AccountKey(fields); valid {
 		return key, true
 	}
+	// The server owns the account-history identity. In particular, a Codex
+	// Workspace-only target must not smuggle the pre-member `codex-account` key
+	// back in through the request body when its canonical identity is invalid.
+	if strings.EqualFold(strings.TrimSpace(target.AuthProviderSnapshot), "codex") {
+		return "", false
+	}
 	key := strings.TrimSpace(target.AccountKey)
+	// A caller cannot establish the owner of the pre-member Codex bucket from
+	// an opaque account_key alone. Reject it even when the rest of the target
+	// omits provider/member fields; otherwise the old Workspace-level bucket
+	// remains an injectable cross-member alias.
+	if isLegacyCodexWorkspaceAccountKey(key) {
+		return "", false
+	}
 	return key, key != ""
+}
+
+func isLegacyCodexWorkspaceAccountKey(key string) bool {
+	key = strings.TrimSpace(key)
+	return strings.HasPrefix(key, "usage-account-history:") && strings.Contains(key, ":codex-account:")
 }
 
 func accountHistoryIdentityFields(target AccountHistoryTarget) usageidentity.Fields {

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -2290,7 +2290,7 @@ func TestAccountHistoryAutoMergesSafeCodexLegacyFileIndex(t *testing.T) {
 	legacy := monitoringEvent("history-codex-legacy", baseMS+2_000, "gpt-codex", "auth-a", "codex-a.json", false, 20, 3, 0, 0, 23, nil)
 	legacy.AuthFileSnapshot = "codex-a.json"
 	legacy.AuthProviderSnapshot = "codex"
-	legacy.AuthAccountIDSnapshot = ""
+	legacy.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
 	legacy.AccountSnapshot = "same@example.com"
 	if _, err := db.InsertEvents(ctx, []usage.Event{stable, legacy}); err != nil {
 		t.Fatalf("insert Codex history events: %v", err)
@@ -2340,13 +2340,17 @@ func TestAccountHistoryRejectsConflictingCodexLegacyFileIndex(t *testing.T) {
 	stable.AuthFileSnapshot = "codex-a.json"
 	stable.AuthProviderSnapshot = "codex"
 	stable.AuthAccountIDSnapshot = "account-a"
+	stable.AccountSnapshot = "same@example.com"
 	legacy := monitoringEvent("history-codex-conflict-legacy", baseMS+2_000, "gpt-codex", "auth-a", "codex-a.json", false, 20, 3, 0, 0, 23, nil)
 	legacy.AuthFileSnapshot = "codex-a.json"
 	legacy.AuthProviderSnapshot = "codex"
+	legacy.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
+	legacy.AccountSnapshot = "same@example.com"
 	conflicting := monitoringEvent("history-codex-conflict-other", baseMS+3_000, "gpt-codex", "auth-a", "codex-a.json", false, 90, 9, 0, 0, 99, nil)
 	conflicting.AuthFileSnapshot = "codex-a.json"
 	conflicting.AuthProviderSnapshot = "codex"
 	conflicting.AuthAccountIDSnapshot = "account-b"
+	conflicting.AccountSnapshot = "same@example.com"
 	if _, err := db.InsertEvents(ctx, []usage.Event{stable, legacy, conflicting}); err != nil {
 		t.Fatalf("insert conflicting Codex history events: %v", err)
 	}
@@ -2472,6 +2476,49 @@ func TestAccountHistoryEmptyTargetDoesNotMatchAnonymousBucket(t *testing.T) {
 	}
 }
 
+func TestAccountHistoryTargetRejectsInjectedCodexWorkspaceKeyWithoutStrongMember(t *testing.T) {
+	legacyWorkspaceKey := "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31"
+	for _, test := range []struct {
+		name            string
+		accountSnapshot string
+	}{
+		{name: "missing member", accountSnapshot: ""},
+		{name: "display member", accountSnapshot: "Alice"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			key, valid := accountHistoryTargetKey(AccountHistoryTarget{
+				RowKey:                "injected-codex-workspace",
+				AccountKey:            legacyWorkspaceKey,
+				AccountSnapshot:       test.accountSnapshot,
+				AuthFileSnapshot:      "alice.json",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AuthIndex:             "auth-1",
+			})
+			want, wantValid := usageidentity.LegacyAccountKey(usageidentity.Fields{
+				AuthFileSnapshot:      "alice.json",
+				AuthIndex:             "auth-1",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AccountSnapshot:       test.accountSnapshot,
+			})
+			if !valid || !wantValid || key != want || key == legacyWorkspaceKey {
+				t.Fatalf("injected legacy Codex workspace key resolved as %q, %v; want credential key %q", key, valid, want)
+			}
+		})
+	}
+}
+
+func TestAccountHistoryTargetRejectsOpaqueCodexWorkspaceKeyWithoutIdentityFields(t *testing.T) {
+	key, valid := accountHistoryTargetKey(AccountHistoryTarget{
+		RowKey:     "opaque-codex-workspace",
+		AccountKey: "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31",
+	})
+	if valid || key != "" {
+		t.Fatalf("opaque Codex workspace key resolved as %q, %v; want empty invalid target", key, valid)
+	}
+}
+
 func TestAccountHistoryRejectsFileTargetWithoutProvider(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	_, err := New(db).AccountHistory(context.Background(), AccountHistoryRequest{
@@ -2521,6 +2568,11 @@ func TestAccountHistoryIncludesLatestCredentialRequestWithoutExposingRawFailureD
 		historical.AccountSnapshot = "alice@example.com"
 		events = append(events, historical)
 	}
+	for index := range events {
+		events[index].Provider = "codex"
+		events[index].AuthProviderSnapshot = "codex"
+		events[index].AuthAccountIDSnapshot = "workspace-1"
+	}
 
 	if _, err := db.InsertEvents(ctx, events); err != nil {
 		t.Fatalf("insert events: %v", err)
@@ -2528,11 +2580,12 @@ func TestAccountHistoryIncludesLatestCredentialRequestWithoutExposingRawFailureD
 
 	resp, err := New(db).AccountHistory(ctx, AccountHistoryRequest{
 		Accounts: []AccountHistoryTarget{{
-			RowKey:               "row-credential-a",
-			AccountSnapshot:      "alice@example.com",
-			AuthFileSnapshot:     "credential-a.json",
-			AuthProviderSnapshot: "codex",
-			AuthIndex:            "auth-1",
+			RowKey:                "row-credential-a",
+			AccountSnapshot:       "alice@example.com",
+			AuthFileSnapshot:      "credential-a.json",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-1",
+			AuthIndex:             "auth-1",
 		}},
 	})
 	if err != nil {

--- a/apps/manager-server/internal/service/proxy/service_test.go
+++ b/apps/manager-server/internal/service/proxy/service_test.go
@@ -446,6 +446,7 @@ func TestPrepareAuthFileFieldsMutationVerifiesIdentityAndRewritesRuntimeSelector
 			"auth_index": "auth-1",
 			"provider":   "codex",
 			"account_id": "account-1",
+			"account":    "user@example.com",
 		}})
 	}))
 	defer server.Close()
@@ -545,6 +546,7 @@ func TestPrepareAuthFileStatusMutationStripsCPAMPIdentityBeforeForwarding(t *tes
 			"auth_index": "auth-1",
 			"provider":   "codex",
 			"account_id": "account-1",
+			"account":    "user@example.com",
 		}})
 	}))
 	defer server.Close()

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -16,6 +16,7 @@ import (
 	quotasnapshotrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/quotasnapshot"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 func newQuotaSnapshotTestService(t *testing.T, nowMS int64) *Service {
@@ -100,6 +101,106 @@ func TestWriteQuerySelectsLatestCompleteObservationAndMergesCodexResetCredits(t 
 	}
 	if got := window.FieldSources["reset_credits"].Source; got != "api_query" {
 		t.Fatalf("reset credit source = %q, want api_query", got)
+	}
+}
+
+func TestCodexQuotaSnapshotsStayMemberScopedAndIgnoreLegacyWorkspaceKey(t *testing.T) {
+	service, path := newQuotaSnapshotTestServiceWithPath(t, 50_000)
+	ctx := context.Background()
+	cycleStart := int64(100)
+	cycleEnd := int64(18_100)
+	duration := int64(18)
+	window := func(used float64, observedAtMS int64) WindowInput {
+		return WindowInput{
+			ProviderWindowID: "five-hour", WindowKind: "five_hour", WindowMode: "fixed",
+			ModelScopeKind: "all", Source: "api_query", SourceObservationID: fmt.Sprintf("observation-%d", observedAtMS),
+			ObservedAtMS: observedAtMS, BoundaryAccuracy: "exact", UsedPercent: &used,
+			CycleStartMS: &cycleStart, CycleEndMS: &cycleEnd, DurationSeconds: &duration,
+		}
+	}
+	account := func(member string) AccountTarget {
+		return AccountTarget{
+			AuthFileSnapshot:      member + ".json",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-1",
+			AuthIndex:             "auth-" + member,
+			AccountSnapshot:       member + "@example.com",
+			Source:                member + ".json",
+		}
+	}
+	for _, entry := range []WriteEntry{
+		{RowKey: "alice", Provider: "codex", Account: account("alice"), Observation: &ObservationInput{
+			Source: "api_query", SourceObservationID: "observation-1000", ObservedAtMS: 1_000,
+			InventoryScopeKey: "codex:rate-limits", InventoryMode: "partial",
+		}, Windows: []WindowInput{window(10, 1_000)}},
+		{RowKey: "bob", Provider: "codex", Account: account("bob"), Observation: &ObservationInput{
+			Source: "api_query", SourceObservationID: "observation-2000", ObservedAtMS: 2_000,
+			InventoryScopeKey: "codex:rate-limits", InventoryMode: "partial",
+		}, Windows: []WindowInput{window(20, 2_000)}},
+	} {
+		if _, err := service.Write(ctx, WriteRequest{Entries: []WriteEntry{entry}}); err != nil {
+			t.Fatalf("write %s snapshot: %v", entry.RowKey, err)
+		}
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open quota database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// This is the v3 workspace-only key emitted before Codex member identity
+	// was introduced. It is intentionally left orphaned rather than fanned out.
+	legacyWorkspaceKey := "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31"
+	if _, err := db.Exec(`insert into account_quota_snapshots (
+		account_key, provider, provider_window_id, window_kind, window_mode,
+		model_scope_kind, source, source_observation_id, observed_at_ms,
+		boundary_accuracy, used_percent, created_at_ms
+	) values (?, 'codex', 'five-hour', 'five_hour', 'fixed', 'all',
+		'api_query', 'legacy-workspace', 3_000, 'exact', 99, 3_000)`, legacyWorkspaceKey); err != nil {
+		t.Fatalf("insert legacy workspace snapshot: %v", err)
+	}
+
+	alice := account("alice")
+	bob := account("bob")
+	aliceKey, aliceOK := usageidentity.AccountKey(alice.identityFields("codex"))
+	bobKey, bobOK := usageidentity.AccountKey(bob.identityFields("codex"))
+	if !aliceOK || !bobOK || aliceKey == bobKey {
+		t.Fatalf("member account keys = alice:%q/%v bob:%q/%v", aliceKey, aliceOK, bobKey, bobOK)
+	}
+	for _, test := range []struct {
+		name    string
+		rowKey  string
+		account AccountTarget
+		want    float64
+	}{
+		{name: "Alice", rowKey: "alice", account: alice, want: 10},
+		{name: "Bob", rowKey: "bob", account: bob, want: 20},
+	} {
+		result, err := service.Query(ctx, QueryRequest{Accounts: []QueryAccount{{
+			RowKey: test.rowKey, Provider: "codex", Account: test.account,
+		}}})
+		if err != nil {
+			t.Fatalf("query %s snapshot: %v", test.name, err)
+		}
+		if len(result.Items) != 1 || result.Items[0].AccountKey == legacyWorkspaceKey || len(result.Items[0].Windows) != 1 {
+			t.Fatalf("%s query included legacy/fan-out data: %#v", test.name, result)
+		}
+		if result.Items[0].Windows[0].UsedPercent == nil || *result.Items[0].Windows[0].UsedPercent != test.want {
+			t.Fatalf("%s used percent = %#v, want %v", test.name, result.Items[0].Windows[0], test.want)
+		}
+	}
+	var aliceRows, bobRows, legacyRows int
+	if err := db.QueryRow(`select count(*) from account_quota_snapshots where account_key = ?`, aliceKey).Scan(&aliceRows); err != nil {
+		t.Fatalf("count Alice snapshots: %v", err)
+	}
+	if err := db.QueryRow(`select count(*) from account_quota_snapshots where account_key = ?`, bobKey).Scan(&bobRows); err != nil {
+		t.Fatalf("count Bob snapshots: %v", err)
+	}
+	if err := db.QueryRow(`select count(*) from account_quota_snapshots where account_key = ?`, legacyWorkspaceKey).Scan(&legacyRows); err != nil {
+		t.Fatalf("count legacy snapshots: %v", err)
+	}
+	if aliceRows != 1 || bobRows != 1 || legacyRows != 1 {
+		t.Fatalf("quota snapshot rows were migrated/fanned out: Alice=%d Bob=%d legacy=%d", aliceRows, bobRows, legacyRows)
 	}
 }
 

--- a/apps/manager-server/internal/store/store_compat_test.go
+++ b/apps/manager-server/internal/store/store_compat_test.go
@@ -58,7 +58,7 @@ func TestStoreCompatMigratesLegacyCodexInspectionOwnershipIdentity(t *testing.T)
 	if err != nil {
 		t.Fatalf("list migrated ownership: %v", err)
 	}
-	if len(items) != 2 || items[0].AuthIndex != "auth-1" || items[0].AccountSnapshot != "" || items[1].AuthIndex != "auth-2" || items[1].AccountSnapshot != "" {
+	if len(items) != 2 || items[0].AuthIndex != "auth-1" || items[0].AccountSnapshot != "" || items[1].AuthIndex != "auth-2" || items[1].AccountSnapshot != "bob@example.com" {
 		t.Fatalf("migrated ownership = %#v", items)
 	}
 }

--- a/apps/manager-server/internal/usageidentity/identity.go
+++ b/apps/manager-server/internal/usageidentity/identity.go
@@ -14,6 +14,9 @@ const FormatVersion = "3"
 const (
 	keyPrefix                    = "usage-account-history"
 	codexAccountIDSnapshotPrefix = "codex-account-id:v1:"
+	// CodexIdentityRevision changes independently from FormatVersion because
+	// the other providers must retain their existing AccountKey values.
+	CodexIdentityRevision = "2"
 )
 
 // CodexAccountIDSnapshot marks a freshly observed, explicit ChatGPT account_id
@@ -21,8 +24,8 @@ const (
 // values in that column predate this provenance marker and must never be
 // reinterpreted as a stable Codex account identity.
 func CodexAccountIDSnapshot(accountID string) string {
-	accountID = strings.TrimSpace(accountID)
-	if accountID == "" {
+	accountID, ok := NormalizeCodexWorkspaceSnapshot(accountID)
+	if !ok {
 		return ""
 	}
 	return codexAccountIDSnapshotPrefix + accountID
@@ -31,11 +34,15 @@ func CodexAccountIDSnapshot(accountID string) string {
 // CodexAccountIDFromSnapshot returns an account id only when the snapshot has
 // explicit provenance from the strict Codex account-id resolver.
 func CodexAccountIDFromSnapshot(snapshot string) string {
-	snapshot = strings.TrimSpace(snapshot)
+	snapshot = strings.Trim(snapshot, " ")
 	if !strings.HasPrefix(snapshot, codexAccountIDSnapshotPrefix) {
 		return ""
 	}
-	return strings.TrimSpace(strings.TrimPrefix(snapshot, codexAccountIDSnapshotPrefix))
+	accountID, ok := NormalizeCodexWorkspaceSnapshot(strings.TrimPrefix(snapshot, codexAccountIDSnapshotPrefix))
+	if !ok {
+		return ""
+	}
+	return accountID
 }
 
 // ProjectIDSnapshot returns only a real provider project snapshot. The
@@ -87,8 +94,14 @@ type Fields struct {
 func AccountKey(fields Fields) (string, bool) {
 	provider := normalizeProvider(fields.AuthProviderSnapshot)
 	if provider == "codex" {
-		if accountID := strings.TrimSpace(fields.AuthAccountIDSnapshot); accountID != "" {
-			return encodeKey("codex-account", provider, accountID), true
+		workspaceID, workspaceOK := ResolveCodexWorkspace(fields)
+		// A provenance marker in the historical project snapshot is legacy
+		// evidence only. It may validate a legacy alias, but it must not
+		// promote an old event into the new stable member bucket.
+		if workspaceOK && strings.Trim(fields.AuthAccountIDSnapshot, " ") != "" {
+			if member, ok := stableCodexMemberSnapshot(fields); ok {
+				return encodeCodexKey("codex-member", provider, workspaceID, member), true
+			}
 		}
 	}
 	return LegacyAccountKey(fields)
@@ -107,6 +120,23 @@ func LegacyAccountKey(fields Fields) (string, bool) {
 	}
 	account := strings.TrimSpace(fields.AccountSnapshot)
 	label := strings.TrimSpace(fields.AuthLabelSnapshot)
+	// A Codex account snapshot is a Workspace identifier, and account/label/
+	// project values are display or provider-scoped fallbacks rather than a
+	// credential identity. Keep Codex's fallback at the physical credential
+	// boundary so an incomplete member snapshot cannot merge a shared
+	// Workspace. A missing history bucket is safer than a cross-member bucket.
+	if provider == "codex" {
+		switch {
+		case authFile != "" && authIndex != "":
+			return encodeKey("file-index", authFile, authIndex), true
+		case authFile != "":
+			return encodeKey("file", authFile, provider), true
+		case authIndex != "":
+			return encodeKey("auth-index", provider, authIndex), true
+		default:
+			return "", false
+		}
+	}
 
 	switch {
 	case authFile != "" && authIndex != "":
@@ -133,11 +163,11 @@ func LegacyAccountKey(fields Fields) (string, bool) {
 }
 
 func PricingStructureRevision(modelPriceRevision string) string {
-	return fmt.Sprintf("model-%s:identity-%s:%s", ModelFormatVersion, FormatVersion, strings.TrimSpace(modelPriceRevision))
+	return fmt.Sprintf("model-%s:identity-%s:codex-%s:%s", ModelFormatVersion, FormatVersion, CodexIdentityRevision, strings.TrimSpace(modelPriceRevision))
 }
 
 func AccountHistoryStructureRevision() string {
-	return fmt.Sprintf("identity-%s:model-%s", FormatVersion, ModelFormatVersion)
+	return fmt.Sprintf("identity-%s:codex-%s:model-%s", FormatVersion, CodexIdentityRevision, ModelFormatVersion)
 }
 
 // MonitoringProjectionStructureRevision versions the derived monitoring
@@ -150,6 +180,19 @@ func MonitoringProjectionStructureRevision() string {
 }
 
 func SQLAccountKeyExpression(alias string) string {
+	return sqlAccountKeyExpression(alias, false)
+}
+
+// SQLAccountKeyExpressionWithoutProject mirrors SQLAccountKeyExpression for
+// derived tables that intentionally do not persist auth_project_id_snapshot.
+// Their remaining identity columns are sufficient for file/index and Codex
+// workspace/member keys, which are the only keys eligible for the
+// account-window daily fast path.
+func SQLAccountKeyExpressionWithoutProject(alias string) string {
+	return sqlAccountKeyExpression(alias, true)
+}
+
+func sqlAccountKeyExpression(alias string, withoutProject bool) string {
 	column := func(name string) string {
 		if alias == "" {
 			return name
@@ -166,19 +209,38 @@ func SQLAccountKeyExpression(alias string) string {
 	account := trimmed("account_snapshot")
 	label := trimmed("auth_label_snapshot")
 	accountID := trimmed("auth_account_id_snapshot")
-	projectID := trimmed("auth_project_id_snapshot")
+	projectID := "''"
+	if !withoutProject {
+		projectID = trimmed("auth_project_id_snapshot")
+	}
 	providerSource := "coalesce(nullif(" + trimmed("auth_provider_snapshot") + ", ''), " + trimmed("provider") + ", '')"
-	providerNormalized := "case lower(replace(trim(" + providerSource + "), '_', '-')) " +
+	providerNormalized := "case lower(replace(" + providerSource + ", '_', '-')) " +
 		"when 'x-ai' then 'xai' when 'grok' then 'xai' " +
-		"else lower(replace(trim(" + providerSource + "), '_', '-')) end"
+		"else lower(replace(" + providerSource + ", '_', '-')) end"
 	authFile := "case when " + authFileSnapshot + " <> '' then " + authFileSnapshot +
 		" when " + source + " <> '' and " + source + " <> " + account + " and " + source + " <> " + label +
 		" then " + source + " else '' end"
 	marker := "'" + codexAccountIDSnapshotPrefix + "'"
 	legacyMarkerAccountID := "case when substr(" + projectID + ", 1, length(" + marker + ")) = " + marker +
 		" then trim(substr(" + projectID + ", length(" + marker + ") + 1)) else '' end"
-	codexAccountID := "case when " + providerNormalized + " = 'codex' then " + accountID + " else '' end"
-	legacyProjectID := "case when " + providerNormalized + " = 'codex' and (" + accountID + " <> '' or " + legacyMarkerAccountID + " <> '') then '' else " + projectID + " end"
+	codexMember := "lower(" + account + ")"
+	printableASCII := func(value string) string {
+		return value + " <> '' and length(" + value + ") = length(cast(" + value + " as blob)) and " +
+			value + " not glob '*[^!-~]*'"
+	}
+	directWorkspacePresent := accountID + " <> ''"
+	markedWorkspacePresent := "substr(" + projectID + ", 1, length(" + marker + ")) = " + marker
+	markedWorkspaceValid := "(" + markedWorkspacePresent + " = 0 or " + legacyMarkerAccountID + " <> '')"
+	codexWorkspaceValid := markedWorkspaceValid + " and (" +
+		"(" + directWorkspacePresent + " = 0) or (" + markedWorkspacePresent + " = 0) or " +
+		accountID + " = " + legacyMarkerAccountID + ")"
+	codexWorkspaceID := accountID
+	codexMemberValid := providerNormalized + " = 'codex' and " + directWorkspacePresent + " and " + codexWorkspaceValid + " and " +
+		printableASCII(account) + " and " +
+		"instr(" + codexMember + ", '@') > 1 and " +
+		"instr(" + codexMember + ", '@') < length(" + codexMember + ") and " +
+		"length(" + codexMember + ") - length(replace(" + codexMember + ", '@', '')) = 1"
+	legacyProjectID := "case when " + providerNormalized + " = 'codex' and " + legacyMarkerAccountID + " <> '' then '' else " + projectID + " end"
 
 	hexValue := func(value string) string { return "hex(" + value + ")" }
 	prefix := "'" + keyPrefix + ":" + FormatVersion + ":"
@@ -194,17 +256,94 @@ func SQLAccountKeyExpression(alias string) string {
 	}
 
 	return "case " +
-		"when " + providerNormalized + " = 'codex' and " + codexAccountID + " <> '' then " + key("codex-account", providerNormalized, codexAccountID) + " " +
+		"when " + codexMemberValid + " then " + key("codex-member", providerNormalized, codexWorkspaceID, codexMember) + " " +
 		"when " + authFile + " <> '' and " + authIndex + " <> '' then " + key("file-index", authFile, authIndex) + " " +
-		"when " + authFile + " <> '' and " + legacyProjectID + " <> '' then " + key("file-project", authFile, providerNormalized, legacyProjectID) + " " +
-		"when " + authFile + " <> '' and " + account + " <> '' then " + key("file-account", authFile, providerNormalized, account) + " " +
-		"when " + authFile + " <> '' and " + label + " <> '' then " + key("file-label", authFile, providerNormalized, label) + " " +
+		"when " + providerNormalized + " = 'codex' and " + authFile + " <> '' then " + key("file", authFile, providerNormalized) + " " +
+		"when " + providerNormalized + " <> 'codex' and " + authFile + " <> '' and " + legacyProjectID + " <> '' then " + key("file-project", authFile, providerNormalized, legacyProjectID) + " " +
+		"when " + providerNormalized + " <> 'codex' and " + authFile + " <> '' and " + account + " <> '' then " + key("file-account", authFile, providerNormalized, account) + " " +
+		"when " + providerNormalized + " <> 'codex' and " + authFile + " <> '' and " + label + " <> '' then " + key("file-label", authFile, providerNormalized, label) + " " +
 		"when " + authFile + " <> '' then " + key("file", authFile, providerNormalized) + " " +
 		"when " + authIndex + " <> '' then " + key("auth-index", providerNormalized, authIndex) + " " +
-		"when " + legacyProjectID + " <> '' then " + key("project", providerNormalized, legacyProjectID) + " " +
-		"when " + account + " <> '' then " + key("account", providerNormalized, account) + " " +
-		"when " + label + " <> '' then " + key("label", providerNormalized, label) + " " +
+		"when " + providerNormalized + " <> 'codex' and " + legacyProjectID + " <> '' then " + key("project", providerNormalized, legacyProjectID) + " " +
+		"when " + providerNormalized + " <> 'codex' and " + account + " <> '' then " + key("account", providerNormalized, account) + " " +
+		"when " + providerNormalized + " <> 'codex' and " + label + " <> '' then " + key("label", providerNormalized, label) + " " +
 		"else '' end"
+}
+
+// ResolveCodexWorkspace returns a workspace only when all explicit Workspace
+// evidence agrees. The legacy project snapshot is trusted only when it carries
+// the explicit CodexAccountIDSnapshot provenance marker; generic project IDs
+// are never Workspace evidence. Invalid or conflicting evidence is rejected so
+// callers can fall back to credential identity or fail closed as appropriate.
+func ResolveCodexWorkspace(fields Fields) (string, bool) {
+	directRaw := fields.AuthAccountIDSnapshot
+	markedRaw := fields.AuthProjectIDSnapshot
+	directPresent := strings.Trim(directRaw, " ") != ""
+	markedPresent := strings.HasPrefix(strings.Trim(markedRaw, " "), codexAccountIDSnapshotPrefix)
+
+	direct := ""
+	if directPresent {
+		var ok bool
+		direct, ok = NormalizeCodexWorkspaceSnapshot(directRaw)
+		if !ok {
+			return "", false
+		}
+	}
+	marked := ""
+	if markedPresent {
+		marked = CodexAccountIDFromSnapshot(markedRaw)
+		if marked == "" {
+			return "", false
+		}
+	}
+	if direct != "" && marked != "" && direct != marked {
+		return "", false
+	}
+	if direct != "" {
+		return direct, true
+	}
+	if marked != "" {
+		return marked, true
+	}
+	return "", false
+}
+
+// NormalizeCodexMemberSnapshot returns a member identity only for a
+// conservative email-shaped account snapshot. Labels, filenames, and other
+// display values are deliberately rejected so a shared Workspace cannot be
+// mistaken for a member.
+func NormalizeCodexMemberSnapshot(value string) (string, bool) {
+	// SQLite's trim/lower functions are ASCII-oriented. Keep the accepted
+	// identity deliberately ASCII-compatible so runtime and SQL rebuilds cannot
+	// normalize the same member differently.
+	value = strings.Trim(value, " ")
+	if value == "" || strings.Count(value, "@") != 1 {
+		return "", false
+	}
+	for index := 0; index < len(value); index++ {
+		if value[index] <= 0x20 || value[index] >= 0x7f {
+			return "", false
+		}
+	}
+	parts := strings.SplitN(value, "@", 2)
+	if parts[0] == "" || parts[1] == "" {
+		return "", false
+	}
+	return strings.ToLower(value), true
+}
+
+// NormalizeCodexWorkspaceSnapshot applies the same trimming SQLite's default
+// trim() uses. Workspace IDs are opaque; only an empty value is unusable.
+func NormalizeCodexWorkspaceSnapshot(value string) (string, bool) {
+	value = strings.Trim(value, " ")
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func stableCodexMemberSnapshot(fields Fields) (string, bool) {
+	return NormalizeCodexMemberSnapshot(fields.AccountSnapshot)
 }
 
 func effectiveAuthFile(fields Fields) string {
@@ -229,10 +368,21 @@ func normalizeProvider(value string) string {
 }
 
 func encodeKey(kind string, values ...string) string {
+	return encodeKeyWithTrim(kind, strings.TrimSpace, values...)
+}
+
+// encodeCodexKey uses the same ASCII-space trimming as the SQL identity
+// expression. Keep this separate from encodeKey so the Codex opaque workspace
+// path cannot change the established AccountKey encoding for other providers.
+func encodeCodexKey(kind string, values ...string) string {
+	return encodeKeyWithTrim(kind, func(value string) string { return strings.Trim(value, " ") }, values...)
+}
+
+func encodeKeyWithTrim(kind string, trim func(string) string, values ...string) string {
 	parts := make([]string, 0, len(values)+3)
 	parts = append(parts, keyPrefix, FormatVersion, kind)
 	for _, value := range values {
-		parts = append(parts, strings.ToUpper(hex.EncodeToString([]byte(strings.TrimSpace(value)))))
+		parts = append(parts, strings.ToUpper(hex.EncodeToString([]byte(trim(value)))))
 	}
 	return strings.Join(parts, ":")
 }

--- a/apps/manager-server/internal/usageidentity/identity_test.go
+++ b/apps/manager-server/internal/usageidentity/identity_test.go
@@ -2,6 +2,7 @@ package usageidentity
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -27,26 +28,197 @@ func TestAccountKeyRejectsMissingIdentity(t *testing.T) {
 	}
 }
 
-func TestAccountKeyKeepsCodexAccountAcrossMutableCredentialIdentity(t *testing.T) {
-	accountID := "account-a"
-	oldKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-a-free.json", AuthIndex: "auth-1", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: accountID})
+func TestAccountKeyKeepsNonCodexProviderMappings(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields Fields
+		want   string
+	}{
+		{
+			name: "Claude file and index",
+			fields: Fields{
+				AuthFileSnapshot:     "claude.json",
+				AuthIndex:            "auth-1",
+				AuthProviderSnapshot: "claude",
+			},
+			want: "usage-account-history:3:file-index:636C617564652E6A736F6E:617574682D31",
+		},
+		{
+			name: "XAI file and project",
+			fields: Fields{
+				AuthFileSnapshot:      "xai.json",
+				AuthProviderSnapshot:  "grok",
+				AuthProjectIDSnapshot: "project-1",
+			},
+			want: "usage-account-history:3:file-project:7861692E6A736F6E:786169:70726F6A6563742D31",
+		},
+		{
+			name: "Gemini account fallback",
+			fields: Fields{
+				AuthProviderSnapshot: "gemini",
+				AccountSnapshot:      "alice@example.com",
+			},
+			want: "usage-account-history:3:account:67656D696E69:616C696365406578616D706C652E636F6D",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := AccountKey(test.fields)
+			if !ok || got != test.want {
+				t.Fatalf("AccountKey(%#v) = %q, %v; want %q, true", test.fields, got, ok, test.want)
+			}
+		})
+	}
+}
+
+func TestAccountKeyUsesCodexWorkspaceAndMemberAcrossMutableCredentialIdentity(t *testing.T) {
+	oldKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-a-free.json", AuthIndex: "auth-1", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AccountSnapshot: " Alice@Example.com "})
 	if !ok {
 		t.Fatal("old key is invalid")
 	}
-	newKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-a-pro.json", AuthIndex: "auth-2", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: accountID})
+	newKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-a-pro.json", AuthIndex: "auth-2", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AccountSnapshot: "alice@example.com"})
 	if !ok {
 		t.Fatal("new key is invalid")
 	}
 	if oldKey != newKey {
-		t.Fatalf("same Codex account split across reauth: old=%q new=%q", oldKey, newKey)
+		t.Fatalf("same Codex member split across reauth: old=%q new=%q", oldKey, newKey)
 	}
-	legacyKey, ok := LegacyAccountKey(Fields{AuthFileSnapshot: "codex-a-pro.json", AuthIndex: "auth-2", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: accountID})
+	legacyKey, ok := LegacyAccountKey(Fields{AuthFileSnapshot: "codex-a-pro.json", AuthIndex: "auth-2", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AccountSnapshot: "alice@example.com"})
 	if !ok || legacyKey == newKey {
 		t.Fatalf("legacy exact credential key = %q, stable key = %q", legacyKey, newKey)
 	}
-	differentKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-b.json", AuthIndex: "auth-3", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "account-b", AccountSnapshot: "same@example.com"})
-	if !ok || differentKey == oldKey {
-		t.Fatalf("different Codex account merged: old=%q different=%q", oldKey, differentKey)
+	differentMemberKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-b.json", AuthIndex: "auth-3", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AccountSnapshot: "bob@example.com"})
+	if !ok || differentMemberKey == oldKey {
+		t.Fatalf("different Codex member merged: alice=%q bob=%q", oldKey, differentMemberKey)
+	}
+	differentWorkspaceKey, ok := AccountKey(Fields{AuthFileSnapshot: "codex-c.json", AuthIndex: "auth-4", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-2", AccountSnapshot: "alice@example.com"})
+	if !ok || differentWorkspaceKey == oldKey {
+		t.Fatalf("same email in different Codex workspace merged: workspace-1=%q workspace-2=%q", oldKey, differentWorkspaceKey)
+	}
+}
+
+func TestAccountKeyFallsBackWhenCodexMemberEvidenceIsMissingOrWeak(t *testing.T) {
+	for _, snapshot := range []string{"", "Alice", "alice@example.com@duplicate"} {
+		fields := Fields{
+			AuthFileSnapshot:      "codex.json",
+			AuthIndex:             "auth-1",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-1",
+			AccountSnapshot:       snapshot,
+		}
+		got, ok := AccountKey(fields)
+		want, wantOK := LegacyAccountKey(fields)
+		if !ok || !wantOK || got != want || strings.Contains(got, ":636F6465782D6D656D626572:") {
+			t.Fatalf("snapshot %q: AccountKey() = %q, %v; want legacy %q, %v", snapshot, got, ok, want, wantOK)
+		}
+	}
+}
+
+func TestLegacyAccountKeyRejectsCodexDisplayFallbackWithoutCredentialIdentity(t *testing.T) {
+	for _, fields := range []Fields{
+		{AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AuthProjectIDSnapshot: "project-1"},
+		{AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AccountSnapshot: "Alice"},
+		{AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-1", AuthLabelSnapshot: "Alice"},
+		{AuthProviderSnapshot: "codex", AccountSnapshot: "alice@example.com"},
+	} {
+		if key, ok := LegacyAccountKey(fields); ok || key != "" {
+			t.Fatalf("LegacyAccountKey(%#v) = %q, %v; want empty, false", fields, key, ok)
+		}
+		if key, ok := AccountKey(fields); ok || key != "" {
+			t.Fatalf("AccountKey(%#v) = %q, %v; want empty, false", fields, key, ok)
+		}
+	}
+}
+
+func TestNormalizeCodexMemberSnapshot(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  string
+		ok    bool
+	}{
+		{value: " Alice@Example.com ", want: "alice@example.com", ok: true},
+		{value: "Alice", ok: false},
+		{value: "@example.com", ok: false},
+		{value: "alice@", ok: false},
+		{value: "alice@example.com@other", ok: false},
+		{value: "alice @example.com", ok: false},
+		{value: "alice\x7f@example.com", ok: false},
+	} {
+		got, ok := NormalizeCodexMemberSnapshot(test.value)
+		if got != test.want || ok != test.ok {
+			t.Fatalf("NormalizeCodexMemberSnapshot(%q) = %q, %v; want %q, %v", test.value, got, ok, test.want, test.ok)
+		}
+	}
+}
+
+func TestNormalizeCodexWorkspaceSnapshotPreservesOpaqueIDs(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  string
+		ok    bool
+	}{
+		{value: " workspace-1 ", want: "workspace-1", ok: true},
+		{value: "workspace-1\t", want: "workspace-1\t", ok: true},
+		{value: "workspace-1\u2003", want: "workspace-1\u2003", ok: true},
+		{value: "workspace-1\x00", want: "workspace-1\x00", ok: true},
+		{value: "workspace 1", want: "workspace 1", ok: true},
+		{value: "工作区-1", want: "工作区-1", ok: true},
+		{value: "   ", ok: false},
+	} {
+		got, ok := NormalizeCodexWorkspaceSnapshot(test.value)
+		if got != test.want || ok != test.ok {
+			t.Fatalf("NormalizeCodexWorkspaceSnapshot(%q) = %q, %v; want %q, %v", test.value, got, ok, test.want, test.ok)
+		}
+	}
+}
+
+func TestLegacyAccountKeyDoesNotUseCodexWorkspaceSnapshotFallback(t *testing.T) {
+	for _, fields := range []Fields{
+		{
+			AuthFileSnapshot:      "codex.json",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-1",
+			AccountSnapshot:       "Alice",
+		},
+		{
+			AuthFileSnapshot:      "codex.json",
+			AuthProviderSnapshot:  "codex",
+			AuthAccountIDSnapshot: "workspace-1",
+			AccountSnapshot:       "Alice",
+			AuthProjectIDSnapshot: "project-1",
+		},
+	} {
+		key, ok := LegacyAccountKey(fields)
+		if !ok || strings.Contains(key, "416C696365") || strings.Contains(key, "776F726B73706163652D31") {
+			t.Fatalf("LegacyAccountKey(%#v) = %q, %v; must not use workspace/display fallback", fields, key, ok)
+		}
+	}
+
+	key, ok := LegacyAccountKey(Fields{
+		AuthFileSnapshot:      "codex.json",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+		AccountSnapshot:       "Alice",
+		AuthIndex:             "auth-1",
+	})
+	if !ok || strings.Contains(key, "416C696365") {
+		t.Fatalf("Codex auth-index fallback = %q, %v; must be credential-only", key, ok)
+	}
+}
+
+func TestCodexMemberRevisionDoesNotChangeGlobalFormatVersion(t *testing.T) {
+	if FormatVersion != "3" {
+		t.Fatalf("FormatVersion = %q, want 3", FormatVersion)
+	}
+	if CodexIdentityRevision != "2" {
+		t.Fatalf("CodexIdentityRevision = %q, want 2", CodexIdentityRevision)
+	}
+	if got := AccountHistoryStructureRevision(); got != "identity-3:codex-2:model-1" {
+		t.Fatalf("account history revision = %q", got)
+	}
+	if got := MonitoringProjectionStructureRevision(); got != "identity-3:codex-2:model-1:project-v1" {
+		t.Fatalf("monitoring projection revision = %q", got)
 	}
 }
 
@@ -98,6 +270,24 @@ func TestSQLAccountKeyExpressionMatchesGo(t *testing.T) {
 	}{
 		{name: "file and auth index", fields: Fields{AuthFileSnapshot: "shared.json", AuthIndex: "auth-a", AuthProviderSnapshot: "x_ai", AuthProjectIDSnapshot: "project-a", AccountSnapshot: "same@example.com", AuthLabelSnapshot: "Same Account", Source: "legacy-source"}, provider: "xai"},
 		{name: "codex stable account", fields: Fields{AuthFileSnapshot: "codex-new.json", AuthIndex: "auth-new", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "account-a", AccountSnapshot: "same@example.com"}, provider: "codex"},
+		{name: "codex second workspace member", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-team", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "bob@example.com"}, provider: "codex"},
+		{name: "codex same member different workspace", fields: Fields{AuthFileSnapshot: "codex-other-workspace.json", AuthIndex: "auth-other-workspace", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-b", AccountSnapshot: "same@example.com"}, provider: "codex"},
+		{name: "codex direct and marked workspace agree", fields: Fields{AuthFileSnapshot: "codex-marked.json", AuthIndex: "auth-marked", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AuthProjectIDSnapshot: CodexAccountIDSnapshot("workspace-a"), AccountSnapshot: "same@example.com"}, provider: "codex"},
+		{name: "codex direct workspace ignores non-ASCII-space marker prefix", fields: Fields{AuthFileSnapshot: "codex-marked-leading-tab.json", AuthIndex: "auth-marked-leading-tab", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AuthProjectIDSnapshot: "\t" + CodexAccountIDSnapshot("workspace-a"), AccountSnapshot: "same@example.com"}, provider: "codex"},
+		{name: "codex marker-only workspace falls back", fields: Fields{AuthFileSnapshot: "codex-marker-only.json", AuthIndex: "auth-marker-only", AuthProviderSnapshot: "codex", AuthProjectIDSnapshot: CodexAccountIDSnapshot("workspace-a"), AccountSnapshot: "same@example.com"}, provider: "codex"},
+		{name: "codex conflicting workspace evidence falls back", fields: Fields{AuthFileSnapshot: "codex-conflict.json", AuthIndex: "auth-conflict", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AuthProjectIDSnapshot: CodexAccountIDSnapshot("workspace-b"), AccountSnapshot: "same@example.com"}, provider: "codex"},
+		{name: "codex missing member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-team", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a"}, provider: "codex"},
+		{name: "codex weak member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-team", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "Alice"}, provider: "codex"},
+		{name: "codex account with generic project fallback", fields: Fields{AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AuthProjectIDSnapshot: "generic-project", AccountSnapshot: "Alice"}, provider: "codex"},
+		{name: "codex weak member with file and generic project", fields: Fields{AuthFileSnapshot: "codex-weak.json", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AuthProjectIDSnapshot: "generic-project", AccountSnapshot: "Alice"}, provider: "codex"},
+		{name: "codex unicode member falls back", fields: Fields{AuthFileSnapshot: "codex-unicode.json", AuthIndex: "auth-unicode", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "álîce@example.com"}, provider: "codex"},
+		{name: "codex control member falls back", fields: Fields{AuthFileSnapshot: "codex-control.json", AuthIndex: "auth-control", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "alice\x0e@example.com"}, provider: "codex"},
+		{name: "codex tab member falls back", fields: Fields{AuthFileSnapshot: "codex-tab-member.json", AuthIndex: "auth-tab-member", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "\talice@example.com"}, provider: "codex"},
+		{name: "codex unicode-space member falls back", fields: Fields{AuthFileSnapshot: "codex-unicode-space-member.json", AuthIndex: "auth-unicode-space-member", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "\u2003alice@example.com"}, provider: "codex"},
+		{name: "codex tab workspace is preserved", fields: Fields{AuthFileSnapshot: "codex-tab.json", AuthIndex: "auth-tab", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a\t", AccountSnapshot: "alice@example.com"}, provider: "codex"},
+		{name: "codex unicode workspace is preserved", fields: Fields{AuthFileSnapshot: "codex-unicode-workspace.json", AuthIndex: "auth-unicode-workspace", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-\u2003a", AccountSnapshot: "alice@example.com"}, provider: "codex"},
+		{name: "codex nul workspace is preserved", fields: Fields{AuthFileSnapshot: "codex-nul-workspace.json", AuthIndex: "auth-nul-workspace", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a\x00", AccountSnapshot: "alice@example.com"}, provider: "codex"},
+		{name: "explicit provider snapshot wins over raw provider", fields: Fields{AuthFileSnapshot: "claude.json", AuthIndex: "auth-claude", AuthProviderSnapshot: "claude", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "same@example.com"}, provider: "codex"},
 		{name: "historical codex project", fields: Fields{AuthFileSnapshot: "codex-old.json", AuthIndex: "auth-old", AuthProviderSnapshot: "codex", AuthProjectIDSnapshot: "generic-project"}, provider: "codex"},
 		{name: "legacy source file and project", fields: Fields{Source: "legacy.json", AuthProviderSnapshot: "vertex", AuthProjectIDSnapshot: "project-a"}, provider: "vertex"},
 		{name: "auth index without file", fields: Fields{AuthIndex: "auth-only", AuthProviderSnapshot: "grok"}, provider: "x-ai"},
@@ -131,7 +321,62 @@ func TestSQLAccountKeyExpressionMatchesGo(t *testing.T) {
 }
 
 func TestPricingStructureRevisionIncludesIdentityFormat(t *testing.T) {
-	if got := PricingStructureRevision("price-revision"); got != "model-1:identity-3:price-revision" {
+	if got := PricingStructureRevision("price-revision"); got != "model-1:identity-3:codex-2:price-revision" {
 		t.Fatalf("revision = %q", got)
+	}
+}
+
+func TestSQLAccountKeyExpressionWithoutProjectMatchesGoForDailyIdentity(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`create table daily (
+		auth_file_snapshot text, auth_index text, auth_provider_snapshot text,
+		auth_account_id_snapshot text, account_snapshot text, auth_label_snapshot text,
+		source text, provider text
+	)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	testCases := []struct {
+		name   string
+		fields Fields
+	}{
+		{name: "codex stable member", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-alice", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "alice@example.com", Source: "codex-team.json"}},
+		{name: "codex second member", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-bob", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "bob@example.com", Source: "codex-team.json"}},
+		{name: "codex missing member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-missing", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", Source: "codex-team.json"}},
+		{name: "codex weak member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-weak", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "Alice", Source: "codex-team.json"}},
+		{name: "codex opaque workspace is preserved", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-opaque-workspace", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a\t", AccountSnapshot: "alice@example.com", Source: "codex-team.json"}},
+		{name: "codex invalid member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-invalid-member", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "alice\x0e@example.com", Source: "codex-team.json"}},
+		{name: "codex tab member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-tab-member", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "\talice@example.com", Source: "codex-team.json"}},
+		{name: "codex unicode-space member falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-unicode-space-member", AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "workspace-a", AccountSnapshot: "\u2003alice@example.com", Source: "codex-team.json"}},
+		{name: "codex marker-only workspace falls back", fields: Fields{AuthFileSnapshot: "codex-team.json", AuthIndex: "auth-marker", AuthProviderSnapshot: "codex", AuthProjectIDSnapshot: CodexAccountIDSnapshot("workspace-a"), AccountSnapshot: "alice@example.com", Source: "codex-team.json"}},
+		{name: "non-codex file index", fields: Fields{AuthFileSnapshot: "claude.json", AuthIndex: "auth-claude", AuthProviderSnapshot: "claude", AccountSnapshot: "same@example.com", Source: "claude.json"}},
+		{name: "non-codex account fallback", fields: Fields{AuthFileSnapshot: "claude.json", AuthProviderSnapshot: "claude", AccountSnapshot: "same@example.com", Source: "claude.json"}},
+		{name: "missing identity", fields: Fields{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.Exec(`delete from daily`); err != nil {
+				t.Fatalf("clear rows: %v", err)
+			}
+			fields := tc.fields
+			if _, err := db.Exec(`insert into daily values (?, ?, ?, ?, ?, ?, ?, ?)`, fields.AuthFileSnapshot, fields.AuthIndex, fields.AuthProviderSnapshot, fields.AuthAccountIDSnapshot, fields.AccountSnapshot, fields.AuthLabelSnapshot, fields.Source, fields.AuthProviderSnapshot); err != nil {
+				t.Fatalf("insert daily row: %v", err)
+			}
+			want, valid := AccountKey(fields)
+			var got string
+			if err := db.QueryRow(`select ` + SQLAccountKeyExpressionWithoutProject("d") + ` from daily d`).Scan(&got); err != nil {
+				t.Fatalf("query daily SQL key: %v", err)
+			}
+			if got != want {
+				t.Fatalf("daily SQL key = %q, want %q", got, want)
+			}
+			if valid != (got != "") {
+				t.Fatalf("valid = %v for daily SQL key %q", valid, got)
+			}
+		})
 	}
 }

--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -285,8 +285,8 @@ func accountActionCandidateIdentity(item model.AccountActionCandidate) (cpaauthf
 				accountSnapshot = member
 			}
 		}
-		if strings.TrimSpace(item.AuthIndex) == "" && (accountIDSnapshot == "" || accountSnapshot == "") {
-			return cpaauthfiles.Identity{}, fmt.Errorf("%w: Codex candidate requires auth_index or workspace+member identity", cpaauthfiles.ErrIdentityMismatch)
+		if strings.TrimSpace(item.AuthIndex) == "" {
+			return cpaauthfiles.Identity{}, fmt.Errorf("%w: Codex credential mutation requires auth_index", cpaauthfiles.ErrIdentityMismatch)
 		}
 	}
 	identity := cpaauthfiles.Identity{

--- a/apps/manager-server/internal/worker/account_action_candidate.go
+++ b/apps/manager-server/internal/worker/account_action_candidate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/credentialpolicy"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 const accountActionCandidateQueueSize = 256
@@ -266,12 +267,34 @@ func accountActionCandidateIdentity(item model.AccountActionCandidate) (cpaauthf
 	if accountSnapshot == fileName {
 		accountSnapshot = ""
 	}
+	provider := credentialpolicy.NormalizeProvider(item.Provider)
+	accountIDSnapshot := strings.TrimSpace(item.AccountIDSnapshot)
+	if provider == "codex" {
+		if accountIDSnapshot != "" {
+			workspace, ok := usageidentity.NormalizeCodexWorkspaceSnapshot(accountIDSnapshot)
+			if !ok {
+				return cpaauthfiles.Identity{}, fmt.Errorf("%w: candidate has invalid Codex workspace identity", cpaauthfiles.ErrIdentityMismatch)
+			}
+			accountIDSnapshot = workspace
+		}
+		if accountSnapshot != "" {
+			member, ok := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+			if !ok {
+				accountSnapshot = ""
+			} else {
+				accountSnapshot = member
+			}
+		}
+		if strings.TrimSpace(item.AuthIndex) == "" && (accountIDSnapshot == "" || accountSnapshot == "") {
+			return cpaauthfiles.Identity{}, fmt.Errorf("%w: Codex candidate requires auth_index or workspace+member identity", cpaauthfiles.ErrIdentityMismatch)
+		}
+	}
 	identity := cpaauthfiles.Identity{
 		AuthFileName:      fileName,
 		AuthIndex:         strings.TrimSpace(item.AuthIndex),
-		Provider:          strings.TrimSpace(item.Provider),
+		Provider:          provider,
 		AccountSnapshot:   accountSnapshot,
-		AccountIDSnapshot: strings.TrimSpace(item.AccountIDSnapshot),
+		AccountIDSnapshot: accountIDSnapshot,
 	}
 	if identity.AuthIndex == "" && identity.AccountSnapshot == "" && identity.AccountIDSnapshot == "" {
 		return cpaauthfiles.Identity{}, fmt.Errorf("%w: candidate has no stable auth index, account ID, or account snapshot", cpaauthfiles.ErrIdentityMismatch)

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -466,7 +466,7 @@ func TestAccountActionCandidateWorkerRejectsAmbiguousStatusMutationScope(t *test
 	}
 }
 
-func TestAccountActionCandidateWorkerSelectsCodexMemberWithinSharedWorkspace(t *testing.T) {
+func TestAccountActionCandidateWorkerRejectsDuplicateCodexCredentialLocator(t *testing.T) {
 	st, err := store.Open(t.TempDir() + "/usage.sqlite")
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -534,15 +534,15 @@ func TestAccountActionCandidateWorkerSelectsCodexMemberWithinSharedWorkspace(t *
 		Reason:              "token revoked",
 	})
 
-	if patchCalls != 1 || patchedName != "runtime-alice" {
-		t.Fatalf("patch target = %q with %d calls, want runtime-alice once", patchedName, patchCalls)
+	if patchCalls != 0 || patchedName != "" {
+		t.Fatalf("patch target = %q with %d calls, want no mutation for duplicate locator", patchedName, patchCalls)
 	}
 	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
 	if err != nil {
 		t.Fatalf("list candidates: %v", err)
 	}
-	if len(items) != 1 || items[0].AutoDisabledAtMS == 0 || items[0].LastError != "" {
-		t.Fatalf("items = %#v, want Alice candidate auto-disabled", items)
+	if len(items) != 1 || items[0].AutoDisabledAtMS != 0 || !strings.Contains(items[0].LastError, "scope is ambiguous") {
+		t.Fatalf("items = %#v, want pending ambiguous failure", items)
 	}
 }
 
@@ -953,7 +953,7 @@ func TestAccountActionCandidateWorkerAutoDisableRejectsWeakIdentity(t *testing.T
 	if err != nil {
 		t.Fatalf("list candidates: %v", err)
 	}
-	if len(items) != 1 || items[0].AutoDisabledAtMS != 0 || !strings.Contains(items[0].LastError, "workspace+member identity") {
+	if len(items) != 1 || items[0].AutoDisabledAtMS != 0 || !strings.Contains(items[0].LastError, "auth_index") {
 		t.Fatalf("items = %#v, want weak-identity failure", items)
 	}
 }

--- a/apps/manager-server/internal/worker/account_action_candidate_test.go
+++ b/apps/manager-server/internal/worker/account_action_candidate_test.go
@@ -466,6 +466,86 @@ func TestAccountActionCandidateWorkerRejectsAmbiguousStatusMutationScope(t *test
 	}
 }
 
+func TestAccountActionCandidateWorkerSelectsCodexMemberWithinSharedWorkspace(t *testing.T) {
+	st, err := store.Open(t.TempDir() + "/usage.sqlite")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	patchCalls := 0
+	patchedName := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v0/management/auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id":         "runtime-alice",
+					"name":       "shared.json",
+					"auth_index": "shared-auth",
+					"provider":   "codex",
+					"account":    "alice@example.com",
+					"account_id": "workspace-1",
+					"disabled":   false,
+				},
+				{
+					"id":         "runtime-bob",
+					"name":       "shared.json",
+					"auth_index": "shared-auth",
+					"provider":   "codex",
+					"account":    "bob@example.com",
+					"account_id": "workspace-1",
+					"disabled":   false,
+				},
+			})
+		case "PATCH /v0/management/auth-files/status":
+			var payload struct {
+				Name     string `json:"name"`
+				Disabled bool   `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			patchCalls++
+			patchedName = payload.Name
+			if !payload.Disabled {
+				http.Error(w, "expected disable", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	NewAccountActionCandidateWorker(st, true).handleCandidate(context.Background(), accountActionCandidate{
+		BaseURL:             server.URL,
+		ManagementKey:       "mgmt",
+		FileName:            "shared.json",
+		AuthIndex:           "shared-auth",
+		DisplayAccount:      "alice@example.com",
+		AccountSnapshot:     "alice@example.com",
+		AccountID:           "workspace-1",
+		Provider:            "codex",
+		ActionType:          model.AccountActionTypeDelete,
+		AutoDisableEligible: true,
+		Reason:              "token revoked",
+	})
+
+	if patchCalls != 1 || patchedName != "runtime-alice" {
+		t.Fatalf("patch target = %q with %d calls, want runtime-alice once", patchedName, patchCalls)
+	}
+	items, err := st.ListAccountActionCandidates(context.Background(), model.AccountActionStatusPending, 10)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(items) != 1 || items[0].AutoDisabledAtMS == 0 || items[0].LastError != "" {
+		t.Fatalf("items = %#v, want Alice candidate auto-disabled", items)
+	}
+}
+
 func TestAccountActionCandidateWorkerRollsBackWhenAutoDisableMarkerFails(t *testing.T) {
 	st, err := store.Open(t.TempDir() + "/usage.sqlite")
 	if err != nil {
@@ -873,7 +953,7 @@ func TestAccountActionCandidateWorkerAutoDisableRejectsWeakIdentity(t *testing.T
 	if err != nil {
 		t.Fatalf("list candidates: %v", err)
 	}
-	if len(items) != 1 || items[0].AutoDisabledAtMS != 0 || !strings.Contains(items[0].LastError, "no stable auth index") {
+	if len(items) != 1 || items[0].AutoDisabledAtMS != 0 || !strings.Contains(items[0].LastError, "workspace+member identity") {
 		t.Fatalf("items = %#v, want weak-identity failure", items)
 	}
 }

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -284,14 +284,24 @@ func (w *RateLimitAutoDisableWorker) handleCandidateLocked(ctx context.Context, 
 	resolvedProvider := normalizeQuotaProvider(firstNonEmpty(provider, current.Provider))
 	resolvedAccountID := firstNonEmpty(accountID, current.AccountID)
 	if resolvedProvider == "codex" {
-		workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(resolvedAccountID)
-		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(resolvedAccountSnapshot)
-		if !workspaceOK || !memberOK {
-			log.Printf("[quota-auto-disable] auth file %q has incomplete Codex workspace+member evidence; skip quota ownership", candidate.FileName)
-			return
+		if strings.TrimSpace(resolvedAccountID) != "" {
+			workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(resolvedAccountID)
+			if !workspaceOK {
+				log.Printf("[quota-auto-disable] auth file %q has invalid Codex workspace evidence; skip quota ownership", candidate.FileName)
+				return
+			}
+			resolvedAccountID = workspace
 		}
-		resolvedAccountID = workspace
-		resolvedAccountSnapshot = member
+		if strings.TrimSpace(resolvedAccountSnapshot) != "" {
+			member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(resolvedAccountSnapshot)
+			if memberOK {
+				resolvedAccountSnapshot = member
+			} else {
+				// Account snapshots can be display labels or filenames. They are
+				// optional quota diagnostics once the credential locator is known.
+				resolvedAccountSnapshot = ""
+			}
+		}
 	}
 	if resolvedProvider == "codex" && resolvedAuthIndex == "" {
 		// quota_cooldowns has no Workspace column. Without the credential locator,
@@ -326,13 +336,6 @@ func (w *RateLimitAutoDisableWorker) handleCandidateLocked(ctx context.Context, 
 
 	owner := firstNonEmpty(candidate.Owner, model.QuotaCooldownOwnerUsage429)
 	cooldownEvidenceJSON := candidate.EvidenceJSON
-	if resolvedProvider == "codex" {
-		cooldownEvidenceJSON = codexCooldownIdentityEvidenceJSON(resolvedAccountID, resolvedAccountSnapshot)
-		if cooldownEvidenceJSON == "" {
-			log.Printf("[quota-auto-disable] auth file %q has invalid Codex cooldown identity evidence; skip quota ownership", candidate.FileName)
-			return
-		}
-	}
 	persisted, err := w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:        candidate.FileName,
 		AuthIndex:           resolvedAuthIndex,
@@ -392,19 +395,27 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 	)
 	currentAccountID := firstNonEmpty(candidate.AccountID, current.AccountID)
 	if currentProvider == "codex" && currentIndex == "" {
-		// There is no Workspace column in quota_cooldowns. A no-index Codex
-		// record cannot be safely resumed or merged across same-name members.
+		// Codex mutation ownership requires a credential locator. Workspace and
+		// member evidence are not a substitute for file+authIndex.
 		return false
 	}
 	if currentProvider == "codex" {
-		workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(currentAccountID)
-		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(currentSnapshot)
-		if !workspaceOK || !memberOK {
-			log.Printf("[quota-auto-disable] Codex cooldown for auth file %q has incomplete workspace+member evidence", candidate.FileName)
-			return false
+		if strings.TrimSpace(currentAccountID) != "" {
+			workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(currentAccountID)
+			if !workspaceOK {
+				log.Printf("[quota-auto-disable] Codex cooldown for auth file %q has invalid workspace evidence", candidate.FileName)
+				return false
+			}
+			currentAccountID = workspace
 		}
-		currentAccountID = workspace
-		currentSnapshot = member
+		if strings.TrimSpace(currentSnapshot) != "" {
+			member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(currentSnapshot)
+			if memberOK {
+				currentSnapshot = member
+			} else {
+				currentSnapshot = ""
+			}
+		}
 	}
 	var existing store.QuotaCooldown
 	for _, item := range active {
@@ -421,14 +432,6 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 		return false
 	}
 	existingSnapshot := quotaActionAccountSnapshot(existing.AuthFileName, existing.AccountSnapshot)
-	if currentProvider == "codex" {
-		storedWorkspace, storedMember, evidenceOK := codexCooldownIdentity(existing)
-		if !evidenceOK || storedWorkspace != currentAccountID || storedMember != currentSnapshot {
-			log.Printf("[quota-auto-disable] Codex cooldown identity mismatch for auth file %q", candidate.FileName)
-			return false
-		}
-		existingSnapshot = storedMember
-	}
 	if existing.AuthIndex == "" {
 		existingProvider := normalizeQuotaProvider(existing.Provider)
 		if existingProvider != "" && currentProvider != "" && existingProvider != currentProvider {
@@ -464,8 +467,6 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 	}
 	if owner == model.QuotaCooldownOwnerXAIFreeUsage {
 		evidenceJSON = mergeXAIProviderUsageEvidence(primaryEvidence, supplementalEvidence, finalRecoverAtMS)
-	} else if currentProvider == "codex" {
-		evidenceJSON = codexCooldownIdentityEvidenceJSON(currentAccountID, currentSnapshot)
 	}
 	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:     candidate.FileName,
@@ -625,17 +626,29 @@ func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseUR
 	provider := normalizeQuotaProvider(item.Provider)
 	accountID := ""
 	if provider == "codex" {
-		var evidenceOK bool
-		accountID, accountSnapshot, evidenceOK = codexCooldownIdentity(item)
-		if !evidenceOK {
-			reason := "Codex cooldown has no verifiable workspace+member evidence"
+		if strings.TrimSpace(accountSnapshot) != "" {
+			member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+			if memberOK {
+				accountSnapshot = member
+			} else {
+				accountSnapshot = ""
+			}
+		}
+		var member string
+		var identityPresent, identityOK bool
+		accountID, member, identityPresent, identityOK = codexCooldownIdentity(item)
+		if !identityOK {
+			reason := "Codex cooldown has conflicting workspace/member evidence"
 			_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
 			log.Printf("[quota-auto-disable] skip cooldown recovery id=%d authFile=%q reason=%s", item.ID, item.AuthFileName, reason)
 			return
 		}
+		if identityPresent && accountSnapshot == "" {
+			accountSnapshot = member
+		}
 	}
 	if provider == "codex" && authIndex == "" {
-		reason := "Codex cooldown has no auth index; workspace-only cooldown identity is not recoverable"
+		reason := "Codex cooldown has no auth index; credential locator is not recoverable"
 		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
 		log.Printf("[quota-auto-disable] skip cooldown recovery id=%d authFile=%q reason=%s", item.ID, item.AuthFileName, reason)
 		return
@@ -1396,10 +1409,24 @@ func quotaCooldownMatchesIdentity(item store.QuotaCooldown, authIndex string, pr
 		if provider != "codex" || itemProvider != "codex" || itemAuthIndex == "" || authIndex == "" || itemAuthIndex != authIndex {
 			return false
 		}
-		storedWorkspace, storedMember, evidenceOK := codexCooldownIdentity(item)
-		currentWorkspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(accountID)
-		currentMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
-		return evidenceOK && workspaceOK && memberOK && storedWorkspace == currentWorkspace && storedMember == currentMember
+		storedWorkspace, storedMember, identityPresent, identityOK := codexCooldownIdentity(item)
+		if !identityOK {
+			return false
+		}
+		currentWorkspace, workspaceOK := optionalCodexWorkspace(accountID)
+		currentMember, memberOK := optionalCodexMember(accountSnapshot)
+		if storedMemberFromColumn, ok := optionalCodexMember(item.AccountSnapshot); ok && memberOK && storedMemberFromColumn != currentMember {
+			return false
+		}
+		if identityPresent {
+			if workspaceOK && storedWorkspace != currentWorkspace {
+				return false
+			}
+			if memberOK && storedMember != currentMember {
+				return false
+			}
+		}
+		return true
 	}
 	if itemAuthIndex != "" {
 		return authIndex != "" && itemAuthIndex == authIndex
@@ -1425,23 +1452,52 @@ func codexCooldownIdentityEvidenceJSON(workspace string, member string) string {
 	return string(raw)
 }
 
-func codexCooldownIdentity(item store.QuotaCooldown) (workspace string, member string, ok bool) {
-	var evidence codexCooldownIdentityEvidence
-	if err := json.Unmarshal([]byte(strings.TrimSpace(item.EvidenceJSON)), &evidence); err != nil {
-		return "", "", false
+func optionalCodexWorkspace(value string) (string, bool) {
+	if strings.TrimSpace(value) == "" {
+		return "", false
 	}
-	workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(evidence.Workspace)
-	member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(evidence.Member)
+	return usageidentity.NormalizeCodexWorkspaceSnapshot(value)
+}
+
+func optionalCodexMember(value string) (string, bool) {
+	if strings.TrimSpace(value) == "" {
+		return "", false
+	}
+	return usageidentity.NormalizeCodexMemberSnapshot(value)
+}
+
+// codexCooldownIdentity reads only the optional identity-shaped fields from
+// EvidenceJSON. Quota/provider evidence may use the same column and must not
+// become an implicit recovery prerequisite.
+func codexCooldownIdentity(item store.QuotaCooldown) (workspace string, member string, present bool, ok bool) {
+	raw := strings.TrimSpace(item.EvidenceJSON)
+	if raw == "" {
+		return "", "", false, true
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return "", "", false, true
+	}
+	workspaceRaw, workspacePresent := fields["workspace"]
+	memberRaw, memberPresent := fields["member"]
+	if !workspacePresent && !memberPresent {
+		return "", "", false, true
+	}
+	if err := json.Unmarshal(workspaceRaw, &workspace); err != nil {
+		return "", "", true, false
+	}
+	if err := json.Unmarshal(memberRaw, &member); err != nil {
+		return "", "", true, false
+	}
+	workspace, workspaceOK := optionalCodexWorkspace(workspace)
+	member, memberOK := optionalCodexMember(member)
 	if !workspaceOK || !memberOK {
-		return "", "", false
+		return "", "", true, false
 	}
-	if storedMember := strings.TrimSpace(item.AccountSnapshot); storedMember != "" {
-		normalizedStoredMember, storedMemberOK := usageidentity.NormalizeCodexMemberSnapshot(storedMember)
-		if !storedMemberOK || normalizedStoredMember != member {
-			return "", "", false
-		}
+	if storedMember, storedMemberOK := optionalCodexMember(item.AccountSnapshot); storedMemberOK && storedMember != member {
+		return "", "", true, false
 	}
-	return workspace, member, true
+	return workspace, member, true, true
 }
 
 func (w *RateLimitAutoDisableWorker) patchAuthFileTarget(ctx context.Context, baseURL string, managementKey string, target cpaauthfiles.StatusMutationTarget, disabled bool) error {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable.go
@@ -19,6 +19,7 @@ import (
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/service/cpaauthfiles"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 const (
@@ -60,6 +61,7 @@ type quotaAutoDisableCandidate struct {
 	AuthIndex       string
 	DisplayAccount  string
 	AccountSnapshot string
+	AccountID       string
 	Provider        string
 	ReasonCode      string
 	WindowKind      string
@@ -68,6 +70,14 @@ type quotaAutoDisableCandidate struct {
 	Reason          string
 	Owner           string
 	EvidenceJSON    string
+}
+
+// quota_cooldowns predates the Codex Workspace/member identity split and has
+// no dedicated Workspace column. Keep the identity evidence in its existing
+// JSON payload so recovery can fail closed without changing the schema.
+type codexCooldownIdentityEvidence struct {
+	Workspace string `json:"workspace"`
+	Member    string `json:"member"`
 }
 
 type authFile = cpaauthfiles.File
@@ -222,11 +232,40 @@ func (w *RateLimitAutoDisableWorker) handleCandidateLocked(ctx context.Context, 
 	}
 	defer releaseMutation()
 
+	provider := normalizeQuotaProvider(candidate.Provider)
+	accountSnapshot := quotaActionAccountSnapshot(candidate.FileName, candidate.AccountSnapshot)
+	accountID := strings.TrimSpace(candidate.AccountID)
+	if provider == "codex" {
+		// quota_cooldowns has no Workspace column. Without auth_index there is
+		// no safe place to persist the credential-level fallback, so do not
+		// disable or later recover a same-name Codex credential by email alone.
+		if strings.TrimSpace(candidate.AuthIndex) == "" {
+			log.Printf("[quota-auto-disable] Codex auth file %q has no auth index; skip quota mutation", candidate.FileName)
+			return
+		}
+		if accountID != "" {
+			workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(accountID)
+			if !workspaceOK {
+				log.Printf("[quota-auto-disable] Codex auth file %q has invalid workspace evidence; skip quota mutation", candidate.FileName)
+				return
+			}
+			accountID = workspace
+		}
+		if accountSnapshot != "" {
+			member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+			if memberOK {
+				accountSnapshot = member
+			} else {
+				accountSnapshot = ""
+			}
+		}
+	}
 	target, ok, err := w.currentAuthFileTarget(ctx, candidate.BaseURL, candidate.ManagementKey, cpaauthfiles.Identity{
-		AuthFileName:    candidate.FileName,
-		AuthIndex:       candidate.AuthIndex,
-		Provider:        candidate.Provider,
-		AccountSnapshot: quotaActionAccountSnapshot(candidate.FileName, candidate.AccountSnapshot),
+		AuthFileName:      candidate.FileName,
+		AuthIndex:         candidate.AuthIndex,
+		Provider:          provider,
+		AccountSnapshot:   accountSnapshot,
+		AccountIDSnapshot: accountID,
 	})
 	if err != nil {
 		log.Printf("[quota-auto-disable] failed to verify auth file %q before disable: %v", candidate.FileName, err)
@@ -239,10 +278,28 @@ func (w *RateLimitAutoDisableWorker) handleCandidateLocked(ctx context.Context, 
 	current := target.File
 	resolvedAuthIndex := firstNonEmpty(candidate.AuthIndex, current.AuthIndex)
 	resolvedAccountSnapshot := firstNonEmpty(
-		quotaActionAccountSnapshot(candidate.FileName, candidate.AccountSnapshot),
+		accountSnapshot,
 		quotaActionAccountSnapshot(current.Name, current.AccountSnapshot),
 	)
-	resolvedProvider := normalizeQuotaProvider(firstNonEmpty(candidate.Provider, current.Provider))
+	resolvedProvider := normalizeQuotaProvider(firstNonEmpty(provider, current.Provider))
+	resolvedAccountID := firstNonEmpty(accountID, current.AccountID)
+	if resolvedProvider == "codex" {
+		workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(resolvedAccountID)
+		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(resolvedAccountSnapshot)
+		if !workspaceOK || !memberOK {
+			log.Printf("[quota-auto-disable] auth file %q has incomplete Codex workspace+member evidence; skip quota ownership", candidate.FileName)
+			return
+		}
+		resolvedAccountID = workspace
+		resolvedAccountSnapshot = member
+	}
+	if resolvedProvider == "codex" && resolvedAuthIndex == "" {
+		// quota_cooldowns has no Workspace column. Without the credential locator,
+		// the same member email in two Workspaces would collide in the legacy
+		// active-identity index even though the JSON evidence differs.
+		log.Printf("[quota-auto-disable] auth file %q has no stable Codex auth index; skip quota ownership", candidate.FileName)
+		return
+	}
 	if resolvedAuthIndex == "" && !hasQuotaFallbackIdentity(resolvedProvider, resolvedAccountSnapshot) {
 		log.Printf("[quota-auto-disable] auth file %q has no stable auth index or provider/account snapshot identity; skip auto disable/recovery ownership", candidate.FileName)
 		return
@@ -268,6 +325,14 @@ func (w *RateLimitAutoDisableWorker) handleCandidateLocked(ctx context.Context, 
 	}
 
 	owner := firstNonEmpty(candidate.Owner, model.QuotaCooldownOwnerUsage429)
+	cooldownEvidenceJSON := candidate.EvidenceJSON
+	if resolvedProvider == "codex" {
+		cooldownEvidenceJSON = codexCooldownIdentityEvidenceJSON(resolvedAccountID, resolvedAccountSnapshot)
+		if cooldownEvidenceJSON == "" {
+			log.Printf("[quota-auto-disable] auth file %q has invalid Codex cooldown identity evidence; skip quota ownership", candidate.FileName)
+			return
+		}
+	}
 	persisted, err := w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:        candidate.FileName,
 		AuthIndex:           resolvedAuthIndex,
@@ -275,7 +340,7 @@ func (w *RateLimitAutoDisableWorker) handleCandidateLocked(ctx context.Context, 
 		Provider:            resolvedProvider,
 		ReasonCode:          candidate.ReasonCode,
 		WindowKind:          candidate.WindowKind,
-		EvidenceJSON:        candidate.EvidenceJSON,
+		EvidenceJSON:        cooldownEvidenceJSON,
 		RecoverAtMS:         candidate.ResetAt.UnixMilli(),
 		Owner:               owner,
 		EventHash:           candidate.EventHash,
@@ -325,9 +390,25 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 		quotaActionAccountSnapshot(candidate.FileName, candidate.AccountSnapshot),
 		quotaActionAccountSnapshot(current.Name, current.AccountSnapshot),
 	)
+	currentAccountID := firstNonEmpty(candidate.AccountID, current.AccountID)
+	if currentProvider == "codex" && currentIndex == "" {
+		// There is no Workspace column in quota_cooldowns. A no-index Codex
+		// record cannot be safely resumed or merged across same-name members.
+		return false
+	}
+	if currentProvider == "codex" {
+		workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(currentAccountID)
+		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(currentSnapshot)
+		if !workspaceOK || !memberOK {
+			log.Printf("[quota-auto-disable] Codex cooldown for auth file %q has incomplete workspace+member evidence", candidate.FileName)
+			return false
+		}
+		currentAccountID = workspace
+		currentSnapshot = member
+	}
 	var existing store.QuotaCooldown
 	for _, item := range active {
-		if item.AuthFileName == candidate.FileName && item.Owner == owner && quotaCooldownMatchesIdentity(item, currentIndex, currentProvider, currentSnapshot) {
+		if item.AuthFileName == candidate.FileName && item.Owner == owner && quotaCooldownMatchesIdentity(item, currentIndex, currentProvider, currentAccountID, currentSnapshot) {
 			existing = item
 			break
 		}
@@ -340,6 +421,14 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 		return false
 	}
 	existingSnapshot := quotaActionAccountSnapshot(existing.AuthFileName, existing.AccountSnapshot)
+	if currentProvider == "codex" {
+		storedWorkspace, storedMember, evidenceOK := codexCooldownIdentity(existing)
+		if !evidenceOK || storedWorkspace != currentAccountID || storedMember != currentSnapshot {
+			log.Printf("[quota-auto-disable] Codex cooldown identity mismatch for auth file %q", candidate.FileName)
+			return false
+		}
+		existingSnapshot = storedMember
+	}
 	if existing.AuthIndex == "" {
 		existingProvider := normalizeQuotaProvider(existing.Provider)
 		if existingProvider != "" && currentProvider != "" && existingProvider != currentProvider {
@@ -375,6 +464,8 @@ func (w *RateLimitAutoDisableWorker) extendExistingCooldown(ctx context.Context,
 	}
 	if owner == model.QuotaCooldownOwnerXAIFreeUsage {
 		evidenceJSON = mergeXAIProviderUsageEvidence(primaryEvidence, supplementalEvidence, finalRecoverAtMS)
+	} else if currentProvider == "codex" {
+		evidenceJSON = codexCooldownIdentityEvidenceJSON(currentAccountID, currentSnapshot)
 	}
 	_, err = w.store.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:     candidate.FileName,
@@ -532,6 +623,23 @@ func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseUR
 	authIndex := strings.TrimSpace(item.AuthIndex)
 	accountSnapshot := quotaActionAccountSnapshot(item.AuthFileName, item.AccountSnapshot)
 	provider := normalizeQuotaProvider(item.Provider)
+	accountID := ""
+	if provider == "codex" {
+		var evidenceOK bool
+		accountID, accountSnapshot, evidenceOK = codexCooldownIdentity(item)
+		if !evidenceOK {
+			reason := "Codex cooldown has no verifiable workspace+member evidence"
+			_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
+			log.Printf("[quota-auto-disable] skip cooldown recovery id=%d authFile=%q reason=%s", item.ID, item.AuthFileName, reason)
+			return
+		}
+	}
+	if provider == "codex" && authIndex == "" {
+		reason := "Codex cooldown has no auth index; workspace-only cooldown identity is not recoverable"
+		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
+		log.Printf("[quota-auto-disable] skip cooldown recovery id=%d authFile=%q reason=%s", item.ID, item.AuthFileName, reason)
+		return
+	}
 	if authIndex == "" && !hasQuotaFallbackIdentity(provider, accountSnapshot) {
 		reason := "cooldown identity has no stable auth index or provider/account snapshot identity"
 		_ = w.store.MarkQuotaCooldownSkipped(ctx, item.ID, reason)
@@ -550,10 +658,11 @@ func (w *RateLimitAutoDisableWorker) recoverCooldown(ctx context.Context, baseUR
 	}
 	defer releaseMutation()
 	target, ok, err := w.currentAuthFileTarget(ctx, baseURL, managementKey, cpaauthfiles.Identity{
-		AuthFileName:    item.AuthFileName,
-		AuthIndex:       authIndex,
-		Provider:        provider,
-		AccountSnapshot: accountSnapshot,
+		AuthFileName:      item.AuthFileName,
+		AuthIndex:         authIndex,
+		Provider:          provider,
+		AccountSnapshot:   accountSnapshot,
+		AccountIDSnapshot: accountID,
 	})
 	if err != nil {
 		if errors.Is(err, cpaauthfiles.ErrIdentityMismatch) {
@@ -658,6 +767,7 @@ func quotaAutoDisableCandidateFromEvent(event usage.Event, baseURL string, manag
 		AuthIndex:       strings.TrimSpace(event.AuthIndex),
 		DisplayAccount:  firstNonEmpty(event.AccountSnapshot, event.AuthLabelSnapshot, event.Source, fileName),
 		AccountSnapshot: quotaActionAccountSnapshot(fileName, event.AccountSnapshot),
+		AccountID:       strings.TrimSpace(event.AuthAccountIDSnapshot),
 		Provider:        "codex",
 		ReasonCode:      quotaReasonCodexUsageLimit,
 		WindowKind:      codexQuotaWindowKindFromEvent(event),
@@ -1277,9 +1387,20 @@ func hasQuotaFallbackIdentity(provider string, accountSnapshot string) bool {
 	return normalizeQuotaProvider(provider) != "" && strings.TrimSpace(accountSnapshot) != ""
 }
 
-func quotaCooldownMatchesIdentity(item store.QuotaCooldown, authIndex string, provider string, accountSnapshot string) bool {
+func quotaCooldownMatchesIdentity(item store.QuotaCooldown, authIndex string, provider string, accountID string, accountSnapshot string) bool {
 	itemAuthIndex := strings.TrimSpace(item.AuthIndex)
 	authIndex = strings.TrimSpace(authIndex)
+	provider = normalizeQuotaProvider(provider)
+	itemProvider := normalizeQuotaProvider(item.Provider)
+	if provider == "codex" || itemProvider == "codex" {
+		if provider != "codex" || itemProvider != "codex" || itemAuthIndex == "" || authIndex == "" || itemAuthIndex != authIndex {
+			return false
+		}
+		storedWorkspace, storedMember, evidenceOK := codexCooldownIdentity(item)
+		currentWorkspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(accountID)
+		currentMember, memberOK := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+		return evidenceOK && workspaceOK && memberOK && storedWorkspace == currentWorkspace && storedMember == currentMember
+	}
 	if itemAuthIndex != "" {
 		return authIndex != "" && itemAuthIndex == authIndex
 	}
@@ -1288,9 +1409,39 @@ func quotaCooldownMatchesIdentity(item store.QuotaCooldown, authIndex string, pr
 	if itemSnapshot == "" || accountSnapshot == "" || itemSnapshot != accountSnapshot {
 		return false
 	}
-	itemProvider := normalizeQuotaProvider(item.Provider)
-	provider = normalizeQuotaProvider(provider)
 	return itemProvider != "" && provider != "" && itemProvider == provider
+}
+
+func codexCooldownIdentityEvidenceJSON(workspace string, member string) string {
+	workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(workspace)
+	member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(member)
+	if !workspaceOK || !memberOK {
+		return ""
+	}
+	raw, err := json.Marshal(codexCooldownIdentityEvidence{Workspace: workspace, Member: member})
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+func codexCooldownIdentity(item store.QuotaCooldown) (workspace string, member string, ok bool) {
+	var evidence codexCooldownIdentityEvidence
+	if err := json.Unmarshal([]byte(strings.TrimSpace(item.EvidenceJSON)), &evidence); err != nil {
+		return "", "", false
+	}
+	workspace, workspaceOK := usageidentity.NormalizeCodexWorkspaceSnapshot(evidence.Workspace)
+	member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(evidence.Member)
+	if !workspaceOK || !memberOK {
+		return "", "", false
+	}
+	if storedMember := strings.TrimSpace(item.AccountSnapshot); storedMember != "" {
+		normalizedStoredMember, storedMemberOK := usageidentity.NormalizeCodexMemberSnapshot(storedMember)
+		if !storedMemberOK || normalizedStoredMember != member {
+			return "", "", false
+		}
+	}
+	return workspace, member, true
 }
 
 func (w *RateLimitAutoDisableWorker) patchAuthFileTarget(ctx context.Context, baseURL string, managementKey string, target cpaauthfiles.StatusMutationTarget, disabled bool) error {

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -532,6 +532,7 @@ func TestExtendExistingCooldownKeepsWinningRecoveryMetadata(t *testing.T) {
 		Provider:     "codex",
 		ReasonCode:   "weekly_limit",
 		WindowKind:   "weekly",
+		EvidenceJSON: codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
 		RecoverAtMS:  existingRecoverAt.UnixMilli(),
 		Owner:        model.QuotaCooldownOwnerUsage429,
 		EventHash:    "evt-weekly",
@@ -542,20 +543,24 @@ func TestExtendExistingCooldownKeepsWinningRecoveryMetadata(t *testing.T) {
 
 	worker := NewRateLimitAutoDisableWorker(st)
 	candidate := quotaAutoDisableCandidate{
-		FileName:   "codex-auth.json",
-		AuthIndex:  "auth-codex-1",
-		Provider:   "codex",
-		Owner:      model.QuotaCooldownOwnerUsage429,
-		ReasonCode: "five_hour_limit",
-		WindowKind: "five_hour",
-		ResetAt:    now.Add(6 * time.Hour),
-		EventHash:  "evt-five-hour",
+		FileName:        "codex-auth.json",
+		AuthIndex:       "auth-codex-1",
+		AccountSnapshot: "user@example.com",
+		AccountID:       "workspace-1",
+		Provider:        "codex",
+		Owner:           model.QuotaCooldownOwnerUsage429,
+		ReasonCode:      "five_hour_limit",
+		WindowKind:      "five_hour",
+		ResetAt:         now.Add(6 * time.Hour),
+		EventHash:       "evt-five-hour",
 	}
 	if !worker.extendExistingCooldown(ctx, candidate, authFile{
-		Name:      candidate.FileName,
-		AuthIndex: candidate.AuthIndex,
-		Provider:  candidate.Provider,
-		Disabled:  true,
+		Name:            candidate.FileName,
+		AuthIndex:       candidate.AuthIndex,
+		Provider:        candidate.Provider,
+		AccountSnapshot: candidate.AccountSnapshot,
+		AccountID:       candidate.AccountID,
+		Disabled:        true,
 	}) {
 		t.Fatal("existing cooldown was not updated")
 	}
@@ -581,8 +586,9 @@ func TestExtendExistingCooldownUsesAuthIndexWhenDisplayAccountChanges(t *testing
 	if _, err := st.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:    "shared.json",
 		AuthIndex:       "auth-1",
-		AccountSnapshot: "old-label@example.com",
+		AccountSnapshot: "alice@example.com",
 		Provider:        "codex",
+		EvidenceJSON:    codexCooldownIdentityEvidenceJSON("workspace-1", "alice@example.com"),
 		RecoverAtMS:     now.Add(time.Hour).UnixMilli(),
 		Owner:           model.QuotaCooldownOwnerUsage429,
 		DisabledAtMS:    now.Add(-time.Hour).UnixMilli(),
@@ -592,18 +598,21 @@ func TestExtendExistingCooldownUsesAuthIndexWhenDisplayAccountChanges(t *testing
 
 	worker := NewRateLimitAutoDisableWorker(st)
 	candidate := quotaAutoDisableCandidate{
-		FileName:       "shared.json",
-		AuthIndex:      "auth-1",
-		DisplayAccount: "new-label@example.com",
-		Provider:       "codex",
-		Owner:          model.QuotaCooldownOwnerUsage429,
-		ResetAt:        now.Add(2 * time.Hour),
+		FileName:        "shared.json",
+		AuthIndex:       "auth-1",
+		DisplayAccount:  "new-label@example.com",
+		AccountSnapshot: "alice@example.com",
+		AccountID:       "workspace-1",
+		Provider:        "codex",
+		Owner:           model.QuotaCooldownOwnerUsage429,
+		ResetAt:         now.Add(2 * time.Hour),
 	}
 	if !worker.extendExistingCooldown(ctx, candidate, authFile{
 		Name:            candidate.FileName,
 		AuthIndex:       candidate.AuthIndex,
 		Provider:        candidate.Provider,
-		AccountSnapshot: candidate.DisplayAccount,
+		AccountSnapshot: candidate.AccountSnapshot,
+		AccountID:       candidate.AccountID,
 		Disabled:        true,
 	}) {
 		t.Fatal("stable auth_index cooldown was not extended after display account changed")
@@ -614,7 +623,7 @@ func TestExtendExistingCooldownUsesAuthIndexWhenDisplayAccountChanges(t *testing
 		t.Fatalf("list active cooldowns: %v", err)
 	}
 	if len(active) != 1 || active[0].RecoverAtMS != candidate.ResetAt.UnixMilli() ||
-		active[0].AuthIndex != candidate.AuthIndex || active[0].AccountSnapshot != candidate.DisplayAccount {
+		active[0].AuthIndex != candidate.AuthIndex || active[0].AccountSnapshot != candidate.AccountSnapshot {
 		t.Fatalf("active cooldown = %#v", active)
 	}
 }
@@ -678,16 +687,20 @@ func TestExtendExistingCooldownSelectsMatchingSharedFileIdentity(t *testing.T) {
 	for _, item := range []store.QuotaCooldownUpsert{
 		{
 			AuthFileName:    "shared.json",
+			AuthIndex:       "alice-auth-1",
 			AccountSnapshot: "alice@example.com",
 			Provider:        "codex",
+			EvidenceJSON:    codexCooldownIdentityEvidenceJSON("workspace-1", "alice@example.com"),
 			RecoverAtMS:     now.Add(time.Hour).UnixMilli(),
 			Owner:           model.QuotaCooldownOwnerUsage429,
 			DisabledAtMS:    now.Add(-time.Hour).UnixMilli(),
 		},
 		{
 			AuthFileName:    "shared.json",
+			AuthIndex:       "bob-auth-1",
 			AccountSnapshot: "bob@example.com",
 			Provider:        "codex",
+			EvidenceJSON:    codexCooldownIdentityEvidenceJSON("workspace-1", "bob@example.com"),
 			RecoverAtMS:     now.Add(2 * time.Hour).UnixMilli(),
 			Owner:           model.QuotaCooldownOwnerUsage429,
 			DisabledAtMS:    now.Add(-time.Hour).UnixMilli(),
@@ -701,16 +714,20 @@ func TestExtendExistingCooldownSelectsMatchingSharedFileIdentity(t *testing.T) {
 	worker := NewRateLimitAutoDisableWorker(st)
 	candidate := quotaAutoDisableCandidate{
 		FileName:        "shared.json",
+		AuthIndex:       "bob-auth-1",
 		DisplayAccount:  "bob@example.com",
 		AccountSnapshot: "bob@example.com",
+		AccountID:       "workspace-1",
 		Provider:        "codex",
 		Owner:           model.QuotaCooldownOwnerUsage429,
 		ResetAt:         now.Add(3 * time.Hour),
 	}
 	if !worker.extendExistingCooldown(ctx, candidate, authFile{
 		Name:            candidate.FileName,
+		AuthIndex:       candidate.AuthIndex,
 		Provider:        candidate.Provider,
 		AccountSnapshot: candidate.DisplayAccount,
+		AccountID:       candidate.AccountID,
 		Disabled:        true,
 	}) {
 		t.Fatal("matching shared-file cooldown was not extended")
@@ -762,6 +779,7 @@ func TestRateLimitAutoDisableWorkerSkipsOwnershipWithoutStableIdentity(t *testin
 		BaseURL:        server.URL,
 		ManagementKey:  "mgmt",
 		FileName:       "auth.json",
+		AuthIndex:      "auth-1",
 		DisplayAccount: "auth.json",
 		Provider:       "codex",
 		ResetAt:        time.Now().Add(time.Hour),
@@ -790,11 +808,13 @@ func TestRateLimitAutoDisableWorkerPersistsVerifiedFallbackSnapshot(t *testing.T
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
-				"id":       "runtime-auth",
-				"name":     "auth.json",
-				"provider": "codex",
-				"account":  "verified@example.com",
-				"disabled": false,
+				"id":         "runtime-auth",
+				"name":       "auth.json",
+				"auth_index": "auth-1",
+				"provider":   "codex",
+				"account":    "verified@example.com",
+				"account_id": "workspace-1",
+				"disabled":   false,
 			}})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
 			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
@@ -808,6 +828,7 @@ func TestRateLimitAutoDisableWorkerPersistsVerifiedFallbackSnapshot(t *testing.T
 		BaseURL:        server.URL,
 		ManagementKey:  "mgmt",
 		FileName:       "auth.json",
+		AuthIndex:      "auth-1",
 		DisplayAccount: "auth.json",
 		ResetAt:        time.Now().Add(time.Hour),
 	})
@@ -816,7 +837,7 @@ func TestRateLimitAutoDisableWorkerPersistsVerifiedFallbackSnapshot(t *testing.T
 	if err != nil {
 		t.Fatalf("list active cooldowns: %v", err)
 	}
-	if len(active) != 1 || active[0].AuthIndex != "" || active[0].AccountSnapshot != "verified@example.com" || active[0].Provider != "codex" {
+	if len(active) != 1 || active[0].AuthIndex != "auth-1" || active[0].AccountSnapshot != "verified@example.com" || active[0].Provider != "codex" {
 		t.Fatalf("active cooldowns = %#v, want verified provider/account fallback identity", active)
 	}
 }
@@ -1192,6 +1213,7 @@ func TestRateLimitAutoDisableWorkerDoesNotRollbackSamePathReplacementAfterPersis
 				"auth_index": "auth-1",
 				"provider":   "codex",
 				"account":    account,
+				"account_id": "workspace-1",
 				"disabled":   getCalls > 1,
 			}})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
@@ -1214,14 +1236,16 @@ func TestRateLimitAutoDisableWorkerDoesNotRollbackSamePathReplacementAfterPersis
 	defer server.Close()
 
 	NewRateLimitAutoDisableWorker(st).handleCandidate(context.Background(), quotaAutoDisableCandidate{
-		BaseURL:        server.URL,
-		ManagementKey:  "mgmt",
-		FileName:       "codex-auth.json",
-		AuthIndex:      "auth-1",
-		DisplayAccount: "original@example.com",
-		Provider:       "codex",
-		ResetAt:        time.Now().Add(time.Hour),
-		EventHash:      "evt-persist-failure-replacement",
+		BaseURL:         server.URL,
+		ManagementKey:   "mgmt",
+		FileName:        "codex-auth.json",
+		AuthIndex:       "auth-1",
+		DisplayAccount:  "original@example.com",
+		AccountSnapshot: "original@example.com",
+		AccountID:       "workspace-1",
+		Provider:        "codex",
+		ResetAt:         time.Now().Add(time.Hour),
+		EventHash:       "evt-persist-failure-replacement",
 	})
 
 	if getCalls != 2 {
@@ -1249,7 +1273,7 @@ func TestRateLimitAutoDisableWorkerCompensatesAfterParentCancellation(t *testing
 			getCalls++
 			disabled := len(patchStates) > 0 && patchStates[len(patchStates)-1]
 			body := fmt.Sprintf(
-				`[{"id":"runtime-codex-7","name":"codex-auth.json","auth_index":"auth-1","provider":"codex","account":"user@example.com","disabled":%t}]`,
+				`[{"id":"runtime-codex-7","name":"codex-auth.json","auth_index":"auth-1","provider":"codex","account":"user@example.com","account_id":"workspace-1","disabled":%t}]`,
 				disabled,
 			)
 			return workerHTTPResponse(r, io.NopCloser(strings.NewReader(body))), nil
@@ -1279,6 +1303,7 @@ func TestRateLimitAutoDisableWorkerCompensatesAfterParentCancellation(t *testing
 		AuthIndex:       "auth-1",
 		DisplayAccount:  "user@example.com",
 		AccountSnapshot: "user@example.com",
+		AccountID:       "workspace-1",
 		Provider:        "codex",
 		ResetAt:         time.Now().Add(time.Hour),
 		EventHash:       "evt-parent-canceled",
@@ -1313,7 +1338,7 @@ func TestRateLimitAutoDisableWorkerCompensationHasTotalTimeout(t *testing.T) {
 				return nil, r.Context().Err()
 			}
 			return workerHTTPResponse(r, io.NopCloser(strings.NewReader(
-				`[{"id":"runtime-codex-7","name":"codex-auth.json","auth_index":"auth-1","provider":"codex","account":"user@example.com","disabled":false}]`,
+				`[{"id":"runtime-codex-7","name":"codex-auth.json","auth_index":"auth-1","provider":"codex","account":"user@example.com","account_id":"workspace-1","disabled":false}]`,
 			))), nil
 		case http.MethodPatch + " /v0/management/auth-files/status":
 			_ = st.Close()
@@ -1333,6 +1358,7 @@ func TestRateLimitAutoDisableWorkerCompensationHasTotalTimeout(t *testing.T) {
 		AuthIndex:       "auth-1",
 		DisplayAccount:  "user@example.com",
 		AccountSnapshot: "user@example.com",
+		AccountID:       "workspace-1",
 		Provider:        "codex",
 		ResetAt:         time.Now().Add(time.Hour),
 		EventHash:       "evt-compensation-timeout",
@@ -1497,8 +1523,8 @@ func TestRateLimitAutoDisableWorkerDoesNotRecoverAmbiguousStatusMutationScope(t 
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode([]map[string]any{
-				{"id": "shared.json", "name": "shared.json", "auth_index": "auth-1", "provider": "codex", "account": "user@example.com", "disabled": true},
-				{"id": "runtime-auth-2", "name": "shared.json", "auth_index": "auth-2", "provider": "codex", "disabled": true},
+				{"id": "shared.json", "name": "shared.json", "auth_index": "auth-1", "provider": "codex", "account": "user@example.com", "account_id": "workspace-1", "disabled": true},
+				{"id": "runtime-auth-2", "name": "shared.json", "auth_index": "auth-2", "provider": "codex", "account": "other@example.com", "account_id": "workspace-1", "disabled": true},
 			})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
 			patchCalls++
@@ -1516,6 +1542,7 @@ func TestRateLimitAutoDisableWorkerDoesNotRecoverAmbiguousStatusMutationScope(t 
 		AuthIndex:        "auth-1",
 		AccountSnapshot:  "user@example.com",
 		Provider:         "codex",
+		EvidenceJSON:     codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
 		RecoverAtMS:      now.Add(-time.Minute).UnixMilli(),
 		Owner:            model.QuotaCooldownOwnerUsage429,
 		EventHash:        "evt-ambiguous-recovery",
@@ -1543,6 +1570,174 @@ func TestRateLimitAutoDisableWorkerDoesNotRecoverAmbiguousStatusMutationScope(t 
 	}
 }
 
+func TestRateLimitAutoDisableWorkerSelectsCodexMemberWithinSharedWorkspace(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	patchCalls := 0
+	patchedName := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v0/management/auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id":         "runtime-alice",
+					"name":       "shared.json",
+					"auth_index": "shared-auth",
+					"provider":   "codex",
+					"account":    "alice@example.com",
+					"account_id": "workspace-1",
+					"disabled":   false,
+				},
+				{
+					"id":         "runtime-bob",
+					"name":       "shared.json",
+					"auth_index": "shared-auth",
+					"provider":   "codex",
+					"account":    "bob@example.com",
+					"account_id": "workspace-1",
+					"disabled":   false,
+				},
+			})
+		case "PATCH /v0/management/auth-files/status":
+			var payload struct {
+				Name     string `json:"name"`
+				Disabled bool   `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			patchCalls++
+			patchedName = payload.Name
+			if !payload.Disabled {
+				http.Error(w, "expected disable", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Now()
+	NewRateLimitAutoDisableWorker(st).handleCandidate(context.Background(), quotaAutoDisableCandidate{
+		BaseURL:         server.URL,
+		ManagementKey:   "mgmt",
+		FileName:        "shared.json",
+		AuthIndex:       "shared-auth",
+		DisplayAccount:  "alice@example.com",
+		AccountSnapshot: "alice@example.com",
+		AccountID:       "workspace-1",
+		Provider:        "codex",
+		ResetAt:         now.Add(time.Hour),
+		EventHash:       "evt-shared-alice",
+	})
+
+	if patchCalls != 1 || patchedName != "runtime-alice" {
+		t.Fatalf("patch target = %q with %d calls, want runtime-alice once", patchedName, patchCalls)
+	}
+	active, err := st.QuotaCooldowns.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("list active cooldowns: %v", err)
+	}
+	if len(active) != 1 || active[0].AccountSnapshot != "alice@example.com" ||
+		active[0].AuthIndex != "shared-auth" || active[0].EvidenceJSON != codexCooldownIdentityEvidenceJSON("workspace-1", "alice@example.com") {
+		t.Fatalf("active cooldowns = %#v, want Alice identity", active)
+	}
+}
+
+func TestRateLimitAutoDisableWorkerRecoversCodexMemberWithinSharedWorkspace(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	patchCalls := 0
+	patchedName := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v0/management/auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id":         "runtime-alice",
+					"name":       "shared.json",
+					"auth_index": "shared-auth",
+					"provider":   "codex",
+					"account":    "alice@example.com",
+					"account_id": "workspace-1",
+					"disabled":   true,
+				},
+				{
+					"id":         "runtime-bob",
+					"name":       "shared.json",
+					"auth_index": "shared-auth",
+					"provider":   "codex",
+					"account":    "bob@example.com",
+					"account_id": "workspace-1",
+					"disabled":   true,
+				},
+			})
+		case "PATCH /v0/management/auth-files/status":
+			var payload struct {
+				Name     string `json:"name"`
+				Disabled bool   `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			patchCalls++
+			patchedName = payload.Name
+			if payload.Disabled {
+				http.Error(w, "expected enable", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	if _, err := st.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
+		AuthFileName:     "shared.json",
+		AuthIndex:        "shared-auth",
+		AccountSnapshot:  "alice@example.com",
+		Provider:         "codex",
+		EvidenceJSON:     codexCooldownIdentityEvidenceJSON("workspace-1", "alice@example.com"),
+		RecoverAtMS:      time.Now().Add(-time.Minute).UnixMilli(),
+		Owner:            model.QuotaCooldownOwnerUsage429,
+		EventHash:        "evt-shared-alice-recovery",
+		PreDisabledState: false,
+		DisabledAtMS:     time.Now().Add(-time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("seed cooldown: %v", err)
+	}
+
+	NewRateLimitAutoDisableWorker(st, collectorpkg.RuntimeConfig{
+		CPAUpstreamURL: server.URL,
+		ManagementKey:  "mgmt",
+	}).enableDue(ctx, time.Now())
+
+	if patchCalls != 1 || patchedName != "runtime-alice" {
+		t.Fatalf("patch target = %q with %d calls, want runtime-alice once", patchedName, patchCalls)
+	}
+	active, err := st.QuotaCooldowns.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("list active cooldowns: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("active cooldowns = %#v, want Alice cooldown recovered", active)
+	}
+}
+
 func TestRateLimitAutoDisableWorkerSkipsRecoveryAfterCredentialIdentityChanges(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {
@@ -1560,6 +1755,7 @@ func TestRateLimitAutoDisableWorkerSkipsRecoveryAfterCredentialIdentityChanges(t
 				"auth_index": "auth-1",
 				"provider":   "codex",
 				"account":    "replacement@example.com",
+				"account_id": "workspace-1",
 				"disabled":   true,
 			}})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
@@ -1578,6 +1774,7 @@ func TestRateLimitAutoDisableWorkerSkipsRecoveryAfterCredentialIdentityChanges(t
 		AuthIndex:        "auth-1",
 		AccountSnapshot:  "original@example.com",
 		Provider:         "codex",
+		EvidenceJSON:     codexCooldownIdentityEvidenceJSON("workspace-1", "original@example.com"),
 		RecoverAtMS:      now.Add(-time.Minute).UnixMilli(),
 		Owner:            model.QuotaCooldownOwnerUsage429,
 		PreDisabledState: false,
@@ -1663,6 +1860,7 @@ func TestRateLimitAutoDisableWorkerSerializesRecoveryAndCooldownExtension(t *tes
 		AuthIndex:        "auth-1",
 		AccountSnapshot:  "user@example.com",
 		Provider:         "codex",
+		EvidenceJSON:     codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
 		RecoverAtMS:      now.Add(-time.Minute).UnixMilli(),
 		Owner:            model.QuotaCooldownOwnerUsage429,
 		PreDisabledState: false,
@@ -1694,6 +1892,7 @@ func TestRateLimitAutoDisableWorkerSerializesRecoveryAndCooldownExtension(t *tes
 				"auth_index": "auth-1",
 				"provider":   "codex",
 				"account":    "user@example.com",
+				"account_id": "workspace-1",
 				"disabled":   currentDisabled,
 			}})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
@@ -1728,14 +1927,16 @@ func TestRateLimitAutoDisableWorkerSerializesRecoveryAndCooldownExtension(t *tes
 	extensionDone := make(chan struct{})
 	go func() {
 		worker.handleCandidate(ctx, quotaAutoDisableCandidate{
-			BaseURL:        server.URL,
-			ManagementKey:  "mgmt",
-			FileName:       "codex-auth.json",
-			AuthIndex:      "auth-1",
-			DisplayAccount: "user@example.com",
-			Provider:       "codex",
-			ResetAt:        now.Add(time.Hour),
-			EventHash:      "evt-extended",
+			BaseURL:         server.URL,
+			ManagementKey:   "mgmt",
+			FileName:        "codex-auth.json",
+			AuthIndex:       "auth-1",
+			DisplayAccount:  "user@example.com",
+			AccountSnapshot: "user@example.com",
+			AccountID:       "workspace-1",
+			Provider:        "codex",
+			ResetAt:         now.Add(time.Hour),
+			EventHash:       "evt-extended",
 		})
 		close(extensionDone)
 	}()
@@ -1796,6 +1997,8 @@ func TestRateLimitAutoDisableWorkerRecoversDueCooldownFromManagerRuntimeConfigAf
 				"name":       "codex-auth.json",
 				"auth_index": "auth-1",
 				"provider":   "codex",
+				"account":    "user@example.com",
+				"account_id": "workspace-1",
 				"disabled":   currentDisabled,
 			}})
 		case "/v0/management/auth-files/status":
@@ -1830,7 +2033,9 @@ func TestRateLimitAutoDisableWorkerRecoversDueCooldownFromManagerRuntimeConfigAf
 	if _, err := st.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName:     "codex-auth.json",
 		AuthIndex:        "auth-1",
+		AccountSnapshot:  "user@example.com",
 		Provider:         "codex",
+		EvidenceJSON:     codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
 		RecoverAtMS:      time.Now().Add(-time.Minute).UnixMilli(),
 		Owner:            model.QuotaCooldownOwnerUsage429,
 		EventHash:        "evt-due",
@@ -2076,6 +2281,7 @@ func TestRateLimitAutoDisableWorkerRollsBackEnableWhenRecoveryPersistenceFails(t
 				"auth_index": "auth-1",
 				"provider":   "codex",
 				"account":    "user@example.com",
+				"account_id": "workspace-1",
 				"disabled":   disabled,
 			}})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
@@ -2102,6 +2308,7 @@ func TestRateLimitAutoDisableWorkerRollsBackEnableWhenRecoveryPersistenceFails(t
 		AuthIndex:        "auth-1",
 		AccountSnapshot:  "user@example.com",
 		Provider:         "codex",
+		EvidenceJSON:     codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
 		RecoverAtMS:      now.Add(-time.Minute).UnixMilli(),
 		Owner:            model.QuotaCooldownOwnerUsage429,
 		EventHash:        "recovery-persistence-failure",
@@ -2158,12 +2365,13 @@ func TestRateLimitAutoDisableWorkerPersistsAndRecoversAfterRestart(t *testing.T)
 			currentDisabled := disabled
 			mu.Unlock()
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
-				"id":        "runtime-codex-auth-1",
-				"name":      "codex-auth.json",
-				"authIndex": "auth-1",
-				"provider":  "codex",
-				"account":   "user@example.com",
-				"disabled":  currentDisabled,
+				"id":         "runtime-codex-auth-1",
+				"name":       "codex-auth.json",
+				"authIndex":  "auth-1",
+				"provider":   "codex",
+				"account":    "user@example.com",
+				"account_id": "workspace-1",
+				"disabled":   currentDisabled,
 			}})
 		case http.MethodPatch:
 			if r.URL.Path != "/v0/management/auth-files/status" {
@@ -2189,14 +2397,16 @@ func TestRateLimitAutoDisableWorkerPersistsAndRecoversAfterRestart(t *testing.T)
 	ctx := context.Background()
 	worker := NewRateLimitAutoDisableWorker(st, collectorpkg.RuntimeConfig{CPAUpstreamURL: server.URL, ManagementKey: "test-management-key"})
 	worker.handleCandidate(ctx, quotaAutoDisableCandidate{
-		BaseURL:        server.URL,
-		ManagementKey:  "test-management-key",
-		FileName:       "codex-auth.json",
-		AuthIndex:      "auth-1",
-		DisplayAccount: "user@example.com",
-		Provider:       "codex",
-		ResetAt:        time.Now().Add(time.Minute),
-		EventHash:      "evt-quota",
+		BaseURL:         server.URL,
+		ManagementKey:   "test-management-key",
+		FileName:        "codex-auth.json",
+		AuthIndex:       "auth-1",
+		DisplayAccount:  "user@example.com",
+		AccountSnapshot: "user@example.com",
+		AccountID:       "workspace-1",
+		Provider:        "codex",
+		ResetAt:         time.Now().Add(time.Minute),
+		EventHash:       "evt-quota",
 	})
 
 	mu.Lock()
@@ -2243,6 +2453,7 @@ func TestRateLimitAutoDisableWorkerStartsNewCycleAfterExternalEnable(t *testing.
 		AuthIndex:       "auth-1",
 		AccountSnapshot: "user@example.com",
 		Provider:        "codex",
+		EvidenceJSON:    codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
 		ReasonCode:      "weekly_limit",
 		WindowKind:      "weekly",
 		RecoverAtMS:     now.Add(7 * 24 * time.Hour).UnixMilli(),
@@ -2269,6 +2480,7 @@ func TestRateLimitAutoDisableWorkerStartsNewCycleAfterExternalEnable(t *testing.
 				"auth_index": "auth-1",
 				"provider":   "codex",
 				"account":    "user@example.com",
+				"account_id": "workspace-1",
 				"disabled":   currentDisabled,
 			}})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
@@ -2302,6 +2514,7 @@ func TestRateLimitAutoDisableWorkerStartsNewCycleAfterExternalEnable(t *testing.
 		AuthIndex:       "auth-1",
 		DisplayAccount:  "user@example.com",
 		AccountSnapshot: "user@example.com",
+		AccountID:       "workspace-1",
 		Provider:        "codex",
 		ReasonCode:      quotaReasonCodexUsageLimit,
 		WindowKind:      "five_hour",
@@ -2361,14 +2574,14 @@ func TestRateLimitAutoDisableWorkerStartsNewCycleAfterExternalEnable(t *testing.
 	}
 }
 
-func TestRateLimitAutoDisableWorkerTargetsSameNameCredentialWithoutAuthIndex(t *testing.T) {
+func TestRateLimitAutoDisableWorkerSkipsSameNameCredentialWithoutAuthIndex(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
 	defer st.Close()
 
-	patchedName := ""
+	patchCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v0/management/auth-files" && r.Method == http.MethodGet:
@@ -2377,14 +2590,7 @@ func TestRateLimitAutoDisableWorkerTargetsSameNameCredentialWithoutAuthIndex(t *
 				{"id": "runtime-second", "name": "shared.json", "provider": "codex", "account": "second@example.com", "disabled": false},
 			})
 		case r.URL.Path == "/v0/management/auth-files/status" && r.Method == http.MethodPatch:
-			var payload struct {
-				Name string `json:"name"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			patchedName = payload.Name
+			patchCalls++
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
 			http.NotFound(w, r)
@@ -2403,15 +2609,15 @@ func TestRateLimitAutoDisableWorkerTargetsSameNameCredentialWithoutAuthIndex(t *
 		EventHash:       "evt-no-auth-index",
 	})
 
-	if patchedName != "runtime-second" {
-		t.Fatalf("patched name = %q, want runtime-second", patchedName)
+	if patchCalls != 0 {
+		t.Fatalf("patch calls = %d, want 0", patchCalls)
 	}
 	active, err := st.QuotaCooldowns.ListActive(context.Background())
 	if err != nil {
 		t.Fatalf("list active cooldowns: %v", err)
 	}
-	if len(active) != 1 || active[0].AuthIndex != "" || active[0].AccountSnapshot != "second@example.com" {
-		t.Fatalf("active cooldowns = %#v, want second credential snapshot identity", active)
+	if len(active) != 0 {
+		t.Fatalf("active cooldowns = %#v, want none", active)
 	}
 }
 

--- a/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
+++ b/apps/manager-server/internal/worker/rate_limit_auto_disable_test.go
@@ -526,13 +526,14 @@ func TestExtendExistingCooldownKeepsWinningRecoveryMetadata(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 	existingRecoverAt := now.Add(12 * time.Hour)
+	existingEvidence := fmt.Sprintf(`{"source":"codex-window","recover_at_ms":%d}`, existingRecoverAt.UnixMilli())
 	if _, err := st.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
 		AuthFileName: "codex-auth.json",
 		AuthIndex:    "auth-codex-1",
 		Provider:     "codex",
 		ReasonCode:   "weekly_limit",
 		WindowKind:   "weekly",
-		EvidenceJSON: codexCooldownIdentityEvidenceJSON("workspace-1", "user@example.com"),
+		EvidenceJSON: existingEvidence,
 		RecoverAtMS:  existingRecoverAt.UnixMilli(),
 		Owner:        model.QuotaCooldownOwnerUsage429,
 		EventHash:    "evt-weekly",
@@ -569,7 +570,7 @@ func TestExtendExistingCooldownKeepsWinningRecoveryMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list active cooldowns: %v", err)
 	}
-	if len(active) != 1 || active[0].RecoverAtMS != existingRecoverAt.UnixMilli() || active[0].ReasonCode != "weekly_limit" || active[0].WindowKind != "weekly" || active[0].EventHash != "evt-weekly" {
+	if len(active) != 1 || active[0].RecoverAtMS != existingRecoverAt.UnixMilli() || active[0].ReasonCode != "weekly_limit" || active[0].WindowKind != "weekly" || active[0].EvidenceJSON != existingEvidence || active[0].EventHash != "evt-weekly" {
 		t.Fatalf("active cooldown = %#v", active)
 	}
 }
@@ -1570,7 +1571,7 @@ func TestRateLimitAutoDisableWorkerDoesNotRecoverAmbiguousStatusMutationScope(t 
 	}
 }
 
-func TestRateLimitAutoDisableWorkerSelectsCodexMemberWithinSharedWorkspace(t *testing.T) {
+func TestRateLimitAutoDisableWorkerRejectsDuplicateCodexCredentialLocator(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -1638,20 +1639,19 @@ func TestRateLimitAutoDisableWorkerSelectsCodexMemberWithinSharedWorkspace(t *te
 		EventHash:       "evt-shared-alice",
 	})
 
-	if patchCalls != 1 || patchedName != "runtime-alice" {
-		t.Fatalf("patch target = %q with %d calls, want runtime-alice once", patchedName, patchCalls)
+	if patchCalls != 0 || patchedName != "" {
+		t.Fatalf("patch target = %q with %d calls, want no mutation for duplicate locator", patchedName, patchCalls)
 	}
 	active, err := st.QuotaCooldowns.ListActive(context.Background())
 	if err != nil {
 		t.Fatalf("list active cooldowns: %v", err)
 	}
-	if len(active) != 1 || active[0].AccountSnapshot != "alice@example.com" ||
-		active[0].AuthIndex != "shared-auth" || active[0].EvidenceJSON != codexCooldownIdentityEvidenceJSON("workspace-1", "alice@example.com") {
-		t.Fatalf("active cooldowns = %#v, want Alice identity", active)
+	if len(active) != 0 {
+		t.Fatalf("active cooldowns = %#v, want no cooldown for duplicate locator", active)
 	}
 }
 
-func TestRateLimitAutoDisableWorkerRecoversCodexMemberWithinSharedWorkspace(t *testing.T) {
+func TestRateLimitAutoDisableWorkerRejectsDuplicateCodexRecoveryLocator(t *testing.T) {
 	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -1726,15 +1726,86 @@ func TestRateLimitAutoDisableWorkerRecoversCodexMemberWithinSharedWorkspace(t *t
 		ManagementKey:  "mgmt",
 	}).enableDue(ctx, time.Now())
 
-	if patchCalls != 1 || patchedName != "runtime-alice" {
-		t.Fatalf("patch target = %q with %d calls, want runtime-alice once", patchedName, patchCalls)
+	if patchCalls != 0 || patchedName != "" {
+		t.Fatalf("patch target = %q with %d calls, want no mutation for duplicate locator", patchedName, patchCalls)
+	}
+	active, err := st.QuotaCooldowns.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("list active cooldowns: %v", err)
+	}
+	if len(active) != 1 || !strings.Contains(active[0].LastError, "scope is ambiguous") {
+		t.Fatalf("active cooldowns = %#v, want retained ambiguous failure", active)
+	}
+}
+
+func TestRateLimitAutoDisableWorkerRecoversLegacyCodexCooldownWithoutIdentityEvidence(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	patchCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v0/management/auth-files":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id":         "runtime-alice",
+				"name":       "codex-auth.json",
+				"auth_index": "auth-1",
+				"provider":   "codex",
+				"account":    "alice@example.com",
+				"account_id": "workspace-1",
+				"disabled":   true,
+			}})
+		case "PATCH /v0/management/auth-files/status":
+			var payload struct {
+				Disabled bool `json:"disabled"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			patchCalls++
+			if payload.Disabled {
+				http.Error(w, "expected enable", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	if _, err := st.UpsertQuotaCooldown(ctx, store.QuotaCooldownUpsert{
+		AuthFileName:     "codex-auth.json",
+		AuthIndex:        "auth-1",
+		Provider:         "codex",
+		EvidenceJSON:     "",
+		RecoverAtMS:      time.Now().Add(-time.Minute).UnixMilli(),
+		Owner:            model.QuotaCooldownOwnerUsage429,
+		PreDisabledState: false,
+		DisabledAtMS:     time.Now().Add(-time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("seed legacy cooldown: %v", err)
+	}
+
+	NewRateLimitAutoDisableWorker(st, collectorpkg.RuntimeConfig{
+		CPAUpstreamURL: server.URL,
+		ManagementKey:  "mgmt",
+	}).enableDue(ctx, time.Now())
+
+	if patchCalls != 1 {
+		t.Fatalf("patch calls = %d, want one enable for legacy cooldown", patchCalls)
 	}
 	active, err := st.QuotaCooldowns.ListActive(ctx)
 	if err != nil {
 		t.Fatalf("list active cooldowns: %v", err)
 	}
 	if len(active) != 0 {
-		t.Fatalf("active cooldowns = %#v, want Alice cooldown recovered", active)
+		t.Fatalf("active cooldowns = %#v, want legacy cooldown recovered", active)
 	}
 }
 

--- a/apps/manager-server/internal/worker/usage_pricing_rollup_test.go
+++ b/apps/manager-server/internal/worker/usage_pricing_rollup_test.go
@@ -129,7 +129,7 @@ func TestUsagePricingRollupWorkerContinuesPendingBacklog(t *testing.T) {
 	worker.continuationDelay = time.Millisecond
 	worker.Start(ctx)
 
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for {
 		state, err := db.UsagePricingState(ctx)
 		if err != nil {

--- a/apps/web/src/features/accounts/model/accountCredentialMutationMarker.test.ts
+++ b/apps/web/src/features/accounts/model/accountCredentialMutationMarker.test.ts
@@ -195,27 +195,28 @@ describe('account credential mutation markers', () => {
     ).toBeNull();
   });
 
-  it('keeps same-Workspace Codex members as distinct credential evidence', () => {
-    const baseline = createAccountCredentialMutationBaseline(
-      [
-        {
-          name: 'alice.json',
-          provider: 'codex',
-          account_id: 'workspace-1',
-          account: 'alice@example.com',
-          authIndex: 'auth-a',
-        },
-        {
-          name: 'bob.json',
-          provider: 'codex',
-          account_id: 'workspace-1',
-          account: 'bob@example.com',
-          authIndex: 'auth-b',
-        },
-      ] as AuthFileItem[],
-      'codex'
-    );
+  it('does not treat a missing Codex member snapshot as a new credential', () => {
+    const baselineFile = {
+      name: 'alice.json',
+      id: 'runtime-alice',
+      provider: 'codex',
+      account_id: 'workspace-1',
+      account: 'alice@example.com',
+      authIndex: 'auth-a',
+    } as AuthFileItem;
+    const baseline = createAccountCredentialMutationBaseline([baselineFile], 'codex');
+    const marker = recordAccountCredentialMutationMarker({
+      connectionFingerprint: 'connection-a',
+      provider: 'codex',
+      baseline,
+      requireObservedMutation: true,
+      createdAtMs: Date.now(),
+    });
 
-    expect(baseline?.credentials[0]?.identityKey).not.toBe(baseline?.credentials[1]?.identityKey);
+    expect(
+      hasAccountCredentialMutationEvidence(marker!, [
+        { ...baselineFile, account: undefined } as AuthFileItem,
+      ])
+    ).toBe(false);
   });
 });

--- a/apps/web/src/features/accounts/model/accountCredentialMutationMarker.test.ts
+++ b/apps/web/src/features/accounts/model/accountCredentialMutationMarker.test.ts
@@ -47,7 +47,7 @@ describe('account credential mutation markers', () => {
       provider: 'xai',
       createdAtMs,
     });
-    const rawStorage = window.sessionStorage.getItem('cpa.accounts.credential-mutation-markers.v2');
+    const rawStorage = window.sessionStorage.getItem('cpa.accounts.credential-mutation-markers.v3');
     expect(rawStorage).toContain('v1:opaque-connection');
     expect(rawStorage).not.toContain('http://');
     expect(rawStorage).not.toContain('management-key');
@@ -193,5 +193,29 @@ describe('account credential mutation markers', () => {
         createdAtMs: Date.now(),
       })
     ).toBeNull();
+  });
+
+  it('keeps same-Workspace Codex members as distinct credential evidence', () => {
+    const baseline = createAccountCredentialMutationBaseline(
+      [
+        {
+          name: 'alice.json',
+          provider: 'codex',
+          account_id: 'workspace-1',
+          account: 'alice@example.com',
+          authIndex: 'auth-a',
+        },
+        {
+          name: 'bob.json',
+          provider: 'codex',
+          account_id: 'workspace-1',
+          account: 'bob@example.com',
+          authIndex: 'auth-b',
+        },
+      ] as AuthFileItem[],
+      'codex'
+    );
+
+    expect(baseline?.credentials[0]?.identityKey).not.toBe(baseline?.credentials[1]?.identityKey);
   });
 });

--- a/apps/web/src/features/accounts/model/accountCredentialMutationMarker.ts
+++ b/apps/web/src/features/accounts/model/accountCredentialMutationMarker.ts
@@ -7,7 +7,6 @@ import {
 import {
   readAuthFileStatusAccountId,
   readAuthFileStatusAuthIndex,
-  readAuthFileStatusCodexMember,
   readAuthFileStatusPhysicalName,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
@@ -61,7 +60,6 @@ const buildCredentialIdentityKey = (file: AuthFileItem): string =>
   JSON.stringify([
     readAuthFileStatusProvider(file),
     readAuthFileStatusAccountId(file),
-    readAuthFileStatusCodexMember(file),
     readAuthFileStatusPhysicalName(file),
     readAuthFileStatusRuntimeId(file),
     readAuthFileStatusAuthIndex(file) ?? '',

--- a/apps/web/src/features/accounts/model/accountCredentialMutationMarker.ts
+++ b/apps/web/src/features/accounts/model/accountCredentialMutationMarker.ts
@@ -7,13 +7,14 @@ import {
 import {
   readAuthFileStatusAccountId,
   readAuthFileStatusAuthIndex,
+  readAuthFileStatusCodexMember,
   readAuthFileStatusPhysicalName,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
 } from '@/utils/authFileCredentialIdentity';
 
-const STORAGE_KEY = 'cpa.accounts.credential-mutation-markers.v2';
-const STORAGE_VERSION = 2;
+const STORAGE_KEY = 'cpa.accounts.credential-mutation-markers.v3';
+const STORAGE_VERSION = 3;
 const MAX_MARKERS = 32;
 const MAX_MARKER_AGE_MS = 24 * 60 * 60 * 1000;
 
@@ -60,6 +61,7 @@ const buildCredentialIdentityKey = (file: AuthFileItem): string =>
   JSON.stringify([
     readAuthFileStatusProvider(file),
     readAuthFileStatusAccountId(file),
+    readAuthFileStatusCodexMember(file),
     readAuthFileStatusPhysicalName(file),
     readAuthFileStatusRuntimeId(file),
     readAuthFileStatusAuthIndex(file) ?? '',

--- a/apps/web/src/features/accounts/model/accountDirectReauth.test.ts
+++ b/apps/web/src/features/accounts/model/accountDirectReauth.test.ts
@@ -125,6 +125,101 @@ describe('accountDirectReauth', () => {
     expect(result).toEqual({ status: 'ambiguous' });
   });
 
+  it('confirms Alice without treating Bob in the same Workspace as ambiguous', () => {
+    const alice = makeFile({
+      name: 'codex-alice.json',
+      id: 'runtime-alice',
+      authIndex: 'auth-alice',
+      account: 'alice@example.com',
+      account_id: 'workspace-1',
+      last_refresh: 1_000,
+      modified: 1_100,
+    });
+    const bob = makeFile({
+      name: 'codex-bob.json',
+      id: 'runtime-bob',
+      authIndex: 'auth-bob',
+      account: 'bob@example.com',
+      account_id: 'workspace-1',
+      last_refresh: 1_000,
+      modified: 1_100,
+    });
+    const baseline = createAccountDirectReauthBaseline({
+      target: {
+        account: 'alice@example.com',
+        fileName: alice.name,
+        runtimeId: alice.id,
+        provider: 'codex',
+        authIndex: alice.authIndex,
+        accountId: 'workspace-1',
+        accountSnapshot: 'Alice@Example.com',
+      },
+      file: alice,
+      files: [alice, bob],
+      resultKeys: [],
+    })!;
+
+    expect(
+      reconcileAccountDirectReauth(baseline, [
+        { ...alice, last_refresh: 2_000, modified: 2_100, status_message: '' },
+        bob,
+      ])
+    ).toMatchObject({ status: 'confirmed' });
+  });
+
+  it("reports a newly observed Bob credential as identity-changed in Alice's Workspace", () => {
+    const baseline = makeBaseline();
+    expect(
+      reconcileAccountDirectReauth(baseline, [
+        makeFile({
+          name: 'codex-bob.json',
+          id: 'runtime-bob',
+          authIndex: 'auth-bob',
+          account: 'bob@example.com',
+          last_refresh: 2_500,
+          modified: 2_550,
+          status_message: '',
+        }),
+      ])
+    ).toMatchObject({ status: 'identity-changed', observedAccountId: 'account-1' });
+  });
+
+  it('reports a newly observed Alice credential in another Workspace as identity-changed', () => {
+    const baseline = makeBaseline();
+    expect(
+      reconcileAccountDirectReauth(baseline, [
+        makeFile({
+          name: 'codex-other-workspace.json',
+          id: 'runtime-other-workspace',
+          authIndex: 'auth-other-workspace',
+          account_id: 'workspace-2',
+          account: 'alice@example.com',
+          last_refresh: 2_500,
+          modified: 2_550,
+          status_message: '',
+        }),
+      ])
+    ).toMatchObject({ status: 'identity-changed', observedAccountId: 'workspace-2' });
+  });
+
+  it('does not reconcile a Workspace-only or weak-member candidate', () => {
+    const baseline = makeBaseline();
+    expect(
+      reconcileAccountDirectReauth(baseline, [
+        makeFile({ account: 'Alice', last_refresh: 2_500, modified: 2_550, status_message: '' }),
+      ])
+    ).toEqual({ status: 'unconfirmed' });
+    expect(
+      reconcileAccountDirectReauth(
+        {
+          ...baseline,
+          target: { ...baseline.target, accountSnapshot: null },
+        },
+        [makeFile({ last_refresh: 2_500, modified: 2_550, status_message: '' })]
+      )
+    ).toEqual({ status: 'unconfirmed' });
+  });
+
   it('does not report recovery when the original credential is unchanged and a new Space appears', () => {
     const original = makeFile();
     const baseline = createAccountDirectReauthBaseline({
@@ -232,6 +327,9 @@ describe('accountDirectReauth', () => {
       storage,
     });
     expect(first).not.toBeNull();
+    const stored = JSON.parse(storage.getItem('cpa.accounts.direct-reauth.v3') ?? '{}');
+    expect(stored.version).toBe(3);
+    expect(stored.items[0].providerCredentials[0].accountSnapshot).toBe('alice@example.com');
 
     const persisted = recordPendingAccountDirectReauth({
       connectionFingerprint: 'connection-a',

--- a/apps/web/src/features/accounts/model/accountDirectReauth.ts
+++ b/apps/web/src/features/accounts/model/accountDirectReauth.ts
@@ -11,13 +11,15 @@ import type { CodexReauthTarget } from '@/features/oauth/codexReauthModel';
 import {
   readAuthFileStatusAccountId,
   readAuthFileStatusAuthIndex,
+  readAuthFileStatusCodexMember,
   readAuthFileStatusPhysicalName,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
+  normalizeCodexMemberSnapshot,
 } from '@/utils/authFileCredentialIdentity';
 
-const STORAGE_KEY = 'cpa.accounts.direct-reauth.v2';
-const STORAGE_VERSION = 2;
+const STORAGE_KEY = 'cpa.accounts.direct-reauth.v3';
+const STORAGE_VERSION = 3;
 const MAX_PENDING_REAUTHS = 16;
 const MAX_PENDING_REAUTH_AGE_MS = 24 * 60 * 60 * 1000;
 
@@ -37,6 +39,7 @@ export interface AccountDirectReauthBaseline {
 export interface AccountDirectReauthCredentialEvidence {
   identityKey: string;
   accountId: string;
+  accountSnapshot: string;
   credentialRefreshAtMs: number;
   updatedAtMs: number;
   statusMessage: string;
@@ -116,6 +119,7 @@ const normalizeProviderCredentialEvidence = (
   return {
     identityKey,
     accountId: normalizeString(record.accountId),
+    accountSnapshot: normalizeCodexMemberSnapshot(record.accountSnapshot),
     credentialRefreshAtMs: normalizeTimestamp(record.credentialRefreshAtMs),
     updatedAtMs: normalizeTimestamp(record.updatedAtMs),
     statusMessage: normalizeString(record.statusMessage),
@@ -230,18 +234,19 @@ const createPendingReauthId = (startedAtMs: number): string => {
 
 const buildTargetIdentityKey = (target: CodexReauthTarget): string =>
   JSON.stringify([
-    normalizeString(target.fileName),
     normalizeProvider(target.provider),
-    normalizeString(target.authIndex === null ? '' : String(target.authIndex ?? '')),
     normalizeString(target.accountId),
-    normalizeString(target.accountSnapshot),
+    normalizeCodexMemberSnapshot(target.accountSnapshot),
+    normalizeString(target.fileName),
     normalizeString(target.runtimeId),
+    normalizeString(target.authIndex === null ? '' : String(target.authIndex ?? '')),
   ]);
 
 const buildCredentialIdentityKey = (file: AuthFileItem): string =>
   JSON.stringify([
     readAuthFileStatusProvider(file),
     readAuthFileStatusAccountId(file),
+    readAuthFileStatusCodexMember(file),
     readAuthFileStatusPhysicalName(file),
     readAuthFileStatusRuntimeId(file),
     readAuthFileStatusAuthIndex(file) ?? '',
@@ -252,6 +257,7 @@ const buildProviderCredentialEvidence = (
 ): AccountDirectReauthCredentialEvidence => ({
   identityKey: buildCredentialIdentityKey(file),
   accountId: readAuthFileStatusAccountId(file),
+  accountSnapshot: readAuthFileStatusCodexMember(file),
   credentialRefreshAtMs: readAuthFileCredentialRefreshAtMs(file) ?? 0,
   updatedAtMs: readAuthFileUpdatedAtMs(file) ?? 0,
   statusMessage: getAuthFileStatusMessage(file),
@@ -356,53 +362,51 @@ export const reconcileAccountDirectReauth = (
   files: readonly AuthFileItem[]
 ): AccountDirectReauthReconciliation => {
   const providerFiles = files.filter((file) => readAuthFileStatusProvider(file) === 'codex');
-  const expectedAccountId = normalizeString(pending.target.accountId);
+  const expectedWorkspace = normalizeString(pending.target.accountId);
+  const expectedMember = normalizeCodexMemberSnapshot(pending.target.accountSnapshot);
 
-  // A display account/email can locate the original row in the UI, but it cannot
-  // prove that an OAuth result belongs to the same ChatGPT Space. Without a
-  // trusted baseline account_id, fail closed instead of auto-confirming by email.
-  if (!expectedAccountId) return { status: 'unconfirmed' };
+  // A Workspace id without a strong member snapshot is not enough to identify a
+  // Team credential. Fail closed instead of treating a display value or a
+  // shared Workspace id as a user identity.
+  if (!expectedWorkspace || !expectedMember) return { status: 'unconfirmed' };
 
   const baselineByIdentity = new Map(
     pending.providerCredentials.map((item) => [item.identityKey, item])
   );
-  const matchingFiles = providerFiles.filter(
-    (file) => readAuthFileStatusAccountId(file) === expectedAccountId
-  );
-  if (matchingFiles.length > 1) return { status: 'ambiguous' };
-  if (matchingFiles.length === 1) {
-    const file = matchingFiles[0];
+  const matchingFiles = providerFiles.filter((file) => {
     const evidence = buildProviderCredentialEvidence(file);
-    if (hasChangedCredentialEvidence(evidence, baselineByIdentity.get(evidence.identityKey))) {
-      return { status: 'confirmed', file };
-    }
+    return evidence.accountId === expectedWorkspace && evidence.accountSnapshot === expectedMember;
+  });
+  const changedMatchingFiles = matchingFiles.filter((file) => {
+    const evidence = buildProviderCredentialEvidence(file);
+    return hasChangedCredentialEvidence(evidence, baselineByIdentity.get(evidence.identityKey));
+  });
+  if (changedMatchingFiles.length > 1) return { status: 'ambiguous' };
+  if (changedMatchingFiles.length === 1) {
+    return { status: 'confirmed', file: changedMatchingFiles[0] };
   }
 
-  // Timestamp/status changes on another credential are not causal evidence for
-  // this reauth: CPA may refresh unrelated Codex credentials in the background.
-  // Only a structurally new credential identity (including an account_id
-  // replacement that changes the identity key) is strong enough to flag a
-  // different Space.
-  const changedDifferentAccountFiles = providerFiles.filter((file) => {
+  // Timestamp/status changes on an existing unrelated credential are not causal
+  // evidence for this reauth: CPA may refresh other Codex credentials in the
+  // background. A new credential identity with a strong Workspace/member pair
+  // is the only evidence strong enough to report a different identity.
+  const changedDifferentIdentityFiles = providerFiles.filter((file) => {
     const evidence = buildProviderCredentialEvidence(file);
     return (
-      Boolean(evidence.accountId) &&
-      evidence.accountId !== expectedAccountId &&
+      Boolean(evidence.accountId && evidence.accountSnapshot) &&
+      (evidence.accountId !== expectedWorkspace || evidence.accountSnapshot !== expectedMember) &&
       !baselineByIdentity.has(evidence.identityKey)
     );
   });
-  const observedAccountIds = new Set(
-    changedDifferentAccountFiles.map((file) => readAuthFileStatusAccountId(file))
-  );
-  if (changedDifferentAccountFiles.length === 1 && observedAccountIds.size === 1) {
-    const file = changedDifferentAccountFiles[0];
+  if (changedDifferentIdentityFiles.length === 1) {
+    const file = changedDifferentIdentityFiles[0];
     return {
       status: 'identity-changed',
       file,
       observedAccountId: readAuthFileStatusAccountId(file),
     };
   }
-  if (changedDifferentAccountFiles.length > 1) return { status: 'ambiguous' };
+  if (changedDifferentIdentityFiles.length > 1) return { status: 'ambiguous' };
   return { status: 'unconfirmed' };
 };
 

--- a/apps/web/src/features/accounts/model/accountOperationalScope.test.ts
+++ b/apps/web/src/features/accounts/model/accountOperationalScope.test.ts
@@ -80,7 +80,7 @@ describe('buildAccountOperationalItemsByRowKey', () => {
     expect(result.get(rows[1].selectionKey)).toEqual([item]);
   });
 
-  it('scopes same-file action candidates by account ID snapshot', () => {
+  it('does not scope same-file action candidates by a Codex workspace ID', () => {
     const files: AuthFileItem[] = [
       {
         name: 'shared.json',
@@ -105,6 +105,6 @@ describe('buildAccountOperationalItemsByRowKey', () => {
     const result = buildAccountOperationalItemsByRowKey(rows, [item]);
 
     expect(result.get(rows[0].selectionKey)).toEqual([]);
-    expect(result.get(rows[1].selectionKey)).toEqual([item]);
+    expect(result.get(rows[1].selectionKey)).toEqual([]);
   });
 });

--- a/apps/web/src/features/accounts/model/accountOperationalScope.ts
+++ b/apps/web/src/features/accounts/model/accountOperationalScope.ts
@@ -41,8 +41,11 @@ export const accountOperationalItemMatchesRow = (
 
 export const buildAccountOperationalScopeKeys = (rows: AccountRow[]): Map<string, string[]> => {
   const eligibleRows = rows.filter((row) => !row.runtimeOnly);
+  const exactCounts = new Map<string, number>();
   const fallbackCounts = new Map<string, number>();
   eligibleRows.forEach((row) => {
+    const exactKey = getAuthFileCodexInspectionKeyForFile(row.raw);
+    exactCounts.set(exactKey, (exactCounts.get(exactKey) ?? 0) + 1);
     const fallbackKey = getAuthFileCodexInspectionKey(row.fileName, null);
     fallbackCounts.set(fallbackKey, (fallbackCounts.get(fallbackKey) ?? 0) + 1);
   });
@@ -51,7 +54,12 @@ export const buildAccountOperationalScopeKeys = (rows: AccountRow[]): Map<string
     eligibleRows.map((row) => {
       const exactKey = getAuthFileCodexInspectionKeyForFile(row.raw);
       const fallbackKey = getAuthFileCodexInspectionKey(row.fileName, null);
-      const keys = [exactKey];
+      // A duplicate exact key means the current response does not contain
+      // enough credential evidence to tell these rows apart. In particular,
+      // Codex workspace-only rows intentionally share a fallback key because
+      // account_id is a Workspace, not a member identity. Do not fan out an
+      // operational item to every row (or pick one arbitrarily).
+      const keys = exactCounts.get(exactKey) === 1 ? [exactKey] : [];
       if (fallbackKey !== exactKey && fallbackCounts.get(fallbackKey) === 1) {
         keys.push(fallbackKey);
       }

--- a/apps/web/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/apps/web/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -46,6 +46,7 @@ import {
   getAuthFileStatusMutationLockKeys,
   readAuthFileStatusAccountId,
   readAuthFileStatusAccountSnapshot,
+  readAuthFileStatusCodexMember,
   readAuthFileStatusPhysicalName,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
@@ -142,7 +143,9 @@ const getAuthFileSourceMemberKey = (file: AuthFileItem): string =>
     readAuthFileStatusRuntimeId(file),
     readAuthFileStatusProvider(file),
     readAuthFileStatusAccountId(file),
-    readAuthFileStatusAccountSnapshot(file),
+    readAuthFileStatusProvider(file) === 'codex'
+      ? readAuthFileStatusCodexMember(file)
+      : readAuthFileStatusAccountSnapshot(file),
   ]);
 
 const getAuthFileSourceMembers = (files: AuthFileItem[], physicalName: string): AuthFileItem[] =>

--- a/apps/web/src/features/authFiles/model/authFileConfiguration.test.ts
+++ b/apps/web/src/features/authFiles/model/authFileConfiguration.test.ts
@@ -140,6 +140,33 @@ describe('parseAuthFileConfigurationSource', () => {
       )
     ).toThrow(AUTH_FILE_CONFIGURATION_TARGET_NOT_FOUND);
   });
+
+  it('matches Codex shared records by member when the auth index is absent', () => {
+    const parsed = parseAuthFileConfigurationSource(
+      JSON.stringify([
+        { type: 'codex', account_id: 'workspace-1', account: 'alice@example.com' },
+        { type: 'codex', account_id: 'workspace-1', account: 'bob@example.com' },
+      ]),
+      makeFile({ authIndex: 'missing', account_id: 'workspace-1', account: 'bob@example.com' })
+    );
+
+    expect(parsed.recordIndex).toBe(1);
+    expect(parsed.record).toMatchObject({ account: 'bob@example.com' });
+  });
+
+  it('rejects a Codex record with conflicting explicit member evidence', () => {
+    expect(() =>
+      parseAuthFileConfigurationSource(
+        JSON.stringify({
+          type: 'codex',
+          account_id: 'workspace-1',
+          account_snapshot: 'bob@example.com',
+          account: 'alice@example.com',
+        }),
+        makeFile({ account_id: 'workspace-1', account: 'alice@example.com' })
+      )
+    ).toThrow(AUTH_FILE_CONFIGURATION_TARGET_NOT_FOUND);
+  });
 });
 
 describe('buildAuthFileConfigurationPatch', () => {

--- a/apps/web/src/features/authFiles/model/authFileConfiguration.test.ts
+++ b/apps/web/src/features/authFiles/model/authFileConfiguration.test.ts
@@ -167,6 +167,20 @@ describe('parseAuthFileConfigurationSource', () => {
       )
     ).toThrow(AUTH_FILE_CONFIGURATION_TARGET_NOT_FOUND);
   });
+
+  it('rejects a Codex record with a conflicting auth index before member fallback', () => {
+    expect(() =>
+      parseAuthFileConfigurationSource(
+        JSON.stringify({
+          type: 'codex',
+          auth_index: 'auth-a',
+          account_id: 'workspace-1',
+          account: 'alice@example.com',
+        }),
+        makeFile({ authIndex: 'auth-b', account_id: 'workspace-1', account: 'alice@example.com' })
+      )
+    ).toThrow(AUTH_FILE_CONFIGURATION_TARGET_NOT_FOUND);
+  });
 });
 
 describe('buildAuthFileConfigurationPatch', () => {

--- a/apps/web/src/features/authFiles/model/authFileConfiguration.ts
+++ b/apps/web/src/features/authFiles/model/authFileConfiguration.ts
@@ -244,6 +244,12 @@ const recordHasFileIdentityConflict = (
   const candidateProvider = normalizeProviderIdentityKey(readAuthFileStatusProvider(candidate));
   if (expectedProvider && candidateProvider && candidateProvider !== expectedProvider) return true;
 
+  const expectedAuthIndex = readAuthFileStatusAuthIndex(file);
+  const candidateAuthIndex = normalizeRecordAuthIndex(record);
+  if (expectedAuthIndex && candidateAuthIndex && candidateAuthIndex !== expectedAuthIndex) {
+    return true;
+  }
+
   const identityProvider = expectedProvider || candidateProvider;
   if (identityProvider === 'codex') {
     if (
@@ -264,12 +270,6 @@ const recordHasFileIdentityConflict = (
     const expectedMember = readAuthFileStatusCodexMember(file);
     const candidateMember = readAuthFileStatusCodexMember(candidate);
     return Boolean(expectedMember && candidateMember && expectedMember !== candidateMember);
-  }
-
-  const expectedAuthIndex = readAuthFileStatusAuthIndex(file);
-  const candidateAuthIndex = normalizeRecordAuthIndex(record);
-  if (expectedAuthIndex && candidateAuthIndex && candidateAuthIndex !== expectedAuthIndex) {
-    return true;
   }
 
   const expectedAccountId = readAuthFileStatusAccountId(file);

--- a/apps/web/src/features/authFiles/model/authFileConfiguration.ts
+++ b/apps/web/src/features/authFiles/model/authFileConfiguration.ts
@@ -14,9 +14,12 @@ import {
 } from '@/features/authFiles/constants';
 import {
   readAuthFileStatusAccountId,
+  readAuthFileStatusAccountIdInvalid,
   readAuthFileStatusAccountSnapshot,
   readAuthFileStatusAuthIndex,
   readAuthFileStatusProvider,
+  readAuthFileStatusCodexMember,
+  readAuthFileStatusCodexMemberInvalid,
 } from '@/utils/authFileStatusMutation';
 
 export const AUTH_FILE_CONFIGURATION_INVALID_JSON = 'AUTH_FILE_CONFIGURATION_INVALID_JSON';
@@ -240,6 +243,28 @@ const recordHasFileIdentityConflict = (
   const expectedProvider = normalizeProviderIdentityKey(readAuthFileStatusProvider(file));
   const candidateProvider = normalizeProviderIdentityKey(readAuthFileStatusProvider(candidate));
   if (expectedProvider && candidateProvider && candidateProvider !== expectedProvider) return true;
+
+  const identityProvider = expectedProvider || candidateProvider;
+  if (identityProvider === 'codex') {
+    if (
+      readAuthFileStatusAccountIdInvalid(file) ||
+      readAuthFileStatusAccountIdInvalid(candidate) ||
+      readAuthFileStatusCodexMemberInvalid(file) ||
+      readAuthFileStatusCodexMemberInvalid(candidate)
+    ) {
+      return true;
+    }
+
+    const expectedWorkspace = readAuthFileStatusAccountId(file);
+    const candidateWorkspace = readAuthFileStatusAccountId(candidate);
+    if (expectedWorkspace && candidateWorkspace && expectedWorkspace !== candidateWorkspace) {
+      return true;
+    }
+
+    const expectedMember = readAuthFileStatusCodexMember(file);
+    const candidateMember = readAuthFileStatusCodexMember(candidate);
+    return Boolean(expectedMember && candidateMember && expectedMember !== candidateMember);
+  }
 
   const expectedAuthIndex = readAuthFileStatusAuthIndex(file);
   const candidateAuthIndex = normalizeRecordAuthIndex(record);

--- a/apps/web/src/features/authFiles/model/credentialStatus.test.ts
+++ b/apps/web/src/features/authFiles/model/credentialStatus.test.ts
@@ -2060,6 +2060,30 @@ describe('credential identity helpers', () => {
       accountSnapshot: 'codex-main@example.com',
     });
     expect(
+      getAuthFilePatchTarget(
+        codexFile({
+          id: 'runtime-team-member',
+          account_id: 'workspace-1',
+          account: 'Alice',
+          email: 'Alice@Example.com',
+        })
+      )
+    ).toMatchObject({
+      provider: 'codex',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    expect(
+      getAuthFilePatchTarget(
+        codexFile({
+          id: 'runtime-weak-member',
+          account_id: 'workspace-1',
+          account: 'Alice',
+          email: undefined,
+        })
+      )
+    ).not.toHaveProperty('accountSnapshot');
+    expect(
       getAuthFilePatchTarget({
         id: 'runtime-unknown',
         name: 'unknown.json',
@@ -2105,7 +2129,7 @@ describe('credential identity helpers', () => {
       account: 'second@example.com',
     });
 
-    expect(getAuthFileSelectionKey(first)).toBe(getAuthFileSelectionKey(renamed));
+    expect(getAuthFileSelectionKey(first)).not.toBe(getAuthFileSelectionKey(renamed));
     expect(getAuthFileSelectionKey(first)).not.toBe(getAuthFileSelectionKey(second));
     expect(getAuthFileNameFromSelectionKey(getAuthFileSelectionKey(second))).toBe(
       'shared-codex.json'

--- a/apps/web/src/features/authFiles/model/credentialStatus.ts
+++ b/apps/web/src/features/authFiles/model/credentialStatus.ts
@@ -29,6 +29,7 @@ import {
   getAuthFileStatusSelectionKey,
   readAuthFileStatusAccountId,
   readAuthFileStatusAccountSnapshot,
+  readAuthFileStatusCodexMember,
   readAuthFileStatusProvider,
 } from '@/utils/authFileStatusMutation';
 
@@ -491,7 +492,10 @@ export const getAuthFilePatchTarget = (file: AuthFileItem): AuthFilePatchTarget 
   const authIndex = readAuthFileAuthIndex(file);
   const provider = normalizeProviderKey(readAuthFileStatusProvider(file));
   const accountId = readAuthFileStatusAccountId(file);
-  const accountSnapshot = readAuthFileStatusAccountSnapshot(file);
+  const accountSnapshot =
+    provider === 'codex'
+      ? readAuthFileStatusCodexMember(file)
+      : readAuthFileStatusAccountSnapshot(file);
   return {
     name: file.name,
     ...(runtimeId ? { runtimeId } : {}),

--- a/apps/web/src/features/demo/demoFixtures.inspection.test.ts
+++ b/apps/web/src/features/demo/demoFixtures.inspection.test.ts
@@ -468,7 +468,7 @@ describe('credential health inspection demo fixtures', () => {
     ).toBe(0);
   });
 
-  it('keeps account IDs distinct from account snapshots in demo action identity', () => {
+  it('does not promote workspace IDs or weak snapshots to demo member identity', () => {
     const base = getDemoCodexInspectionRun().results.find((item) => item.id === 503);
     if (!base) throw new Error('missing demo Codex inspection result 503');
 
@@ -489,7 +489,8 @@ describe('credential health inspection demo fixtures', () => {
       accountSnapshot: 'shared-identity',
     });
 
-    expect(accountIdIdentity).not.toBe(accountSnapshotIdentity);
+    expect(accountIdIdentity).toBe('shared.json::-');
+    expect(accountSnapshotIdentity).toBe('shared.json::-');
   });
 
   it('marks executed demo actions as handled in the returned detail', async () => {

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -3650,6 +3650,91 @@ describe('executeCodexInspectionActions', () => {
     expect(storage.setItem).toHaveBeenCalledTimes(1);
   });
 
+  it('does not block a canonical automatic credential when a fallback sibling becomes duplicated', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const canonical = createResultItem('disable', {
+      key: 'fallback-granularity.json::auth-1::canonical',
+      fileName: 'fallback-granularity.json',
+      runtimeId: 'runtime-canonical',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'canonical@example.com',
+      displayAccount: 'canonical@example.com',
+    });
+    const sibling = createResultItem('disable', {
+      key: 'fallback-granularity.json::auth-2::sibling',
+      fileName: 'fallback-granularity.json',
+      runtimeId: 'runtime-sibling',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'sibling@example.com',
+      displayAccount: 'sibling@example.com',
+    });
+    const lateDuplicate = createResultItem('disable', {
+      key: 'fallback-granularity.json::auth-2::late-duplicate',
+      fileName: 'fallback-granularity.json',
+      runtimeId: 'runtime-late-duplicate',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'late-duplicate@example.com',
+      displayAccount: 'late-duplicate@example.com',
+    });
+    const initialFiles = [canonical, sibling].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const freshFiles = [...initialFiles, createCurrentAuthFile(lateDuplicate, { disabled: false })];
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, disabled) => ({
+        status: 'ok',
+        disabled,
+        mutationScope: 'credential',
+      }));
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValue({ files: freshFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [canonical, sibling],
+      referenceItems: [canonical, sibling],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-fallback-sibling-toctou',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: 'runtime-canonical',
+        authIndex: 'auth-1',
+      }),
+      true,
+      expect.any(Function)
+    );
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: canonical.key,
+          status: 'success',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: sibling.key,
+          status: 'needs_review',
+          success: true,
+          error: expect.stringContaining('authIndex'),
+        }),
+      ])
+    );
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    const storedOwnership =
+      storage.getItem('cli-proxy-codex-inspection-disable-ownership-v2') ?? '';
+    expect(storedOwnership).toContain(canonical.accountSnapshot);
+    expect(storedOwnership).not.toContain(sibling.accountSnapshot);
+  });
+
   it('blocks an automatic source-file group when any Codex persisted locator is duplicated', async () => {
     const storage = createStorage();
     vi.stubGlobal('localStorage', storage);
@@ -4460,6 +4545,85 @@ describe('executeCodexInspectionActions', () => {
       expect.arrayContaining([
         expect.objectContaining({ accountKey: first.key, status: 'failed', success: false }),
         expect.objectContaining({ accountKey: second.key, status: 'skipped', success: true }),
+      ])
+    );
+  });
+
+  it('allows the canonical plugin attempt before rejecting fallback for a duplicated sibling', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const canonical = createResultItem('disable', {
+      key: 'plugin-sibling-duplicate.json::auth-1',
+      fileName: 'plugin-sibling-duplicate.json',
+      runtimeId: 'runtime-plugin-canonical',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'canonical@example.com',
+    });
+    const sibling = createResultItem('disable', {
+      key: 'plugin-sibling-duplicate.json::auth-2',
+      fileName: 'plugin-sibling-duplicate.json',
+      runtimeId: 'runtime-plugin-sibling',
+      provider: 'codex',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'sibling@example.com',
+    });
+    const duplicateSibling = createResultItem('disable', {
+      key: 'plugin-sibling-duplicate.json::auth-2::duplicate',
+      fileName: 'plugin-sibling-duplicate.json',
+      runtimeId: 'runtime-plugin-duplicate',
+      provider: 'codex',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'other-sibling@example.com',
+    });
+    const initialFiles = [canonical, sibling].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const freshFiles = [
+      ...initialFiles,
+      createCurrentAuthFile(duplicateSibling, { disabled: false }),
+    ];
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, _disabled, verifyFallback) => {
+        expect(verifyFallback).toEqual(expect.any(Function));
+        await verifyFallback?.();
+        return { status: 'ok', disabled: true, mutationScope: 'source-file' };
+      });
+    const sourceStatusSpy = vi.spyOn(authFilesApi, 'setVerifiedSourceFileStatus');
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: freshFiles })
+      .mockResolvedValue({ files: freshFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [canonical, sibling],
+      referenceItems: [canonical, sibling],
+      previousFiles: [],
+      connectionFingerprint: 'scope-plugin-sibling-duplicate',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(sourceStatusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: canonical.key,
+          status: 'failed',
+          success: false,
+        }),
+        expect.objectContaining({
+          accountKey: sibling.key,
+          status: 'skipped',
+          success: true,
+        }),
       ])
     );
   });

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -3198,8 +3198,7 @@ describe('executeCodexInspectionActions', () => {
         accountId: null,
         accountSnapshot: 'disable@example.com',
       },
-      true,
-      expect.any(Function)
+      true
     );
     expect(execution.outcomes).toEqual([
       expect.objectContaining({
@@ -3479,8 +3478,160 @@ describe('executeCodexInspectionActions', () => {
     expect(statusSpy).toHaveBeenCalledTimes(1);
     expect(statusSpy).toHaveBeenCalledWith(
       expect.objectContaining({ runtimeId: 'runtime-charlie', authIndex: 'auth-2' }),
-      true,
-      expect.any(Function)
+      true
+    );
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: duplicate.key,
+          status: 'needs_review',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: unique.key,
+          status: 'success',
+          success: true,
+        }),
+      ])
+    );
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps unique automatic credentials independent when all same-file results are selected', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const first = createResultItem('disable', {
+      key: 'granularity-all-selected.json::auth-1::alice',
+      fileName: 'granularity-all-selected.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+      displayAccount: 'alice@example.com',
+    });
+    const second = createResultItem('disable', {
+      key: 'granularity-all-selected.json::auth-1::bob',
+      fileName: 'granularity-all-selected.json',
+      runtimeId: 'runtime-bob',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'bob@example.com',
+      displayAccount: 'bob@example.com',
+    });
+    const third = createResultItem('disable', {
+      key: 'granularity-all-selected.json::auth-2::charlie',
+      fileName: 'granularity-all-selected.json',
+      runtimeId: 'runtime-charlie',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'charlie@example.com',
+      displayAccount: 'charlie@example.com',
+    });
+    const currentFiles = [first, second, third].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const statusSpy = vi.spyOn(authFilesApi, 'setStatusWithFallback').mockResolvedValue({
+      status: 'ok',
+      disabled: true,
+      mutationScope: 'credential',
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({ files: currentFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [first, second, third],
+      referenceItems: [first, second, third],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-all-selected-granularity',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeId: 'runtime-charlie', authIndex: 'auth-2' }),
+      true
+    );
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: first.key,
+          status: 'needs_review',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: second.key,
+          status: 'needs_review',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: third.key,
+          status: 'success',
+          success: true,
+        }),
+      ])
+    );
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a unique automatic credential executable when another locator duplicates during refresh', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const duplicate = createResultItem('disable', {
+      key: 'granularity-toctou.json::auth-1::alice',
+      fileName: 'granularity-toctou.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+      displayAccount: 'alice@example.com',
+    });
+    const unique = createResultItem('disable', {
+      key: 'granularity-toctou.json::auth-2::charlie',
+      fileName: 'granularity-toctou.json',
+      runtimeId: 'runtime-charlie',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'charlie@example.com',
+      displayAccount: 'charlie@example.com',
+    });
+    const lateDuplicate = createCurrentAuthFile(
+      {
+        ...duplicate,
+        key: 'granularity-toctou.json::auth-1::bob',
+        runtimeId: 'runtime-bob',
+        accountSnapshot: 'bob@example.com',
+        displayAccount: 'bob@example.com',
+      },
+      { disabled: false }
+    );
+    const initialFiles = [
+      createCurrentAuthFile(duplicate, { disabled: false }),
+      createCurrentAuthFile(unique, { disabled: false }),
+    ];
+    const freshFiles = [...initialFiles.slice(0, 1), lateDuplicate, initialFiles[1]];
+    const statusSpy = vi.spyOn(authFilesApi, 'setStatusWithFallback').mockResolvedValue({
+      status: 'ok',
+      disabled: true,
+      mutationScope: 'credential',
+    });
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: freshFiles })
+      .mockResolvedValue({ files: freshFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [duplicate, unique],
+      referenceItems: [duplicate, unique],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-toctou-granularity',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeId: 'runtime-charlie', authIndex: 'auth-2' }),
+      true
     );
     expect(execution.outcomes).toEqual(
       expect.arrayContaining([
@@ -3919,9 +4070,13 @@ describe('executeCodexInspectionActions', () => {
       const statusSpy = vi
         .spyOn(authFilesApi, 'setStatusWithFallback')
         .mockImplementation(async (_target, disabled, verifyFallback) => {
-          if (!verifyFallback) throw new Error('missing plugin source fallback verifier');
-          verifiedSourceIdentities = await verifyFallback();
-          return { status: 'ok', disabled, mutationScope: 'source-file' };
+          if (source === 'manual') {
+            if (!verifyFallback) throw new Error('missing plugin source fallback verifier');
+            verifiedSourceIdentities = await verifyFallback();
+            return { status: 'ok', disabled, mutationScope: 'source-file' };
+          }
+          if (verifyFallback) throw new Error('unexpected plugin source fallback verifier');
+          return { status: 'ok', disabled, mutationScope: 'credential' };
         });
       vi.spyOn(authFilesApi, 'list')
         .mockResolvedValueOnce({ files: currentFiles })
@@ -3940,51 +4095,88 @@ describe('executeCodexInspectionActions', () => {
         source,
       });
 
-      expect(statusSpy).toHaveBeenCalledTimes(1);
-      expect(statusSpy).toHaveBeenCalledWith(
-        {
-          name: 'plugin-source.json',
-          runtimeId: 'runtime-plugin-1',
-          authIndex: 'auth-1',
-          provider: 'codex',
-          accountId: 'account-1',
-          accountSnapshot: 'first-plugin@example.com',
-        },
-        nextDisabled,
-        expect.any(Function)
-      );
-      expect(verifiedSourceIdentities).toEqual([
-        {
-          name: 'plugin-source.json',
-          runtimeId: 'runtime-plugin-1',
-          authIndex: 'auth-1',
-          provider: 'codex',
-          accountId: 'account-1',
-          accountSnapshot: 'first-plugin@example.com',
-        },
-        {
-          name: 'plugin-source.json',
-          runtimeId: 'runtime-plugin-2',
-          authIndex: 'auth-2',
-          provider: 'codex',
-          accountId: 'account-2',
-          accountSnapshot: 'second-plugin@example.com',
-        },
-      ]);
-      expect(execution.outcomes).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            accountKey: first.key,
-            status: 'success',
-            success: true,
-          }),
-          expect.objectContaining({
-            accountKey: second.key,
-            status: 'skipped',
-            success: true,
-          }),
-        ])
-      );
+      if (source === 'manual') {
+        expect(statusSpy).toHaveBeenCalledTimes(1);
+        expect(statusSpy).toHaveBeenCalledWith(
+          {
+            name: 'plugin-source.json',
+            runtimeId: 'runtime-plugin-1',
+            authIndex: 'auth-1',
+            provider: 'codex',
+            accountId: 'account-1',
+            accountSnapshot: 'first-plugin@example.com',
+          },
+          nextDisabled,
+          expect.any(Function)
+        );
+        expect(verifiedSourceIdentities).toEqual([
+          {
+            name: 'plugin-source.json',
+            runtimeId: 'runtime-plugin-1',
+            authIndex: 'auth-1',
+            provider: 'codex',
+            accountId: 'account-1',
+            accountSnapshot: 'first-plugin@example.com',
+          },
+          {
+            name: 'plugin-source.json',
+            runtimeId: 'runtime-plugin-2',
+            authIndex: 'auth-2',
+            provider: 'codex',
+            accountId: 'account-2',
+            accountSnapshot: 'second-plugin@example.com',
+          },
+        ]);
+        expect(execution.outcomes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              accountKey: first.key,
+              status: 'success',
+              success: true,
+            }),
+            expect.objectContaining({
+              accountKey: second.key,
+              status: 'skipped',
+              success: true,
+            }),
+          ])
+        );
+      } else {
+        expect(statusSpy).toHaveBeenCalledTimes(2);
+        expect(statusSpy.mock.calls).toEqual(
+          expect.arrayContaining([
+            [
+              expect.objectContaining({
+                runtimeId: 'runtime-plugin-1',
+                authIndex: 'auth-1',
+              }),
+              nextDisabled,
+            ],
+            [
+              expect.objectContaining({
+                runtimeId: 'runtime-plugin-2',
+                authIndex: 'auth-2',
+              }),
+              nextDisabled,
+            ],
+          ])
+        );
+        expect(verifiedSourceIdentities).toBeUndefined();
+        expect(execution.outcomes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              accountKey: first.key,
+              status: 'success',
+              success: true,
+            }),
+            expect.objectContaining({
+              accountKey: second.key,
+              status: 'success',
+              success: true,
+            }),
+          ])
+        );
+      }
       if (source === 'auto' && action === 'disable') {
         expect(
           getCodexInspectionOwnedDisableIdentityKeys(

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -1741,7 +1741,7 @@ describe('Server Codex inspection action presentation', () => {
     expect(Array.from(getMixedServerCodexInspectionActionIds(results))).toEqual([]);
   });
 
-  it('keeps same-file status actions independent by account snapshot when auth_index is absent', () => {
+  it('does not expose same-file status actions without a credential locator', () => {
     const results = [
       {
         id: 1,
@@ -1763,7 +1763,7 @@ describe('Server Codex inspection action presentation', () => {
       },
     ];
 
-    expect(Array.from(getCanonicalServerCodexInspectionActionIds(results))).toEqual([1, 2]);
+    expect(Array.from(getCanonicalServerCodexInspectionActionIds(results))).toEqual([]);
     expect(Array.from(getMixedServerCodexInspectionActionIds(results))).toEqual([]);
   });
 

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -152,7 +152,7 @@ const createCurrentAuthFile = (
     type: item.provider,
     auth_index: item.authIndex,
     ...(item.accountId ? { id_token: { account_id: item.accountId } } : {}),
-    ...(!item.accountId && item.accountSnapshot && item.accountSnapshot !== item.fileName
+    ...(item.accountSnapshot && item.accountSnapshot !== item.fileName
       ? { account: item.accountSnapshot }
       : {}),
     disabled: item.disabled,
@@ -1907,6 +1907,7 @@ describe('executeCodexInspectionActions', () => {
             statusCode: 401,
             provider: 'xai',
             accountId: '',
+            runtimeId: 'reauth-runtime-1',
           })
         ),
       ],
@@ -2054,7 +2055,12 @@ describe('executeCodexInspectionActions', () => {
       settings: createRunResult().settings,
       items: [
         toReauthDeleteExecutionItem(
-          createResultItem('reauth', { fileName: 'reauth.json', provider: 'xai', accountId: '' })
+          createResultItem('reauth', {
+            fileName: 'reauth.json',
+            provider: 'xai',
+            accountId: '',
+            runtimeId: 'reauth-runtime-1',
+          })
         ),
       ],
       previousFiles: [],
@@ -2215,6 +2221,50 @@ describe('executeCodexInspectionActions', () => {
     expect(deleteSpy).not.toHaveBeenCalled();
     expect(execution.outcomes).toEqual([
       expect.objectContaining({ action: 'delete', status: 'failed', success: false }),
+    ]);
+  });
+
+  it('rejects a Codex Workspace-only delete when the credential runtime ID changes', async () => {
+    const deleteSpy = vi.spyOn(authFilesApi, 'deleteFileByName').mockResolvedValue({
+      status: 'ok',
+      deleted: 1,
+      files: ['workspace.json'],
+      failed: [],
+    });
+    const item = createResultItem('delete', {
+      key: 'workspace.json::workspace-only',
+      fileName: 'workspace.json',
+      runtimeId: 'runtime-original',
+      authIndex: null,
+      accountId: 'workspace-1',
+      accountSnapshot: null,
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({
+      files: [
+        createCurrentAuthFile(item, {
+          id: 'runtime-replacement',
+          auth_index: null,
+          account: 'bob@example.com',
+        }),
+      ],
+    });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-workspace-only-runtime-drift',
+      source: 'manual',
+    });
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        action: 'delete',
+        status: 'failed',
+        success: false,
+        error: expect.stringContaining('账号标识已变化'),
+      }),
     ]);
   });
 
@@ -3092,7 +3142,7 @@ describe('executeCodexInspectionActions', () => {
           authIndex: 'auth-1',
           provider: 'codex',
           accountId: 'account-1',
-          accountSnapshot: null,
+          accountSnapshot: 'first-plugin@example.com',
         },
         {
           name: 'plugin-source.json',
@@ -3100,7 +3150,7 @@ describe('executeCodexInspectionActions', () => {
           authIndex: 'auth-2',
           provider: 'codex',
           accountId: 'account-2',
-          accountSnapshot: null,
+          accountSnapshot: 'second-plugin@example.com',
         },
       ]);
       expect(execution.outcomes).toEqual(
@@ -3505,7 +3555,7 @@ describe('executeCodexInspectionActions', () => {
           authIndex: 'auth-1',
           provider: 'codex',
           accountId: 'account-1',
-          accountSnapshot: null,
+          accountSnapshot: 'disable@example.com',
         },
         {
           name: 'shared.json',
@@ -3513,7 +3563,7 @@ describe('executeCodexInspectionActions', () => {
           authIndex: 'auth-2',
           provider: 'codex',
           accountId: 'account-2',
-          accountSnapshot: null,
+          accountSnapshot: 'disable@example.com',
         },
       ]
     );
@@ -3544,12 +3594,14 @@ describe('executeCodexInspectionActions', () => {
           provider: 'codex',
           authIndex: 'auth-1',
           accountId: 'account-1',
+          accountSnapshot: 'disable@example.com',
         }),
         getCodexInspectionOwnershipIdentityKey({
           fileName: 'shared.json',
           provider: 'codex',
           authIndex: 'auth-2',
           accountId: 'account-2',
+          accountSnapshot: 'disable@example.com',
         }),
       ])
     );
@@ -3918,6 +3970,7 @@ describe('executeCodexInspectionActions', () => {
         key: 'shared.json::second',
         fileName: 'shared.json',
         displayAccount: 'second@example.com',
+        accountSnapshot: 'first@example.com',
       }),
     ];
     vi.spyOn(authFilesApi, 'list')

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -4349,6 +4349,138 @@ describe('executeCodexInspectionActions', () => {
     expect(storage.setItem).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    {
+      action: 'disable' as const,
+      initialDisabled: false,
+      requestedDisabled: true,
+    },
+    {
+      action: 'enable' as const,
+      initialDisabled: true,
+      requestedDisabled: false,
+    },
+  ])(
+    'continues the $action sibling independently when the canonical credential fails',
+    async ({ action, initialDisabled, requestedDisabled }) => {
+      const storage = createStorage();
+      vi.stubGlobal('localStorage', storage);
+      const first = createResultItem(action, {
+        key: `ordinary-failure.json::auth-1::${action}`,
+        fileName: 'ordinary-failure.json',
+        runtimeId: 'runtime-canonical',
+        authIndex: 'auth-1',
+        accountId: 'account-canonical',
+        accountSnapshot: 'canonical@example.com',
+        displayAccount: 'canonical@example.com',
+        disabled: initialDisabled,
+        autoRecoverEligible: action === 'enable',
+      });
+      const second = createResultItem(action, {
+        key: `ordinary-failure.json::auth-2::${action}`,
+        fileName: 'ordinary-failure.json',
+        runtimeId: 'runtime-sibling',
+        authIndex: 'auth-2',
+        accountId: 'account-sibling',
+        accountSnapshot: 'sibling@example.com',
+        displayAccount: 'sibling@example.com',
+        disabled: initialDisabled,
+        autoRecoverEligible: action === 'enable',
+      });
+      const currentFiles = [first, second].map((item) =>
+        createCurrentAuthFile(item, { disabled: initialDisabled })
+      );
+      const finalFiles = [
+        createCurrentAuthFile(first, { disabled: initialDisabled }),
+        createCurrentAuthFile(second, { disabled: requestedDisabled }),
+      ];
+      const scope = `scope-auto-ordinary-canonical-failure-${action}`;
+      if (action === 'enable') {
+        [first, second].forEach((item) =>
+          recordCodexInspectionDisableOwnership(scope, {
+            fileName: item.fileName,
+            provider: item.provider,
+            authIndex: item.authIndex,
+            accountId: item.accountId,
+            accountSnapshot: item.accountSnapshot,
+          })
+        );
+      }
+      const statusSpy = vi
+        .spyOn(authFilesApi, 'setStatusWithFallback')
+        .mockImplementation(async (target, disabled, verifyFallback) => {
+          if (target.runtimeId === first.runtimeId) {
+            expect(verifyFallback).toEqual(expect.any(Function));
+            throw new Error('canonical credential update failed');
+          }
+          expect(verifyFallback).toBeUndefined();
+          return { status: 'ok', disabled, mutationScope: 'credential' };
+        });
+      const listSpy = vi
+        .spyOn(authFilesApi, 'list')
+        .mockResolvedValueOnce({ files: currentFiles })
+        .mockResolvedValueOnce({ files: currentFiles })
+        .mockResolvedValueOnce({ files: currentFiles })
+        .mockResolvedValueOnce({ files: finalFiles });
+
+      const execution = await executeCodexInspectionActions({
+        settings: createRunResult().settings,
+        items: [first, second],
+        referenceItems: [first, second],
+        previousFiles: [],
+        connectionFingerprint: scope,
+        source: 'auto',
+      });
+
+      expect(listSpy).toHaveBeenCalledTimes(4);
+      expect(statusSpy).toHaveBeenCalledTimes(2);
+      expect(statusSpy.mock.calls.map(([target]) => target.runtimeId)).toEqual([
+        first.runtimeId,
+        second.runtimeId,
+      ]);
+      expect(execution.outcomes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            accountKey: first.key,
+            status: 'failed',
+            success: false,
+            error: 'canonical credential update failed',
+          }),
+          expect.objectContaining({
+            accountKey: second.key,
+            status: 'success',
+            success: true,
+          }),
+        ])
+      );
+      expect(
+        execution.outcomes.find((outcome) => outcome.accountKey === second.key)?.status
+      ).not.toBe('skipped');
+
+      const owned = getCodexInspectionOwnedDisableIdentityKeys(scope, finalFiles);
+      const siblingOwnershipKey = getCodexInspectionOwnershipIdentityKey({
+        fileName: second.fileName,
+        provider: second.provider,
+        authIndex: second.authIndex,
+        accountId: second.accountId,
+        accountSnapshot: second.accountSnapshot,
+      });
+      const canonicalOwnershipKey = getCodexInspectionOwnershipIdentityKey({
+        fileName: first.fileName,
+        provider: first.provider,
+        authIndex: first.authIndex,
+        accountId: first.accountId,
+        accountSnapshot: first.accountSnapshot,
+      });
+      if (action === 'disable') {
+        expect(owned).toEqual(new Set([siblingOwnershipKey]));
+        expect(storage.setItem).toHaveBeenCalledTimes(1);
+      } else {
+        expect(owned).toEqual(new Set([canonicalOwnershipKey]));
+      }
+    }
+  );
+
   it('blocks a duplicate plugin locator without falling back for a unique sibling', async () => {
     const storage = createStorage();
     vi.stubGlobal('localStorage', storage);
@@ -4470,13 +4602,13 @@ describe('executeCodexInspectionActions', () => {
       source: 'auto',
     });
 
-    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledTimes(2);
     expect(sourceStatusSpy).not.toHaveBeenCalled();
     expect(storage.setItem).not.toHaveBeenCalled();
     expect(execution.outcomes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ accountKey: first.key, status: 'failed', success: false }),
-        expect.objectContaining({ accountKey: second.key, status: 'skipped', success: true }),
+        expect.objectContaining({ accountKey: second.key, status: 'failed', success: false }),
       ])
     );
   });
@@ -4538,13 +4670,13 @@ describe('executeCodexInspectionActions', () => {
       source: 'auto',
     });
 
-    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledTimes(2);
     expect(sourceStatusSpy).not.toHaveBeenCalled();
     expect(storage.setItem).not.toHaveBeenCalled();
     expect(execution.outcomes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ accountKey: first.key, status: 'failed', success: false }),
-        expect.objectContaining({ accountKey: second.key, status: 'skipped', success: true }),
+        expect.objectContaining({ accountKey: second.key, status: 'failed', success: false }),
       ])
     );
   });
@@ -4621,7 +4753,7 @@ describe('executeCodexInspectionActions', () => {
         }),
         expect.objectContaining({
           accountKey: sibling.key,
-          status: 'skipped',
+          status: 'needs_review',
           success: true,
         }),
       ])

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -4070,13 +4070,12 @@ describe('executeCodexInspectionActions', () => {
       const statusSpy = vi
         .spyOn(authFilesApi, 'setStatusWithFallback')
         .mockImplementation(async (_target, disabled, verifyFallback) => {
-          if (source === 'manual') {
-            if (!verifyFallback) throw new Error('missing plugin source fallback verifier');
-            verifiedSourceIdentities = await verifyFallback();
-            return { status: 'ok', disabled, mutationScope: 'source-file' };
+          if (!verifyFallback) {
+            if (source === 'manual') throw new Error('missing plugin source fallback verifier');
+            return { status: 'ok', disabled, mutationScope: 'credential' };
           }
-          if (verifyFallback) throw new Error('unexpected plugin source fallback verifier');
-          return { status: 'ok', disabled, mutationScope: 'credential' };
+          verifiedSourceIdentities = await verifyFallback();
+          return { status: 'ok', disabled, mutationScope: 'source-file' };
         });
       vi.spyOn(authFilesApi, 'list')
         .mockResolvedValueOnce({ files: currentFiles })
@@ -4142,26 +4141,37 @@ describe('executeCodexInspectionActions', () => {
           ])
         );
       } else {
-        expect(statusSpy).toHaveBeenCalledTimes(2);
-        expect(statusSpy.mock.calls).toEqual(
-          expect.arrayContaining([
-            [
-              expect.objectContaining({
-                runtimeId: 'runtime-plugin-1',
-                authIndex: 'auth-1',
-              }),
-              nextDisabled,
-            ],
-            [
-              expect.objectContaining({
-                runtimeId: 'runtime-plugin-2',
-                authIndex: 'auth-2',
-              }),
-              nextDisabled,
-            ],
-          ])
+        expect(statusSpy).toHaveBeenCalledTimes(1);
+        expect(statusSpy).toHaveBeenCalledWith(
+          {
+            name: 'plugin-source.json',
+            runtimeId: 'runtime-plugin-1',
+            authIndex: 'auth-1',
+            provider: 'codex',
+            accountId: 'account-1',
+            accountSnapshot: 'first-plugin@example.com',
+          },
+          nextDisabled,
+          expect.any(Function)
         );
-        expect(verifiedSourceIdentities).toBeUndefined();
+        expect(verifiedSourceIdentities).toEqual([
+          {
+            name: 'plugin-source.json',
+            runtimeId: 'runtime-plugin-1',
+            authIndex: 'auth-1',
+            provider: 'codex',
+            accountId: 'account-1',
+            accountSnapshot: 'first-plugin@example.com',
+          },
+          {
+            name: 'plugin-source.json',
+            runtimeId: 'runtime-plugin-2',
+            authIndex: 'auth-2',
+            provider: 'codex',
+            accountId: 'account-2',
+            accountSnapshot: 'second-plugin@example.com',
+          },
+        ]);
         expect(execution.outcomes).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -4171,7 +4181,7 @@ describe('executeCodexInspectionActions', () => {
             }),
             expect.objectContaining({
               accountKey: second.key,
-              status: 'success',
+              status: 'skipped',
               success: true,
             }),
           ])
@@ -4199,6 +4209,260 @@ describe('executeCodexInspectionActions', () => {
       }
     }
   );
+
+  it('keeps all-unique automatic credentials independent within one physical file', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const first = createResultItem('disable', {
+      key: 'ordinary-all-unique.json::auth-1',
+      fileName: 'ordinary-all-unique.json',
+      runtimeId: 'runtime-ordinary-1',
+      authIndex: 'auth-1',
+      accountId: 'account-1',
+      accountSnapshot: 'first@example.com',
+    });
+    const second = createResultItem('disable', {
+      key: 'ordinary-all-unique.json::auth-2',
+      fileName: 'ordinary-all-unique.json',
+      runtimeId: 'runtime-ordinary-2',
+      authIndex: 'auth-2',
+      accountId: 'account-2',
+      accountSnapshot: 'second@example.com',
+    });
+    const currentFiles = [first, second].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, disabled) => ({
+        status: 'ok',
+        disabled,
+        mutationScope: 'credential',
+      }));
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({ files: currentFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [first, second],
+      referenceItems: [first, second],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-all-unique-ordinary',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(2);
+    expect(statusSpy.mock.calls.map(([target]) => target.runtimeId).sort()).toEqual([
+      'runtime-ordinary-1',
+      'runtime-ordinary-2',
+    ]);
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ accountKey: first.key, status: 'success', success: true }),
+        expect.objectContaining({ accountKey: second.key, status: 'success', success: true }),
+      ])
+    );
+    expect(storage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks a duplicate plugin locator without falling back for a unique sibling', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const first = createResultItem('disable', {
+      key: 'plugin-duplicate.json::auth-1::alice',
+      fileName: 'plugin-duplicate.json',
+      runtimeId: 'runtime-plugin-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const second = createResultItem('disable', {
+      key: 'plugin-duplicate.json::auth-1::bob',
+      fileName: 'plugin-duplicate.json',
+      runtimeId: 'runtime-plugin-bob',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'bob@example.com',
+    });
+    const unique = createResultItem('disable', {
+      key: 'plugin-duplicate.json::auth-2::charlie',
+      fileName: 'plugin-duplicate.json',
+      runtimeId: 'runtime-plugin-charlie',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'charlie@example.com',
+    });
+    const currentFiles = [first, second, unique].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, disabled, verifyFallback) => {
+        expect(verifyFallback).toBeUndefined();
+        return { status: 'ok', disabled, mutationScope: 'credential' };
+      });
+    const sourceStatusSpy = vi.spyOn(authFilesApi, 'setVerifiedSourceFileStatus');
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({ files: currentFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [first, second, unique],
+      referenceItems: [first, second, unique],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-plugin-duplicate-locator',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeId: 'runtime-plugin-charlie', authIndex: 'auth-2' }),
+      true
+    );
+    expect(sourceStatusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ accountKey: first.key, status: 'needs_review', success: true }),
+        expect.objectContaining({ accountKey: second.key, status: 'needs_review', success: true }),
+        expect.objectContaining({ accountKey: unique.key, status: 'success', success: true }),
+      ])
+    );
+  });
+
+  it('rejects automatic plugin fallback when source membership grows before fallback', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const first = createResultItem('disable', {
+      key: 'plugin-membership-growth.json::auth-1',
+      fileName: 'plugin-membership-growth.json',
+      runtimeId: 'runtime-plugin-1',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'first@example.com',
+    });
+    const second = createResultItem('disable', {
+      key: 'plugin-membership-growth.json::auth-2',
+      fileName: 'plugin-membership-growth.json',
+      runtimeId: 'runtime-plugin-2',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'second@example.com',
+    });
+    const initialFiles = [first, second].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const added = createCurrentAuthFile(
+      createResultItem('disable', {
+        key: 'plugin-membership-growth.json::auth-3',
+        fileName: 'plugin-membership-growth.json',
+        runtimeId: 'runtime-plugin-3',
+        authIndex: 'auth-3',
+        accountId: 'workspace-1',
+        accountSnapshot: 'third@example.com',
+      }),
+      { disabled: false }
+    );
+    const grownFiles = [...initialFiles, added];
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, _disabled, verifyFallback) => {
+        if (!verifyFallback) throw new Error('missing plugin source fallback verifier');
+        await verifyFallback();
+        return { status: 'ok', disabled: true, mutationScope: 'source-file' };
+      });
+    const sourceStatusSpy = vi.spyOn(authFilesApi, 'setVerifiedSourceFileStatus');
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: grownFiles })
+      .mockResolvedValue({ files: grownFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [first, second],
+      referenceItems: [first, second],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-plugin-membership-growth',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(sourceStatusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ accountKey: first.key, status: 'failed', success: false }),
+        expect.objectContaining({ accountKey: second.key, status: 'skipped', success: true }),
+      ])
+    );
+  });
+
+  it('rejects automatic plugin fallback when a locator duplicates before fallback', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const first = createResultItem('disable', {
+      key: 'plugin-locator-toctou.json::auth-1',
+      fileName: 'plugin-locator-toctou.json',
+      runtimeId: 'runtime-plugin-1',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'first@example.com',
+    });
+    const second = createResultItem('disable', {
+      key: 'plugin-locator-toctou.json::auth-2',
+      fileName: 'plugin-locator-toctou.json',
+      runtimeId: 'runtime-plugin-2',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'second@example.com',
+    });
+    const initialFiles = [first, second].map((item) =>
+      createCurrentAuthFile(item, { disabled: false })
+    );
+    const duplicate = createCurrentAuthFile(
+      createResultItem('disable', {
+        key: 'plugin-locator-toctou.json::auth-1::duplicate',
+        fileName: 'plugin-locator-toctou.json',
+        runtimeId: 'runtime-plugin-duplicate',
+        authIndex: 'auth-1',
+        accountId: 'workspace-1',
+        accountSnapshot: 'duplicate@example.com',
+      }),
+      { disabled: false }
+    );
+    const freshFiles = [initialFiles[0], duplicate, initialFiles[1]];
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, _disabled, verifyFallback) => {
+        if (!verifyFallback) throw new Error('missing plugin source fallback verifier');
+        await verifyFallback();
+        return { status: 'ok', disabled: true, mutationScope: 'source-file' };
+      });
+    const sourceStatusSpy = vi.spyOn(authFilesApi, 'setVerifiedSourceFileStatus');
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: initialFiles })
+      .mockResolvedValueOnce({ files: freshFiles })
+      .mockResolvedValue({ files: freshFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [first, second],
+      referenceItems: [first, second],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-plugin-locator-toctou',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(sourceStatusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ accountKey: first.key, status: 'failed', success: false }),
+        expect.objectContaining({ accountKey: second.key, status: 'skipped', success: true }),
+      ])
+    );
+  });
 
   it('updates every ordinary same-name credential instead of treating the group as one file', async () => {
     const first = createResultItem('disable', {

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -64,6 +64,7 @@ import {
 import {
   getCodexInspectionOwnedDisableIdentityKeys,
   getCodexInspectionOwnershipIdentityKey,
+  hasCodexInspectionStableIdentity,
   recordCodexInspectionDisableOwnership,
 } from './model/codexInspectionOwnership';
 import { toInspectionAccount } from './model/codexInspectionProbe';
@@ -1482,6 +1483,38 @@ describe('resolveCodexInspectionAutoActionItems', () => {
       ['delete.json', 'delete'],
       ['disable.json', 'disable'],
       ['enable.json', 'enable'],
+    ]);
+  });
+
+  it('blocks runtime-only Codex automatic status mutation before calling the API', async () => {
+    const statusSpy = vi.spyOn(authFilesApi, 'setStatusWithFallback').mockResolvedValue({
+      status: 'ok',
+      disabled: true,
+      mutationScope: 'credential',
+    });
+    const item = {
+      ...createResultItem('disable', {
+        fileName: 'runtime-only.json',
+        runtimeId: 'runtime-only',
+      }),
+      authIndex: null,
+    } as CodexInspectionResultItem;
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-runtime-only-auto',
+      source: 'auto',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'needs_review',
+        success: true,
+      }),
     ]);
   });
 });
@@ -4403,6 +4436,132 @@ describe('Codex inspection disable ownership', () => {
         accountSnapshot: null,
       }),
     ]);
+  });
+
+  it('keeps ownership when a uniquely located credential temporarily loses optional evidence', () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    recordCodexInspectionDisableOwnership('scope-missing-evidence', {
+      fileName: 'alice.json',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+
+    const current = {
+      id: 'runtime-alice',
+      name: 'alice.json',
+      type: 'codex',
+      auth_index: 'auth-1',
+      disabled: true,
+    } as AuthFileItem;
+
+    expect(
+      Array.from(getCodexInspectionOwnedDisableIdentityKeys('scope-missing-evidence', [current]))
+    ).toEqual([
+      getCodexInspectionOwnershipIdentityKey({
+        fileName: 'alice.json',
+        provider: 'codex',
+        authIndex: 'auth-1',
+      }),
+    ]);
+    expect(storage.getItem('cli-proxy-codex-inspection-disable-ownership-v2')).toContain(
+      'scope-missing-evidence'
+    );
+  });
+
+  it.each([
+    {
+      label: 'Workspace evidence conflicts',
+      file: {
+        id: 'runtime-alice',
+        name: 'alice.json',
+        type: 'codex',
+        auth_index: 'auth-1',
+        account_id: 'workspace-2',
+        account: 'alice@example.com',
+        disabled: true,
+      },
+    },
+    {
+      label: 'member evidence conflicts',
+      file: {
+        id: 'runtime-alice',
+        name: 'alice.json',
+        type: 'codex',
+        auth_index: 'auth-1',
+        account_id: 'workspace-1',
+        account: 'bob@example.com',
+        disabled: true,
+      },
+    },
+  ])('does not recover ownership when $label', ({ file }) => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    recordCodexInspectionDisableOwnership('scope-evidence-conflict', {
+      fileName: 'alice.json',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+
+    expect(
+      getCodexInspectionOwnedDisableIdentityKeys('scope-evidence-conflict', [
+        file as AuthFileItem,
+      ])
+    ).toEqual(new Set());
+  });
+
+  it('keeps duplicate Codex locators ambiguous without narrowing by member evidence', () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    recordCodexInspectionDisableOwnership('scope-duplicate-locator', {
+      fileName: 'team.json',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const files = [
+      {
+        id: 'runtime-alice',
+        name: 'team.json',
+        type: 'codex',
+        auth_index: 'auth-1',
+        account_id: 'workspace-1',
+        account: 'alice@example.com',
+        disabled: true,
+      },
+      {
+        id: 'runtime-bob',
+        name: 'team.json',
+        type: 'codex',
+        auth_index: 'auth-1',
+        account_id: 'workspace-1',
+        account: 'bob@example.com',
+        disabled: true,
+      },
+    ] as AuthFileItem[];
+
+    expect(getCodexInspectionOwnedDisableIdentityKeys('scope-duplicate-locator', files)).toEqual(
+      new Set()
+    );
+    expect(storage.getItem('cli-proxy-codex-inspection-disable-ownership-v2')).toContain(
+      'scope-duplicate-locator'
+    );
+  });
+
+  it('does not treat a runtime-only Codex identity as automatic ownership', () => {
+    expect(
+      hasCodexInspectionStableIdentity({
+        fileName: 'runtime-only.json',
+        provider: 'codex',
+        runtimeId: 'runtime-only',
+        authIndex: null,
+      })
+    ).toBe(false);
   });
 
   it('permanently removes an ambiguous legacy wildcard ownership record', () => {

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -2301,6 +2301,200 @@ describe('executeCodexInspectionActions', () => {
     ]);
   });
 
+  it('allows delete when Codex optional evidence temporarily disappears', async () => {
+    const item = createResultItem('delete', {
+      key: 'alice.json::auth-1',
+      fileName: 'alice.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const currentFile = {
+      id: 'runtime-alice',
+      name: 'alice.json',
+      type: 'codex',
+      auth_index: 'auth-1',
+      disabled: false,
+    } as AuthFileItem;
+    const deleteSpy = vi.spyOn(authFilesApi, 'deleteFileByName').mockResolvedValue({
+      status: 'ok',
+      deleted: 1,
+      files: ['alice.json'],
+      failed: [],
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({ files: [currentFile] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-delete-missing-evidence',
+      source: 'manual',
+    });
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        action: 'delete',
+        status: 'success',
+        success: true,
+      }),
+    ]);
+  });
+
+  it.each([
+    {
+      label: 'Workspace evidence conflicts',
+      currentFile: {
+        id_token: { account_id: 'workspace-1' },
+        metadata: { id_token: { chatgpt_account_id: 'workspace-2' } },
+        account: 'alice@example.com',
+      },
+    },
+    {
+      label: 'member evidence conflicts',
+      currentFile: {
+        id_token: { account_id: 'workspace-1' },
+        account: 'alice@example.com',
+        email: 'bob@example.com',
+      },
+    },
+  ])('rejects delete when current Codex $label', async ({ currentFile }) => {
+    const item = createResultItem('delete', {
+      key: 'alice.json::auth-1',
+      fileName: 'alice.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const deleteSpy = vi.spyOn(authFilesApi, 'deleteFileByName').mockResolvedValue({
+      status: 'ok',
+      deleted: 1,
+      files: ['alice.json'],
+      failed: [],
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValueOnce({
+      files: [
+        {
+          id: 'runtime-alice',
+          name: 'alice.json',
+          type: 'codex',
+          auth_index: 'auth-1',
+          disabled: false,
+          ...currentFile,
+        } as AuthFileItem,
+      ],
+    });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-delete-invalid-evidence',
+      source: 'manual',
+    });
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        action: 'delete',
+        status: 'failed',
+        success: false,
+      }),
+    ]);
+  });
+
+  it('rejects delete when current Codex Workspace conflicts even without expected evidence', async () => {
+    const item = createResultItem('delete', {
+      key: 'workspace-only.json::auth-1',
+      fileName: 'workspace-only.json',
+      runtimeId: 'runtime-workspace-only',
+      authIndex: 'auth-1',
+      accountId: null,
+      accountSnapshot: null,
+    });
+    const deleteSpy = vi.spyOn(authFilesApi, 'deleteFileByName').mockResolvedValue({
+      status: 'ok',
+      deleted: 1,
+      files: ['workspace-only.json'],
+      failed: [],
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValueOnce({
+      files: [
+        {
+          id: 'runtime-workspace-only',
+          name: 'workspace-only.json',
+          type: 'codex',
+          auth_index: 'auth-1',
+          id_token: {
+            account_id: 'workspace-1',
+            metadata: { id_token: { chatgpt_account_id: 'workspace-2' } },
+          },
+          disabled: false,
+        } as AuthFileItem,
+      ],
+    });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-delete-unexpected-invalid-evidence',
+      source: 'manual',
+    });
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(execution.outcomes[0]).toMatchObject({ status: 'failed', success: false });
+  });
+
+  it('rejects delete without a credential locator even when Codex evidence matches', async () => {
+    const item = {
+      ...createResultItem('delete', {
+        key: 'workspace-only.json::workspace-only',
+        fileName: 'workspace-only.json',
+        runtimeId: null,
+        authIndex: null,
+        accountId: 'workspace-1',
+        accountSnapshot: 'alice@example.com',
+      }),
+      authIndex: null,
+    };
+    const deleteSpy = vi.spyOn(authFilesApi, 'deleteFileByName').mockResolvedValue({
+      status: 'ok',
+      deleted: 1,
+      files: ['workspace-only.json'],
+      failed: [],
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValueOnce({
+      files: [
+        {
+          id: 'runtime-workspace-only',
+          name: 'workspace-only.json',
+          type: 'codex',
+          auth_index: null,
+          id_token: { account_id: 'workspace-1' },
+          account: 'alice@example.com',
+          disabled: false,
+        } as AuthFileItem,
+      ],
+    });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-delete-no-locator',
+      source: 'manual',
+    });
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(execution.outcomes[0]).toMatchObject({ status: 'needs_review', success: true });
+  });
+
   it('rejects disable and enable when the current auth identities changed', async () => {
     const statusSpy = vi
       .spyOn(authFilesApi, 'setStatusWithFallback')
@@ -3030,6 +3224,366 @@ describe('executeCodexInspectionActions', () => {
         }),
       ])
     );
+  });
+
+  it('blocks automatic Codex disable when the persisted file/auth-index locator is duplicated', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const item = createResultItem('disable', {
+      key: 'shared.json::auth-1::alice',
+      fileName: 'shared.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const alice = createCurrentAuthFile(item, { disabled: false });
+    const bob = {
+      ...alice,
+      id: 'runtime-bob',
+      account: 'bob@example.com',
+    } as AuthFileItem;
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof authFilesApi.setStatusWithFallback>>);
+    vi.spyOn(authFilesApi, 'list').mockResolvedValueOnce({ files: [alice, bob] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-duplicate-locator',
+      source: 'auto',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'needs_review',
+        success: true,
+        error: expect.stringContaining('authIndex'),
+      }),
+    ]);
+  });
+
+  it('blocks an automatic source-file group when any Codex persisted locator is duplicated', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const sourceItem = createResultItem('disable', {
+      key: 'shared.json::auth-1::alice',
+      fileName: 'shared.json',
+      runtimeId: 'shared.json',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const childItem = createResultItem('disable', {
+      key: 'shared.json::auth-2::bob',
+      fileName: 'shared.json',
+      runtimeId: 'runtime-bob',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'bob@example.com',
+    });
+    const source = createCurrentAuthFile(sourceItem, { disabled: false });
+    const child = createCurrentAuthFile(childItem, { disabled: false });
+    const duplicateChild = {
+      ...child,
+      id: 'runtime-other-bob',
+      account: 'other-bob@example.com',
+    } as AuthFileItem;
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof authFilesApi.setStatusWithFallback>>);
+    const sourceStatusSpy = vi
+      .spyOn(authFilesApi, 'setVerifiedSourceFileStatus')
+      .mockResolvedValue({ status: 'ok', disabled: true, mutationScope: 'source-file' });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValueOnce({
+      files: [source, child, duplicateChild],
+    });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [sourceItem, childItem],
+      referenceItems: [sourceItem, childItem],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-source-duplicate-locator',
+      source: 'auto',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(sourceStatusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: sourceItem.key,
+          status: 'needs_review',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: childItem.key,
+          status: 'needs_review',
+          success: true,
+        }),
+      ])
+    );
+  });
+
+  it('keeps manual unique runtime-id mutation available without an auth index', async () => {
+    const item = {
+      ...createResultItem('disable', {
+        key: 'manual-runtime-only.json::runtime-manual',
+        fileName: 'manual-runtime-only.json',
+        runtimeId: 'runtime-manual',
+        authIndex: null,
+        accountId: null,
+        accountSnapshot: null,
+      }),
+      authIndex: null,
+    };
+    const currentFile = {
+      id: 'runtime-manual',
+      name: 'manual-runtime-only.json',
+      type: 'codex',
+      auth_index: null,
+      disabled: false,
+    } as AuthFileItem;
+    const statusSpy = vi.spyOn(authFilesApi, 'setStatusWithFallback').mockResolvedValue({
+      status: 'ok',
+      disabled: true,
+      mutationScope: 'credential',
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({ files: [currentFile] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-manual-runtime-only',
+      source: 'manual',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'success',
+        success: true,
+      }),
+    ]);
+  });
+
+  it('allows a status mutation when Codex optional evidence temporarily disappears', async () => {
+    const item = createResultItem('disable', {
+      key: 'alice.json::auth-1',
+      fileName: 'alice.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const currentFile = {
+      id: 'runtime-alice',
+      name: 'alice.json',
+      type: 'codex',
+      auth_index: 'auth-1',
+      disabled: false,
+    } as AuthFileItem;
+    const statusSpy = vi.spyOn(authFilesApi, 'setStatusWithFallback').mockResolvedValue({
+      status: 'ok',
+      disabled: true,
+      mutationScope: 'credential',
+    });
+    vi.spyOn(authFilesApi, 'list').mockResolvedValue({ files: [currentFile] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-missing-evidence',
+      source: 'manual',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        action: 'disable',
+        status: 'success',
+        success: true,
+      }),
+    ]);
+  });
+
+  it.each([
+    {
+      label: 'Workspace evidence conflicts',
+      currentFile: {
+        id_token: { account_id: 'workspace-1' },
+        metadata: { id_token: { chatgpt_account_id: 'workspace-2' } },
+        account: 'alice@example.com',
+      },
+    },
+    {
+      label: 'member evidence conflicts',
+      currentFile: {
+        id_token: { account_id: 'workspace-1' },
+        account: 'alice@example.com',
+        email: 'bob@example.com',
+      },
+    },
+  ])('rejects status mutation when current Codex $label', async ({ currentFile }) => {
+    const item = createResultItem('disable', {
+      key: 'alice.json::auth-1',
+      fileName: 'alice.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof authFilesApi.setStatusWithFallback>>);
+    vi.spyOn(authFilesApi, 'list').mockResolvedValueOnce({
+      files: [
+        {
+          id: 'runtime-alice',
+          name: 'alice.json',
+          type: 'codex',
+          auth_index: 'auth-1',
+          disabled: false,
+          ...currentFile,
+        } as AuthFileItem,
+      ],
+    });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-codex-invalid-evidence',
+      source: 'manual',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'failed',
+        success: false,
+      }),
+    ]);
+  });
+
+  it('keeps plugin source membership stable when Codex evidence temporarily disappears', async () => {
+    const item = createResultItem('disable', {
+      key: 'plugin-source.json::auth-1',
+      fileName: 'plugin-source.json',
+      runtimeId: 'runtime-plugin-1',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'plugin@example.com',
+    });
+    const snapshotFile = createCurrentAuthFile(item, { disabled: false });
+    const currentFile = {
+      id: 'runtime-plugin-1',
+      name: 'plugin-source.json',
+      type: 'codex',
+      auth_index: 'auth-1',
+      disabled: false,
+    } as AuthFileItem;
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, _disabled, verifyFallback) => {
+        expect(verifyFallback).toBeDefined();
+        await verifyFallback?.();
+        return { status: 'ok', disabled: true, mutationScope: 'source-file' };
+      });
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: [snapshotFile] })
+      .mockResolvedValueOnce({ files: [snapshotFile] })
+      .mockResolvedValueOnce({ files: [currentFile] })
+      .mockResolvedValueOnce({ files: [{ ...currentFile, disabled: true }] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-plugin-missing-evidence',
+      source: 'manual',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'success',
+        success: true,
+      }),
+    ]);
+  });
+
+  it.each([
+    {
+      label: 'Workspace evidence conflicts',
+      currentOverrides: { id_token: { account_id: 'workspace-2' } },
+    },
+    {
+      label: 'member evidence conflicts',
+      currentOverrides: { account: 'other-member@example.com' },
+    },
+    {
+      label: 'Workspace evidence is invalid',
+      currentOverrides: {
+        id_token: { account_id: 'workspace-1' },
+        metadata: { id_token: { chatgpt_account_id: 'workspace-2' } },
+      },
+    },
+  ])('rejects plugin source fallback when current Codex $label', async ({ currentOverrides }) => {
+    const item = createResultItem('disable', {
+      key: 'plugin-source.json::auth-1',
+      fileName: 'plugin-source.json',
+      runtimeId: 'runtime-plugin-1',
+      provider: 'codex',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'plugin@example.com',
+    });
+    const snapshotFile = createCurrentAuthFile(item, { disabled: false });
+    const freshFile = { ...snapshotFile, ...currentOverrides } as AuthFileItem;
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockImplementation(async (_target, _disabled, verifyFallback) => {
+        await verifyFallback?.();
+        return { status: 'ok', disabled: true, mutationScope: 'source-file' };
+      });
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: [snapshotFile] })
+      .mockResolvedValueOnce({ files: [snapshotFile] })
+      .mockResolvedValueOnce({ files: [freshFile] })
+      .mockResolvedValue({ files: [freshFile] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-plugin-conflicting-evidence',
+      source: 'manual',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'failed',
+        success: false,
+        error: expect.stringContaining('成员'),
+      }),
+    ]);
   });
 
   it('uses a verified source-file fallback for a single plugin virtual credential', async () => {
@@ -4508,9 +5062,7 @@ describe('Codex inspection disable ownership', () => {
     });
 
     expect(
-      getCodexInspectionOwnedDisableIdentityKeys('scope-evidence-conflict', [
-        file as AuthFileItem,
-      ])
+      getCodexInspectionOwnedDisableIdentityKeys('scope-evidence-conflict', [file as AuthFileItem])
     ).toEqual(new Set());
   });
 

--- a/apps/web/src/features/monitoring/codexInspection.test.ts
+++ b/apps/web/src/features/monitoring/codexInspection.test.ts
@@ -3268,6 +3268,237 @@ describe('executeCodexInspectionActions', () => {
     ]);
   });
 
+  it('blocks automatic disable when a persisted locator becomes duplicated before mutation', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const item = createResultItem('disable', {
+      key: 'toctou.json::auth-1',
+      fileName: 'toctou.json',
+      runtimeId: 'runtime-original',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const initialFile = createCurrentAuthFile(item, { disabled: false });
+    const duplicateFile = createCurrentAuthFile(
+      { ...item, runtimeId: 'runtime-duplicate' },
+      { disabled: false }
+    );
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof authFilesApi.setStatusWithFallback>>);
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: [initialFile] })
+      .mockResolvedValue({ files: [initialFile, duplicateFile] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-toctou-single',
+      source: 'auto',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'needs_review',
+        success: true,
+        error: expect.stringContaining('authIndex'),
+      }),
+    ]);
+  });
+
+  it('does not narrow an automatic TOCTOU duplicate by Codex member evidence', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const item = createResultItem('disable', {
+      key: 'team-toctou.json::auth-1::alice',
+      fileName: 'team-toctou.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+      displayAccount: 'alice@example.com',
+    });
+    const initialFile = createCurrentAuthFile(item, { disabled: false });
+    const bob = createCurrentAuthFile(
+      {
+        ...item,
+        key: 'team-toctou.json::auth-1::bob',
+        runtimeId: 'runtime-bob',
+        accountSnapshot: 'bob@example.com',
+        displayAccount: 'bob@example.com',
+      },
+      { disabled: false }
+    );
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof authFilesApi.setStatusWithFallback>>);
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: [initialFile] })
+      .mockResolvedValue({ files: [initialFile, bob] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [item],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-toctou-member-duplicate',
+      source: 'auto',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual([
+      expect.objectContaining({
+        accountKey: item.key,
+        status: 'needs_review',
+        success: true,
+      }),
+    ]);
+  });
+
+  it('blocks an automatic source-file group when its persisted locator becomes duplicated', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const sourceItem = createResultItem('disable', {
+      key: 'toctou-plugin.json::auth-1',
+      fileName: 'toctou-plugin.json',
+      runtimeId: 'toctou-plugin.json',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const childItem = createResultItem('disable', {
+      key: 'toctou-plugin.json::auth-2',
+      fileName: 'toctou-plugin.json',
+      runtimeId: 'runtime-child',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'bob@example.com',
+    });
+    const source = createCurrentAuthFile(sourceItem, { disabled: false });
+    const child = createCurrentAuthFile(childItem, { disabled: false });
+    const duplicateChild = createCurrentAuthFile(
+      { ...childItem, runtimeId: 'runtime-duplicate-child' },
+      { disabled: false }
+    );
+    const statusSpy = vi
+      .spyOn(authFilesApi, 'setStatusWithFallback')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof authFilesApi.setStatusWithFallback>>);
+    const sourceStatusSpy = vi
+      .spyOn(authFilesApi, 'setVerifiedSourceFileStatus')
+      .mockResolvedValue({ status: 'ok', disabled: true, mutationScope: 'source-file' });
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: [source, child] })
+      .mockResolvedValue({ files: [source, child, duplicateChild] });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [sourceItem, childItem],
+      referenceItems: [sourceItem, childItem],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-toctou-source-group',
+      source: 'auto',
+    });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    expect(sourceStatusSpy).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: sourceItem.key,
+          status: 'needs_review',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: childItem.key,
+          status: 'skipped',
+          success: true,
+        }),
+      ])
+    );
+  });
+
+  it('only blocks the exact duplicate persisted locator for automatic credentials', async () => {
+    const storage = createStorage();
+    vi.stubGlobal('localStorage', storage);
+    const duplicate = createResultItem('disable', {
+      key: 'granularity.json::auth-1::alice',
+      fileName: 'granularity.json',
+      runtimeId: 'runtime-alice',
+      authIndex: 'auth-1',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
+    const duplicateSibling = createCurrentAuthFile(
+      {
+        ...duplicate,
+        key: 'granularity.json::auth-1::bob',
+        runtimeId: 'runtime-bob',
+        accountSnapshot: 'bob@example.com',
+        displayAccount: 'bob@example.com',
+      },
+      { disabled: false }
+    );
+    const unique = createResultItem('disable', {
+      key: 'granularity.json::auth-2::charlie',
+      fileName: 'granularity.json',
+      runtimeId: 'runtime-charlie',
+      authIndex: 'auth-2',
+      accountId: 'workspace-1',
+      accountSnapshot: 'charlie@example.com',
+      displayAccount: 'charlie@example.com',
+    });
+    const currentFiles = [
+      createCurrentAuthFile(duplicate, { disabled: false }),
+      duplicateSibling,
+      createCurrentAuthFile(unique, { disabled: false }),
+    ];
+    const statusSpy = vi.spyOn(authFilesApi, 'setStatusWithFallback').mockResolvedValue({
+      status: 'ok',
+      disabled: true,
+      mutationScope: 'credential',
+    });
+    vi.spyOn(authFilesApi, 'list')
+      .mockResolvedValueOnce({ files: currentFiles })
+      .mockResolvedValue({ files: currentFiles });
+
+    const execution = await executeCodexInspectionActions({
+      settings: createRunResult().settings,
+      items: [duplicate, unique],
+      referenceItems: [duplicate, unique],
+      previousFiles: [],
+      connectionFingerprint: 'scope-auto-locator-granularity',
+      source: 'auto',
+    });
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(statusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeId: 'runtime-charlie', authIndex: 'auth-2' }),
+      true,
+      expect.any(Function)
+    );
+    expect(execution.outcomes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountKey: duplicate.key,
+          status: 'needs_review',
+          success: true,
+        }),
+        expect.objectContaining({
+          accountKey: unique.key,
+          status: 'success',
+          success: true,
+        }),
+      ])
+    );
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+  });
+
   it('blocks an automatic source-file group when any Codex persisted locator is duplicated', async () => {
     const storage = createStorage();
     vi.stubGlobal('localStorage', storage);

--- a/apps/web/src/features/monitoring/codexInspection.ts
+++ b/apps/web/src/features/monitoring/codexInspection.ts
@@ -908,6 +908,7 @@ export const resolveCodexInspectionAutoActionPlan = (
     const stableItems = group.items.filter((item) =>
       hasCodexInspectionStableIdentity({
         fileName: item.fileName,
+        runtimeId: item.runtimeId,
         provider: item.provider,
         authIndex: item.authIndex,
         accountId: item.accountId,

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -17,10 +17,12 @@ import { normalizeAuthIndex } from '@/utils/authIndex';
 import {
   readAuthFileStatusAccountId,
   readAuthFileStatusAccountSnapshot,
+  readAuthFileStatusCodexMember,
   readAuthFileStatusRuntimeId,
   resolveAuthFileStatusMutationTarget,
   type AuthFileStatusMutationResolution,
 } from '@/utils/authFileStatusMutation';
+import { normalizeCodexMemberSnapshot } from '@/utils/authFileCredentialIdentity';
 import { resolveAuthProvider } from '@/utils/quota/validators';
 import { clampPositiveInteger } from './codexInspectionSettings';
 import {
@@ -390,14 +392,20 @@ const normalizeProvider = (value: unknown): string => {
 
 const readCurrentFileName = (file: AuthFileItem): string => String(file.name ?? '').trim();
 
-const buildDeleteIdentityTarget = (file: AuthFileItem): AuthFileDeleteIdentityTarget => ({
-  name: readCurrentFileName(file),
-  runtimeId: readAuthFileStatusRuntimeId(file) || null,
-  authIndex: normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']),
-  provider: resolveAuthProvider(file),
-  accountId: readAuthFileStatusAccountId(file) || null,
-  accountSnapshot: readAuthFileStatusAccountSnapshot(file) || null,
-});
+const buildDeleteIdentityTarget = (file: AuthFileItem): AuthFileDeleteIdentityTarget => {
+  const provider = normalizeProvider(resolveAuthProvider(file));
+  return {
+    name: readCurrentFileName(file),
+    runtimeId: readAuthFileStatusRuntimeId(file) || null,
+    authIndex: normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']),
+    provider,
+    accountId: readAuthFileStatusAccountId(file) || null,
+    accountSnapshot:
+      (provider === 'codex'
+        ? readAuthFileStatusCodexMember(file)
+        : readAuthFileStatusAccountSnapshot(file)) || null,
+  };
+};
 
 const getAuthFileSourceMemberIdentityKey = (file: AuthFileItem): string =>
   JSON.stringify(buildDeleteIdentityTarget(file));
@@ -414,7 +422,17 @@ const authFileSourceMembershipMatches = (
 
 const readInspectionAccountSnapshot = (item: CodexInspectionResultItem): string => {
   const snapshot = item.accountSnapshot?.trim() ?? '';
-  return snapshot && snapshot !== item.fileName.trim() ? snapshot : '';
+  if (!snapshot || snapshot === item.fileName.trim()) return '';
+  return normalizeProvider(item.provider) === 'codex'
+    ? normalizeCodexMemberSnapshot(snapshot)
+    : snapshot;
+};
+
+const readCurrentInspectionAccountSnapshot = (file: AuthFileItem): string => {
+  const provider = normalizeProvider(resolveAuthProvider(file));
+  return provider === 'codex'
+    ? readAuthFileStatusCodexMember(file)
+    : readAuthFileStatusAccountSnapshot(file);
 };
 
 const matchesCurrentActionIdentity = (
@@ -425,14 +443,25 @@ const matchesCurrentActionIdentity = (
   const currentProvider = normalizeProvider(resolveAuthProvider(file));
   const expectedProvider = normalizeProvider(item.provider);
   if (!currentProvider || !expectedProvider || currentProvider !== expectedProvider) return false;
+  const runtimeId = readAuthFileStatusRuntimeId(file);
+  const expectedRuntimeId = item.runtimeId?.trim() ?? '';
+  if (expectedRuntimeId && runtimeId !== expectedRuntimeId) return false;
   const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']);
   if (item.authIndex && authIndex !== normalizeAuthIndex(item.authIndex)) return false;
   const accountId = readAuthFileStatusAccountId(file);
   const expectedAccountId = item.accountId?.trim() ?? '';
-  if (expectedAccountId) return accountId === expectedAccountId;
+  if (expectedAccountId) {
+    if (accountId !== expectedAccountId) return false;
+    const expectedMember = readInspectionAccountSnapshot(item);
+    return (
+      normalizeProvider(item.provider) !== 'codex' ||
+      !expectedMember ||
+      readCurrentInspectionAccountSnapshot(file) === expectedMember
+    );
+  }
   const expectedSnapshot = readInspectionAccountSnapshot(item);
   if (!expectedSnapshot) return normalizeAuthIndex(item.authIndex) !== null;
-  return readAuthFileStatusAccountSnapshot(file) === expectedSnapshot;
+  return readCurrentInspectionAccountSnapshot(file) === expectedSnapshot;
 };
 
 type ResolvedStatusActionItem = {

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -311,6 +311,7 @@ const planExecutionItems = (
     if (
       !hasCodexInspectionStableIdentity({
         fileName: item.fileName,
+        runtimeId: item.runtimeId,
         provider: item.provider,
         authIndex: item.authIndex,
         accountId: item.accountId,
@@ -418,6 +419,25 @@ const authFileSourceMembershipMatches = (
   const expectedKeys = expectedMembers.map(getAuthFileSourceMemberIdentityKey).sort();
   const currentKeys = currentMembers.map(getAuthFileSourceMemberIdentityKey).sort();
   return expectedKeys.every((key, index) => key === currentKeys[index]);
+};
+
+const hasAmbiguousCredentialLocator = (
+  currentCandidates: AuthFileItem[],
+  referenceItems: CodexInspectionResultItem[]
+): boolean => {
+  const candidatesByAuthIndex = new Map<string, number>();
+  currentCandidates.forEach((file) => {
+    const authIndex = normalizeAuthIndex(
+      file['auth_index'] ?? file.authIndex ?? file['auth-index']
+    );
+    if (authIndex === null) return;
+    candidatesByAuthIndex.set(authIndex, (candidatesByAuthIndex.get(authIndex) ?? 0) + 1);
+  });
+  return referenceItems.some((item) => {
+    if (item.runtimeId?.trim()) return false;
+    const authIndex = normalizeAuthIndex(item.authIndex);
+    return authIndex !== null && (candidatesByAuthIndex.get(authIndex) ?? 0) > 1;
+  });
 };
 
 const readInspectionAccountSnapshot = (item: CodexInspectionResultItem): string => {
@@ -534,6 +554,10 @@ const deleteActionCoversCurrentFile = (
 ): boolean => {
   if (currentFiles.length === 0) return false;
   const normalizedFileName = fileName.trim();
+  const currentCandidates = currentFiles.filter(
+    (file) => readCurrentFileName(file) === normalizedFileName
+  );
+  if (hasAmbiguousCredentialLocator(currentCandidates, referenceItems)) return false;
   const deleteByIdentity = new Map<string, CodexInspectionResultItem>();
   for (const item of referenceItems) {
     if (item.fileName.trim() !== normalizedFileName) continue;

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -544,6 +544,24 @@ const hasDuplicateCodexPersistedLocator = (
   );
 };
 
+const hasUniqueCodexPersistedLocator = (
+  currentFiles: AuthFileItem[],
+  item: CodexInspectionResultItem
+): boolean => {
+  const locatorKey = getCodexPersistedLocatorKey(item.fileName, item.provider, item.authIndex);
+  if (!locatorKey) return false;
+  return (
+    currentFiles.filter(
+      (file) =>
+        getCodexPersistedLocatorKey(
+          readCurrentFileName(file),
+          resolveAuthProvider(file),
+          file['auth_index'] ?? file.authIndex ?? file['auth-index']
+        ) === locatorKey
+    ).length === 1
+  );
+};
+
 const readInspectionAccountSnapshot = (item: CodexInspectionResultItem): string => {
   const snapshot = item.accountSnapshot?.trim() ?? '';
   if (!snapshot || snapshot === item.fileName.trim()) return '';
@@ -577,6 +595,13 @@ type ResolvedStatusActionItem = {
 };
 
 type StatusActionGroupPlan = {
+  canonicalKey: string;
+  action: 'disable' | 'enable';
+  members: CodexInspectionResultItem[];
+  affectedFiles: AuthFileItem[];
+};
+
+type AutomaticSourceFallbackPlan = {
   canonicalKey: string;
   action: 'disable' | 'enable';
   members: CodexInspectionResultItem[];
@@ -632,6 +657,56 @@ const buildStatusActionGroupPlans = (
       affectedFiles: currentFiles,
     });
   });
+  return plans;
+};
+
+const buildAutomaticSourceFallbackPlans = (
+  resolvedItems: Map<string, ResolvedStatusActionItem>,
+  currentFilesByName: Map<string, AuthFileItem[]>,
+  currentFiles: AuthFileItem[]
+): Map<string, AutomaticSourceFallbackPlan> => {
+  const plans = new Map<string, AutomaticSourceFallbackPlan>();
+  const entriesByFile = new Map<string, ResolvedStatusActionItem[]>();
+  resolvedItems.forEach((entry) => {
+    const fileName = readCurrentFileName(entry.currentFile);
+    const entries = entriesByFile.get(fileName) ?? [];
+    entries.push(entry);
+    entriesByFile.set(fileName, entries);
+  });
+
+  currentFilesByName.forEach((affectedFiles, fileName) => {
+    const entries = entriesByFile.get(fileName) ?? [];
+    if (entries.length !== affectedFiles.length || affectedFiles.length === 0) return;
+
+    const members: CodexInspectionResultItem[] = [];
+    let action: 'disable' | 'enable' | null = null;
+    for (const affectedFile of affectedFiles) {
+      const matches = entries.filter((entry) => entry.currentFile === affectedFile);
+      const entry = matches[0];
+      if (!entry || matches.length !== 1 || !isStatusExecutionAction(entry.item)) return;
+      if (
+        entry.resolution.scope !== 'credential' ||
+        normalizeProvider(entry.item.provider) !== 'codex' ||
+        !hasUniqueCodexPersistedLocator(currentFiles, entry.item)
+      ) {
+        return;
+      }
+      if (action === null) action = entry.item.action;
+      if (entry.item.action !== action) return;
+      members.push(entry.item);
+    }
+
+    if (!action || !statusActionCoversCurrentFile(affectedFiles, members, fileName)) return;
+    const canonical = members[0];
+    if (!canonical) return;
+    plans.set(fileName, {
+      canonicalKey: canonical.key,
+      action,
+      members,
+      affectedFiles,
+    });
+  });
+
   return plans;
 };
 
@@ -764,6 +839,11 @@ const verifyPluginSourceStatusFallback = async (
   if (
     !authFileSourceMembershipMatches(snapshotMembers, freshMembers) ||
     !statusActionCoversCurrentFile(freshMembers, actionMembers, physicalName) ||
+    actionMembers.some(
+      (member) =>
+        normalizeProvider(member.provider) === 'codex' &&
+        !hasUniqueCodexPersistedLocator(freshFiles, member)
+    ) ||
     !resolution.target ||
     resolution.failure !== null ||
     resolution.scope !== 'credential' ||
@@ -868,6 +948,21 @@ type PatchedStatusActionMember = {
   item: CodexInspectionResultItem;
   originalDisabled: boolean;
 };
+
+type StatusChangeMutationScope = 'credential' | 'source-file' | null;
+
+type StatusChangeExecutionResult = {
+  outcome: CodexInspectionExecutionOutcome;
+  mutationScope: StatusChangeMutationScope;
+};
+
+const buildStatusChangeExecutionResult = (
+  outcome: CodexInspectionExecutionOutcome,
+  mutationScope: StatusChangeMutationScope = null
+): StatusChangeExecutionResult => ({
+  outcome,
+  mutationScope,
+});
 
 const rollbackPatchedStatusActionMembers = async (
   patchedMembers: PatchedStatusActionMember[],
@@ -1052,8 +1147,9 @@ const executeStatusChange = async (
   disabled: boolean,
   actionMembers: CodexInspectionResultItem[] = [],
   requestScope?: AuthFilesApiRequestScope,
-  automatic = false
-): Promise<CodexInspectionExecutionOutcome> => {
+  automatic = false,
+  sourceFallbackMembers?: CodexInspectionResultItem[]
+): Promise<StatusChangeExecutionResult> => {
   let snapshotMembers: AuthFileItem[] = [];
   let singleMember: VerifiedStatusActionMember | null = null;
   let actionGroup: VerifiedStatusActionGroup | null = null;
@@ -1064,27 +1160,33 @@ const executeStatusChange = async (
       automatic &&
       disabled &&
       normalizeProvider(item.provider) === 'codex' &&
-      (actionMembers.length > 0 ? actionMembers : [item]).some((member) =>
-        hasDuplicateCodexPersistedLocator(currentFiles, member)
+      (sourceFallbackMembers ?? (actionMembers.length > 0 ? actionMembers : [item])).some(
+        (member) => hasDuplicateCodexPersistedLocator(currentFiles, member)
       )
     ) {
-      return buildActionValidationOutcome(item, 'needs_review', AUTOMATIC_PERSISTED_LOCATOR_REASON);
+      return buildStatusChangeExecutionResult(
+        buildActionValidationOutcome(item, 'needs_review', AUTOMATIC_PERSISTED_LOCATOR_REASON)
+      );
     }
     if (actionMembers.length > 0) {
       actionGroup = resolveVerifiedStatusActionGroup(currentFiles, actionMembers, item.fileName);
       if (!actionGroup) {
-        return buildActionValidationOutcome(
-          item,
-          'failed',
-          '认证文件成员、Provider 或账号标识已变化，已拒绝状态修改'
+        return buildStatusChangeExecutionResult(
+          buildActionValidationOutcome(
+            item,
+            'failed',
+            '认证文件成员、Provider 或账号标识已变化，已拒绝状态修改'
+          )
         );
       }
       snapshotMembers = actionGroup.affectedFiles;
       if (actionGroup.affectedFiles.every((file) => (file.disabled === true) === disabled)) {
-        return buildActionValidationOutcome(
-          item,
-          'skipped',
-          disabled ? '账号已是禁用状态，未重复执行' : '账号已是启用状态，未重复执行'
+        return buildStatusChangeExecutionResult(
+          buildActionValidationOutcome(
+            item,
+            'skipped',
+            disabled ? '账号已是禁用状态，未重复执行' : '账号已是启用状态，未重复执行'
+          )
         );
       }
     } else {
@@ -1098,45 +1200,56 @@ const executeStatusChange = async (
       });
       const currentFile = resolution.target;
       if (!currentFile || !matchesCurrentActionIdentity(currentFile, item)) {
-        return buildActionValidationOutcome(
-          item,
-          'failed',
-          '认证文件不存在、Provider 不匹配或账号标识已变化，已拒绝执行'
+        return buildStatusChangeExecutionResult(
+          buildActionValidationOutcome(
+            item,
+            'failed',
+            '认证文件不存在、Provider 不匹配或账号标识已变化，已拒绝执行'
+          )
         );
       }
       if (resolution.failure !== null || resolution.scope === 'ambiguous') {
-        return buildActionValidationOutcome(item, 'failed', STATUS_MUTATION_SCOPE_REASON);
+        return buildStatusChangeExecutionResult(
+          buildActionValidationOutcome(item, 'failed', STATUS_MUTATION_SCOPE_REASON)
+        );
       }
       if (resolution.scope !== 'credential') {
-        return buildActionValidationOutcome(item, 'failed', STATUS_MUTATION_SCOPE_REASON);
+        return buildStatusChangeExecutionResult(
+          buildActionValidationOutcome(item, 'failed', STATUS_MUTATION_SCOPE_REASON)
+        );
       }
 
       snapshotMembers = currentFiles.filter(
         (file) => readCurrentFileName(file) === readCurrentFileName(currentFile)
       );
 
-      if ((currentFile.disabled === true) === disabled) {
-        return buildActionValidationOutcome(
-          item,
-          'skipped',
-          disabled ? '账号已是禁用状态，未重复执行' : '账号已是启用状态，未重复执行'
+      if ((currentFile.disabled === true) === disabled && sourceFallbackMembers === undefined) {
+        return buildStatusChangeExecutionResult(
+          buildActionValidationOutcome(
+            item,
+            'skipped',
+            disabled ? '账号已是禁用状态，未重复执行' : '账号已是启用状态，未重复执行'
+          )
         );
       }
       singleMember = { item, currentFile, resolution };
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error || '未知错误');
-    return buildActionValidationOutcome(
-      item,
-      'failed',
-      `执行状态修改前刷新认证文件失败，已拒绝执行：${message}`
+    return buildStatusChangeExecutionResult(
+      buildActionValidationOutcome(
+        item,
+        'failed',
+        `执行状态修改前刷新认证文件失败，已拒绝执行：${message}`
+      )
     );
   }
 
   try {
+    let mutationScope: StatusChangeMutationScope = null;
     if (actionGroup) {
       if (actionGroup.sourceMember) {
-        await setVerifiedSourceFileStatus(
+        const result = await setVerifiedSourceFileStatus(
           buildStatusActionTarget(
             actionGroup.sourceMember.item,
             actionGroup.sourceMember.currentFile
@@ -1145,6 +1258,7 @@ const executeStatusChange = async (
           actionGroup.affectedFiles.map(buildDeleteIdentityTarget),
           requestScope
         );
+        mutationScope = result.mutationScope;
       } else {
         const patchedMembers: PatchedStatusActionMember[] = [];
         for (let index = 0; index < actionGroup.members.length; index++) {
@@ -1167,6 +1281,7 @@ const executeStatusChange = async (
                     requestScope
                   )
                 : await setAuthFileStatusWithFallback(target, disabled, undefined, requestScope);
+            mutationScope = result.mutationScope ?? null;
             if (result.mutationScope === 'source-file') break;
             patchedMembers.push({
               item: member.item,
@@ -1187,39 +1302,43 @@ const executeStatusChange = async (
       }
     } else if (singleMember) {
       const target = buildStatusActionTarget(singleMember.item, singleMember.currentFile);
+      const isAutomaticCodex =
+        automatic && normalizeProvider(singleMember.item.provider) === 'codex';
       const verifyPluginSourceFallback =
-        automatic &&
-        normalizeProvider(singleMember.item.provider) === 'codex' &&
-        snapshotMembers.length > 1
+        isAutomaticCodex && sourceFallbackMembers === undefined && snapshotMembers.length > 1
           ? undefined
           : () =>
               verifyPluginSourceStatusFallback(
                 snapshotMembers,
-                [singleMember.item],
+                sourceFallbackMembers ?? [singleMember.item],
                 singleMember.item,
                 readAuthFileStatusRuntimeId(singleMember.currentFile),
                 requestScope
               );
-      await setAuthFileStatusWithFallback(
+      const result = await setAuthFileStatusWithFallback(
         target,
         disabled,
         verifyPluginSourceFallback,
         requestScope
       );
+      mutationScope = result.mutationScope ?? null;
     } else {
       throw new Error('认证凭证状态修改目标未通过校验');
     }
-    return {
-      accountKey: item.key,
-      action: disabled ? 'disable' : 'enable',
-      fileName: item.fileName,
-      displayAccount: item.displayAccount,
-      status: 'success',
-      success: true,
-      error: '',
-    };
+    return buildStatusChangeExecutionResult(
+      {
+        accountKey: item.key,
+        action: disabled ? 'disable' : 'enable',
+        fileName: item.fileName,
+        displayAccount: item.displayAccount,
+        status: 'success',
+        success: true,
+        error: '',
+      },
+      mutationScope
+    );
   } catch (error) {
-    return {
+    return buildStatusChangeExecutionResult({
       accountKey: item.key,
       action: disabled ? 'disable' : 'enable',
       fileName: item.fileName,
@@ -1227,7 +1346,7 @@ const executeStatusChange = async (
       status: 'failed',
       success: false,
       error: error instanceof Error ? error.message : String(error || '状态更新失败'),
-    };
+    });
   }
 };
 
@@ -1260,6 +1379,8 @@ export const executeCodexInspectionActions = async ({
   let executableItems = dedupedItems;
   let preflightFiles: AuthFileItem[] | null = null;
   const statusGroupMembersByAccountKey = new Map<string, CodexInspectionResultItem[]>();
+  const automaticSourceFileMembersByAccountKey = new Map<string, CodexInspectionResultItem[]>();
+  let automaticSourceFallbackPlans = new Map<string, AutomaticSourceFallbackPlan>();
 
   if (source === 'manual' || source === 'auto') {
     onLog?.(
@@ -1342,6 +1463,10 @@ export const executeCodexInspectionActions = async ({
         currentFilesByName,
         source === 'auto'
       );
+      automaticSourceFallbackPlans =
+        source === 'auto'
+          ? buildAutomaticSourceFallbackPlans(resolvedStatusItems, currentFilesByName, currentFiles)
+          : new Map<string, AutomaticSourceFallbackPlan>();
       const validatedItems: CodexInspectionResultItem[] = [];
       dedupedItems.forEach((item) => {
         const currentCandidates = currentFilesByName.get(item.fileName.trim()) ?? [];
@@ -1359,6 +1484,17 @@ export const executeCodexInspectionActions = async ({
               currentFile ? readCurrentFileName(currentFile) : item.fileName.trim()
             )
           : undefined;
+        const automaticSourceFallbackPlan = isStatusExecutionAction(item)
+          ? automaticSourceFallbackPlans.get(
+              currentFile ? readCurrentFileName(currentFile) : item.fileName.trim()
+            )
+          : undefined;
+        const automaticSourceFallbackNeedsMutation = Boolean(
+          automaticSourceFallbackPlan &&
+          !automaticSourceFallbackPlan.affectedFiles.every(
+            (file) => (file.disabled === true) === (item.action === 'disable')
+          )
+        );
         const automaticPersistedLocatorAmbiguous =
           source === 'auto' &&
           item.action === 'disable' &&
@@ -1425,6 +1561,7 @@ export const executeCodexInspectionActions = async ({
           outcome = buildActionValidationOutcome(item, 'needs_review', FILE_DELETE_COVERAGE_REASON);
         } else if (
           item.action === 'disable' &&
+          !automaticSourceFallbackNeedsMutation &&
           (statusActionGroupPlan
             ? statusActionGroupPlan.affectedFiles.every((file) => file.disabled === true)
             : currentFile.disabled === true)
@@ -1432,6 +1569,7 @@ export const executeCodexInspectionActions = async ({
           outcome = buildActionValidationOutcome(item, 'skipped', '账号已是禁用状态，未重复执行');
         } else if (
           item.action === 'enable' &&
+          !automaticSourceFallbackNeedsMutation &&
           (statusActionGroupPlan
             ? statusActionGroupPlan.affectedFiles.every((file) => file.disabled !== true)
             : currentFile.disabled !== true)
@@ -1503,6 +1641,100 @@ export const executeCodexInspectionActions = async ({
   const disableItems = executableItems.filter((item) => item.action === 'disable');
   const enableItems = executableItems.filter((item) => item.action === 'enable');
 
+  const executeStatusItems = async (
+    items: CodexInspectionResultItem[],
+    disabled: boolean
+  ): Promise<CodexInspectionExecutionOutcome[]> => {
+    type StatusExecutionUnit = {
+      item: CodexInspectionResultItem;
+      sourceFallbackMembers?: CodexInspectionResultItem[];
+    };
+
+    const units: StatusExecutionUnit[] = [];
+    const plannedKeys = new Set<string>();
+    const itemsByKey = new Map(items.map((item) => [item.key, item] as const));
+    automaticSourceFallbackPlans.forEach((plan) => {
+      if (plan.action !== (disabled ? 'disable' : 'enable')) return;
+      const members = plan.members.map((member) => itemsByKey.get(member.key));
+      if (members.some((member) => !member)) return;
+      const resolvedMembers = members as CodexInspectionResultItem[];
+      const canonical = resolvedMembers[0];
+      if (!canonical) return;
+      units.push({ item: canonical, sourceFallbackMembers: resolvedMembers });
+      resolvedMembers.forEach((member) => plannedKeys.add(member.key));
+    });
+    items.forEach((item) => {
+      if (!plannedKeys.has(item.key)) units.push({ item });
+    });
+
+    const unitOutcomes = await runConcurrently(
+      units,
+      settings.deleteWorkers,
+      async (unit): Promise<CodexInspectionExecutionOutcome[]> => {
+        const result = await executeStatusChange(
+          unit.item,
+          disabled,
+          statusGroupMembersByAccountKey.get(unit.item.key),
+          requestScope,
+          source === 'auto',
+          unit.sourceFallbackMembers
+        );
+        const resultOutcomes = [result.outcome];
+        const fallbackMembers = unit.sourceFallbackMembers;
+        if (!fallbackMembers) return resultOutcomes;
+
+        if (result.outcome.success && result.mutationScope === 'source-file') {
+          automaticSourceFileMembersByAccountKey.set(result.outcome.accountKey, fallbackMembers);
+          if (fallbackMembers.length <= 1) return resultOutcomes;
+          resultOutcomes.push(
+            ...fallbackMembers
+              .slice(1)
+              .map((member) =>
+                buildActionValidationOutcome(
+                  member,
+                  'skipped',
+                  '该认证目标已由另一条结果处理',
+                  result.outcome.accountKey
+                )
+              )
+          );
+          return resultOutcomes;
+        }
+
+        if (fallbackMembers.length <= 1) return resultOutcomes;
+
+        if (!result.outcome.success) {
+          resultOutcomes.push(
+            ...fallbackMembers
+              .slice(1)
+              .map((member) =>
+                buildActionValidationOutcome(
+                  member,
+                  'skipped',
+                  '该认证目标已由另一条结果处理',
+                  result.outcome.accountKey
+                )
+              )
+          );
+          return resultOutcomes;
+        }
+
+        for (const member of fallbackMembers.slice(1)) {
+          const siblingResult = await executeStatusChange(
+            member,
+            disabled,
+            statusGroupMembersByAccountKey.get(member.key),
+            requestScope,
+            source === 'auto'
+          );
+          resultOutcomes.push(siblingResult.outcome);
+        }
+        return resultOutcomes;
+      }
+    );
+    return unitOutcomes.flat();
+  };
+
   if (deleteItems.length > 0) {
     const deleteOutcomes = await runConcurrently(deleteItems, settings.deleteWorkers, (item) =>
       executeDelete(item, actionReferenceItems, requestScope)
@@ -1512,15 +1744,7 @@ export const executeCodexInspectionActions = async ({
   }
 
   if (disableItems.length > 0) {
-    const disableOutcomes = await runConcurrently(disableItems, settings.deleteWorkers, (item) =>
-      executeStatusChange(
-        item,
-        true,
-        statusGroupMembersByAccountKey.get(item.key),
-        requestScope,
-        source === 'auto'
-      )
-    );
+    const disableOutcomes = await executeStatusItems(disableItems, true);
     if (source === 'auto') {
       const itemByAccountKey = new Map(disableItems.map((item) => [item.key, item] as const));
       for (const outcome of disableOutcomes) {
@@ -1528,11 +1752,15 @@ export const executeCodexInspectionActions = async ({
         const item = itemByAccountKey.get(outcome.accountKey);
         if (!item) continue;
         const statusGroupMembers = statusGroupMembersByAccountKey.get(outcome.accountKey);
-        const persisted = statusGroupMembers
+        const automaticSourceFileMembers = automaticSourceFileMembersByAccountKey.get(
+          outcome.accountKey
+        );
+        const ownershipMembers = automaticSourceFileMembers ?? statusGroupMembers;
+        const persisted = ownershipMembers
           ? replaceCodexInspectionDisableOwnershipForFile(
               connectionFingerprint,
               item.fileName,
-              statusGroupMembers.map((member) => ({
+              ownershipMembers.map((member) => ({
                 fileName: member.fileName,
                 provider: member.provider,
                 authIndex: member.authIndex,
@@ -1554,17 +1782,19 @@ export const executeCodexInspectionActions = async ({
           false,
           statusGroupMembers,
           requestScope,
-          source === 'auto'
+          source === 'auto',
+          automaticSourceFileMembersByAccountKey.get(outcome.accountKey)
         );
         const rolledBack =
-          rollbackOutcome.success &&
-          (rollbackOutcome.status === 'success' || rollbackOutcome.status === 'skipped');
+          rollbackOutcome.outcome.success &&
+          (rollbackOutcome.outcome.status === 'success' ||
+            rollbackOutcome.outcome.status === 'skipped');
         outcome.status = 'failed';
         outcome.success = false;
         outcome.error = rolledBack
           ? '自动禁用所有权保存失败，禁用操作已回滚'
           : `自动禁用所有权保存失败，且禁用回滚失败：${
-              rollbackOutcome.error || '未知错误'
+              rollbackOutcome.outcome.error || '未知错误'
             }；请到凭证管理中手动恢复`;
       }
     }
@@ -1573,15 +1803,7 @@ export const executeCodexInspectionActions = async ({
   }
 
   if (enableItems.length > 0) {
-    const enableOutcomes = await runConcurrently(enableItems, settings.deleteWorkers, (item) =>
-      executeStatusChange(
-        item,
-        false,
-        statusGroupMembersByAccountKey.get(item.key),
-        requestScope,
-        source === 'auto'
-      )
-    );
+    const enableOutcomes = await executeStatusItems(enableItems, false);
     enableOutcomes.forEach((outcome) => logExecutionOutcome(outcome, onLog, t));
     outcomes.push(...enableOutcomes);
   }
@@ -1592,10 +1814,13 @@ export const executeCodexInspectionActions = async ({
     const item = itemByAccountKey.get(outcome.accountKey);
     if (!item) return;
     const statusGroupMembers = statusGroupMembersByAccountKey.get(outcome.accountKey);
+    const automaticSourceFileMembers = automaticSourceFileMembersByAccountKey.get(
+      outcome.accountKey
+    );
     if (outcome.action === 'disable' && source === 'auto') {
       return;
     }
-    if (outcome.action === 'delete' || statusGroupMembers) {
+    if (outcome.action === 'delete' || statusGroupMembers || automaticSourceFileMembers) {
       clearCodexInspectionDisableOwnershipForFile(connectionFingerprint, item.fileName);
       return;
     }

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -512,20 +512,34 @@ const hasAmbiguousCredentialLocator = (
   });
 };
 
+const getCodexPersistedLocatorKey = (
+  fileName: unknown,
+  provider: unknown,
+  authIndex: unknown
+): string | null => {
+  const normalizedFileName = String(fileName ?? '').trim();
+  const normalizedProvider = normalizeProvider(provider);
+  const normalizedAuthIndex = normalizeAuthIndex(authIndex);
+  if (!normalizedFileName || normalizedProvider !== 'codex' || normalizedAuthIndex === null) {
+    return null;
+  }
+  return JSON.stringify([normalizedFileName, normalizedProvider, normalizedAuthIndex]);
+};
+
 const hasDuplicateCodexPersistedLocator = (
   currentFiles: AuthFileItem[],
   item: CodexInspectionResultItem
 ): boolean => {
-  if (normalizeProvider(item.provider) !== 'codex') return false;
-  const fileName = item.fileName.trim();
-  const authIndex = normalizeAuthIndex(item.authIndex);
-  if (!fileName || !authIndex) return false;
+  const locatorKey = getCodexPersistedLocatorKey(item.fileName, item.provider, item.authIndex);
+  if (!locatorKey) return false;
   return (
     currentFiles.filter(
       (file) =>
-        readCurrentFileName(file) === fileName &&
-        normalizeProvider(resolveAuthProvider(file)) === 'codex' &&
-        normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']) === authIndex
+        getCodexPersistedLocatorKey(
+          readCurrentFileName(file),
+          resolveAuthProvider(file),
+          file['auth_index'] ?? file.authIndex ?? file['auth-index']
+        ) === locatorKey
     ).length > 1
   );
 };
@@ -1035,7 +1049,8 @@ const executeStatusChange = async (
   item: CodexInspectionResultItem,
   disabled: boolean,
   actionMembers: CodexInspectionResultItem[] = [],
-  requestScope?: AuthFilesApiRequestScope
+  requestScope?: AuthFilesApiRequestScope,
+  automatic = false
 ): Promise<CodexInspectionExecutionOutcome> => {
   let snapshotMembers: AuthFileItem[] = [];
   let singleMember: VerifiedStatusActionMember | null = null;
@@ -1043,6 +1058,16 @@ const executeStatusChange = async (
   try {
     const response = await listAuthFiles(requestScope);
     const currentFiles = Array.isArray(response.files) ? response.files : [];
+    if (
+      automatic &&
+      disabled &&
+      normalizeProvider(item.provider) === 'codex' &&
+      (actionMembers.length > 0 ? actionMembers : [item]).some((member) =>
+        hasDuplicateCodexPersistedLocator(currentFiles, member)
+      )
+    ) {
+      return buildActionValidationOutcome(item, 'needs_review', AUTOMATIC_PERSISTED_LOCATOR_REASON);
+    }
     if (actionMembers.length > 0) {
       actionGroup = resolveVerifiedStatusActionGroup(currentFiles, actionMembers, item.fileName);
       if (!actionGroup) {
@@ -1264,7 +1289,7 @@ export const executeCodexInspectionActions = async ({
         filesByName.set(fileName, siblings);
         return filesByName;
       }, new Map<string, AuthFileItem[]>());
-      const automaticDuplicatePersistedLocatorFiles =
+      const automaticDuplicatePersistedLocatorKeys =
         source === 'auto'
           ? new Set(
               dedupedItems
@@ -1274,7 +1299,10 @@ export const executeCodexInspectionActions = async ({
                     normalizeProvider(item.provider) === 'codex' &&
                     hasDuplicateCodexPersistedLocator(currentFiles, item)
                 )
-                .map((item) => item.fileName.trim())
+                .map((item) =>
+                  getCodexPersistedLocatorKey(item.fileName, item.provider, item.authIndex)
+                )
+                .filter((key): key is string => key !== null)
             )
           : new Set<string>();
       const statusResolutionByKey = new Map<string, AuthFileStatusMutationResolution>();
@@ -1326,7 +1354,9 @@ export const executeCodexInspectionActions = async ({
           source === 'auto' &&
           item.action === 'disable' &&
           normalizeProvider(item.provider) === 'codex' &&
-          automaticDuplicatePersistedLocatorFiles.has(item.fileName.trim());
+          automaticDuplicatePersistedLocatorKeys.has(
+            getCodexPersistedLocatorKey(item.fileName, item.provider, item.authIndex) ?? ''
+          );
         let outcome: CodexInspectionExecutionOutcome | null = null;
         if (automaticPersistedLocatorAmbiguous) {
           outcome = buildActionValidationOutcome(
@@ -1474,7 +1504,13 @@ export const executeCodexInspectionActions = async ({
 
   if (disableItems.length > 0) {
     const disableOutcomes = await runConcurrently(disableItems, settings.deleteWorkers, (item) =>
-      executeStatusChange(item, true, statusGroupMembersByAccountKey.get(item.key), requestScope)
+      executeStatusChange(
+        item,
+        true,
+        statusGroupMembersByAccountKey.get(item.key),
+        requestScope,
+        source === 'auto'
+      )
     );
     if (source === 'auto') {
       const itemByAccountKey = new Map(disableItems.map((item) => [item.key, item] as const));
@@ -1508,7 +1544,8 @@ export const executeCodexInspectionActions = async ({
           item,
           false,
           statusGroupMembers,
-          requestScope
+          requestScope,
+          source === 'auto'
         );
         const rolledBack =
           rollbackOutcome.success &&
@@ -1528,7 +1565,13 @@ export const executeCodexInspectionActions = async ({
 
   if (enableItems.length > 0) {
     const enableOutcomes = await runConcurrently(enableItems, settings.deleteWorkers, (item) =>
-      executeStatusChange(item, false, statusGroupMembersByAccountKey.get(item.key), requestScope)
+      executeStatusChange(
+        item,
+        false,
+        statusGroupMembersByAccountKey.get(item.key),
+        requestScope,
+        source === 'auto'
+      )
     );
     enableOutcomes.forEach((outcome) => logExecutionOutcome(outcome, onLog, t));
     outcomes.push(...enableOutcomes);

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -1156,12 +1156,13 @@ const executeStatusChange = async (
   try {
     const response = await listAuthFiles(requestScope);
     const currentFiles = Array.isArray(response.files) ? response.files : [];
+    const mutationLocatorMembers = actionMembers.length > 0 ? actionMembers : [item];
     if (
       automatic &&
       disabled &&
       normalizeProvider(item.provider) === 'codex' &&
-      (sourceFallbackMembers ?? (actionMembers.length > 0 ? actionMembers : [item])).some(
-        (member) => hasDuplicateCodexPersistedLocator(currentFiles, member)
+      mutationLocatorMembers.some((member) =>
+        hasDuplicateCodexPersistedLocator(currentFiles, member)
       )
     ) {
       return buildStatusChangeExecutionResult(

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -1704,22 +1704,6 @@ export const executeCodexInspectionActions = async ({
 
         if (fallbackMembers.length <= 1) return resultOutcomes;
 
-        if (!result.outcome.success) {
-          resultOutcomes.push(
-            ...fallbackMembers
-              .slice(1)
-              .map((member) =>
-                buildActionValidationOutcome(
-                  member,
-                  'skipped',
-                  '该认证目标已由另一条结果处理',
-                  result.outcome.accountKey
-                )
-              )
-          );
-          return resultOutcomes;
-        }
-
         for (const member of fallbackMembers.slice(1)) {
           const siblingResult = await executeStatusChange(
             member,

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -590,7 +590,8 @@ const isStatusExecutionAction = (
 
 const buildStatusActionGroupPlans = (
   resolvedItems: Map<string, ResolvedStatusActionItem>,
-  currentFilesByName: Map<string, AuthFileItem[]>
+  currentFilesByName: Map<string, AuthFileItem[]>,
+  automatic: boolean
 ): Map<string, StatusActionGroupPlan> => {
   const plans = new Map<string, StatusActionGroupPlan>();
   const entriesByFile = new Map<string, ResolvedStatusActionItem[]>();
@@ -619,6 +620,7 @@ const buildStatusActionGroupPlans = (
     const sourceEntries = matchedEntries.filter(
       (entry) => entry.resolution.scope === 'source-file'
     );
+    if (automatic && sourceEntries.length === 0) return;
     if (!action || sourceEntries.length > 1) return;
     const canonicalEntry = sourceEntries[0] ?? matchedEntries[0];
     if (!canonicalEntry) return;
@@ -1185,17 +1187,23 @@ const executeStatusChange = async (
       }
     } else if (singleMember) {
       const target = buildStatusActionTarget(singleMember.item, singleMember.currentFile);
+      const verifyPluginSourceFallback =
+        automatic &&
+        normalizeProvider(singleMember.item.provider) === 'codex' &&
+        snapshotMembers.length > 1
+          ? undefined
+          : () =>
+              verifyPluginSourceStatusFallback(
+                snapshotMembers,
+                [singleMember.item],
+                singleMember.item,
+                readAuthFileStatusRuntimeId(singleMember.currentFile),
+                requestScope
+              );
       await setAuthFileStatusWithFallback(
         target,
         disabled,
-        () =>
-          verifyPluginSourceStatusFallback(
-            snapshotMembers,
-            [singleMember.item],
-            singleMember.item,
-            readAuthFileStatusRuntimeId(singleMember.currentFile),
-            requestScope
-          ),
+        verifyPluginSourceFallback,
         requestScope
       );
     } else {
@@ -1331,7 +1339,8 @@ export const executeCodexInspectionActions = async ({
       });
       const statusActionGroupPlans = buildStatusActionGroupPlans(
         resolvedStatusItems,
-        currentFilesByName
+        currentFilesByName,
+        source === 'auto'
       );
       const validatedItems: CodexInspectionResultItem[] = [];
       dedupedItems.forEach((item) => {

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -290,7 +290,8 @@ const buildExecutionActionGroups = (items: CodexInspectionResultItem[]) => {
 
 const planExecutionItems = (
   items: CodexInspectionResultItem[],
-  referenceItems: CodexInspectionResultItem[]
+  referenceItems: CodexInspectionResultItem[],
+  requireAuthIndex: boolean
 ) => {
   const preflightOutcomes: CodexInspectionExecutionOutcome[] = [];
   const { groupByItemKey } = buildExecutionActionGroups(
@@ -308,16 +309,17 @@ const planExecutionItems = (
       );
       return;
     }
-    if (
-      !hasCodexInspectionStableIdentity({
-        fileName: item.fileName,
-        runtimeId: item.runtimeId,
-        provider: item.provider,
-        authIndex: item.authIndex,
-        accountId: item.accountId,
-        accountSnapshot: item.accountSnapshot,
-      })
-    ) {
+    const hasStableIdentity = requireAuthIndex
+      ? hasCodexInspectionStableIdentity({
+          fileName: item.fileName,
+          runtimeId: item.runtimeId,
+          provider: item.provider,
+          authIndex: item.authIndex,
+          accountId: item.accountId,
+          accountSnapshot: item.accountSnapshot,
+        })
+      : hasManualInspectionIdentity(item);
+    if (!hasStableIdentity) {
       preflightOutcomes.push(
         buildPreflightOutcome(
           item,
@@ -389,6 +391,22 @@ const normalizeProvider = (value: unknown): string => {
     .replace(/_/g, '-');
   if (normalized === 'x-ai' || normalized === 'grok') return 'xai';
   return normalized;
+};
+
+const hasManualInspectionIdentity = (item: CodexInspectionResultItem): boolean => {
+  if (normalizeProvider(item.provider) !== 'codex') {
+    return hasCodexInspectionStableIdentity({
+      fileName: item.fileName,
+      runtimeId: item.runtimeId,
+      provider: item.provider,
+      authIndex: item.authIndex,
+      accountId: item.accountId,
+      accountSnapshot: item.accountSnapshot,
+    });
+  }
+  return Boolean(
+    item.fileName.trim() && (item.runtimeId?.trim() || normalizeAuthIndex(item.authIndex))
+  );
 };
 
 const readCurrentFileName = (file: AuthFileItem): string => String(file.name ?? '').trim();
@@ -1144,7 +1162,8 @@ export const executeCodexInspectionActions = async ({
   const actionReferenceItems = mergeExecutionReferenceItems(items, referenceItems ?? items);
   const plan = planExecutionItems(
     items,
-    (referenceItems ?? items).filter((item) => !suppliedPreflightAccountKeys.has(item.key))
+    (referenceItems ?? items).filter((item) => !suppliedPreflightAccountKeys.has(item.key)),
+    source === 'auto'
   );
   const dedupedItems = plan.items;
   const outcomes: CodexInspectionExecutionOutcome[] = [

--- a/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionExecution.ts
@@ -37,6 +37,8 @@ import {
 const identityT = ((key: string) => key) as TFunction;
 const STATUS_MUTATION_SCOPE_REASON =
   '认证凭证缺少唯一 runtime ID，或 runtime ID 与物理文件选择器冲突，已阻止状态修改，请人工确认';
+const AUTOMATIC_PERSISTED_LOCATOR_REASON =
+  '自动禁用凭证的物理文件与 authIndex 不是唯一定位，已阻止状态修改，请人工确认';
 const FILE_DELETE_COVERAGE_REASON =
   '删除动作未完整覆盖该物理认证文件当前包含的全部凭证，已阻止删除，请人工确认';
 const PLUGIN_SOURCE_STATUS_CHANGED_REASON =
@@ -427,16 +429,68 @@ const buildDeleteIdentityTarget = (file: AuthFileItem): AuthFileDeleteIdentityTa
 };
 
 const getAuthFileSourceMemberIdentityKey = (file: AuthFileItem): string =>
+  JSON.stringify([
+    readCurrentFileName(file),
+    normalizeProvider(resolveAuthProvider(file)),
+    readAuthFileStatusRuntimeId(file),
+    normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']),
+  ]);
+
+const getAuthFileSourceMemberEvidenceKey = (file: AuthFileItem): string =>
   JSON.stringify(buildDeleteIdentityTarget(file));
+
+const matchesAuthFileIdentityTarget = (
+  file: AuthFileItem,
+  target: AuthFileStatusTarget
+): boolean => {
+  const resolution = resolveAuthFileStatusMutationTarget([file], target);
+  // The caller may still need the resolver's scope/failure to reject a missing
+  // runtime ID or an ambiguous mutation target. This helper only answers the
+  // identity question, so retain a uniquely matched file when the resolver's
+  // later operational checks report ambiguity.
+  return (
+    resolution.target === file &&
+    (resolution.failure === null || resolution.failure === 'ambiguous')
+  );
+};
+
+const authFileSourceMemberMatches = (
+  expectedMember: AuthFileItem,
+  currentMember: AuthFileItem
+): boolean => {
+  if (
+    getAuthFileSourceMemberIdentityKey(expectedMember) !==
+    getAuthFileSourceMemberIdentityKey(currentMember)
+  ) {
+    return false;
+  }
+
+  const expectedProvider = normalizeProvider(resolveAuthProvider(expectedMember));
+  if (expectedProvider !== 'codex') {
+    return (
+      getAuthFileSourceMemberEvidenceKey(expectedMember) ===
+      getAuthFileSourceMemberEvidenceKey(currentMember)
+    );
+  }
+
+  return matchesAuthFileIdentityTarget(currentMember, buildDeleteIdentityTarget(expectedMember));
+};
 
 const authFileSourceMembershipMatches = (
   expectedMembers: AuthFileItem[],
   currentMembers: AuthFileItem[]
 ): boolean => {
   if (expectedMembers.length !== currentMembers.length) return false;
-  const expectedKeys = expectedMembers.map(getAuthFileSourceMemberIdentityKey).sort();
-  const currentKeys = currentMembers.map(getAuthFileSourceMemberIdentityKey).sort();
-  return expectedKeys.every((key, index) => key === currentKeys[index]);
+  const usedCurrentIndexes = new Set<number>();
+  return expectedMembers.every((expectedMember) => {
+    const currentIndex = currentMembers.findIndex(
+      (currentMember, index) =>
+        !usedCurrentIndexes.has(index) && authFileSourceMemberMatches(expectedMember, currentMember)
+    );
+    if (currentIndex < 0) return false;
+    usedCurrentIndexes.add(currentIndex);
+    return true;
+  });
 };
 
 const hasAmbiguousCredentialLocator = (
@@ -458,6 +512,24 @@ const hasAmbiguousCredentialLocator = (
   });
 };
 
+const hasDuplicateCodexPersistedLocator = (
+  currentFiles: AuthFileItem[],
+  item: CodexInspectionResultItem
+): boolean => {
+  if (normalizeProvider(item.provider) !== 'codex') return false;
+  const fileName = item.fileName.trim();
+  const authIndex = normalizeAuthIndex(item.authIndex);
+  if (!fileName || !authIndex) return false;
+  return (
+    currentFiles.filter(
+      (file) =>
+        readCurrentFileName(file) === fileName &&
+        normalizeProvider(resolveAuthProvider(file)) === 'codex' &&
+        normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']) === authIndex
+    ).length > 1
+  );
+};
+
 const readInspectionAccountSnapshot = (item: CodexInspectionResultItem): string => {
   const snapshot = item.accountSnapshot?.trim() ?? '';
   if (!snapshot || snapshot === item.fileName.trim()) return '';
@@ -466,40 +538,22 @@ const readInspectionAccountSnapshot = (item: CodexInspectionResultItem): string 
     : snapshot;
 };
 
-const readCurrentInspectionAccountSnapshot = (file: AuthFileItem): string => {
-  const provider = normalizeProvider(resolveAuthProvider(file));
-  return provider === 'codex'
-    ? readAuthFileStatusCodexMember(file)
-    : readAuthFileStatusAccountSnapshot(file);
-};
-
 const matchesCurrentActionIdentity = (
   file: AuthFileItem,
   item: CodexInspectionResultItem
 ): boolean => {
-  if (readCurrentFileName(file) !== item.fileName) return false;
-  const currentProvider = normalizeProvider(resolveAuthProvider(file));
-  const expectedProvider = normalizeProvider(item.provider);
-  if (!currentProvider || !expectedProvider || currentProvider !== expectedProvider) return false;
-  const runtimeId = readAuthFileStatusRuntimeId(file);
-  const expectedRuntimeId = item.runtimeId?.trim() ?? '';
-  if (expectedRuntimeId && runtimeId !== expectedRuntimeId) return false;
-  const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']);
-  if (item.authIndex && authIndex !== normalizeAuthIndex(item.authIndex)) return false;
-  const accountId = readAuthFileStatusAccountId(file);
-  const expectedAccountId = item.accountId?.trim() ?? '';
-  if (expectedAccountId) {
-    if (accountId !== expectedAccountId) return false;
-    const expectedMember = readInspectionAccountSnapshot(item);
-    return (
-      normalizeProvider(item.provider) !== 'codex' ||
-      !expectedMember ||
-      readCurrentInspectionAccountSnapshot(file) === expectedMember
-    );
-  }
-  const expectedSnapshot = readInspectionAccountSnapshot(item);
-  if (!expectedSnapshot) return normalizeAuthIndex(item.authIndex) !== null;
-  return readCurrentInspectionAccountSnapshot(file) === expectedSnapshot;
+  const resolution = resolveAuthFileStatusMutationTarget([file], {
+    name: item.fileName,
+    runtimeId: item.runtimeId,
+    authIndex: item.authIndex,
+    provider: item.provider,
+    accountId: item.accountId,
+    accountSnapshot: readInspectionAccountSnapshot(item),
+  });
+  return (
+    resolution.target === file &&
+    (resolution.failure === null || resolution.failure === 'ambiguous')
+  );
 };
 
 type ResolvedStatusActionItem = {
@@ -1210,6 +1264,19 @@ export const executeCodexInspectionActions = async ({
         filesByName.set(fileName, siblings);
         return filesByName;
       }, new Map<string, AuthFileItem[]>());
+      const automaticDuplicatePersistedLocatorFiles =
+        source === 'auto'
+          ? new Set(
+              dedupedItems
+                .filter(
+                  (item) =>
+                    item.action === 'disable' &&
+                    normalizeProvider(item.provider) === 'codex' &&
+                    hasDuplicateCodexPersistedLocator(currentFiles, item)
+                )
+                .map((item) => item.fileName.trim())
+            )
+          : new Set<string>();
       const statusResolutionByKey = new Map<string, AuthFileStatusMutationResolution>();
       const resolvedStatusItems = new Map<string, ResolvedStatusActionItem>();
       dedupedItems.filter(isStatusExecutionAction).forEach((item) => {
@@ -1255,8 +1322,19 @@ export const executeCodexInspectionActions = async ({
               currentFile ? readCurrentFileName(currentFile) : item.fileName.trim()
             )
           : undefined;
+        const automaticPersistedLocatorAmbiguous =
+          source === 'auto' &&
+          item.action === 'disable' &&
+          normalizeProvider(item.provider) === 'codex' &&
+          automaticDuplicatePersistedLocatorFiles.has(item.fileName.trim());
         let outcome: CodexInspectionExecutionOutcome | null = null;
-        if (!currentFile) {
+        if (automaticPersistedLocatorAmbiguous) {
+          outcome = buildActionValidationOutcome(
+            item,
+            'needs_review',
+            AUTOMATIC_PERSISTED_LOCATOR_REASON
+          );
+        } else if (!currentFile) {
           outcome = buildActionValidationOutcome(
             item,
             'failed',

--- a/apps/web/src/features/monitoring/model/codexInspectionOwnership.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionOwnership.ts
@@ -2,9 +2,11 @@ import type { AuthFileItem } from '@/types';
 import { normalizeAuthIndex } from '@/utils/authIndex';
 import {
   readAuthFileStatusAccountId,
+  readAuthFileStatusAccountIdInvalid,
   readAuthFileStatusAccountSnapshot,
   readAuthFileStatusProvider,
   readAuthFileStatusCodexMember,
+  readAuthFileStatusCodexMemberInvalid,
   normalizeCodexMemberSnapshot,
 } from '@/utils/authFileStatusMutation';
 
@@ -34,6 +36,8 @@ export type CodexInspectionOwnershipIdentity = {
   authIndex?: string | number | null;
   accountId?: string | null;
   accountSnapshot?: string | null;
+  accountIdInvalid?: boolean;
+  accountSnapshotInvalid?: boolean;
 };
 
 const normalizeAccountId = (value: unknown): string | null => {
@@ -64,11 +68,13 @@ type NormalizedOwnershipIdentity = {
   authIndex: string | null;
   accountId: string | null;
   accountSnapshot: string | null;
+  accountIdInvalid: boolean;
+  accountSnapshotInvalid: boolean;
 };
 
 const hasStableLocator = (identity: NormalizedOwnershipIdentity): boolean => {
   if (identity.provider === 'codex') {
-    return Boolean(identity.runtimeId || identity.authIndex);
+    return Boolean(identity.authIndex);
   }
   return Boolean(identity.authIndex || identity.accountId || identity.accountSnapshot);
 };
@@ -89,6 +95,8 @@ const normalizeIdentity = (identity: unknown): NormalizedOwnershipIdentity => {
     authIndex: normalizeAuthIndex(source.authIndex),
     accountId,
     accountSnapshot: normalizeAccountSnapshot(source.accountSnapshot, fileName, provider),
+    accountIdInvalid: source.accountIdInvalid === true,
+    accountSnapshotInvalid: source.accountSnapshotInvalid === true,
   };
 };
 
@@ -277,6 +285,8 @@ export const getCodexInspectionOwnershipIdentityForFile = (
       provider === 'codex'
         ? readAuthFileStatusCodexMember(file)
         : readAuthFileStatusAccountSnapshot(file),
+    accountIdInvalid: readAuthFileStatusAccountIdInvalid(file),
+    accountSnapshotInvalid: readAuthFileStatusCodexMemberInvalid(file),
   };
 };
 
@@ -293,18 +303,28 @@ const matchesIdentityForRecovery = (
     normalizedRecord.provider !== normalizedIdentity.provider
   )
     return false;
+  if (
+    normalizedRecord.provider === 'codex' &&
+    (normalizedIdentity.accountIdInvalid || normalizedIdentity.accountSnapshotInvalid)
+  ) {
+    return false;
+  }
   if (normalizedRecord.authIndex && normalizedRecord.authIndex !== normalizedIdentity.authIndex)
     return false;
   if (normalizedRecord.provider === 'codex') {
-    if (normalizedRecord.accountId) {
-      if (normalizedRecord.accountId !== normalizedIdentity.accountId) return false;
-      if (normalizedRecord.accountSnapshot) {
-        return normalizedRecord.accountSnapshot === normalizedIdentity.accountSnapshot;
-      }
-      return normalizedRecord.authIndex !== null;
+    if (
+      normalizedRecord.accountId &&
+      normalizedIdentity.accountId &&
+      normalizedRecord.accountId !== normalizedIdentity.accountId
+    ) {
+      return false;
     }
-    if (normalizedRecord.accountSnapshot) {
-      return normalizedRecord.accountSnapshot === normalizedIdentity.accountSnapshot;
+    if (
+      normalizedRecord.accountSnapshot &&
+      normalizedIdentity.accountSnapshot &&
+      normalizedRecord.accountSnapshot !== normalizedIdentity.accountSnapshot
+    ) {
+      return false;
     }
     return normalizedRecord.authIndex !== null;
   }
@@ -326,14 +346,25 @@ const matchesIdentityForCleanup = (
   if (normalizedRecord.fileName !== normalizedIdentity.fileName) return false;
   if (normalizedRecord.provider && normalizedRecord.provider !== normalizedIdentity.provider)
     return false;
+  if (
+    normalizedRecord.provider === 'codex' &&
+    (normalizedIdentity.accountIdInvalid || normalizedIdentity.accountSnapshotInvalid)
+  ) {
+    return false;
+  }
   if (normalizedRecord.authIndex && normalizedRecord.authIndex !== normalizedIdentity.authIndex)
     return false;
   if (normalizedRecord.provider === 'codex') {
-    if (normalizedRecord.accountId && normalizedRecord.accountId !== normalizedIdentity.accountId) {
+    if (
+      normalizedRecord.accountId &&
+      normalizedIdentity.accountId &&
+      normalizedRecord.accountId !== normalizedIdentity.accountId
+    ) {
       return false;
     }
     if (
       normalizedRecord.accountSnapshot &&
+      normalizedIdentity.accountSnapshot &&
       normalizedRecord.accountSnapshot !== normalizedIdentity.accountSnapshot
     ) {
       return false;

--- a/apps/web/src/features/monitoring/model/codexInspectionOwnership.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionOwnership.ts
@@ -29,6 +29,7 @@ type DisableOwnershipReadResult = {
 
 export type CodexInspectionOwnershipIdentity = {
   fileName: string;
+  runtimeId?: string | null;
   provider?: string | null;
   authIndex?: string | number | null;
   accountId?: string | null;
@@ -58,6 +59,7 @@ const normalizeAccountSnapshot = (
 
 type NormalizedOwnershipIdentity = {
   fileName: string;
+  runtimeId: string;
   provider: string;
   authIndex: string | null;
   accountId: string | null;
@@ -66,7 +68,7 @@ type NormalizedOwnershipIdentity = {
 
 const hasStableLocator = (identity: NormalizedOwnershipIdentity): boolean => {
   if (identity.provider === 'codex') {
-    return Boolean(identity.authIndex || identity.accountSnapshot);
+    return Boolean(identity.runtimeId || identity.authIndex);
   }
   return Boolean(identity.authIndex || identity.accountId || identity.accountSnapshot);
 };
@@ -77,10 +79,12 @@ const normalizeIdentity = (identity: unknown): NormalizedOwnershipIdentity => {
       ? (identity as Record<string, unknown>)
       : {};
   const fileName = typeof source.fileName === 'string' ? source.fileName.trim() : '';
+  const runtimeId = typeof source.runtimeId === 'string' ? source.runtimeId.trim() : '';
   const provider = normalizeProvider(source.provider);
   const accountId = normalizeAccountId(source.accountId);
   return {
     fileName,
+    runtimeId,
     provider,
     authIndex: normalizeAuthIndex(source.authIndex),
     accountId,
@@ -471,11 +475,36 @@ export const getCodexInspectionOwnedDisableIdentityKeys = (
   const owned = new Set<string>();
   let changed = false;
   Object.entries(scoped).forEach(([key, record]) => {
-    const matches = files.filter(
-      (file) =>
-        file.disabled === true &&
-        matchesIdentityForRecovery(record, getCodexInspectionOwnershipIdentityForFile(file))
-    );
+    const normalizedRecord = normalizeIdentity(record);
+    const locatorMatches =
+      normalizedRecord.provider === 'codex' && normalizedRecord.authIndex
+        ? files.filter((file) => {
+            const identity = getCodexInspectionOwnershipIdentityForFile(file);
+            const normalizedIdentity = normalizeIdentity(identity);
+            return (
+              normalizedIdentity.fileName === normalizedRecord.fileName &&
+              normalizedIdentity.provider === normalizedRecord.provider &&
+              normalizedIdentity.authIndex === normalizedRecord.authIndex
+            );
+          })
+        : [];
+    if (normalizedRecord.provider === 'codex' && locatorMatches.length > 1) {
+      // Member evidence is verification data, not a selector. Keep an
+      // ambiguous ownership record until the inventory has one credential for
+      // the persisted file/auth-index locator.
+      return;
+    }
+    const matches =
+      normalizedRecord.provider === 'codex'
+        ? locatorMatches.filter((file) =>
+            file.disabled === true &&
+            matchesIdentityForRecovery(record, getCodexInspectionOwnershipIdentityForFile(file))
+          )
+        : files.filter(
+            (file) =>
+              file.disabled === true &&
+              matchesIdentityForRecovery(record, getCodexInspectionOwnershipIdentityForFile(file))
+          );
     if (matches.length === 1) {
       owned.add(
         getCodexInspectionOwnershipIdentityKey(

--- a/apps/web/src/features/monitoring/model/codexInspectionOwnership.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionOwnership.ts
@@ -4,6 +4,8 @@ import {
   readAuthFileStatusAccountId,
   readAuthFileStatusAccountSnapshot,
   readAuthFileStatusProvider,
+  readAuthFileStatusCodexMember,
+  normalizeCodexMemberSnapshot,
 } from '@/utils/authFileStatusMutation';
 
 const STORAGE_KEY = 'cli-proxy-codex-inspection-disable-ownership-v2';
@@ -44,8 +46,13 @@ const normalizeProvider = (value: unknown): string => {
   return normalized;
 };
 
-const normalizeAccountSnapshot = (value: unknown, fileName: string): string | null => {
+const normalizeAccountSnapshot = (
+  value: unknown,
+  fileName: string,
+  provider: string
+): string | null => {
   const normalized = typeof value === 'string' ? value.trim() : '';
+  if (provider === 'codex') return normalizeCodexMemberSnapshot(normalized) || null;
   return normalized && normalized !== fileName ? normalized : null;
 };
 
@@ -57,8 +64,12 @@ type NormalizedOwnershipIdentity = {
   accountSnapshot: string | null;
 };
 
-const hasStableLocator = (identity: NormalizedOwnershipIdentity): boolean =>
-  Boolean(identity.authIndex || identity.accountId || identity.accountSnapshot);
+const hasStableLocator = (identity: NormalizedOwnershipIdentity): boolean => {
+  if (identity.provider === 'codex') {
+    return Boolean(identity.authIndex || identity.accountSnapshot);
+  }
+  return Boolean(identity.authIndex || identity.accountId || identity.accountSnapshot);
+};
 
 const normalizeIdentity = (identity: unknown): NormalizedOwnershipIdentity => {
   const source =
@@ -66,13 +77,14 @@ const normalizeIdentity = (identity: unknown): NormalizedOwnershipIdentity => {
       ? (identity as Record<string, unknown>)
       : {};
   const fileName = typeof source.fileName === 'string' ? source.fileName.trim() : '';
+  const provider = normalizeProvider(source.provider);
   const accountId = normalizeAccountId(source.accountId);
   return {
     fileName,
-    provider: normalizeProvider(source.provider),
+    provider,
     authIndex: normalizeAuthIndex(source.authIndex),
     accountId,
-    accountSnapshot: normalizeAccountSnapshot(source.accountSnapshot, fileName),
+    accountSnapshot: normalizeAccountSnapshot(source.accountSnapshot, fileName, provider),
   };
 };
 
@@ -85,7 +97,11 @@ export const getCodexInspectionOwnershipIdentityKey = (
     normalized.provider,
     normalized.authIndex,
     normalized.accountId,
-    normalized.accountId ? null : normalized.accountSnapshot,
+    normalized.provider === 'codex'
+      ? normalized.accountSnapshot
+      : normalized.accountId
+        ? null
+        : normalized.accountSnapshot,
   ]);
 };
 
@@ -246,13 +262,19 @@ const readStore = (): DisableOwnershipStore => readStoreResult().store;
 
 export const getCodexInspectionOwnershipIdentityForFile = (
   file: AuthFileItem
-): CodexInspectionOwnershipIdentity => ({
-  fileName: file.name,
-  provider: readAuthFileStatusProvider(file),
-  authIndex: normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']),
-  accountId: readAuthFileStatusAccountId(file),
-  accountSnapshot: readAuthFileStatusAccountSnapshot(file),
-});
+): CodexInspectionOwnershipIdentity => {
+  const provider = readAuthFileStatusProvider(file);
+  return {
+    fileName: file.name,
+    provider,
+    authIndex: normalizeAuthIndex(file['auth_index'] ?? file.authIndex ?? file['auth-index']),
+    accountId: readAuthFileStatusAccountId(file),
+    accountSnapshot:
+      provider === 'codex'
+        ? readAuthFileStatusCodexMember(file)
+        : readAuthFileStatusAccountSnapshot(file),
+  };
+};
 
 const matchesIdentityForRecovery = (
   record: DisableOwnershipRecord,
@@ -269,6 +291,19 @@ const matchesIdentityForRecovery = (
     return false;
   if (normalizedRecord.authIndex && normalizedRecord.authIndex !== normalizedIdentity.authIndex)
     return false;
+  if (normalizedRecord.provider === 'codex') {
+    if (normalizedRecord.accountId) {
+      if (normalizedRecord.accountId !== normalizedIdentity.accountId) return false;
+      if (normalizedRecord.accountSnapshot) {
+        return normalizedRecord.accountSnapshot === normalizedIdentity.accountSnapshot;
+      }
+      return normalizedRecord.authIndex !== null;
+    }
+    if (normalizedRecord.accountSnapshot) {
+      return normalizedRecord.accountSnapshot === normalizedIdentity.accountSnapshot;
+    }
+    return normalizedRecord.authIndex !== null;
+  }
   if (normalizedRecord.accountId) {
     return normalizedRecord.accountId === normalizedIdentity.accountId;
   }
@@ -289,6 +324,18 @@ const matchesIdentityForCleanup = (
     return false;
   if (normalizedRecord.authIndex && normalizedRecord.authIndex !== normalizedIdentity.authIndex)
     return false;
+  if (normalizedRecord.provider === 'codex') {
+    if (normalizedRecord.accountId && normalizedRecord.accountId !== normalizedIdentity.accountId) {
+      return false;
+    }
+    if (
+      normalizedRecord.accountSnapshot &&
+      normalizedRecord.accountSnapshot !== normalizedIdentity.accountSnapshot
+    ) {
+      return false;
+    }
+    return true;
+  }
   if (normalizedRecord.accountId && normalizedRecord.accountId !== normalizedIdentity.accountId)
     return false;
   if (normalizedRecord.accountId) return true;

--- a/apps/web/src/features/monitoring/model/codexInspectionPresentation.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionPresentation.ts
@@ -683,7 +683,7 @@ export const isActionableServerCodexInspectionResult = (
     Partial<
       Pick<
         CodexInspectionResult,
-        'fileName' | 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot'
+        'fileName' | 'runtimeId' | 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot'
       >
     >
 ) => {
@@ -694,6 +694,7 @@ export const isActionableServerCodexInspectionResult = (
     (status === 'pending' || status === 'failed') &&
     hasCodexInspectionStableIdentity({
       fileName: item.fileName ?? '',
+      runtimeId: item.runtimeId,
       provider: item.provider,
       authIndex: item.authIndex,
       accountId: item.accountId,
@@ -722,7 +723,7 @@ type ServerActionIdentity = Pick<CodexInspectionResult, 'id' | 'fileName' | 'act
   Partial<
     Pick<
       CodexInspectionResult,
-      'provider' | 'authIndex' | 'accountId' | 'accountSnapshot' | 'actionStatus'
+      'runtimeId' | 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot' | 'actionStatus'
     >
   >;
 
@@ -768,7 +769,10 @@ export const getCanonicalServerCodexInspectionActionIds = (
   results: Array<
     Pick<CodexInspectionResult, 'id' | 'fileName' | 'action' | 'actionStatus'> &
       Partial<
-        Pick<CodexInspectionResult, 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot'>
+        Pick<
+          CodexInspectionResult,
+          'runtimeId' | 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot'
+        >
       >
   >
 ) => {
@@ -788,7 +792,10 @@ export const getMixedServerCodexInspectionActionIds = (
   results: Array<
     Pick<CodexInspectionResult, 'id' | 'fileName' | 'action'> &
       Partial<
-        Pick<CodexInspectionResult, 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot'>
+        Pick<
+          CodexInspectionResult,
+          'runtimeId' | 'provider' | 'authIndex' | 'accountId' | 'accountSnapshot'
+        >
       >
   >
 ) => {

--- a/apps/web/src/features/monitoring/model/codexInspectionProbe.test.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionProbe.test.ts
@@ -95,7 +95,7 @@ describe('toInspectionAccount', () => {
     ).toBe(first.key);
   });
 
-  it('uses the account ID before a mutable display label for a missing auth_index', () => {
+  it('keeps same-Workspace Codex members distinct without an auth_index', () => {
     const first = toInspectionAccount({
       name: 'shared.json',
       type: 'codex',
@@ -109,7 +109,7 @@ describe('toInspectionAccount', () => {
       account_id: 'account-1',
     });
 
-    expect(renamed.key).toBe(first.key);
+    expect(renamed.key).not.toBe(first.key);
   });
 
   it('uses generic project identity and display-account aliases', () => {

--- a/apps/web/src/features/monitoring/model/codexInspectionProbe.ts
+++ b/apps/web/src/features/monitoring/model/codexInspectionProbe.ts
@@ -6,6 +6,7 @@ import {
   getAuthFileStatusIdentityKey,
   readAuthFileStatusAccountId,
   readAuthFileStatusAccountSnapshot,
+  readAuthFileStatusCodexMember,
 } from '@/utils/authFileStatusMutation';
 import {
   buildCodexQuotaWindowInfos,
@@ -96,10 +97,13 @@ export const toInspectionAccount = (file: AuthFileItem): CodexInspectionAccount 
   const runtimeId = readString(file.id) || null;
   const fileName = readAuthFileName(file);
   const displayAccount = readDisplayAccount(file);
-  const accountSnapshot = readAuthFileStatusAccountSnapshot(file) || null;
   const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
   const accountId = readAuthFileStatusAccountId(file);
   const provider = resolveAuthProvider(file);
+  const accountSnapshot =
+    (provider === 'codex'
+      ? readAuthFileStatusCodexMember(file)
+      : readAuthFileStatusAccountSnapshot(file)) || null;
   return {
     key: buildInspectionAccountKey({
       fileName,

--- a/apps/web/src/features/oauth/CodexReauthDialog.test.tsx
+++ b/apps/web/src/features/oauth/CodexReauthDialog.test.tsx
@@ -79,6 +79,7 @@ const TARGET = {
   account: 'codex@example.com',
   fileName: 'codex.json',
   accountId: 'acct-1',
+  accountSnapshot: 'alice@example.com',
   provider: 'codex',
   authIndex: 'auth-1',
 };
@@ -140,6 +141,39 @@ describe('CodexReauthDialog connection lifecycle', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('restarts the OAuth link when the targeted Workspace member changes', async () => {
+    mocks.startAuth.mockResolvedValue({ url: 'https://auth.example/codex', state: 'state-1' });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <CodexReauthDialog
+          open
+          target={TARGET}
+          requestScope={REQUEST_SCOPE}
+          onClose={vi.fn()}
+        />
+      );
+    });
+    await flushEffects();
+    expect(mocks.startAuth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer.update(
+        <CodexReauthDialog
+          open
+          target={{ ...TARGET, accountSnapshot: 'bob@example.com' }}
+          requestScope={REQUEST_SCOPE}
+          onClose={vi.fn()}
+        />
+      );
+    });
+    await flushEffects();
+
+    expect(mocks.startAuth).toHaveBeenCalledTimes(2);
+    act(() => renderer.unmount());
   });
 
   it('ignores a late auth-link response after the CPA scope changes', async () => {

--- a/apps/web/src/features/oauth/CodexReauthDialog.tsx
+++ b/apps/web/src/features/oauth/CodexReauthDialog.tsx
@@ -8,6 +8,7 @@ import { oauthApi } from '@/services/api';
 import type { ApiClientRequestScope } from '@/services/api/client';
 import { useNotificationStore } from '@/stores';
 import { copyToClipboard } from '@/utils/clipboard';
+import { normalizeCodexMemberSnapshot } from '@/utils/authFileCredentialIdentity';
 import {
   isCodexReauthReconciliationError,
   type CodexReauthTarget,
@@ -90,10 +91,17 @@ export function CodexReauthDialog({
 
   const targetKey = useMemo(
     () =>
-      target ? [target.account, target.fileName ?? '', target.accountId ?? ''].join('\u0000') : '',
+      target
+        ? [
+            target.account,
+            target.fileName ?? '',
+            target.accountId ?? '',
+            normalizeCodexMemberSnapshot(target.accountSnapshot),
+          ].join('\u0000')
+        : '',
     // Keep primitive fields only. Including `target` would restart OAuth after Accounts reload.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stable session identity
-    [target?.account, target?.accountId, target?.fileName]
+    [target?.account, target?.accountId, target?.accountSnapshot, target?.fileName]
   );
   const dialogContext = useMemo<CodexReauthDialogContext>(
     () => ({

--- a/apps/web/src/features/oauth/codexReauthModel.ts
+++ b/apps/web/src/features/oauth/codexReauthModel.ts
@@ -1,7 +1,7 @@
 import type { AuthFileItem } from '@/types';
 import {
   readAuthFileStatusAccountId,
-  readAuthFileStatusAccountSnapshot,
+  readAuthFileStatusCodexMember,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
 } from '@/utils/authFileStatusMutation';
@@ -27,8 +27,7 @@ export class CodexReauthReconciliationError extends Error {
 
 export const isCodexReauthReconciliationError = (
   error: unknown
-): error is CodexReauthReconciliationError =>
-  error instanceof CodexReauthReconciliationError;
+): error is CodexReauthReconciliationError => error instanceof CodexReauthReconciliationError;
 
 export type CodexReauthTarget = {
   account: string;
@@ -70,6 +69,6 @@ export const createCodexReauthTargetFromAuthFile = (file: AuthFileItem): CodexRe
     provider: readAuthFileStatusProvider(file) || null,
     authIndex: (record.authIndex ?? record.auth_index ?? null) as string | number | null,
     accountId,
-    accountSnapshot: readAuthFileStatusAccountSnapshot(file) || null,
+    accountSnapshot: readAuthFileStatusCodexMember(file) || null,
   };
 };

--- a/apps/web/src/services/api/authFiles.test.ts
+++ b/apps/web/src/services/api/authFiles.test.ts
@@ -250,6 +250,85 @@ describe('authFilesApi list normalization', () => {
     expect(result.total).toBe(2);
   });
 
+  it('preserves same-name auth file rows when authIndex matches but runtime IDs differ', async () => {
+    mocks.get.mockResolvedValue({
+      files: [
+        {
+          name: 'shared.json',
+          id: 'runtime-a',
+          type: 'codex',
+          authIndex: 'auth-1',
+          account: 'alice@example.com',
+        },
+        {
+          name: 'shared.json',
+          id: 'runtime-b',
+          type: 'codex',
+          authIndex: 'auth-1',
+          account: 'bob@example.com',
+        },
+      ],
+    });
+
+    const result = await authFilesApi.list();
+
+    expect(result.files).toEqual([
+      expect.objectContaining({
+        name: 'shared.json',
+        id: 'runtime-a',
+        authIndex: 'auth-1',
+        account: 'alice@example.com',
+      }),
+      expect.objectContaining({
+        name: 'shared.json',
+        id: 'runtime-b',
+        authIndex: 'auth-1',
+        account: 'bob@example.com',
+      }),
+    ]);
+    expect(result.total).toBe(2);
+  });
+
+  it('merges same-name auth file representations when authIndex and runtime ID match', async () => {
+    mocks.get.mockResolvedValue({
+      files: [
+        {
+          name: 'shared.json',
+          id: 'runtime-a',
+          type: 'codex',
+          authIndex: 'auth-1',
+          source: 'runtime',
+          status: 'ok',
+        },
+        {
+          name: 'shared.json',
+          id: 'runtime-a',
+          type: 'codex',
+          authIndex: 'auth-1',
+          source: 'file',
+          path: '/auth/shared.json',
+          size: 123,
+        },
+      ],
+    });
+
+    const result = await authFilesApi.list();
+
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0]).toEqual(
+      expect.objectContaining({
+        name: 'shared.json',
+        id: 'runtime-a',
+        authIndex: 'auth-1',
+        source: 'file',
+        path: '/auth/shared.json',
+        size: 123,
+        status: 'ok',
+      })
+    );
+    expect(result.total).toBe(1);
+  });
+
   it('still merges duplicate same-name rows when authIndex is absent', async () => {
     mocks.get.mockResolvedValue({
       files: [

--- a/apps/web/src/services/api/authFiles.test.ts
+++ b/apps/web/src/services/api/authFiles.test.ts
@@ -1507,6 +1507,37 @@ describe('authFilesApi patchFieldsForAuthIndexes', () => {
     expect(mocks.postForm).not.toHaveBeenCalled();
   });
 
+  it('allows missing Codex Workspace and member evidence for a uniquely located source record', async () => {
+    const rawText = JSON.stringify({
+      type: 'codex',
+      auth_index: 'auth-1',
+      priority: 1,
+    });
+    mocks.getRaw.mockResolvedValue({ data: new Blob([rawText]) });
+    mocks.postForm.mockResolvedValue({
+      status: 'ok',
+      uploaded: 1,
+      files: ['codex.json'],
+      failed: [],
+    });
+    const target = {
+      name: 'codex.json',
+      runtimeId: 'runtime-auth-1',
+      authIndex: 'auth-1',
+      provider: 'codex',
+      accountId: 'workspace-a',
+      accountSnapshot: 'alice@example.com',
+    };
+
+    await expect(
+      authFilesApi.patchFieldsForAuthIndexes('codex.json', [target], [target], { priority: 10 })
+    ).resolves.toBeUndefined();
+
+    await expect(getUploadedFile().text()).resolves.toBe(
+      JSON.stringify({ type: 'codex', auth_index: 'auth-1', priority: 10 })
+    );
+  });
+
   it('uses a runtime locator when the Codex member snapshot is only a display value', async () => {
     const rawText = JSON.stringify({
       type: 'codex',

--- a/apps/web/src/services/api/authFiles.test.ts
+++ b/apps/web/src/services/api/authFiles.test.ts
@@ -1479,6 +1479,85 @@ describe('authFilesApi patchFieldsForAuthIndexes', () => {
 
     expect(mocks.postForm).not.toHaveBeenCalled();
   });
+
+  it('rejects conflicting Codex member evidence before reuploading the source file', async () => {
+    mocks.getRaw.mockResolvedValue({
+      data: new Blob([
+        JSON.stringify({
+          type: 'codex',
+          auth_index: 'auth-1',
+          account_id: 'workspace-a',
+          accountSnapshot: 'alice@example.com',
+          account_snapshot: 'bob@example.com',
+        }),
+      ]),
+    });
+    const target = {
+      name: 'codex.json',
+      runtimeId: 'runtime-1',
+      authIndex: 'auth-1',
+      provider: 'codex',
+      accountId: 'workspace-a',
+    };
+
+    await expect(
+      authFilesApi.patchFieldsForAuthIndexes('codex.json', [target], [target], { priority: 10 })
+    ).rejects.toThrow('Auth file patch target changed');
+
+    expect(mocks.postForm).not.toHaveBeenCalled();
+  });
+
+  it('uses a runtime locator when the Codex member snapshot is only a display value', async () => {
+    const rawText = JSON.stringify({
+      type: 'codex',
+      account_id: 'workspace-a',
+      account: 'Alice',
+      priority: 1,
+    });
+    mocks.getRaw.mockResolvedValue({ data: new Blob([rawText]) });
+    mocks.postForm.mockResolvedValue({
+      status: 'ok',
+      uploaded: 1,
+      files: ['codex.json'],
+      failed: [],
+    });
+    const target = {
+      name: 'codex.json',
+      runtimeId: 'runtime-auth-1',
+      provider: 'codex',
+      accountId: 'workspace-a',
+      accountSnapshot: 'Alice',
+    };
+
+    await expect(
+      authFilesApi.patchFieldsForAuthIndexes('codex.json', [target], [target], { priority: 10 })
+    ).resolves.toBeUndefined();
+
+    await expect(getUploadedFile().text()).resolves.toBe(
+      JSON.stringify({ type: 'codex', account_id: 'workspace-a', account: 'Alice', priority: 10 })
+    );
+  });
+
+  it('rejects a weak Codex member snapshot without a credential locator', async () => {
+    const rawText = JSON.stringify({
+      type: 'codex',
+      account_id: 'workspace-a',
+      account: 'Alice',
+    });
+    mocks.getRaw.mockResolvedValue({ data: new Blob([rawText]) });
+    const target = {
+      name: 'codex.json',
+      provider: 'codex',
+      accountId: 'workspace-a',
+      accountSnapshot: 'Alice',
+    };
+
+    await expect(
+      authFilesApi.patchFieldsForAuthIndexes('codex.json', [target], [target], { priority: 10 })
+    ).rejects.toThrow('Auth file patch target changed');
+
+    expect(mocks.postForm).not.toHaveBeenCalled();
+  });
 });
 
 describe('applyAuthFileFieldsPatchToRecord', () => {

--- a/apps/web/src/services/api/authFiles.ts
+++ b/apps/web/src/services/api/authFiles.ts
@@ -7,8 +7,12 @@ import type { AuthFilesResponse } from '@/types/authFile';
 import type { AuthFileItem, OAuthModelAliasEntry } from '@/types';
 import {
   readAuthFileStatusAccountId,
+  readAuthFileStatusAccountIdInvalid,
   readAuthFileStatusAccountSnapshot,
+  readAuthFileStatusCodexMember,
+  readAuthFileStatusCodexMemberInvalid,
   readAuthFileStatusProvider,
+  normalizeCodexMemberSnapshot,
 } from '@/utils/authFileStatusMutation';
 import { sha256RawTextHex } from '@/utils/apiKeyHash';
 import { parseTimestampMs } from '@/utils/timestamp';
@@ -847,19 +851,48 @@ const authFileRecordMatchesPatchTarget = (
   target: AuthFileStatusTarget
 ): boolean => {
   const authFileRecord = { name: '', ...record } as AuthFileItem;
+  const credentialLocatorPresent = Boolean(
+    String(target.runtimeId ?? '').trim() || normalizePatchAuthIndex(target.authIndex)
+  );
   const expectedProvider = normalizePatchProviderIdentity(target.provider);
   const actualProvider = normalizePatchProviderIdentity(readAuthFileStatusProvider(authFileRecord));
   if (expectedProvider && actualProvider && actualProvider !== expectedProvider) {
     return false;
   }
+  if (actualProvider === 'codex' && readAuthFileStatusAccountIdInvalid(authFileRecord)) {
+    return false;
+  }
 
   const expectedAccountId = String(target.accountId ?? '').trim();
   if (expectedAccountId) {
-    return readAuthFileStatusAccountId(authFileRecord) === expectedAccountId;
+    if (readAuthFileStatusAccountId(authFileRecord) !== expectedAccountId) return false;
+    if (actualProvider === 'codex') {
+      const expectedSnapshot = String(target.accountSnapshot ?? '').trim();
+      const expectedMember = normalizeCodexMemberSnapshot(expectedSnapshot);
+      if (!expectedMember) {
+        // A Workspace-only target must still carry a credential locator. The
+        // raw source record may be one of several Team members in one file.
+        return credentialLocatorPresent && !readAuthFileStatusCodexMemberInvalid(authFileRecord);
+      }
+      return (
+        !readAuthFileStatusCodexMemberInvalid(authFileRecord) &&
+        readAuthFileStatusCodexMember(authFileRecord) === expectedMember
+      );
+    }
+    return true;
   }
 
   const expectedAccountSnapshot = String(target.accountSnapshot ?? '').trim();
   if (expectedAccountSnapshot) {
+    if (actualProvider === 'codex') {
+      const expectedMember = normalizeCodexMemberSnapshot(expectedAccountSnapshot);
+      return (
+        credentialLocatorPresent &&
+        Boolean(expectedMember) &&
+        !readAuthFileStatusCodexMemberInvalid(authFileRecord) &&
+        readAuthFileStatusCodexMember(authFileRecord) === expectedMember
+      );
+    }
     return readAuthFileStatusAccountSnapshot(authFileRecord) === expectedAccountSnapshot;
   }
 

--- a/apps/web/src/services/api/authFiles.ts
+++ b/apps/web/src/services/api/authFiles.ts
@@ -12,6 +12,7 @@ import {
   readAuthFileStatusCodexMember,
   readAuthFileStatusCodexMemberInvalid,
   readAuthFileStatusProvider,
+  readAuthFileStatusRuntimeId,
   normalizeCodexMemberSnapshot,
 } from '@/utils/authFileStatusMutation';
 import { sha256RawTextHex } from '@/utils/apiKeyHash';
@@ -437,6 +438,10 @@ const readAuthIndexField = (entry: AuthFileEntry): string => {
 const getAuthFileDedupeKey = (entry: AuthFileEntry): string => {
   const name = readTextField(entry, 'name');
   const authIndex = readAuthIndexField(entry);
+  const runtimeId = readAuthFileStatusRuntimeId(entry);
+  if (name && authIndex && runtimeId) {
+    return `${name}\u0000${authIndex}\u0000${runtimeId}`;
+  }
   if (name && authIndex) return `${name}\u0000${authIndex}`;
   return name || JSON.stringify(entry);
 };
@@ -890,9 +895,7 @@ const authFileRecordMatchesPatchTarget = (
       if (!credentialLocatorPresent || !expectedMember) return false;
       if (readAuthFileStatusCodexMemberInvalid(authFileRecord)) return false;
       const currentMember = readAuthFileStatusCodexMember(authFileRecord);
-      return (
-        !currentMember || currentMember === expectedMember
-      );
+      return !currentMember || currentMember === expectedMember;
     }
     return readAuthFileStatusAccountSnapshot(authFileRecord) === expectedAccountSnapshot;
   }

--- a/apps/web/src/services/api/authFiles.ts
+++ b/apps/web/src/services/api/authFiles.ts
@@ -865,8 +865,9 @@ const authFileRecordMatchesPatchTarget = (
 
   const expectedAccountId = String(target.accountId ?? '').trim();
   if (expectedAccountId) {
-    if (readAuthFileStatusAccountId(authFileRecord) !== expectedAccountId) return false;
     if (actualProvider === 'codex') {
+      const currentWorkspace = readAuthFileStatusAccountId(authFileRecord);
+      if (currentWorkspace && currentWorkspace !== expectedAccountId) return false;
       const expectedSnapshot = String(target.accountSnapshot ?? '').trim();
       const expectedMember = normalizeCodexMemberSnapshot(expectedSnapshot);
       if (!expectedMember) {
@@ -874,11 +875,11 @@ const authFileRecordMatchesPatchTarget = (
         // raw source record may be one of several Team members in one file.
         return credentialLocatorPresent && !readAuthFileStatusCodexMemberInvalid(authFileRecord);
       }
-      return (
-        !readAuthFileStatusCodexMemberInvalid(authFileRecord) &&
-        readAuthFileStatusCodexMember(authFileRecord) === expectedMember
-      );
+      if (readAuthFileStatusCodexMemberInvalid(authFileRecord)) return false;
+      const currentMember = readAuthFileStatusCodexMember(authFileRecord);
+      return !currentMember || currentMember === expectedMember;
     }
+    if (readAuthFileStatusAccountId(authFileRecord) !== expectedAccountId) return false;
     return true;
   }
 
@@ -886,11 +887,11 @@ const authFileRecordMatchesPatchTarget = (
   if (expectedAccountSnapshot) {
     if (actualProvider === 'codex') {
       const expectedMember = normalizeCodexMemberSnapshot(expectedAccountSnapshot);
+      if (!credentialLocatorPresent || !expectedMember) return false;
+      if (readAuthFileStatusCodexMemberInvalid(authFileRecord)) return false;
+      const currentMember = readAuthFileStatusCodexMember(authFileRecord);
       return (
-        credentialLocatorPresent &&
-        Boolean(expectedMember) &&
-        !readAuthFileStatusCodexMemberInvalid(authFileRecord) &&
-        readAuthFileStatusCodexMember(authFileRecord) === expectedMember
+        !currentMember || currentMember === expectedMember
       );
     }
     return readAuthFileStatusAccountSnapshot(authFileRecord) === expectedAccountSnapshot;

--- a/apps/web/src/services/api/usageService.ts
+++ b/apps/web/src/services/api/usageService.ts
@@ -2371,6 +2371,7 @@ const getDemoCodexInspectionActionsResponse = (
     if (
       !hasCodexInspectionStableIdentity({
         fileName: result.fileName,
+        runtimeId: result.runtimeId,
         provider: result.provider,
         authIndex: result.authIndex,
         accountId: result.accountId,

--- a/apps/web/src/utils/authFileCredentialIdentity.test.ts
+++ b/apps/web/src/utils/authFileCredentialIdentity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { resolveCredentialIdentity } from './authFileCredentialIdentity';
+import type { AuthFileItem } from '@/types';
+import {
+  normalizeCodexMemberSnapshot,
+  readAuthFileStatusCodexMember,
+  readAuthFileStatusCodexMemberInvalid,
+  resolveCredentialIdentity,
+} from './authFileCredentialIdentity';
 
 describe('credentialIdentity', () => {
   it('normalizes the complete credential identity from one auth-file row', () => {
@@ -24,12 +30,12 @@ describe('credentialIdentity', () => {
     });
   });
 
-  it('honors explicit identity snapshots supplied by an async target', () => {
+  it('honors explicit identity snapshots when the display account is weak', () => {
     expect(
       resolveCredentialIdentity({
         name: 'shared.json',
         type: 'codex',
-        account: 'stale@example.com',
+        account: 'Stale display account',
         accountSnapshot: 'current@example.com',
         authLabelSnapshot: 'Current label',
         accountId: 'account-current',
@@ -43,6 +49,41 @@ describe('credentialIdentity', () => {
       authLabelSnapshot: 'Current label',
       authIndex: 'auth-current',
     });
+  });
+
+  it('prefers an explicit Codex member snapshot over a weak display account', () => {
+    expect(
+      readAuthFileStatusCodexMember({
+        name: 'shared.json',
+        provider: 'codex',
+        accountSnapshot: ' Alice@Example.com ',
+        account: 'Stale display account',
+      } as AuthFileItem)
+    ).toBe('alice@example.com');
+  });
+
+  it('fails closed when a strong explicit snapshot conflicts with account or email', () => {
+    for (const field of ['account', 'email'] as const) {
+      const file = {
+        name: 'shared.json',
+        provider: 'codex',
+        accountSnapshot: 'alice@example.com',
+        [field]: 'bob@example.com',
+      } as AuthFileItem;
+      expect(readAuthFileStatusCodexMember(file)).toBe('');
+      expect(readAuthFileStatusCodexMemberInvalid(file)).toBe(true);
+    }
+  });
+
+  it('fails closed when explicit Codex member snapshots conflict', () => {
+    const file = {
+      name: 'shared.json',
+      provider: 'codex',
+      accountSnapshot: 'alice@example.com',
+      account_snapshot: 'bob@example.com',
+    } as AuthFileItem;
+    expect(readAuthFileStatusCodexMember(file)).toBe('');
+    expect(readAuthFileStatusCodexMemberInvalid(file)).toBe(true);
   });
 
   it('does not treat generic Codex project or sub fields as a ChatGPT account id', () => {
@@ -66,5 +107,88 @@ describe('credentialIdentity', () => {
         metadata: { id_token: { chatgpt_account_id: ' account-a ' } },
       })
     ).toMatchObject({ provider: 'codex', accountId: 'account-a' });
+  });
+
+  it('normalizes only strong Codex email member evidence', () => {
+    expect(normalizeCodexMemberSnapshot(' Alice@Example.com ')).toBe('alice@example.com');
+    expect(normalizeCodexMemberSnapshot('Alice')).toBe('');
+    expect(normalizeCodexMemberSnapshot('alice@example.com@other')).toBe('');
+    expect(normalizeCodexMemberSnapshot('alice @example.com')).toBe('');
+    expect(normalizeCodexMemberSnapshot('álîce@example.com')).toBe('');
+    expect(normalizeCodexMemberSnapshot('alice\u000e@example.com')).toBe('');
+    expect(normalizeCodexMemberSnapshot('alice\u007f@example.com')).toBe('');
+  });
+
+  it('finds a valid Codex email without promoting a weak display value', () => {
+    expect(
+      readAuthFileStatusCodexMember({
+        name: 'codex.json',
+        provider: 'codex',
+        account: 'Alice',
+        email: ' Alice@Example.com ',
+        label: 'Primary',
+      })
+    ).toBe('alice@example.com');
+    expect(
+      readAuthFileStatusCodexMember({
+        name: 'codex.json',
+        provider: 'codex',
+        account: 'Alice',
+        label: 'Primary',
+      })
+    ).toBe('');
+  });
+
+  it('falls through a weak explicit snapshot to a strong account/email field', () => {
+    expect(
+      readAuthFileStatusCodexMember({
+        name: 'codex.json',
+        provider: 'codex',
+        accountSnapshot: 'Pro 20x Workspace',
+        account: 'Alice',
+        email: ' Alice@Example.com ',
+      } as AuthFileItem)
+    ).toBe('alice@example.com');
+  });
+
+  it('ignores a weak explicit Codex snapshot instead of blocking credential identity', () => {
+    expect(
+      resolveCredentialIdentity({
+        name: 'codex.json',
+        provider: 'codex',
+        accountSnapshot: 'Pro 20x Workspace',
+        account_id: 'workspace-1',
+        auth_index: 'auth-1',
+      })
+    ).toMatchObject({
+      provider: 'codex',
+      accountId: 'workspace-1',
+      accountSnapshot: '',
+      authIndex: 'auth-1',
+    });
+    expect(
+      readAuthFileStatusCodexMemberInvalid({
+        name: 'codex.json',
+        provider: 'codex',
+        account_snapshot: 'Pro 20x Workspace',
+      } as AuthFileItem)
+    ).toBe(false);
+  });
+
+  it('uses the strong Codex member when the account field is only a display label', () => {
+    expect(
+      resolveCredentialIdentity({
+        name: 'codex.json',
+        provider: 'codex',
+        account: 'Alice',
+        email: ' Alice@Example.com ',
+        account_id: 'workspace-1',
+        auth_index: 'auth-1',
+      })
+    ).toMatchObject({
+      provider: 'codex',
+      accountId: 'workspace-1',
+      accountSnapshot: 'alice@example.com',
+    });
   });
 });

--- a/apps/web/src/utils/authFileCredentialIdentity.ts
+++ b/apps/web/src/utils/authFileCredentialIdentity.ts
@@ -1,6 +1,9 @@
 import type { AuthFileItem } from '@/types';
 import { normalizeAuthIndex } from '@/utils/authIndex';
-import { resolveCodexChatgptAccountId } from '@/utils/quota/resolvers';
+import {
+  isCodexChatgptAccountIdInvalid,
+  resolveCodexChatgptAccountId,
+} from '@/utils/quota/resolvers';
 import { resolveAuthProvider } from '@/utils/quota/validators';
 
 export interface CredentialIdentity {
@@ -107,6 +110,9 @@ export const readAuthFileStatusAccountId = (file: AuthFileItem): string => {
   return '';
 };
 
+export const readAuthFileStatusAccountIdInvalid = (file: AuthFileItem): boolean =>
+  readAuthFileStatusProvider(file) === 'codex' && isCodexChatgptAccountIdInvalid(file);
+
 export const readAuthFileStatusAccountSnapshot = (file: AuthFileItem): string => {
   for (const value of [file.account, file.email, file.display_account, file.displayAccount]) {
     const normalized = normalizeIdentityValue(value);
@@ -115,6 +121,53 @@ export const readAuthFileStatusAccountSnapshot = (file: AuthFileItem): string =>
   return '';
 };
 
+// Keep this deliberately narrower than the display-account reader. The CPA
+// auth-files response may use account/label-like values for presentation, but
+// only a conservative email-shaped value is strong enough to identify a Codex
+// Workspace member.
+export const normalizeCodexMemberSnapshot = (value: unknown): string => {
+  if (typeof value !== 'string') return '';
+  // Match the backend/SQLite normalizer: only ASCII spaces are trimmed and
+  // only printable ASCII values are eligible, keeping runtime and rebuild
+  // identity keys byte-for-byte compatible.
+  const normalized = value.replace(/^ +| +$/g, '');
+  const at = normalized.indexOf('@');
+  if (
+    !normalized ||
+    at <= 0 ||
+    at === normalized.length - 1 ||
+    normalized.indexOf('@', at + 1) !== -1 ||
+    Array.from(normalized).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x20 || code >= 0x7f;
+    })
+  ) {
+    return '';
+  }
+  return normalized.toLowerCase();
+};
+
+const resolveCodexMemberSnapshot = (file: AuthFileItem): { member: string; invalid: boolean } => {
+  // accountSnapshot/account_snapshot/account/email can all carry member
+  // evidence in different response shapes. Weak display values are ignored,
+  // but every strong email-shaped value must agree; selecting an explicit
+  // field over another strong field would hide an identity conflict.
+  const members = [file.accountSnapshot, file.account_snapshot, file.account, file.email]
+    .map(normalizeCodexMemberSnapshot)
+    .filter(Boolean);
+  const member = members[0] ?? '';
+  if (members.some((candidate) => candidate !== member)) {
+    return { member: '', invalid: true };
+  }
+  return { member, invalid: false };
+};
+
+export const readAuthFileStatusCodexMember = (file: AuthFileItem): string =>
+  resolveCodexMemberSnapshot(file).member;
+
+export const readAuthFileStatusCodexMemberInvalid = (file: AuthFileItem): boolean =>
+  readAuthFileStatusProvider(file) === 'codex' && resolveCodexMemberSnapshot(file).invalid;
+
 export const readAuthFileStatusAuthLabelSnapshot = (file: AuthFileItem): string =>
   firstNonEmptyIdentityValue(file.label, file.note);
 
@@ -122,16 +175,25 @@ export const resolveCredentialIdentity = (
   target: AuthFileItem | CredentialIdentityTarget
 ): CredentialIdentity => {
   const record = target as CredentialIdentityTarget;
+  const provider = readAuthFileStatusProvider(record);
   const directAccountSnapshot = normalizeIdentityValue(record.accountSnapshot);
   const directAuthLabelSnapshot = normalizeIdentityValue(record.authLabelSnapshot);
+  const directAccountId = normalizeIdentityValue(record.accountId);
+  const accountSnapshot =
+    provider === 'codex'
+      ? readAuthFileStatusCodexMember(record)
+      : directAccountSnapshot || readAuthFileStatusAccountSnapshot(record);
   return {
     physicalName:
       normalizeIdentityValue(record.physicalName) || readAuthFileStatusPhysicalName(record),
     runtimeId: normalizeIdentityValue(record.runtimeId) || readAuthFileStatusRuntimeId(record),
     authIndex: normalizeAuthIndex(record.authIndex ?? record['auth_index'] ?? record['auth-index']),
-    provider: readAuthFileStatusProvider(record),
-    accountId: normalizeIdentityValue(record.accountId) || readAuthFileStatusAccountId(record),
-    accountSnapshot: directAccountSnapshot || readAuthFileStatusAccountSnapshot(record),
+    provider,
+    accountId:
+      provider === 'codex' && readAuthFileStatusAccountIdInvalid(record)
+        ? ''
+        : directAccountId || readAuthFileStatusAccountId(record),
+    accountSnapshot,
     authLabelSnapshot: directAuthLabelSnapshot || readAuthFileStatusAuthLabelSnapshot(record),
   };
 };
@@ -146,8 +208,8 @@ export const isCredentialIdentityVerified = (
       : '';
   return Boolean(
     identity.authIndex ||
-      identity.accountId ||
-      accountSnapshot ||
-      (identity.runtimeId && identity.runtimeId !== identity.physicalName)
+    identity.accountId ||
+    accountSnapshot ||
+    (identity.runtimeId && identity.runtimeId !== identity.physicalName)
   );
 };

--- a/apps/web/src/utils/authFileStatusMutation.test.ts
+++ b/apps/web/src/utils/authFileStatusMutation.test.ts
@@ -244,6 +244,27 @@ describe('resolveAuthFileStatusMutationTarget', () => {
     ).toMatchObject({ target: current, scope: 'ambiguous', failure: 'identity-changed' });
   });
 
+  it('allows missing Codex Workspace and member evidence for a uniquely located credential', () => {
+    const current = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      disabled: true,
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([current], {
+        name: 'same.json',
+        runtimeId: 'runtime-auth-1',
+        authIndex: 'auth-1',
+        provider: 'codex',
+        accountId: 'workspace-1',
+        accountSnapshot: 'alice@example.com',
+      })
+    ).toMatchObject({ target: current, scope: 'credential', failure: null });
+  });
+
   it('checks a strong account/email member on an AuthFileItem target', () => {
     const requested = {
       id: 'runtime-auth-1',

--- a/apps/web/src/utils/authFileStatusMutation.test.ts
+++ b/apps/web/src/utils/authFileStatusMutation.test.ts
@@ -262,7 +262,7 @@ describe('resolveAuthFileStatusMutationTarget', () => {
     });
   });
 
-  it('disambiguates a shared file/auth-index selector by Codex Workspace member', () => {
+  it('keeps a duplicate file/auth-index selector ambiguous despite Codex member evidence', () => {
     const alice = {
       id: 'runtime-alice',
       name: 'team.json',
@@ -288,7 +288,7 @@ describe('resolveAuthFileStatusMutationTarget', () => {
         accountId: 'workspace-1',
         accountSnapshot: 'ALICE@EXAMPLE.COM',
       })
-    ).toMatchObject({ target: alice, scope: 'credential', failure: null });
+    ).toMatchObject({ target: null, scope: 'ambiguous', failure: 'ambiguous' });
   });
 
   it('keeps a shared selector ambiguous when a sibling lacks member evidence', () => {
@@ -388,6 +388,25 @@ describe('resolveAuthFileStatusMutationTarget', () => {
         accountSnapshot: 'Alice',
       })
     ).toMatchObject({ target: current, scope: 'credential', failure: null });
+  });
+
+  it('does not use Workspace/member alone for a Codex mutation', () => {
+    const current = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      type: 'codex',
+      account_id: 'workspace-1',
+      account: 'alice@example.com',
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([current], {
+        name: 'same.json',
+        provider: 'codex',
+        accountId: 'workspace-1',
+        accountSnapshot: 'alice@example.com',
+      })
+    ).toMatchObject({ target: current, scope: 'ambiguous', failure: 'identity-changed' });
   });
 
   it('fails closed for a weak Codex member snapshot without a credential locator', () => {

--- a/apps/web/src/utils/authFileStatusMutation.test.ts
+++ b/apps/web/src/utils/authFileStatusMutation.test.ts
@@ -5,6 +5,7 @@ import {
   getAuthFileStatusMutationLockKeys,
   getAuthFileStatusSelectionKey,
   readAuthFileStatusAccountId,
+  readAuthFileStatusAccountIdInvalid,
   readAuthFileStatusAccountSnapshot,
   readAuthFileStatusProvider,
   resolveAuthFileStatusMutationTarget,
@@ -57,9 +58,22 @@ describe('auth file status identity keys', () => {
       account: 'second@example.com',
     } as AuthFileItem;
 
-    expect(getAuthFileStatusIdentityKey(first)).toBe(getAuthFileStatusIdentityKey(renamed));
+    expect(getAuthFileStatusIdentityKey(first)).not.toBe(getAuthFileStatusIdentityKey(renamed));
     expect(getAuthFileStatusIdentityKey(first)).not.toBe(getAuthFileStatusIdentityKey(second));
     expect(getAuthFileStatusSelectionKey(first)).not.toBe(getAuthFileStatusSelectionKey(second));
+  });
+
+  it('keeps the existing account-ID precedence for non-Codex providers', () => {
+    const original = {
+      id: 'runtime-auth-1',
+      name: 'shared.json',
+      type: 'xai',
+      account_id: 'account-1',
+      account: 'original@example.com',
+    } as AuthFileItem;
+    const refreshed = { ...original, account: 'display-changed@example.com' } as AuthFileItem;
+
+    expect(getAuthFileStatusIdentityKey(original)).toBe(getAuthFileStatusIdentityKey(refreshed));
   });
 
   it('uses a normalized provider plus runtime ID when account metadata is absent', () => {
@@ -120,6 +134,18 @@ describe('auth file status identity keys', () => {
 
     expect(readAuthFileStatusProvider(file)).toBe('vertex');
     expect(readAuthFileStatusAccountSnapshot(file)).toBe('project@example.com');
+  });
+
+  it('marks conflicting Codex Workspace evidence invalid', () => {
+    const file = {
+      name: 'codex.json',
+      type: 'codex',
+      account_id: 'workspace-a',
+      metadata: { id_token: { account_id: 'workspace-b' } },
+    } as AuthFileItem;
+
+    expect(readAuthFileStatusAccountId(file)).toBe('');
+    expect(readAuthFileStatusAccountIdInvalid(file)).toBe(true);
   });
 });
 
@@ -196,7 +222,7 @@ describe('resolveAuthFileStatusMutationTarget', () => {
     });
   });
 
-  it('keeps an account-ID match authoritative when the display snapshot changes', () => {
+  it('rejects a Codex member change even when the Workspace ID is unchanged', () => {
     const current = {
       id: 'runtime-auth-1',
       name: 'same.json',
@@ -215,7 +241,173 @@ describe('resolveAuthFileStatusMutationTarget', () => {
         accountId: 'account-1',
         accountSnapshot: 'original@example.com',
       })
+    ).toMatchObject({ target: current, scope: 'ambiguous', failure: 'identity-changed' });
+  });
+
+  it('checks a strong account/email member on an AuthFileItem target', () => {
+    const requested = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-1',
+      account: 'alice@example.com',
+    } as AuthFileItem;
+    const current = { ...requested, account: 'bob@example.com' } as AuthFileItem;
+
+    expect(resolveAuthFileStatusMutationTarget([current], requested)).toMatchObject({
+      target: current,
+      scope: 'ambiguous',
+      failure: 'identity-changed',
+    });
+  });
+
+  it('disambiguates a shared file/auth-index selector by Codex Workspace member', () => {
+    const alice = {
+      id: 'runtime-alice',
+      name: 'team.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-1',
+      account: 'alice@example.com',
+    } as AuthFileItem;
+    const bob = {
+      id: 'runtime-bob',
+      name: 'team.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-1',
+      account: 'bob@example.com',
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([alice, bob], {
+        name: 'team.json',
+        authIndex: 'auth-1',
+        provider: 'codex',
+        accountId: 'workspace-1',
+        accountSnapshot: 'ALICE@EXAMPLE.COM',
+      })
+    ).toMatchObject({ target: alice, scope: 'credential', failure: null });
+  });
+
+  it('keeps a shared selector ambiguous when a sibling lacks member evidence', () => {
+    const alice = {
+      id: 'runtime-alice',
+      name: 'team.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-1',
+      account: 'alice@example.com',
+    } as AuthFileItem;
+    const unknown = {
+      id: 'runtime-unknown',
+      name: 'team.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-1',
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([alice, unknown], {
+        name: 'team.json',
+        authIndex: 'auth-1',
+        provider: 'codex',
+        accountId: 'workspace-1',
+        accountSnapshot: 'alice@example.com',
+      })
+    ).toMatchObject({ target: null, scope: 'ambiguous', failure: 'ambiguous' });
+  });
+
+  it('rejects a Codex mutation when Workspace evidence is invalid even if the auth index matches', () => {
+    const current = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-a',
+      metadata: { id_token: { account_id: 'workspace-b' } },
+      account: 'alice@example.com',
+    } as AuthFileItem;
+
+    const resolution = resolveAuthFileStatusMutationTarget([current], {
+      name: 'same.json',
+      runtimeId: 'runtime-auth-1',
+      authIndex: 'auth-1',
+      provider: 'codex',
+      accountId: 'workspace-a',
+      accountSnapshot: 'alice@example.com',
+    });
+
+    expect(resolution).toMatchObject({
+      target: current,
+      scope: 'ambiguous',
+      failure: 'identity-changed',
+    });
+  });
+
+  it('fails closed when a Codex member evidence snapshot is conflicting even without a target member', () => {
+    const current = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'workspace-a',
+      accountSnapshot: 'alice@example.com',
+      account_snapshot: 'bob@example.com',
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([current], {
+        name: 'same.json',
+        runtimeId: 'runtime-auth-1',
+        authIndex: 'auth-1',
+        provider: 'codex',
+        accountId: 'workspace-a',
+      })
+    ).toMatchObject({ target: current, scope: 'ambiguous', failure: 'identity-changed' });
+  });
+
+  it('uses the credential locator when a Codex target carries a weak member snapshot', () => {
+    const current = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'account-1',
+      account: 'Alice',
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([current], {
+        name: 'same.json',
+        runtimeId: 'runtime-auth-1',
+        authIndex: 'auth-1',
+        provider: 'codex',
+        accountId: 'account-1',
+        accountSnapshot: 'Alice',
+      })
     ).toMatchObject({ target: current, scope: 'credential', failure: null });
+  });
+
+  it('fails closed for a weak Codex member snapshot without a credential locator', () => {
+    const current = {
+      id: 'runtime-auth-1',
+      name: 'same.json',
+      auth_index: 'auth-1',
+      type: 'codex',
+      account_id: 'account-1',
+      account: 'Alice',
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileStatusMutationTarget([current], {
+        name: 'same.json',
+        provider: 'codex',
+        accountId: 'account-1',
+        accountSnapshot: 'Alice',
+      })
+    ).toMatchObject({ target: current, scope: 'ambiguous', failure: 'identity-changed' });
   });
 
   it('rejects a status mutation when either side is missing a real provider', () => {

--- a/apps/web/src/utils/authFileStatusMutation.ts
+++ b/apps/web/src/utils/authFileStatusMutation.ts
@@ -1,21 +1,29 @@
 import type { AuthFileItem } from '@/types';
 import {
   readAuthFileStatusAccountId,
+  readAuthFileStatusAccountIdInvalid,
   readAuthFileStatusAccountSnapshot,
   readAuthFileStatusAuthIndex,
+  readAuthFileStatusCodexMember,
+  readAuthFileStatusCodexMemberInvalid,
   readAuthFileStatusPhysicalName,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
+  normalizeCodexMemberSnapshot,
   resolveCredentialIdentity,
 } from '@/utils/authFileCredentialIdentity';
 
 export {
   readAuthFileStatusAccountId,
+  readAuthFileStatusAccountIdInvalid,
   readAuthFileStatusAccountSnapshot,
   readAuthFileStatusAuthIndex,
+  readAuthFileStatusCodexMember,
+  readAuthFileStatusCodexMemberInvalid,
   readAuthFileStatusPhysicalName,
   readAuthFileStatusProvider,
   readAuthFileStatusRuntimeId,
+  normalizeCodexMemberSnapshot,
 } from '@/utils/authFileCredentialIdentity';
 
 const SELECTION_KEY_SEPARATOR = '\u0000';
@@ -53,6 +61,8 @@ export type AuthFileStatusMutationResolution = {
 
 const normalizeIdentityTarget = (target: AuthFileStatusIdentityTarget) => {
   const identity = resolveCredentialIdentity(target as AuthFileItem & AuthFileStatusMutationTarget);
+  const requestedAccountSnapshot =
+    typeof target.accountSnapshot === 'string' ? target.accountSnapshot.trim() : '';
   return {
     name: identity.physicalName,
     runtimeId: identity.runtimeId,
@@ -60,26 +70,37 @@ const normalizeIdentityTarget = (target: AuthFileStatusIdentityTarget) => {
     provider: identity.provider,
     accountId: identity.accountId,
     accountSnapshot: identity.accountSnapshot,
+    accountSnapshotProvided:
+      requestedAccountSnapshot.length > 0 || Boolean(identity.accountSnapshot),
   };
 };
 
 const normalizeTarget = (target: AuthFileStatusMutationTarget) => normalizeIdentityTarget(target);
+
+const hasCredentialLocator = (target: ReturnType<typeof normalizeTarget>): boolean =>
+  Boolean(target.runtimeId || target.authIndex);
 
 export const getAuthFileStatusIdentityKey = (target: AuthFileStatusIdentityTarget): string => {
   const normalized = normalizeIdentityTarget(target);
   if (normalized.authIndex) return `${normalized.name}::${normalized.authIndex}`;
 
   const accountSnapshot =
-    normalized.accountSnapshot && normalized.accountSnapshot !== normalized.name
-      ? normalized.accountSnapshot
-      : '';
-  if (normalized.accountId || accountSnapshot) {
+    normalized.provider === 'codex'
+      ? normalizeCodexMemberSnapshot(normalized.accountSnapshot)
+      : normalized.accountSnapshot && normalized.accountSnapshot !== normalized.name
+        ? normalized.accountSnapshot
+        : '';
+  const fallbackAccountSnapshot =
+    normalized.accountId && normalized.provider !== 'codex' ? '' : accountSnapshot;
+  const stableAccountId =
+    normalized.provider === 'codex' && !accountSnapshot ? '' : normalized.accountId;
+  if (stableAccountId || fallbackAccountSnapshot) {
     return `${normalized.name}::-::${JSON.stringify([
       normalized.name,
       normalized.provider,
       null,
-      normalized.accountId || null,
-      normalized.accountId ? null : accountSnapshot || null,
+      stableAccountId || null,
+      fallbackAccountSnapshot || null,
     ])}`;
   }
 
@@ -97,20 +118,44 @@ const authFileMatchesRequestedIdentity = (
   target: ReturnType<typeof normalizeTarget>
 ): boolean => {
   const provider = readAuthFileStatusProvider(file);
+  const credentialLocatorPresent = hasCredentialLocator(target);
   if (!provider || !target.provider || provider !== target.provider) return false;
+  if (provider === 'codex' && readAuthFileStatusAccountIdInvalid(file)) return false;
+  if (provider === 'codex' && readAuthFileStatusCodexMemberInvalid(file)) return false;
 
   if (target.accountId) {
-    return readAuthFileStatusAccountId(file) === target.accountId;
+    if (readAuthFileStatusAccountId(file) !== target.accountId) return false;
+    if (target.provider === 'codex') {
+      const expectedMember = target.accountSnapshotProvided
+        ? normalizeCodexMemberSnapshot(target.accountSnapshot)
+        : '';
+      // A Workspace id without a strong member snapshot is only safe when the
+      // request still carries a credential-level locator (runtime id/auth
+      // index). Never let a Workspace-only target select a Team member.
+      if (!expectedMember) return credentialLocatorPresent;
+      return readAuthFileStatusCodexMember(file) === expectedMember;
+    }
+    return true;
   }
 
   if (target.accountSnapshot && target.accountSnapshot !== target.name) {
+    if (target.provider === 'codex') {
+      const expectedMember = normalizeCodexMemberSnapshot(target.accountSnapshot);
+      // Member email without its Workspace is not a complete Codex identity;
+      // use it only as an additional check on an exact credential locator.
+      return (
+        credentialLocatorPresent &&
+        Boolean(expectedMember) &&
+        readAuthFileStatusCodexMember(file) === expectedMember
+      );
+    }
     return readAuthFileStatusAccountSnapshot(file) === target.accountSnapshot;
   }
 
   // CPA auth entries are allowed to omit account metadata. A stable auth index,
   // together with the already-checked runtime ID, physical name, and provider,
   // still identifies the current credential without falling back to a filename-only match.
-  return target.authIndex !== null;
+  return credentialLocatorPresent;
 };
 
 export const getAuthFileStatusSelectionKey = (target: AuthFileStatusIdentityTarget): string => {
@@ -133,6 +178,38 @@ const findTargetWithoutRuntimeId = (
     if (target.authIndex === null) return true;
     return readAuthFileStatusAuthIndex(file) === target.authIndex;
   });
+
+const narrowCodexSelectorMatches = (
+  matches: AuthFileItem[],
+  target: ReturnType<typeof normalizeTarget>
+): AuthFileItem[] | null => {
+  if (
+    matches.length <= 1 ||
+    target.provider !== 'codex' ||
+    !target.accountId ||
+    !normalizeCodexMemberSnapshot(target.accountSnapshot)
+  ) {
+    return null;
+  }
+
+  // Disambiguate a shared file/auth-index selector only when every candidate
+  // has complete Workspace+member evidence. An unknown or conflicting sibling
+  // must remain visible as ambiguity rather than being hidden by a known match.
+  if (
+    matches.some(
+      (file) =>
+        readAuthFileStatusAccountIdInvalid(file) ||
+        readAuthFileStatusCodexMemberInvalid(file) ||
+        !readAuthFileStatusAccountId(file) ||
+        !readAuthFileStatusCodexMember(file)
+    )
+  ) {
+    return null;
+  }
+
+  const narrowed = matches.filter((file) => authFileMatchesRequestedIdentity(file, target));
+  return narrowed.length > 0 ? narrowed : null;
+};
 
 export const resolveAuthFileStatusMutationTarget = (
   files: AuthFileItem[],
@@ -159,6 +236,8 @@ export const resolveAuthFileStatusMutationTarget = (
     if (matches.length === 0) {
       return { target: null, scope: 'ambiguous', affectedFiles: [], failure: 'not-found' };
     }
+    const narrowed = narrowCodexSelectorMatches(matches, target);
+    if (narrowed) matches = narrowed;
   }
 
   if (matches.length !== 1) {

--- a/apps/web/src/utils/authFileStatusMutation.ts
+++ b/apps/web/src/utils/authFileStatusMutation.ts
@@ -124,17 +124,19 @@ const authFileMatchesRequestedIdentity = (
   if (provider === 'codex' && readAuthFileStatusCodexMemberInvalid(file)) return false;
 
   if (target.accountId) {
-    if (readAuthFileStatusAccountId(file) !== target.accountId) return false;
     if (target.provider === 'codex') {
+      const currentWorkspace = readAuthFileStatusAccountId(file);
+      if (currentWorkspace && currentWorkspace !== target.accountId) return false;
       const expectedMember = target.accountSnapshotProvided
         ? normalizeCodexMemberSnapshot(target.accountSnapshot)
         : '';
       // Workspace/member is verification evidence, not a credential locator.
       // Require runtime ID or auth index before any Codex mutation can use it.
       if (!credentialLocatorPresent) return false;
-      if (!expectedMember) return true;
-      return readAuthFileStatusCodexMember(file) === expectedMember;
+      const currentMember = readAuthFileStatusCodexMember(file);
+      return !expectedMember || !currentMember || currentMember === expectedMember;
     }
+    if (readAuthFileStatusAccountId(file) !== target.accountId) return false;
     return true;
   }
 
@@ -143,11 +145,9 @@ const authFileMatchesRequestedIdentity = (
       const expectedMember = normalizeCodexMemberSnapshot(target.accountSnapshot);
       // Member email without its Workspace is not a complete Codex identity;
       // use it only as an additional check on an exact credential locator.
-      return (
-        credentialLocatorPresent &&
-        Boolean(expectedMember) &&
-        readAuthFileStatusCodexMember(file) === expectedMember
-      );
+      if (!credentialLocatorPresent || !expectedMember) return false;
+      const currentMember = readAuthFileStatusCodexMember(file);
+      return !currentMember || currentMember === expectedMember;
     }
     return readAuthFileStatusAccountSnapshot(file) === target.accountSnapshot;
   }

--- a/apps/web/src/utils/authFileStatusMutation.ts
+++ b/apps/web/src/utils/authFileStatusMutation.ts
@@ -129,10 +129,10 @@ const authFileMatchesRequestedIdentity = (
       const expectedMember = target.accountSnapshotProvided
         ? normalizeCodexMemberSnapshot(target.accountSnapshot)
         : '';
-      // A Workspace id without a strong member snapshot is only safe when the
-      // request still carries a credential-level locator (runtime id/auth
-      // index). Never let a Workspace-only target select a Team member.
-      if (!expectedMember) return credentialLocatorPresent;
+      // Workspace/member is verification evidence, not a credential locator.
+      // Require runtime ID or auth index before any Codex mutation can use it.
+      if (!credentialLocatorPresent) return false;
+      if (!expectedMember) return true;
       return readAuthFileStatusCodexMember(file) === expectedMember;
     }
     return true;
@@ -179,38 +179,6 @@ const findTargetWithoutRuntimeId = (
     return readAuthFileStatusAuthIndex(file) === target.authIndex;
   });
 
-const narrowCodexSelectorMatches = (
-  matches: AuthFileItem[],
-  target: ReturnType<typeof normalizeTarget>
-): AuthFileItem[] | null => {
-  if (
-    matches.length <= 1 ||
-    target.provider !== 'codex' ||
-    !target.accountId ||
-    !normalizeCodexMemberSnapshot(target.accountSnapshot)
-  ) {
-    return null;
-  }
-
-  // Disambiguate a shared file/auth-index selector only when every candidate
-  // has complete Workspace+member evidence. An unknown or conflicting sibling
-  // must remain visible as ambiguity rather than being hidden by a known match.
-  if (
-    matches.some(
-      (file) =>
-        readAuthFileStatusAccountIdInvalid(file) ||
-        readAuthFileStatusCodexMemberInvalid(file) ||
-        !readAuthFileStatusAccountId(file) ||
-        !readAuthFileStatusCodexMember(file)
-    )
-  ) {
-    return null;
-  }
-
-  const narrowed = matches.filter((file) => authFileMatchesRequestedIdentity(file, target));
-  return narrowed.length > 0 ? narrowed : null;
-};
-
 export const resolveAuthFileStatusMutationTarget = (
   files: AuthFileItem[],
   requestedTarget: AuthFileStatusMutationTarget
@@ -236,8 +204,6 @@ export const resolveAuthFileStatusMutationTarget = (
     if (matches.length === 0) {
       return { target: null, scope: 'ambiguous', affectedFiles: [], failure: 'not-found' };
     }
-    const narrowed = narrowCodexSelectorMatches(matches, target);
-    if (narrowed) matches = narrowed;
   }
 
   if (matches.length !== 1) {

--- a/apps/web/src/utils/quota/resolvers.test.ts
+++ b/apps/web/src/utils/quota/resolvers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { resolveCodexChatgptAccountId } from './resolvers';
+import {
+  isCodexChatgptAccountIdInvalid,
+  resolveCodexChatgptAccountId,
+  resolveCodexChatgptAccountIdEvidence,
+} from './resolvers';
 
 describe('resolveCodexChatgptAccountId', () => {
   it.each([
@@ -18,5 +22,49 @@ describe('resolveCodexChatgptAccountId', () => {
         id_token: { account_id: 'token-account' },
       })
     ).toBe('token-account');
+  });
+
+  it('rejects conflicting explicit Workspace evidence instead of using the first candidate', () => {
+    const file = {
+      name: 'codex.json',
+      account_id: 'workspace-a',
+      metadata: { id_token: { chatgpt_account_id: 'workspace-b' } },
+    };
+    expect(resolveCodexChatgptAccountId(file)).toBeNull();
+    expect(resolveCodexChatgptAccountIdEvidence(file)).toEqual({ accountId: null, invalid: true });
+    expect(isCodexChatgptAccountIdInvalid(file)).toBe(true);
+  });
+
+  it('rejects malformed explicit Workspace evidence even when another candidate is valid', () => {
+    const file = {
+      name: 'codex.json',
+      account_id: 'workspace-a',
+      chatgptAccountId: { unexpected: 'object' },
+    };
+    expect(resolveCodexChatgptAccountId(file)).toBeNull();
+    expect(isCodexChatgptAccountIdInvalid(file)).toBe(true);
+  });
+
+  it('accepts matching direct and JWT Workspace evidence', () => {
+    const payload = btoa(JSON.stringify({ chatgpt_account_id: 'workspace-a' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    expect(
+      resolveCodexChatgptAccountId({
+        name: 'codex.json',
+        account_id: ' workspace-a ',
+        id_token: `header.${payload}.signature`,
+      })
+    ).toBe('workspace-a');
+  });
+
+  it.each([
+    ['workspace-a\t', 'workspace-a\t'],
+    ['workspace-a\u2003', 'workspace-a\u2003'],
+    ['workspace-a\u0000', 'workspace-a\u0000'],
+    ['工作区-a', '工作区-a'],
+  ])('preserves opaque Workspace value %j', (value, expected) => {
+    expect(resolveCodexChatgptAccountId({ name: 'codex.json', account_id: ` ${value} ` })).toBe(expected);
   });
 });

--- a/apps/web/src/utils/quota/resolvers.ts
+++ b/apps/web/src/utils/quota/resolvers.ts
@@ -3,68 +3,112 @@
  */
 
 import type { AuthFileItem } from '@/types';
-import { normalizeStringValue, normalizePlanType, parseIdTokenPayload } from './parsers';
+import { normalizePlanType, parseIdTokenPayload } from './parsers';
 
-const resolveAccountIdCandidate = (value: unknown): string | null => {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  return normalizeStringValue(
-    record.chatgpt_account_id ?? record.chatgptAccountId ?? record.account_id ?? record.accountId
-  );
+const CODEX_ACCOUNT_ID_FIELDS = [
+  'chatgpt_account_id',
+  'chatgptAccountId',
+  'account_id',
+  'accountId',
+] as const;
+
+const CODEX_NESTED_EVIDENCE_FIELDS = ['id_token', 'idToken', 'metadata', 'attributes'] as const;
+
+export type CodexChatgptAccountIdEvidence = {
+  accountId: string | null;
+  invalid: boolean;
+};
+
+const readRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+// Workspace IDs are opaque. Match the backend/SQLite rule: trim only ASCII
+// spaces and preserve every other byte of a non-empty value.
+const normalizeCodexWorkspaceId = (value: unknown): string | null => {
+  let normalized: string;
+  if (typeof value === 'string') {
+    normalized = value.replace(/^ +| +$/g, '');
+  } else if (typeof value === 'number' && Number.isFinite(value)) {
+    normalized = String(value);
+  } else {
+    return null;
+  }
+  return normalized || null;
+};
+
+const readCodexAccountIdCandidate = (
+  value: unknown
+): { value: string | null; present: boolean; valid: boolean } => {
+  if (value === undefined || value === null) {
+    return { value: null, present: false, valid: true };
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return { value: null, present: false, valid: true };
+  }
+  const normalized = normalizeCodexWorkspaceId(value);
+  return normalized
+    ? { value: normalized, present: true, valid: true }
+    : { value: null, present: true, valid: false };
+};
+
+const resolveCodexChatgptAccountIdEvidenceFromValue = (
+  value: unknown
+): CodexChatgptAccountIdEvidence => {
+  const candidates = new Set<string>();
+  let invalid = false;
+  const visited = new Set<object>();
+
+  const visit = (input: unknown) => {
+    const record = readRecord(input);
+    if (!record) {
+      const payload = parseIdTokenPayload(input);
+      if (payload) visit(payload);
+      return;
+    }
+    if (visited.has(record)) return;
+    visited.add(record);
+
+    CODEX_ACCOUNT_ID_FIELDS.forEach((field) => {
+      if (!(field in record)) return;
+      const candidate = readCodexAccountIdCandidate(record[field]);
+      if (!candidate.present) return;
+      if (!candidate.valid || !candidate.value) {
+        invalid = true;
+        return;
+      }
+      candidates.add(candidate.value);
+    });
+
+    CODEX_NESTED_EVIDENCE_FIELDS.forEach((field) => {
+      const nested = record[field];
+      if (nested === undefined || nested === null) return;
+      visit(nested);
+    });
+  };
+
+  visit(value);
+  if (invalid || candidates.size > 1) return { accountId: null, invalid: true };
+  return { accountId: candidates.values().next().value ?? null, invalid: false };
 };
 
 export function extractCodexChatgptAccountId(value: unknown): string | null {
-  const direct = resolveAccountIdCandidate(value);
-  if (direct) return direct;
+  return resolveCodexChatgptAccountIdEvidenceFromValue(value).accountId;
+}
 
-  const payload = parseIdTokenPayload(value);
-  if (!payload) return null;
-  return normalizeStringValue(
-    payload.chatgpt_account_id ??
-      payload.chatgptAccountId ??
-      payload.account_id ??
-      payload.accountId
-  );
+export function resolveCodexChatgptAccountIdEvidence(
+  file: AuthFileItem
+): CodexChatgptAccountIdEvidence {
+  return resolveCodexChatgptAccountIdEvidenceFromValue(file);
 }
 
 export function resolveCodexChatgptAccountId(file: AuthFileItem): string | null {
-  const metadata =
-    file && typeof file.metadata === 'object' && file.metadata !== null
-      ? (file.metadata as Record<string, unknown>)
-      : null;
-  const attributes =
-    file && typeof file.attributes === 'object' && file.attributes !== null
-      ? (file.attributes as Record<string, unknown>)
-      : null;
+  return resolveCodexChatgptAccountIdEvidenceFromValue(file).accountId;
+}
 
-  const directCandidates = [
-    file.chatgpt_account_id,
-    file.chatgptAccountId,
-    file.account_id,
-    file.accountId,
-    metadata?.chatgpt_account_id,
-    metadata?.chatgptAccountId,
-    metadata?.account_id,
-    metadata?.accountId,
-    attributes?.chatgpt_account_id,
-    attributes?.chatgptAccountId,
-    attributes?.account_id,
-    attributes?.accountId,
-  ];
-
-  for (const candidate of directCandidates) {
-    const id = normalizeStringValue(candidate) ?? resolveAccountIdCandidate(candidate);
-    if (id) return id;
-  }
-
-  const tokenCandidates = [file.id_token, metadata?.id_token, attributes?.id_token];
-
-  for (const candidate of tokenCandidates) {
-    const id = extractCodexChatgptAccountId(candidate);
-    if (id) return id;
-  }
-
-  return null;
+export function isCodexChatgptAccountIdInvalid(file: AuthFileItem): boolean {
+  return resolveCodexChatgptAccountIdEvidenceFromValue(file).invalid;
 }
 
 export function resolveCodexPlanType(file: AuthFileItem): string | null {


### PR DESCRIPTION
## Summary

Separate Codex credential and usage identity by Workspace plus strong member evidence. Preserve history continuity for same-member reauth while preventing shared Workspace members from inheriting each other&#39;s usage or mutation targets.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Derive Codex stable identity from Workspace plus a normalized strong member email; fall back to credential identity when member evidence is missing, weak, or conflicting.
- Keep Go and SQL identity generation aligned, add the Codex-specific identity revision, accept legacy v3 revisions, and schedule existing derived rebuilds without changing immutable raw events.
- Apply the same fail-closed Workspace/member checks to legacy history and account-window reads, monitoring, pricing, quota snapshots, auth-file actions, inspection ownership, and automatic recovery.
- Reconcile Web OAuth evidence by Workspace plus member identity, including the confirmed, ambiguous, identity-changed, and unconfirmed outcomes.

## User Impact

Team and Business members in the same Workspace now have isolated usage, cost, quota, and credential actions. Reauthenticating the same member preserves history continuity. Credentials without strong member evidence are kept separate or unconfirmed instead of being merged.

## Compatibility / Runtime Notes

- CPA panel mode: No CPA changes or new CPA fields are required.
- Manager Server mode: Existing runtime and credential APIs remain compatible; derived rebuild work uses the existing background mechanisms.
- Full Docker / native packages: No packaging or native artifact changes are included.

## Data / Security Notes

No tables or columns were added. `usage_events` remains immutable; its raw JSON, hashes, timestamps, and token fields are not rewritten. Legacy Workspace-only Codex quota snapshots are not fanned out to members and remain unavailable to new member-level queries. Ambiguous credential ownership fails closed.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert this PR/merge commit as a unit. Immutable usage events remain available, and the existing derived-data maintenance/rebuild path can restore projections for the selected identity revision.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run manager-server:test
cd apps/manager-server &amp;&amp; go test -race ./...
npm test
npm run type-check
npm run lint
npm run build
git diff --check
```

All listed checks passed. Lint reported 0 errors and one pre-existing warning in `AccountHealthBadge.tsx:73`. Manual UI screenshots were not required because there is no layout change; reauth and identity behavior are covered by automated tests.

## Screenshots / Recordings

N/A — no visual layout change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is an internal correctness and safety fix with no new user-facing capability requiring documentation.

## Related

Fixes #671 #678 