### PR TITLE
feat(accounts): show Antigravity model-family quota matrix in the list

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -1101,7 +1101,7 @@
 
 .quotaMatrixCells {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
   align-items: center;
   gap: 8px;
   min-width: 0;
@@ -1127,6 +1127,7 @@
 }
 
 .quotaMatrixTrack {
+  display: block;
   height: 4px;
   min-width: 0;
 }
@@ -5457,6 +5458,7 @@
   }
 
   .quotaMatrixCells {
+    grid-template-columns: repeat(auto-fit, minmax(106px, 1fr));
     gap: 6px;
   }
 

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -7047,7 +7047,7 @@ describe('AccountsPage replacement flows', () => {
     expect(readText(otherGroup)).toContain('Grok Code Fast');
   });
 
-  it('keeps Antigravity Pro model groups out of the list and in quota details', async () => {
+  it('renders Antigravity Pro model groups in the quota matrix and keeps them in quota details', async () => {
     mocks.files = [
       {
         name: 'antigravity-pro-matrix.json',
@@ -7112,13 +7112,17 @@ describe('AccountsPage replacement flows', () => {
     });
 
     const renderer = await renderAccountsPage();
-    const matrices = renderer.root.findAll(
-      (node) => typeof node.props['data-account-quota-matrix'] === 'string'
+    const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
+    card.findByProps({
+      'data-account-quota-matrix': getAuthFileSelectionKey(mocks.files[0]),
+    });
+    expect(card.findAllByProps({ 'data-account-quota-matrix-row': 'five_hour' })).toHaveLength(1);
+    expect(card.findAllByProps({ 'data-account-quota-matrix-row': 'weekly' })).toHaveLength(1);
+    const cells = card.findAll(
+      (node) => typeof node.props['data-account-quota-matrix-cell'] === 'string'
     );
-    expect(matrices).toHaveLength(0);
-    expect(
-      readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
-    ).toContain('accounts.quota_details_only');
+    expect(cells).toHaveLength(4);
+    expect(readText(card)).not.toContain('accounts.quota_details_only');
 
     await act(async () => {
       findAccountDetailRegion(
@@ -7135,7 +7139,7 @@ describe('AccountsPage replacement flows', () => {
     expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
   });
 
-  it('keeps Antigravity Free model groups out of the list and in quota details', async () => {
+  it('renders Antigravity Free model groups in the quota matrix when two groups exist and keeps them in quota details', async () => {
     mocks.files = [
       {
         name: 'antigravity-free-weekly.json',
@@ -7186,13 +7190,17 @@ describe('AccountsPage replacement flows', () => {
     });
 
     const renderer = await renderAccountsPage();
-    const matrices = renderer.root.findAll(
-      (node) => typeof node.props['data-account-quota-matrix'] === 'string'
+    const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
+    card.findByProps({
+      'data-account-quota-matrix': getAuthFileSelectionKey(mocks.files[0]),
+    });
+    expect(card.findAllByProps({ 'data-account-quota-matrix-row': 'five_hour' })).toHaveLength(0);
+    expect(card.findAllByProps({ 'data-account-quota-matrix-row': 'weekly' })).toHaveLength(1);
+    const cells = card.findAll(
+      (node) => typeof node.props['data-account-quota-matrix-cell'] === 'string'
     );
-    expect(matrices).toHaveLength(0);
-    expect(
-      readText(findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0])))
-    ).toContain('accounts.quota_details_only');
+    expect(cells).toHaveLength(2);
+    expect(readText(card)).not.toContain('accounts.quota_details_only');
 
     await act(async () => {
       findAccountDetailRegion(
@@ -7207,6 +7215,148 @@ describe('AccountsPage replacement flows', () => {
     expect(readText(modelQuotaGroup)).toContain('antigravity_quota.group_claude_gpt_models');
     expect(readText(modelQuotaGroup)).toContain('antigravity_quota.group_gemini_models');
     expect(renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' })).toHaveLength(0);
+  });
+
+  it('keeps Antigravity with a single model group in quota details only', async () => {
+    mocks.files = [
+      {
+        name: 'antigravity-single-group.json',
+        type: 'antigravity',
+        provider: 'antigravity',
+        authIndex: 'antigravity-single-group-01',
+        account: 'AG Single Group',
+        label: 'Antigravity Single Group',
+        priority: 0,
+        disabled: false,
+      } as AuthFileItem,
+    ];
+    mocks.quotaState.antigravityQuota = buildCredentialScopedQuotaRecord(mocks.files[0], {
+      status: 'success',
+      subscription: { plan: 'free', tierName: 'Free', tierId: 'g1-free' },
+      groups: [
+        {
+          id: 'gemini-models',
+          label: 'Gemini Models',
+          description: 'Models within this group: Gemini Flash, Gemini Pro',
+          models: ['gemini-2.5-flash', 'gemini-2.5-pro'],
+          buckets: [
+            {
+              id: 'gemini-weekly',
+              label: 'Weekly Limit',
+              window: 'weekly',
+              remainingFraction: 0.76,
+              resetTime: '2026-07-15T12:00:00Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    const renderer = await renderAccountsPage();
+    const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
+    const matrices = card.findAll(
+      (node) => typeof node.props['data-account-quota-matrix'] === 'string'
+    );
+    expect(matrices).toHaveLength(0);
+    expect(readText(card)).toContain('accounts.quota_details_only');
+
+    await act(async () => {
+      findAccountDetailRegion(
+        renderer,
+        getAuthFileSelectionKey(mocks.files[0]),
+        'quota'
+      ).props.onClick();
+    });
+
+    const modelQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
+    expect(modelQuotaGroup.findAllByType(QuotaWindowCard)).toHaveLength(1);
+  });
+
+  it('renders Antigravity quota matrix in selection mode and uses card selection instead of opening details', async () => {
+    mocks.files = [
+      {
+        name: 'antigravity-pro-matrix.json',
+        type: 'antigravity',
+        provider: 'antigravity',
+        authIndex: 'antigravity-pro-matrix-04',
+        account: 'AG Pro Matrix',
+        label: 'Antigravity Pro Matrix',
+        priority: 0,
+        disabled: false,
+      } as AuthFileItem,
+    ];
+    mocks.quotaState.antigravityQuota = buildCredentialScopedQuotaRecord(mocks.files[0], {
+      status: 'success',
+      subscription: { plan: 'pro', tierName: 'Pro', tierId: 'g1-pro' },
+      groups: [
+        {
+          id: 'gemini-models',
+          label: 'Gemini Models',
+          description: 'Models within this group: Gemini Flash, Gemini Pro',
+          models: ['gemini-2.5-flash', 'gemini-2.5-pro'],
+          buckets: [
+            {
+              id: 'gemini-5h',
+              label: 'Five Hour Limit',
+              window: '5h',
+              remainingFraction: 0.96,
+              resetTime: '2026-07-09T12:00:00Z',
+            },
+            {
+              id: 'gemini-weekly',
+              label: 'Weekly Limit',
+              window: 'weekly',
+              remainingFraction: 0.04,
+              resetTime: '2026-07-15T12:00:00Z',
+            },
+          ],
+        },
+        {
+          id: 'claude-gpt-models',
+          label: 'Claude and GPT models',
+          description: 'Models within this group: Claude Sonnet, GPT-OSS',
+          models: ['claude-sonnet-4-5', 'gpt-oss-120b-medium'],
+          buckets: [
+            {
+              id: '3p-5h',
+              label: 'Five Hour Limit',
+              window: '5h',
+              remainingFraction: 0.11,
+              resetTime: '2026-07-09T11:00:00Z',
+            },
+            {
+              id: '3p-weekly',
+              label: 'Weekly Limit',
+              window: 'weekly',
+              remainingFraction: 0.19,
+              resetTime: '2026-07-13T12:00:00Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    const selectionKey = getAuthFileSelectionKey(mocks.files[0]);
+    const renderer = await renderAccountsPage();
+
+    await act(async () => {
+      findHostButtonByText(renderer, 'accounts.selection_mode_enter').props.onClick();
+    });
+
+    const card = findAccountCardByKey(renderer, selectionKey);
+    const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
+    expect(quotaRegion.type).toBe('div');
+    expect(quotaRegion.props['data-account-detail-trigger']).toBeUndefined();
+    expect(quotaRegion.props.onClick).toBeUndefined();
+    expect(card.findByProps({ 'data-account-quota-matrix': selectionKey })).toBeTruthy();
+
+    await act(async () => {
+      card.props.onClick();
+    });
+
+    expect(mocks.toggleSelect).toHaveBeenCalledWith(selectionKey);
+    expect(renderer.root.findAllByType(AccountQuotaTab)).toHaveLength(0);
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it('keeps the accounts view in card mode without table controls', async () => {
@@ -12889,10 +13039,7 @@ describe('AccountsPage replacement flows', () => {
     const secondMarker = recordAccountCredentialMutationMarker({
       connectionFingerprint: 'http://cpa-a.local:8317:manager-key',
       provider: 'codex',
-      baseline: createAccountCredentialMutationBaseline(
-        [existingFile, firstOauthFile],
-        'codex'
-      ),
+      baseline: createAccountCredentialMutationBaseline([existingFile, firstOauthFile], 'codex'),
       requireObservedMutation: true,
       createdAtMs: secondMarkerAtMs,
     });
@@ -12962,10 +13109,7 @@ describe('AccountsPage replacement flows', () => {
     const secondMarker = recordAccountCredentialMutationMarker({
       connectionFingerprint: 'http://cpa-a.local:8317:manager-key',
       provider: 'codex',
-      baseline: createAccountCredentialMutationBaseline(
-        [existingFile, firstOauthFile],
-        'codex'
-      ),
+      baseline: createAccountCredentialMutationBaseline([existingFile, firstOauthFile], 'codex'),
       requireObservedMutation: true,
       createdAtMs: secondMarkerAtMs,
     });

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -166,6 +166,8 @@ import {
 import {
   buildAccountQuotaDisplayWindows,
   getQuotaWindowShortLabel,
+  isIntervalAccountQuotaWindow,
+  isModelScopedAccountQuotaWindow,
   isStandardAccountQuotaListWindow,
   type AccountQuotaDisplayWindow,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
@@ -189,6 +191,7 @@ import {
   DETAIL_EVENTS_LIMIT,
   DETAIL_EVENTS_RANGE_MS,
   PAGE_SIZE_OPTIONS,
+  buildAntigravityQuotaMatrix,
   formatHistoryNumber,
   formatHistorySuccessRate,
   formatPercent,
@@ -266,6 +269,7 @@ import {
   AccountModelsTab,
   AccountOverviewTab,
   AccountProviderTabs,
+  AccountQuotaMatrix,
   AccountQuotaTab,
   AccountsBatchDeletePreview,
 } from '@/features/accounts/components';
@@ -6897,6 +6901,14 @@ export function AccountsPage() {
             const quotaWindows =
               quotaDisplayWindowsByRowKey.get(row.selectionKey) ?? buildQuotaDisplayWindows(row);
             const standardQuotaWindows = quotaWindows.filter(isStandardAccountQuotaListWindow);
+            const modelQuotaWindows = quotaWindows.filter(
+              (window) =>
+                isIntervalAccountQuotaWindow(window) && isModelScopedAccountQuotaWindow(window)
+            );
+            const antigravityQuotaMatrix =
+              standardQuotaWindows.length === 0
+                ? buildAntigravityQuotaMatrix(row, modelQuotaWindows)
+                : null;
             const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
             const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
             const item = buildAccountListItem(row, {
@@ -6911,7 +6923,18 @@ export function AccountsPage() {
               quotaWindows.length > 0
                 ? t('accounts.quota_details_only')
                 : t('accounts.quota_source_none');
+            const antigravityQuotaMatrixTitle = antigravityQuotaMatrix
+              ? antigravityQuotaMatrix.rows
+                  .flatMap((matrixRow) =>
+                    matrixRow.cells.map(
+                      (cell) =>
+                        `${cell.displayLabel} ${matrixRow.label} ${formatPercent(cell.window.remainingPercent)}`
+                    )
+                  )
+                  .join(' · ')
+              : '';
             const quotaWindowTitle =
+              antigravityQuotaMatrixTitle ||
               standardQuotaWindows
                 .map((window) => {
                   const label = window.groupLabel
@@ -6919,7 +6942,8 @@ export function AccountsPage() {
                     : window.label;
                   return `${label}: ${formatPercent(window.remainingPercent)}`;
                 })
-                .join('\n') || quotaEmptyLabel;
+                .join('\n') ||
+              quotaEmptyLabel;
             const healthTitle = t(
               item.health.tooltipKey,
               formatQuotaResetTooltipParams(
@@ -7205,6 +7229,11 @@ export function AccountsPage() {
                             </span>
                           );
                         })
+                      ) : antigravityQuotaMatrix ? (
+                        <AccountQuotaMatrix
+                          accountKey={row.selectionKey}
+                          matrix={antigravityQuotaMatrix}
+                        />
                       ) : (
                         <span className={styles.quotaEmptyState} data-account-quota-empty="true">
                           {quotaEmptyLabel}

--- a/apps/web/src/features/accounts/components/AccountQuotaMatrix.test.tsx
+++ b/apps/web/src/features/accounts/components/AccountQuotaMatrix.test.tsx
@@ -1,0 +1,215 @@
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+import type { AccountQuotaDisplayWindow } from '@/features/accounts/model/accountQuotaDisplayWindows';
+import type { AntigravityQuotaMatrix } from '@/features/accounts/model/accountsPagePresentation';
+import { AccountQuotaMatrix } from './AccountQuotaMatrix';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'en-US' },
+    }),
+  };
+});
+
+const makeQuotaWindow = (
+  overrides: Partial<AccountQuotaDisplayWindow> = {}
+): AccountQuotaDisplayWindow =>
+  ({
+    key: 'test-window',
+    label: '5 Hour Limit',
+    kind: 'five_hour',
+    remainingPercent: 50,
+    usedPercent: 50,
+    resetLabel: 'in 2 hours',
+    resetAccuracy: 'exact',
+    limitWindowSeconds: 18000,
+    resetAtMs: Date.now() + 7200000,
+    fromMs: Date.now() - 10800000,
+    toMs: Date.now() + 7200000,
+    source: 'antigravity',
+    observationSource: 'response_header',
+    observedAtMs: Date.now(),
+    windowMode: 'fixed',
+    groupLabel: 'Gemini Models',
+    ...overrides,
+  }) as AccountQuotaDisplayWindow;
+
+const renderMatrix = (accountKey: string, matrix: AntigravityQuotaMatrix): ReactTestRenderer => {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(<AccountQuotaMatrix accountKey={accountKey} matrix={matrix} />);
+  });
+  return renderer;
+};
+
+describe('AccountQuotaMatrix', () => {
+  it('renders with span-based phrasing content without any div elements', () => {
+    const matrix: AntigravityQuotaMatrix = {
+      windowKeys: new Set(['gemini-5h', 'claude-5h']),
+      rows: [
+        {
+          key: 'five_hour',
+          label: '5H',
+          cells: [
+            {
+              groupLabel: 'Gemini Models',
+              displayLabel: 'Gemini',
+              window: makeQuotaWindow({ key: 'gemini-5h', remainingPercent: 80 }),
+            },
+            {
+              groupLabel: 'Claude and GPT models',
+              displayLabel: 'Claude',
+              window: makeQuotaWindow({ key: 'claude-5h', remainingPercent: 15 }),
+            },
+          ],
+        },
+      ],
+    };
+
+    const renderer = renderMatrix('test-account', matrix);
+
+    const divs = renderer.root.findAll((node) => node.type === 'div');
+    expect(divs).toHaveLength(0);
+
+    const matrixRoot = renderer.root.findByProps({ 'data-account-quota-matrix': 'test-account' });
+    expect(matrixRoot.type).toBe('span');
+  });
+
+  it('renders row and cell data hooks matching the matrix layout', () => {
+    const matrix: AntigravityQuotaMatrix = {
+      windowKeys: new Set(['gemini-5h', 'claude-5h', 'gemini-weekly', 'claude-weekly']),
+      rows: [
+        {
+          key: 'five_hour',
+          label: '5H',
+          cells: [
+            {
+              groupLabel: 'Gemini Models',
+              displayLabel: 'Gemini',
+              window: makeQuotaWindow({ key: 'gemini-5h', remainingPercent: 90 }),
+            },
+            {
+              groupLabel: 'Claude and GPT models',
+              displayLabel: 'Claude',
+              window: makeQuotaWindow({ key: 'claude-5h', remainingPercent: 40 }),
+            },
+          ],
+        },
+        {
+          key: 'weekly',
+          label: '7D',
+          cells: [
+            {
+              groupLabel: 'Gemini Models',
+              displayLabel: 'Gemini',
+              window: makeQuotaWindow({ key: 'gemini-weekly', remainingPercent: 30 }),
+            },
+            {
+              groupLabel: 'Claude and GPT models',
+              displayLabel: 'Claude',
+              window: makeQuotaWindow({ key: 'claude-weekly', remainingPercent: 60 }),
+            },
+          ],
+        },
+      ],
+    };
+
+    const renderer = renderMatrix('account-key-1', matrix);
+
+    expect(
+      renderer.root.findAllByProps({ 'data-account-quota-matrix': 'account-key-1' })
+    ).toHaveLength(1);
+    expect(
+      renderer.root.findAllByProps({ 'data-account-quota-matrix-row': 'five_hour' })
+    ).toHaveLength(1);
+    expect(
+      renderer.root.findAllByProps({ 'data-account-quota-matrix-row': 'weekly' })
+    ).toHaveLength(1);
+
+    expect(
+      renderer.root.findByProps({
+        'data-account-quota-matrix-cell': 'five_hour:Gemini Models',
+      })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({
+        'data-account-quota-matrix-cell': 'five_hour:Claude and GPT models',
+      })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({
+        'data-account-quota-matrix-cell': 'weekly:Gemini Models',
+      })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({
+        'data-account-quota-matrix-cell': 'weekly:Claude and GPT models',
+      })
+    ).toBeTruthy();
+  });
+
+  it('assigns color tier classes to quota bars based on remaining percent thresholds', () => {
+    const matrix: AntigravityQuotaMatrix = {
+      windowKeys: new Set(['w-neutral', 'w-bad', 'w-warn', 'w-good']),
+      rows: [
+        {
+          key: 'five_hour',
+          label: '5H',
+          cells: [
+            {
+              groupLabel: 'Group Neutral',
+              displayLabel: 'Neutral',
+              window: makeQuotaWindow({ key: 'w-neutral', remainingPercent: null }),
+            },
+            {
+              groupLabel: 'Group Bad',
+              displayLabel: 'Bad',
+              window: makeQuotaWindow({ key: 'w-bad', remainingPercent: 0 }),
+            },
+          ],
+        },
+        {
+          key: 'weekly',
+          label: '7D',
+          cells: [
+            {
+              groupLabel: 'Group Warn',
+              displayLabel: 'Warn',
+              window: makeQuotaWindow({ key: 'w-warn', remainingPercent: 19 }),
+            },
+            {
+              groupLabel: 'Group Good',
+              displayLabel: 'Good',
+              window: makeQuotaWindow({ key: 'w-good', remainingPercent: 20 }),
+            },
+          ],
+        },
+      ],
+    };
+
+    const renderer = renderMatrix('color-test', matrix);
+
+    const findBarForCell = (cellHook: string) => {
+      const cell = renderer.root.findByProps({ 'data-account-quota-matrix-cell': cellHook });
+      const bar = cell.findAll(
+        (node) =>
+          typeof node.props.className === 'string' &&
+          node.props.className.includes('quotaBar') &&
+          !node.props.className.includes('quotaTrack')
+      )[0];
+      if (!bar) throw new Error(`Bar not found for ${cellHook}`);
+      return bar.props.className as string;
+    };
+
+    expect(findBarForCell('five_hour:Group Neutral')).toContain('quotaBarNeutral');
+    expect(findBarForCell('five_hour:Group Bad')).toContain('quotaBarBad');
+    expect(findBarForCell('weekly:Group Warn')).toContain('quotaBarWarn');
+    expect(findBarForCell('weekly:Group Good')).toContain('quotaBarGood');
+  });
+});

--- a/apps/web/src/features/accounts/components/AccountQuotaMatrix.tsx
+++ b/apps/web/src/features/accounts/components/AccountQuotaMatrix.tsx
@@ -21,15 +21,15 @@ const getRemainingPercentBarClass = (remainingPercent: number | null) => {
 export function AccountQuotaMatrix({ accountKey, matrix }: AccountQuotaMatrixProps) {
   const { t, i18n } = useTranslation();
   return (
-    <div className={styles.quotaMatrix} data-account-quota-matrix={accountKey}>
+    <span className={styles.quotaMatrix} data-account-quota-matrix={accountKey}>
       {matrix.rows.map((matrixRow) => (
-        <div
+        <span
           key={matrixRow.key}
           className={styles.quotaMatrixRow}
           data-account-quota-matrix-row={matrixRow.key}
         >
           <span className={styles.quotaMatrixWindowLabel}>{matrixRow.label}</span>
-          <div className={styles.quotaMatrixCells}>
+          <span className={styles.quotaMatrixCells}>
             {matrixRow.cells.map((cell) => {
               const windowRemaining = cell.window.remainingPercent;
               const windowWidth = Math.max(0, Math.min(100, windowRemaining ?? 0));
@@ -45,7 +45,7 @@ export function AccountQuotaMatrix({ accountKey, matrix }: AccountQuotaMatrixPro
                 .filter(Boolean)
                 .join(' · ');
               return (
-                <div
+                <span
                   key={cell.window.key}
                   className={styles.quotaMatrixCell}
                   data-account-quota-matrix-cell={`${matrixRow.key}:${cell.groupLabel}`}
@@ -54,7 +54,7 @@ export function AccountQuotaMatrix({ accountKey, matrix }: AccountQuotaMatrixPro
                   <span className={styles.quotaMatrixGroupLabel} title={cell.groupLabel}>
                     {cell.displayLabel}
                   </span>
-                  <div
+                  <span
                     className={`${styles.quotaTrack} ${styles.quotaMatrixTrack}`}
                     aria-hidden="true"
                   >
@@ -64,16 +64,16 @@ export function AccountQuotaMatrix({ accountKey, matrix }: AccountQuotaMatrixPro
                       )}`}
                       style={{ width: `${windowWidth}%` }}
                     />
-                  </div>
+                  </span>
                   <strong className={styles.quotaMatrixPercent}>
                     {windowRemaining !== null ? formatPercent(windowRemaining) : '-'}
                   </strong>
-                </div>
+                </span>
               );
             })}
-          </div>
-        </div>
+          </span>
+        </span>
       ))}
-    </div>
+    </span>
   );
 }

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
@@ -373,6 +373,9 @@ describe('accountQuotaDisplayWindows', () => {
       limitWindowSeconds: 7 * 24 * 60 * 60,
       modelScope: { kind: 'family', key: 'claude_gpt', complete: true },
     });
+    expect(windows.map(isIntervalAccountQuotaWindow)).toEqual([true, true, true]);
+    expect(windows.map(isModelScopedAccountQuotaWindow)).toEqual([true, true, true]);
+    expect(windows.map(isStandardAccountQuotaListWindow)).toEqual([false, false, false]);
   });
 
   it('adds Kimi usage amounts and formatted reset hints', () => {


### PR DESCRIPTION
## Summary

Restore inline 5H/7D quota matrix display on credential list cards for Antigravity accounts whose model windows can construct a two-group matrix, replacing the "details only" placeholder introduced in PR #667. Refactor matrix DOM nodes from div to span elements to preserve HTML validity inside phrasing button triggers while keeping other provider quotas unchanged.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Connect `buildAntigravityQuotaMatrix` in `AccountsPage.tsx` using interval model-scoped quota windows when `standardQuotaWindows` is empty.
- Inline render `AccountQuotaMatrix` inside the account card quota trigger region when a matrix is available.
- Refactor `AccountQuotaMatrix` internal elements from `div` to `span` for valid phrasing content inside interactive `<button>` elements, and add `display: block` to `.quotaMatrixTrack` in SCSS.
- Harden matrix grid responsiveness by switching `.quotaMatrixCells` to `repeat(auto-fit, minmax(...))`; cells stack vertically via auto-fit when the quota column is narrower than two cells.
- Update quota tooltip and `aria-label` to describe the matrix contents (e.g. model group name, duration window, and remaining percentages) rather than the details-only placeholder label.
- Add unit tests in `AccountQuotaMatrix.test.tsx` verifying phrasing content (no `div`), row/cell data hooks, and remaining percentage color tier classifications.
- Update `AccountsPage.test.tsx` assertions for Antigravity Pro and Free accounts to assert the presence of inline matrix rows and cells while maintaining regression guards for other providers.
- Formatting changes in two `createAccountCredentialMutationBaseline` calls at the end of `AccountsPage.test.tsx` originated from Prettier compliance against dev baseline code style during `prettier --check` and contain no functional or assertion logic changes.

## User Impact

Users viewing Antigravity credentials in the credential list immediately see their model family 5-hour and 7-day quota progress bars at a glance without having to open the account detail drawer. Clicking the quota matrix continues to open the quota detail tab as expected.

## Compatibility / Runtime Notes

- CPA panel mode: Fully compatible with SPA standalone mode; no backend changes.
- Manager Server mode: N/A (frontend presentation logic only).
- Full Docker / native packages: Bundled within web static assets; no container configuration changes required.

## Data / Security Notes

N/A

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this pull request.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
1. npm run type-check -> exit code 0
2. npm run lint -> exit code 0 (1 baseline warning: AccountHealthBadge.tsx:73 react-refresh/only-export-components)
3. npm run test -> exit code 0 (215 test files passed, 2832 tests passed; phrasing structure validated via AccountQuotaMatrix.test.tsx assert 0 div nodes)
4. npm --workspace apps/web run test -- src/features/accounts -> exit code 0 (41 test files passed, 776 tests passed)
5. npm run build -> exit code 0 (vite build succeeded)
6. npx prettier --check apps/web/src/features/accounts/... -> exit code 0
7. git diff --check origin/dev...HEAD -> clean (exit code 0)
8. git status --porcelain -> clean (exit code 0)
9. git log --oneline origin/dev..HEAD -> exactly 1 commit
10. git diff --name-only origin/dev..HEAD -> only apps/web/ paths modified
11. viewport checks at 1920px and 1280px (demo mode) -> side-by-side cells at 1920px, stacked cells at 1280px, zero text clipping
```

## Screenshots / Recordings

![Antigravity credential card with inline quota matrix (1920px)](https://img.riba2534.cn/images/2026/09/antigravity-builder-card-1920-crop.png)
*(Captured from demo mode credential list at 1920px viewport with sample Antigravity builder credentials)*

![Antigravity credential card with stacked quota cells (1280px)](https://img.riba2534.cn/images/2026/09/antigravity-builder-card-1280-crop.png)
*(Captured at 1280px viewport where narrow quota column falls back to stacked cells)*

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:
Not needed — inline UI restoration of Antigravity model quota matrix aligned with existing quota presentation conventions; documentation already covers quota tracking and detail drawer capabilities.

## Related

Closes #679
