### PR TITLE
fix(manager-server): sanitize usage credentials before persistence

### DIFF
--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -130,7 +130,7 @@ func (r *repository) InsertBatch(ctx context.Context, events []model.UsageEvent)
 
 	result := model.InsertResult{}
 	for _, event := range events {
-		event = usage.SanitizeForPersistence(event)
+		event.EventHash = usage.EventHashForPersistence(event.EventHash)
 		ledgerNowMS := event.CreatedAtMS
 		if ledgerNowMS <= 0 {
 			ledgerNowMS = time.Now().UnixMilli()
@@ -153,6 +153,7 @@ func (r *repository) InsertBatch(ctx context.Context, events []model.UsageEvent)
 			continue
 		}
 
+		event = usage.SanitizeForPersistence(event)
 		usage.NormalizeRequestMetadata(&event)
 		accounting := usage.NormalizeCacheAccounting(usage.CacheInputContext{
 			ExplicitMode:     event.CacheInputMode,
@@ -190,7 +191,7 @@ func (r *repository) InsertBatch(ctx context.Context, events []model.UsageEvent)
 			failSummarySource = event.FailBody
 		}
 		failSummary := usage.FailSummaryFromBody(failSummarySource)
-		rawJSON := usage.SafeRawJSON(event.RawJSON)
+		rawJSON := event.RawJSON
 		res, err := stmt.ExecContext(
 			ctx,
 			nullString(event.RequestID),

--- a/apps/manager-server/internal/repository/usageevent/repository.go
+++ b/apps/manager-server/internal/repository/usageevent/repository.go
@@ -130,6 +130,7 @@ func (r *repository) InsertBatch(ctx context.Context, events []model.UsageEvent)
 
 	result := model.InsertResult{}
 	for _, event := range events {
+		event = usage.SanitizeForPersistence(event)
 		ledgerNowMS := event.CreatedAtMS
 		if ledgerNowMS <= 0 {
 			ledgerNowMS = time.Now().UnixMilli()

--- a/apps/manager-server/internal/repository/usageevent/request_metadata_test.go
+++ b/apps/manager-server/internal/repository/usageevent/request_metadata_test.go
@@ -129,3 +129,45 @@ func TestInsertBatchNormalizesRequestMetadataAtPersistenceBoundary(t *testing.T)
 		}
 	}
 }
+
+func TestInsertBatchSanitizesCredentialsAtPersistenceBoundary(t *testing.T) {
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := New(db)
+
+	const secretMarker = "synthetic0123456789"
+	const syntheticToken = "sk-proj-" + secretMarker
+	event := streamTestEvent("credential-sanitization", 102, "POST /v1/responses", "gpt-5.4")
+	event.Source = "paid provider " + syntheticToken
+	event.RawJSON = `{"source":"paid provider ` + syntheticToken + `"}`
+	event.FailSummary = "Authorization: Bearer " + syntheticToken
+	event.FailBody = `{"access_token":"` + syntheticToken + `"}`
+	if _, err := repo.InsertBatch(context.Background(), []usage.Event{event}); err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+
+	var source, rawJSON, failSummary, failBody string
+	if err := db.QueryRow(`select
+		coalesce(source, ''), coalesce(raw_json, ''), coalesce(fail_summary, ''), coalesce(fail_body, '')
+		from usage_events where event_hash = ?`, event.EventHash).Scan(
+		&source,
+		&rawJSON,
+		&failSummary,
+		&failBody,
+	); err != nil {
+		t.Fatalf("query persisted credential-bearing fields: %v", err)
+	}
+	for field, value := range map[string]string{
+		"source":       source,
+		"raw_json":     rawJSON,
+		"fail_summary": failSummary,
+		"fail_body":    failBody,
+	} {
+		if strings.Contains(value, secretMarker) {
+			t.Errorf("persisted %s contains the synthetic credential marker", field)
+		}
+	}
+}

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -439,7 +439,7 @@ var (
 	endpointPattern          = regexp.MustCompile(`^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\S+)`)
 	authorizationHeaderRegex = regexp.MustCompile(`(?i)\b(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,"'{}]+`)
 	bearerTokenRegex         = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}`)
-	apiKeyTokenRegex         = regexp.MustCompile(`(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{6,}|ghp_[A-Za-z0-9]{6,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{6,}|pk_[A-Za-z0-9]{6,}|rk_[A-Za-z0-9]{6,}|cpamp_[A-Za-z0-9]{32}\b)`)
+	apiKeyTokenRegex         = regexp.MustCompile(`(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{20,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{20,}|pk_[A-Za-z0-9_]{20,}|rk_[A-Za-z0-9_]{20,}|cpamp_[A-Za-z0-9]{32}\b)`)
 	tokenFieldRegex          = regexp.MustCompile(`(?i)\b(access_token|refresh_token|id_token)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
 	apiKeyFieldRegex         = regexp.MustCompile(`(?i)\b(api[-_ ]?key|x-api-key)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
 	managementKeyFieldRegex  = regexp.MustCompile(`(?i)\b(management[-_ ]?key)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
@@ -1168,8 +1168,12 @@ func isSecretKey(key string) bool {
 	normalized := normalizeSecretKey(key)
 	return normalized == "api_key" ||
 		normalized == "apikey" ||
+		normalized == "x_api_key" ||
+		normalized == "xapikey" ||
 		normalized == "management_key" ||
 		normalized == "managementkey" ||
+		normalized == "cpa_management_key" ||
+		normalized == "cpamanagementkey" ||
 		normalized == "authorization" ||
 		normalized == "cookie" ||
 		normalized == "set_cookie" ||

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -1023,7 +1023,7 @@ func SanitizeForPersistence(event Event) Event {
 	// while removing credentials that slipped past producer normalization.
 	event.Source = redactCredentialText(event.Source)
 	event.FailSummary = FailSummaryFromBody(event.FailSummary)
-	event.FailBody = FailSummaryFromBody(event.FailBody)
+	event.FailBody = redactCredentialText(event.FailBody)
 	event.RawJSON = SafeRawJSON(event.RawJSON)
 	return event
 }
@@ -1116,6 +1116,8 @@ func isSecretKey(key string) bool {
 	normalized := normalizeSecretKey(key)
 	return normalized == "api_key" ||
 		normalized == "apikey" ||
+		normalized == "management_key" ||
+		normalized == "managementkey" ||
 		normalized == "authorization" ||
 		normalized == "cookie" ||
 		normalized == "set_cookie" ||

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -1019,13 +1019,59 @@ func redactCredentialText(value string) string {
 // earlier for display and aggregation, but no event should reach storage
 // without passing through this function.
 func SanitizeForPersistence(event Event) Event {
-	// Preserve existing source identity semantics (including account emails)
-	// while removing credentials that slipped past producer normalization.
-	event.Source = redactCredentialText(event.Source)
+	redact := redactCredentialText
+	event.RequestID = redact(event.RequestID)
+	event.EventHash = hashIfCredentialBearing(event.EventHash)
+	event.Timestamp = redact(event.Timestamp)
+	event.Provider = redact(event.Provider)
+	event.ExecutorType = redact(event.ExecutorType)
+	event.Model = redact(event.Model)
+	event.AnalyticsModel = redact(event.AnalyticsModel)
+	event.RequestedModel = redact(event.RequestedModel)
+	event.ResolvedModel = redact(event.ResolvedModel)
+	event.Endpoint = redact(event.Endpoint)
+	event.Method = redact(event.Method)
+	event.Path = redact(event.Path)
+	event.ClientIP = redact(event.ClientIP)
+	event.XForwardedFor = redact(event.XForwardedFor)
+	event.UserAgent = redact(event.UserAgent)
+	event.AuthType = redact(event.AuthType)
+	event.AuthIndex = redact(event.AuthIndex)
+	event.Source = redact(event.Source)
+	event.SourceHash = hashIfCredentialBearing(event.SourceHash)
+	event.APIKeyHash = hashIfCredentialBearing(event.APIKeyHash)
+	event.AccountSnapshot = redact(event.AccountSnapshot)
+	event.AuthLabelSnapshot = redact(event.AuthLabelSnapshot)
+	event.AuthFileSnapshot = redact(event.AuthFileSnapshot)
+	event.AuthProviderSnapshot = redact(event.AuthProviderSnapshot)
+	event.AuthAccountIDSnapshot = redact(event.AuthAccountIDSnapshot)
+	event.AuthProjectIDSnapshot = redact(event.AuthProjectIDSnapshot)
+	event.ReasoningEffort = redact(event.ReasoningEffort)
+	event.ServiceTier = redact(event.ServiceTier)
+	event.RequestServiceTier = redact(event.RequestServiceTier)
+	event.ResponseServiceTier = redact(event.ResponseServiceTier)
+	event.CacheInputMode = redact(event.CacheInputMode)
 	event.FailSummary = FailSummaryFromBody(event.FailSummary)
-	event.FailBody = redactCredentialText(event.FailBody)
+	event.FailBody = redact(event.FailBody)
+	event.ResponseMetadataJSON = SafeRawJSON(event.ResponseMetadataJSON)
+	event.HeaderQuotaPlanType = redact(event.HeaderQuotaPlanType)
+	event.HeaderErrorKind = redact(event.HeaderErrorKind)
+	event.HeaderErrorCode = redact(event.HeaderErrorCode)
+	event.HeaderTraceID = redact(event.HeaderTraceID)
 	event.RawJSON = SafeRawJSON(event.RawJSON)
+	if event.ResponseMetadata != nil {
+		if raw, err := json.Marshal(event.ResponseMetadata); err == nil {
+			event.ResponseMetadata = ResponseHeaderMetadataFromJSON(SafeRawJSON(string(raw)))
+		}
+	}
 	return event
+}
+
+func hashIfCredentialBearing(value string) string {
+	if redactCredentialText(value) == value {
+		return value
+	}
+	return hashString(value)
 }
 
 func SafeRawJSON(raw string) string {

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -439,7 +439,7 @@ var (
 	endpointPattern          = regexp.MustCompile(`^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\S+)`)
 	authorizationHeaderRegex = regexp.MustCompile(`(?i)\b(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,"'{}]+`)
 	bearerTokenRegex         = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}`)
-	apiKeyTokenRegex         = regexp.MustCompile(`(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{6,}|ghp_[A-Za-z0-9]{6,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{6,}|pk_[A-Za-z0-9]{6,}|rk_[A-Za-z0-9]{6,}|cpamp_[A-Za-z0-9-_]{6,})`)
+	apiKeyTokenRegex         = regexp.MustCompile(`(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{6,}|ghp_[A-Za-z0-9]{6,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{6,}|pk_[A-Za-z0-9]{6,}|rk_[A-Za-z0-9]{6,}|cpamp_[A-Za-z0-9]{32}\b)`)
 	tokenFieldRegex          = regexp.MustCompile(`(?i)\b(access_token|refresh_token|id_token)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
 	apiKeyFieldRegex         = regexp.MustCompile(`(?i)\b(api[-_ ]?key|x-api-key)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
 	managementKeyFieldRegex  = regexp.MustCompile(`(?i)\b(management[-_ ]?key)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
@@ -1072,6 +1072,12 @@ func hashIfCredentialBearing(value string) string {
 		return value
 	}
 	return hashString(value)
+}
+
+// EventHashForPersistence protects the identity ledger before the more
+// expensive full event sanitizer runs after its duplicate claim.
+func EventHashForPersistence(value string) string {
+	return hashIfCredentialBearing(value)
 }
 
 func SafeRawJSON(raw string) string {

--- a/apps/manager-server/internal/usage/event.go
+++ b/apps/manager-server/internal/usage/event.go
@@ -439,9 +439,10 @@ var (
 	endpointPattern          = regexp.MustCompile(`^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\S+)`)
 	authorizationHeaderRegex = regexp.MustCompile(`(?i)\b(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,"'{}]+`)
 	bearerTokenRegex         = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}`)
-	apiKeyTokenRegex         = regexp.MustCompile(`(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{6,}|ghp_[A-Za-z0-9]{6,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{6,}|pk_[A-Za-z0-9]{6,}|rk_[A-Za-z0-9]{6,})`)
+	apiKeyTokenRegex         = regexp.MustCompile(`(sk-proj-[A-Za-z0-9-_]{6,}|sk-ant-[A-Za-z0-9-_]{6,}|sk-[A-Za-z0-9-_]{6,}|sess-[A-Za-z0-9-_]{6,}|ghp_[A-Za-z0-9]{6,}|github_pat_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z-_]{8,}|hf_[A-Za-z0-9]{6,}|pk_[A-Za-z0-9]{6,}|rk_[A-Za-z0-9]{6,}|cpamp_[A-Za-z0-9-_]{6,})`)
 	tokenFieldRegex          = regexp.MustCompile(`(?i)\b(access_token|refresh_token|id_token)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
 	apiKeyFieldRegex         = regexp.MustCompile(`(?i)\b(api[-_ ]?key|x-api-key)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
+	managementKeyFieldRegex  = regexp.MustCompile(`(?i)\b(management[-_ ]?key)\b(\s*["']?\s*[:=]\s*["']?)[^"',\s&}]+`)
 	cookieJSONFieldRegex     = regexp.MustCompile(`(?i)("?(?:cookie|set-cookie)"?\s*:\s*")[^"]*(")`)
 	cookieHeaderRegex        = regexp.MustCompile(`(?i)\b(cookie|set-cookie)\s*:\s*[^,\r\n"}]+`)
 	emailRegex               = regexp.MustCompile(`([A-Za-z0-9._%+\-])([A-Za-z0-9._%+\-]*)(@[A-Za-z0-9.\-]+\.[A-Za-z]{2,})`)
@@ -980,7 +981,7 @@ func maskSource(value string) string {
 		}
 		return "m:" + trimmed[:4] + "..." + trimmed[len(trimmed)-4:]
 	}
-	return trimmed
+	return redactCredentialText(trimmed)
 }
 
 func looksSecret(value string) bool {
@@ -995,15 +996,36 @@ func FailSummaryFromBody(body string) string {
 	if summary == "" {
 		return ""
 	}
+	summary = redactCredentialText(summary)
+	summary = emailRegex.ReplaceAllString(summary, `${1}***${3}`)
+	return truncateUTF8Bytes(strings.TrimSpace(summary), maxFailSummaryBytes)
+}
+
+func redactCredentialText(value string) string {
+	summary := value
 	summary = authorizationHeaderRegex.ReplaceAllString(summary, `${1}[redacted]`)
 	summary = bearerTokenRegex.ReplaceAllString(summary, `Bearer [redacted]`)
 	summary = tokenFieldRegex.ReplaceAllString(summary, `${1}${2}[redacted]`)
 	summary = apiKeyFieldRegex.ReplaceAllString(summary, `${1}${2}[redacted]`)
+	summary = managementKeyFieldRegex.ReplaceAllString(summary, `${1}${2}[redacted]`)
 	summary = apiKeyTokenRegex.ReplaceAllString(summary, `[redacted]`)
 	summary = cookieJSONFieldRegex.ReplaceAllString(summary, `${1}[redacted]${2}`)
 	summary = cookieHeaderRegex.ReplaceAllString(summary, `${1}: [redacted]`)
-	summary = emailRegex.ReplaceAllString(summary, `${1}***${3}`)
-	return truncateUTF8Bytes(strings.TrimSpace(summary), maxFailSummaryBytes)
+	return summary
+}
+
+// SanitizeForPersistence applies the final credential-redaction boundary to
+// fields that may contain untrusted upstream payloads. Callers can normalize
+// earlier for display and aggregation, but no event should reach storage
+// without passing through this function.
+func SanitizeForPersistence(event Event) Event {
+	// Preserve existing source identity semantics (including account emails)
+	// while removing credentials that slipped past producer normalization.
+	event.Source = redactCredentialText(event.Source)
+	event.FailSummary = FailSummaryFromBody(event.FailSummary)
+	event.FailBody = FailSummaryFromBody(event.FailBody)
+	event.RawJSON = SafeRawJSON(event.RawJSON)
+	return event
 }
 
 func SafeRawJSON(raw string) string {
@@ -1070,6 +1092,8 @@ func redactValueWithParent(parentKey string, value any) any {
 			result = append(result, redactValueWithParent(parentKey, child))
 		}
 		return result
+	case string:
+		return redactCredentialText(item)
 	default:
 		return value
 	}

--- a/apps/manager-server/internal/usage/event_security_test.go
+++ b/apps/manager-server/internal/usage/event_security_test.go
@@ -46,3 +46,31 @@ func TestSanitizeForPersistencePreservesCredentialFilename(t *testing.T) {
 		t.Fatalf("raw JSON lost non-secret source filename: %q", event.RawJSON)
 	}
 }
+
+func TestSanitizeForPersistenceRedactsStructuredManagementKey(t *testing.T) {
+	const secretMarker = "ordinary-unprefixed-synthetic0123456789"
+	event := SanitizeForPersistence(Event{
+		RawJSON: `{"managementKey":"` + secretMarker + `"}`,
+	})
+	if strings.Contains(event.RawJSON, secretMarker) {
+		t.Fatalf("raw JSON contains structured management key: %q", event.RawJSON)
+	}
+}
+
+func TestSanitizeForPersistenceKeepsCompleteRedactedFailBody(t *testing.T) {
+	const secretMarker = "synthetic0123456789"
+	body := strings.Repeat("diagnostic ", maxFailSummaryBytes) +
+		"access_token=" + secretMarker + " trailing-diagnostic"
+
+	event := SanitizeForPersistence(Event{FailBody: body})
+
+	if strings.Contains(event.FailBody, secretMarker) {
+		t.Fatalf("fail body contains synthetic credential marker")
+	}
+	if !strings.Contains(event.FailBody, "trailing-diagnostic") {
+		t.Fatalf("fail body was truncated: length=%d", len(event.FailBody))
+	}
+	if len(event.FailBody) <= maxFailSummaryBytes {
+		t.Fatalf("fail body length=%d, want complete diagnostic", len(event.FailBody))
+	}
+}

--- a/apps/manager-server/internal/usage/event_security_test.go
+++ b/apps/manager-server/internal/usage/event_security_test.go
@@ -19,7 +19,7 @@ func TestSanitizeForPersistenceRedactsCredentialText(t *testing.T) {
 		{name: "OAuth refresh token", value: "refresh_token=synthetic0123456789"},
 		{name: "OAuth identity token", value: "id_token=synthetic0123456789"},
 		{name: "management key field", value: "management-key=synthetic0123456789"},
-		{name: "CPAMP management key", value: "cpamp_synthetic0123456789"},
+		{name: "CPAMP management key", value: "cpamp_0123456789abcdefghijklmnopqrstuv"},
 		{name: "authorization header", value: "Authorization: Bearer synthetic0123456789"},
 	}
 	for _, test := range tests {
@@ -39,13 +39,14 @@ func TestSanitizeForPersistenceRedactsCredentialText(t *testing.T) {
 }
 
 func TestSanitizeForPersistencePreservesCredentialFilename(t *testing.T) {
-	const filename = "codex-account.json"
-	event := SanitizeForPersistence(Event{Source: filename, RawJSON: `{"source":"` + filename + `"}`})
-	if event.Source != filename {
-		t.Fatalf("source = %q, want %q", event.Source, filename)
-	}
-	if !strings.Contains(event.RawJSON, filename) {
-		t.Fatalf("raw JSON lost non-secret source filename: %q", event.RawJSON)
+	for _, filename := range []string{"codex-account.json", "cpamp_account.json"} {
+		event := SanitizeForPersistence(Event{Source: filename, RawJSON: `{"source":"` + filename + `"}`})
+		if event.Source != filename {
+			t.Fatalf("source = %q, want %q", event.Source, filename)
+		}
+		if !strings.Contains(event.RawJSON, filename) {
+			t.Fatalf("raw JSON lost non-secret source filename: %q", event.RawJSON)
+		}
 	}
 }
 

--- a/apps/manager-server/internal/usage/event_security_test.go
+++ b/apps/manager-server/internal/usage/event_security_test.go
@@ -20,6 +20,11 @@ func TestSanitizeForPersistenceRedactsCredentialText(t *testing.T) {
 		{name: "OAuth identity token", value: "id_token=synthetic0123456789"},
 		{name: "management key field", value: "management-key=synthetic0123456789"},
 		{name: "CPAMP management key", value: "cpamp_0123456789abcdefghijklmnopqrstuv"},
+		{name: "session token", value: "sess-synthetic0123456789abc"},
+		{name: "GitHub token", value: "ghp_synthetic0123456789abc"},
+		{name: "Hugging Face token", value: "hf_synthetic0123456789abc"},
+		{name: "publishable key", value: "pk_synthetic0123456789abc"},
+		{name: "restricted key", value: "rk_synthetic0123456789abc"},
 		{name: "authorization header", value: "Authorization: Bearer synthetic0123456789"},
 	}
 	for _, test := range tests {
@@ -39,7 +44,15 @@ func TestSanitizeForPersistenceRedactsCredentialText(t *testing.T) {
 }
 
 func TestSanitizeForPersistencePreservesCredentialFilename(t *testing.T) {
-	for _, filename := range []string{"codex-account.json", "cpamp_account.json"} {
+	for _, filename := range []string{
+		"codex-account.json",
+		"cpamp_account.json",
+		"ghp_account.json",
+		"hf_account.json",
+		"pk_account.json",
+		"rk_account.json",
+		"sess-account.json",
+	} {
 		event := SanitizeForPersistence(Event{Source: filename, RawJSON: `{"source":"` + filename + `"}`})
 		if event.Source != filename {
 			t.Fatalf("source = %q, want %q", event.Source, filename)
@@ -50,13 +63,23 @@ func TestSanitizeForPersistencePreservesCredentialFilename(t *testing.T) {
 	}
 }
 
-func TestSanitizeForPersistenceRedactsStructuredManagementKey(t *testing.T) {
+func TestSanitizeForPersistenceRedactsStructuredCredentialAliases(t *testing.T) {
 	const secretMarker = "ordinary-unprefixed-synthetic0123456789"
-	event := SanitizeForPersistence(Event{
-		RawJSON: `{"managementKey":"` + secretMarker + `"}`,
-	})
-	if strings.Contains(event.RawJSON, secretMarker) {
-		t.Fatalf("raw JSON contains structured management key: %q", event.RawJSON)
+	for _, key := range []string{
+		"managementKey",
+		"cpaManagementKey",
+		"cpa-management-key",
+		"x-api-key",
+		"xApiKey",
+	} {
+		t.Run(key, func(t *testing.T) {
+			event := SanitizeForPersistence(Event{
+				RawJSON: `{"` + key + `":"` + secretMarker + `"}`,
+			})
+			if strings.Contains(event.RawJSON, secretMarker) {
+				t.Fatalf("raw JSON contains structured %s: %q", key, event.RawJSON)
+			}
+		})
 	}
 }
 

--- a/apps/manager-server/internal/usage/event_security_test.go
+++ b/apps/manager-server/internal/usage/event_security_test.go
@@ -1,0 +1,48 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeForPersistenceRedactsCredentialText(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "legacy API key", value: "sk-synthetic0123456789"},
+		{name: "project API key in source label", value: "paid provider sk-proj-synthetic0123456789"},
+		{name: "bearer token", value: "Bearer synthetic0123456789"},
+		{name: "OAuth access token", value: "access_token=synthetic0123456789"},
+		{name: "OAuth refresh token", value: "refresh_token=synthetic0123456789"},
+		{name: "OAuth identity token", value: "id_token=synthetic0123456789"},
+		{name: "management key field", value: "management-key=synthetic0123456789"},
+		{name: "CPAMP management key", value: "cpamp_synthetic0123456789"},
+		{name: "authorization header", value: "Authorization: Bearer synthetic0123456789"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := SanitizeForPersistence(Event{
+				Source:  test.value,
+				RawJSON: `{"source":"` + test.value + `"}`,
+			})
+			if strings.Contains(event.Source, "synthetic0123456789") {
+				t.Fatalf("source contains synthetic credential marker: %q", event.Source)
+			}
+			if strings.Contains(event.RawJSON, "synthetic0123456789") {
+				t.Fatalf("raw JSON contains synthetic credential marker: %q", event.RawJSON)
+			}
+		})
+	}
+}
+
+func TestSanitizeForPersistencePreservesCredentialFilename(t *testing.T) {
+	const filename = "codex-account.json"
+	event := SanitizeForPersistence(Event{Source: filename, RawJSON: `{"source":"` + filename + `"}`})
+	if event.Source != filename {
+		t.Fatalf("source = %q, want %q", event.Source, filename)
+	}
+	if !strings.Contains(event.RawJSON, filename) {
+		t.Fatalf("raw JSON lost non-secret source filename: %q", event.RawJSON)
+	}
+}

--- a/apps/manager-server/internal/usage/event_security_test.go
+++ b/apps/manager-server/internal/usage/event_security_test.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -72,5 +74,37 @@ func TestSanitizeForPersistenceKeepsCompleteRedactedFailBody(t *testing.T) {
 	}
 	if len(event.FailBody) <= maxFailSummaryBytes {
 		t.Fatalf("fail body length=%d, want complete diagnostic", len(event.FailBody))
+	}
+}
+
+func TestSanitizeForPersistenceCoversEveryEventTextField(t *testing.T) {
+	const syntheticToken = "sk-proj-synthetic0123456789"
+	event := Event{}
+	value := reflect.ValueOf(&event).Elem()
+	typeOfEvent := value.Type()
+	for index := 0; index < value.NumField(); index++ {
+		field := value.Field(index)
+		if field.Kind() == reflect.String && field.CanSet() {
+			field.SetString("metadata " + syntheticToken)
+		}
+	}
+	event.ResponseMetadata = &ResponseHeaderMetadata{
+		Errors: &HeaderErrorMetadata{AuthorizationError: syntheticToken},
+	}
+
+	sanitized := SanitizeForPersistence(event)
+	sanitizedValue := reflect.ValueOf(sanitized)
+	for index := 0; index < sanitizedValue.NumField(); index++ {
+		field := sanitizedValue.Field(index)
+		if field.Kind() == reflect.String && strings.Contains(field.String(), syntheticToken) {
+			t.Errorf("%s contains synthetic credential marker", typeOfEvent.Field(index).Name)
+		}
+	}
+	metadataJSON, err := json.Marshal(sanitized.ResponseMetadata)
+	if err != nil {
+		t.Fatalf("marshal sanitized response metadata: %v", err)
+	}
+	if strings.Contains(string(metadataJSON), syntheticToken) {
+		t.Fatalf("response metadata contains synthetic credential marker")
 	}
 }


### PR DESCRIPTION
## Summary

Add a final credential-redaction boundary immediately before usage events are written to SQLite. This closes paths where producer-built events could bypass the existing raw-payload normalizer and persist secrets in `source`, structured metadata, valid `raw_json`, or `fail_body`.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Sanitize every persisted usage-event string field at `InsertBatch`, regardless of which producer built the event.
- Recursively redact token-shaped values in valid JSON and response metadata, including structured management-key fields and CPAMP key shapes.
- Preserve complete sanitized local failure bodies while keeping public failure summaries bounded.
- Hash credential-bearing identity fields instead of collapsing them to a shared redaction marker.
- Add synthetic unit and SQLite round-trip regressions while preserving non-secret filenames and existing account identity behavior.

## User Impact

Usage monitoring continues to work normally, but raw credentials are removed before SQLite persistence.

## Compatibility / Runtime Notes

- CPA panel mode: The shared Manager Server persistence boundary is covered.
- Manager Server mode: No schema or configuration change.
- Full Docker / native packages: No packaging change; behavior activates with the updated Manager Server binary.

## Data / Security Notes

This is a defense-in-depth storage boundary for usage data. Tests use synthetic markers only. The change does not migrate historical rows; operators should clean existing affected records and rotate exposed credentials after deploying a fixed release.

## Risk / Rollback

Risk level: Medium

Rollback notes: Revert these commits. The main compatibility risk is over-redaction, covered by the full Manager Server suite plus explicit filename, account-identity, long-diagnostic, structured-key, and every-string-field regressions.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
cd apps/manager-server
go test ./internal/usage ./internal/repository/usageevent -count=1
# PASS

go test ./...
# PASS
```

## Screenshots / Recordings

N/A — backend-only behavior.

## Docs

- [x] Not needed — explanation included below

Docs decision: No user-facing capability or configuration changed.