### PR TITLE
🐛 fix(accounts): restore Codex previous-window history

### DIFF
--- a/apps/manager-server/internal/repository/quotasnapshot/legacy_migration_test.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/legacy_migration_test.go
@@ -223,6 +223,48 @@ func TestQuotaReadersHideAttachedLegacyCodexWorkspaceRows(t *testing.T) {
 	if len(states) != 0 {
 		t.Fatalf("attached legacy Codex window states = %#v, want none", states)
 	}
+	legacyStates, err := repository.ListLegacyCodexWorkspaceWindowStates(context.Background(), legacyKey, "codex")
+	if err != nil {
+		t.Fatalf("list attached legacy window states through compatibility reader: %v", err)
+	}
+	if len(legacyStates) != 1 || legacyStates[0].ID != windowID || legacyStates[0].AccountKey != legacyKey {
+		t.Fatalf("legacy compatibility window states = %#v, want window %d", legacyStates, windowID)
+	}
+
+	memberKey := strings.Replace(legacyKey, ":codex-account:", ":codex-member:", 1)
+	memberWindowResult, err := db.Exec(`insert into account_quota_windows (
+		account_key, provider, provider_window_id, window_kind, window_mode,
+		model_scope_kind, model_scope_key, model_ids_json, scope_fingerprint,
+		inventory_scope_key, relationship_kind, container_provider_window_id,
+		availability, generation, absence_count, first_seen_at_ms, last_seen_at_ms,
+		last_observation_id, created_at_ms, updated_at_ms
+	) select ?, provider, provider_window_id, window_kind, window_mode,
+		model_scope_kind, model_scope_key, model_ids_json, scope_fingerprint,
+		inventory_scope_key, relationship_kind, container_provider_window_id,
+		availability, generation, absence_count, first_seen_at_ms, last_seen_at_ms,
+		last_observation_id, created_at_ms, updated_at_ms
+		from account_quota_windows where id = ?`, memberKey, windowID)
+	if err != nil {
+		t.Fatalf("insert member lifecycle window: %v", err)
+	}
+	memberWindowID, err := memberWindowResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("read member lifecycle window id: %v", err)
+	}
+	memberStates, err := repository.ListWindowStates(context.Background(), memberKey, "codex")
+	if err != nil {
+		t.Fatalf("list member window states: %v", err)
+	}
+	if len(memberStates) != 1 || memberStates[0].ID != memberWindowID {
+		t.Fatalf("member window states = %#v, want window %d", memberStates, memberWindowID)
+	}
+	legacyMemberStates, err := repository.ListLegacyCodexWorkspaceWindowStates(context.Background(), memberKey, "codex")
+	if err != nil {
+		t.Fatalf("list member states through legacy compatibility reader: %v", err)
+	}
+	if len(legacyMemberStates) != 0 {
+		t.Fatalf("legacy compatibility reader exposed member states = %#v", legacyMemberStates)
+	}
 }
 
 func TestQuotaReadersHideLegacyCodexWorkspaceRowsWithoutProviderMetadata(t *testing.T) {

--- a/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/lifecycle.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/codexquota"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/model"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
 
 const (
@@ -2032,6 +2033,29 @@ func resolveContainerCycleID(
 }
 
 func (r *repository) ListWindowStates(ctx context.Context, accountKey, provider string) ([]model.AccountQuotaWindowState, error) {
+	return r.listWindowStates(ctx, accountKey, provider, false)
+}
+
+func (r *repository) ListLegacyCodexWorkspaceWindowStates(
+	ctx context.Context,
+	accountKey, provider string,
+) ([]model.AccountQuotaWindowState, error) {
+	legacyPrefix := "usage-account-history:" + usageidentity.FormatVersion + ":codex-account:"
+	if !strings.EqualFold(strings.TrimSpace(provider), "codex") || !strings.HasPrefix(strings.TrimSpace(accountKey), legacyPrefix) {
+		return []model.AccountQuotaWindowState{}, nil
+	}
+	return r.listWindowStates(ctx, accountKey, provider, true)
+}
+
+func (r *repository) listWindowStates(
+	ctx context.Context,
+	accountKey, provider string,
+	includeLegacyCodexWorkspace bool,
+) ([]model.AccountQuotaWindowState, error) {
+	legacyFilter := `and ` + excludeLegacyCodexWorkspaceSnapshotSQL("")
+	if includeLegacyCodexWorkspace {
+		legacyFilter = ""
+	}
 	rows, err := r.db.QueryContext(ctx, `select
 		id, account_key, provider, provider_window_id, window_kind, window_mode,
 		model_scope_kind, coalesce(model_scope_key, ''), coalesce(model_ids_json, ''),
@@ -2039,7 +2063,7 @@ func (r *repository) ListWindowStates(ctx context.Context, accountKey, provider 
 		coalesce(container_provider_window_id, ''), availability, generation,
 		first_seen_at_ms, last_seen_at_ms, missing_since_ms, deactivated_at_ms
 		from account_quota_windows where account_key = ? and provider = ?
-			and `+excludeLegacyCodexWorkspaceSnapshotSQL("")+`
+			`+legacyFilter+`
 		order by updated_at_ms desc, id desc`, strings.TrimSpace(accountKey), strings.TrimSpace(provider))
 	if err != nil {
 		return nil, err

--- a/apps/manager-server/internal/repository/quotasnapshot/repository.go
+++ b/apps/manager-server/internal/repository/quotasnapshot/repository.go
@@ -43,10 +43,18 @@ type LegacyBackfillResult struct {
 	Completed      bool
 }
 
+type CyclePlanEvidence struct {
+	SnapshotCount    int64
+	MissingPlanCount int64
+	PlanTypes        []string
+}
+
 type Repository interface {
 	InsertObservationWrites(ctx context.Context, writes []model.AccountQuotaObservationWrite) error
 	ListCandidates(ctx context.Context, accountKey, provider string, limit int) ([]model.AccountQuotaSnapshot, error)
 	ListWindowStates(ctx context.Context, accountKey, provider string) ([]model.AccountQuotaWindowState, error)
+	ListLegacyCodexWorkspaceWindowStates(ctx context.Context, accountKey, provider string) ([]model.AccountQuotaWindowState, error)
+	ListCyclePlanEvidence(ctx context.Context, cycleIDs []int64) (map[int64]CyclePlanEvidence, error)
 }
 
 type repository struct {
@@ -621,6 +629,61 @@ func (r *repository) ListCandidates(ctx context.Context, accountKey, provider st
 		items = append(items, item)
 	}
 	return items, rows.Err()
+}
+
+func (r *repository) ListCyclePlanEvidence(ctx context.Context, cycleIDs []int64) (map[int64]CyclePlanEvidence, error) {
+	uniqueIDs := make([]int64, 0, len(cycleIDs))
+	seen := make(map[int64]struct{}, len(cycleIDs))
+	for _, cycleID := range cycleIDs {
+		if cycleID <= 0 {
+			continue
+		}
+		if _, exists := seen[cycleID]; exists {
+			continue
+		}
+		seen[cycleID] = struct{}{}
+		uniqueIDs = append(uniqueIDs, cycleID)
+	}
+	if len(uniqueIDs) == 0 {
+		return map[int64]CyclePlanEvidence{}, nil
+	}
+	sort.Slice(uniqueIDs, func(i, j int) bool { return uniqueIDs[i] < uniqueIDs[j] })
+	placeholders := make([]string, len(uniqueIDs))
+	args := make([]any, len(uniqueIDs))
+	for index, cycleID := range uniqueIDs {
+		placeholders[index] = "?"
+		args[index] = cycleID
+	}
+	rows, err := r.db.QueryContext(ctx, `select
+		cycle_id, lower(trim(coalesce(plan_type, ''))) as normalized_plan_type, count(*)
+		from account_quota_snapshots
+		where cycle_id in (`+strings.Join(placeholders, ",")+`)
+		group by cycle_id, normalized_plan_type
+		order by cycle_id, normalized_plan_type`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	evidenceByCycle := make(map[int64]CyclePlanEvidence, len(uniqueIDs))
+	for rows.Next() {
+		var cycleID, count int64
+		var planType string
+		if err := rows.Scan(&cycleID, &planType, &count); err != nil {
+			return nil, err
+		}
+		evidence := evidenceByCycle[cycleID]
+		evidence.SnapshotCount += count
+		if planType == "" {
+			evidence.MissingPlanCount += count
+		} else {
+			evidence.PlanTypes = append(evidence.PlanTypes, planType)
+		}
+		evidenceByCycle[cycleID] = evidence
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return evidenceByCycle, nil
 }
 
 func nullString(value string) any {

--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -3,6 +3,7 @@ package usageevent
 import (
 	"context"
 	"database/sql"
+	"sort"
 	"strings"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
@@ -35,9 +36,10 @@ func ResolveCodexLegacyAccountKey(
 		return "", false, nil
 	}
 
-	evidence := legacyAccountIdentityEvidence{}
+	events := make([]legacyAccountIdentityEvent, 0)
 	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
 		rows, err := queryer.QueryContext(ctx, `select
+			e.id,
 			coalesce(e.provider, ''),
 			coalesce(e.auth_provider_snapshot, ''),
 			coalesce(e.auth_account_id_snapshot, ''),
@@ -48,24 +50,17 @@ func ResolveCodexLegacyAccountKey(
 		if err != nil {
 			return "", false, err
 		}
-		predicateEvidence := legacyAccountIdentityEvidence{}
-		allowed, err := scanLegacyAccountIdentity(rows, targetAccountID, targetMember, &predicateEvidence)
+		predicateEvents, err := scanLegacyAccountIdentityRows(rows)
 		if err != nil {
 			return "", false, err
 		}
-		if !allowed {
-			// An empty predicate is expected when a legacy event used one of the
-			// other physical-identity shapes. Continue so source-only history can
-			// still be inherited; any rows that were found but failed validation
-			// remain a fail-closed conflict.
-			if predicateEvidence.found {
-				return "", false, nil
-			}
-			continue
-		}
-		evidence.found = evidence.found || predicateEvidence.found
+		events = append(events, predicateEvents...)
 	}
-	return legacyKey, evidence.found, nil
+	sort.Slice(events, func(i, j int) bool { return events[i].id < events[j].id })
+	if !legacyAccountIdentityAllowed(events, targetAccountID, targetMember) {
+		return "", false, nil
+	}
+	return legacyKey, true, nil
 }
 
 // ResolveCodexLegacyAccountKey evaluates the same check through a short
@@ -147,55 +142,90 @@ func legacySourceIdentityGuards() string {
 		and (e.auth_label_snapshot is null or lower(trim(e.source)) <> lower(trim(e.auth_label_snapshot)))`
 }
 
-type legacyAccountIdentityEvidence struct {
-	found bool
+type legacyAccountIdentityEvent struct {
+	id              int64
+	provider        string
+	authProvider    string
+	accountID       string
+	projectID       string
+	accountSnapshot string
 }
 
-func scanLegacyAccountIdentity(
-	rows *sql.Rows,
-	targetAccountID, targetMember string,
-	evidence *legacyAccountIdentityEvidence,
-) (bool, error) {
+func scanLegacyAccountIdentityRows(rows *sql.Rows) ([]legacyAccountIdentityEvent, error) {
 	defer rows.Close()
+	events := make([]legacyAccountIdentityEvent, 0)
 	for rows.Next() {
-		evidence.found = true
-		var provider, authProvider, accountID, projectID, accountSnapshot string
-		if err := rows.Scan(&provider, &authProvider, &accountID, &projectID, &accountSnapshot); err != nil {
-			return false, err
+		var event legacyAccountIdentityEvent
+		if err := rows.Scan(
+			&event.id,
+			&event.provider,
+			&event.authProvider,
+			&event.accountID,
+			&event.projectID,
+			&event.accountSnapshot,
+		); err != nil {
+			return nil, err
 		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func legacyAccountIdentityAllowed(
+	events []legacyAccountIdentityEvent,
+	targetAccountID, targetMember string,
+) bool {
+	strongWorkspaceFound := false
+	for _, event := range events {
 		hasProvider := false
-		for _, value := range []string{provider, authProvider} {
+		for _, value := range []string{event.provider, event.authProvider} {
 			normalized := normalizeIdentityProvider(value)
 			if normalized == "" {
 				continue
 			}
 			hasProvider = true
 			if normalized != "codex" {
-				return false, nil
+				return false
 			}
 		}
 		if !hasProvider {
-			return false, nil
+			return false
 		}
 
-		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(accountSnapshot)
+		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(event.accountSnapshot)
 		if !memberOK || member != targetMember {
-			return false, nil
+			return false
 		}
 
+		directWorkspacePresent := strings.Trim(event.accountID, " ") != ""
+		markedWorkspacePresent := usageidentity.HasCodexAccountIDSnapshotMarker(event.projectID)
 		workspace, workspaceOK := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
-			AuthAccountIDSnapshot: accountID,
-			AuthProjectIDSnapshot: projectID,
-			AccountSnapshot:       accountSnapshot,
+			AuthAccountIDSnapshot: event.accountID,
+			AuthProjectIDSnapshot: event.projectID,
+			AccountSnapshot:       event.accountSnapshot,
 		})
-		if !workspaceOK || workspace != targetAccountID {
-			return false, nil
+		if directWorkspacePresent || markedWorkspacePresent {
+			if !workspaceOK || workspace != targetAccountID {
+				return false
+			}
+			if directWorkspacePresent {
+				strongWorkspaceFound = true
+			}
+			continue
+		}
+
+		// A fully legacy event with no Workspace provenance is eligible only
+		// as a leading prefix. Once direct Workspace evidence has established
+		// the member identity, a later regression to weak evidence is
+		// ambiguous credential reuse and must fail closed.
+		if strongWorkspaceFound {
+			return false
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return false, err
-	}
-	return evidence.found, nil
+	return strongWorkspaceFound
 }
 
 func normalizeIdentityProvider(value string) string {

--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -3,7 +3,6 @@ package usageevent
 import (
 	"context"
 	"database/sql"
-	"sort"
 	"strings"
 
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
@@ -39,12 +38,13 @@ func ResolveCodexLegacyAccountKey(
 	events := make([]legacyAccountIdentityEvent, 0)
 	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
 		rows, err := queryer.QueryContext(ctx, `select
-			e.id,
 			coalesce(e.provider, ''),
 			coalesce(e.auth_provider_snapshot, ''),
 			coalesce(e.auth_account_id_snapshot, ''),
 			coalesce(e.auth_project_id_snapshot, ''),
-			coalesce(e.account_snapshot, '')
+			coalesce(e.account_snapshot, ''),
+			coalesce(e.auth_snapshot_at_ms, 0),
+			coalesce(e.created_at_ms, 0)
 		from usage_events e
 		where `+predicate.sql, predicate.args...)
 		if err != nil {
@@ -56,7 +56,6 @@ func ResolveCodexLegacyAccountKey(
 		}
 		events = append(events, predicateEvents...)
 	}
-	sort.Slice(events, func(i, j int) bool { return events[i].id < events[j].id })
 	if !legacyAccountIdentityAllowed(events, targetAccountID, targetMember) {
 		return "", false, nil
 	}
@@ -143,12 +142,13 @@ func legacySourceIdentityGuards() string {
 }
 
 type legacyAccountIdentityEvent struct {
-	id              int64
-	provider        string
-	authProvider    string
-	accountID       string
-	projectID       string
-	accountSnapshot string
+	provider         string
+	authProvider     string
+	accountID        string
+	projectID        string
+	accountSnapshot  string
+	authSnapshotAtMS int64
+	createdAtMS      int64
 }
 
 func scanLegacyAccountIdentityRows(rows *sql.Rows) ([]legacyAccountIdentityEvent, error) {
@@ -157,12 +157,13 @@ func scanLegacyAccountIdentityRows(rows *sql.Rows) ([]legacyAccountIdentityEvent
 	for rows.Next() {
 		var event legacyAccountIdentityEvent
 		if err := rows.Scan(
-			&event.id,
 			&event.provider,
 			&event.authProvider,
 			&event.accountID,
 			&event.projectID,
 			&event.accountSnapshot,
+			&event.authSnapshotAtMS,
+			&event.createdAtMS,
 		); err != nil {
 			return nil, err
 		}
@@ -174,11 +175,32 @@ func scanLegacyAccountIdentityRows(rows *sql.Rows) ([]legacyAccountIdentityEvent
 	return events, nil
 }
 
+func legacyIdentityEvidenceAtMS(event legacyAccountIdentityEvent) (int64, bool) {
+	if event.authSnapshotAtMS > 0 {
+		return event.authSnapshotAtMS, true
+	}
+	if event.createdAtMS > 0 {
+		return event.createdAtMS, true
+	}
+	return 0, false
+}
+
 func legacyAccountIdentityAllowed(
 	events []legacyAccountIdentityEvent,
 	targetAccountID, targetMember string,
 ) bool {
-	strongWorkspaceFound := false
+	trustedWorkspaceFound := false
+	directWorkspaceFound := false
+	weakFound := false
+
+	var minTrustedEvidenceAt int64
+	hasTrustedEvidenceAt := false
+	trustedChronologyKnown := true
+
+	var maxWeakEvidenceAt int64
+	hasWeakEvidenceAt := false
+	weakChronologyKnown := true
+
 	for _, event := range events {
 		hasProvider := false
 		for _, value := range []string{event.provider, event.authProvider} {
@@ -211,21 +233,43 @@ func legacyAccountIdentityAllowed(
 			if !workspaceOK || workspace != targetAccountID {
 				return false
 			}
+			trustedWorkspaceFound = true
 			if directWorkspacePresent {
-				strongWorkspaceFound = true
+				directWorkspaceFound = true
+			}
+			evidenceTime, timeOK := legacyIdentityEvidenceAtMS(event)
+			if !timeOK {
+				trustedChronologyKnown = false
+			} else if !hasTrustedEvidenceAt || evidenceTime < minTrustedEvidenceAt {
+				minTrustedEvidenceAt = evidenceTime
+				hasTrustedEvidenceAt = true
 			}
 			continue
 		}
 
-		// A fully legacy event with no Workspace provenance is eligible only
-		// as a leading prefix. Once direct Workspace evidence has established
-		// the member identity, a later regression to weak evidence is
-		// ambiguous credential reuse and must fail closed.
-		if strongWorkspaceFound {
-			return false
+		weakFound = true
+		evidenceTime, timeOK := legacyIdentityEvidenceAtMS(event)
+		if !timeOK {
+			weakChronologyKnown = false
+		} else if !hasWeakEvidenceAt || evidenceTime > maxWeakEvidenceAt {
+			maxWeakEvidenceAt = evidenceTime
+			hasWeakEvidenceAt = true
 		}
 	}
-	return strongWorkspaceFound
+
+	if !trustedWorkspaceFound {
+		return false
+	}
+	if !weakFound {
+		return true
+	}
+	if !directWorkspaceFound {
+		return false
+	}
+	if !weakChronologyKnown || !trustedChronologyKnown || !hasWeakEvidenceAt || !hasTrustedEvidenceAt {
+		return false
+	}
+	return maxWeakEvidenceAt < minTrustedEvidenceAt
 }
 
 func normalizeIdentityProvider(value string) string {

--- a/apps/manager-server/internal/repository/usageevent/account_identity_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_test.go
@@ -164,6 +164,97 @@ func TestResolveCodexLegacyAccountKeyRequiresProviderAndMatchingAccountIDs(t *te
 	}
 }
 
+func TestResolveCodexLegacyAccountKeyAcceptsOnlyLeadingWeakIdentityPrefix(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		buildEvents func() []usage.Event
+		wantAllowed bool
+	}{
+		{
+			name: "weak prefix followed by direct workspace",
+			buildEvents: func() []usage.Event {
+				weak := identityTestEvent("weak-prefix", 1, "codex-a.json", "auth-a", "codex", "")
+				strong := identityTestEvent("strong-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				return []usage.Event{weak, strong}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "weak source prefix followed by direct file workspace",
+			buildEvents: func() []usage.Event {
+				weak := identityTestEvent("weak-source-prefix", 1, "", "auth-a", "codex", "")
+				weak.Source = "codex-a.json"
+				strong := identityTestEvent("strong-file-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				return []usage.Event{weak, strong}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "valid marked prefix followed by direct workspace",
+			buildEvents: func() []usage.Event {
+				marked := identityTestEvent("marked-prefix", 1, "codex-a.json", "auth-a", "codex", "")
+				marked.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
+				strong := identityTestEvent("strong-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				return []usage.Event{marked, strong}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "weak identity without direct anchor",
+			buildEvents: func() []usage.Event {
+				return []usage.Event{identityTestEvent("weak-only", 1, "codex-a.json", "auth-a", "codex", "")}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "weak identity after direct anchor",
+			buildEvents: func() []usage.Event {
+				strong := identityTestEvent("strong-anchor", 1, "codex-a.json", "auth-a", "codex", "account-a")
+				weak := identityTestEvent("weak-tail", 2, "codex-a.json", "auth-a", "codex", "")
+				return []usage.Event{strong, weak}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "malformed provenance prefix",
+			buildEvents: func() []usage.Event {
+				invalid := identityTestEvent("invalid-prefix", 1, "codex-a.json", "auth-a", "codex", "")
+				invalid.AuthProjectIDSnapshot = "codex-account-id:v1:"
+				strong := identityTestEvent("strong-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				return []usage.Event{invalid, strong}
+			},
+			wantAllowed: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			if _, err := repo.InsertBatch(context.Background(), test.buildEvents()); err != nil {
+				t.Fatalf("insert identity events: %v", err)
+			}
+
+			key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), usageidentity.Fields{
+				AuthFileSnapshot:      "codex-a.json",
+				AuthIndex:             "auth-a",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "account-a",
+				AccountSnapshot:       "same@example.com",
+				Source:                "codex-a.json",
+			})
+			if err != nil {
+				t.Fatalf("resolve legacy identity: %v", err)
+			}
+			if allowed != test.wantAllowed {
+				t.Fatalf("allowed = %v, want %v (key=%q)", allowed, test.wantAllowed, key)
+			}
+		})
+	}
+}
+
 func TestResolveCodexLegacyAccountKeyAcceptsLegacySourceFile(t *testing.T) {
 	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
 	if err != nil {

--- a/apps/manager-server/internal/repository/usageevent/account_identity_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_test.go
@@ -1,6 +1,7 @@
 package usageevent
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"testing"
@@ -173,8 +174,8 @@ func TestResolveCodexLegacyAccountKeyAcceptsOnlyLeadingWeakIdentityPrefix(t *tes
 		{
 			name: "weak prefix followed by direct workspace",
 			buildEvents: func() []usage.Event {
-				weak := identityTestEvent("weak-prefix", 1, "codex-a.json", "auth-a", "codex", "")
-				strong := identityTestEvent("strong-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				weak := identityChronologyEvent("weak-prefix", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				strong := identityChronologyEvent("strong-anchor", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
 				return []usage.Event{weak, strong}
 			},
 			wantAllowed: true,
@@ -182,9 +183,9 @@ func TestResolveCodexLegacyAccountKeyAcceptsOnlyLeadingWeakIdentityPrefix(t *tes
 		{
 			name: "weak source prefix followed by direct file workspace",
 			buildEvents: func() []usage.Event {
-				weak := identityTestEvent("weak-source-prefix", 1, "", "auth-a", "codex", "")
+				weak := identityChronologyEvent("weak-source-prefix", 1000, "", "auth-a", "codex", "", "")
 				weak.Source = "codex-a.json"
-				strong := identityTestEvent("strong-file-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				strong := identityChronologyEvent("strong-file-anchor", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
 				return []usage.Event{weak, strong}
 			},
 			wantAllowed: true,
@@ -192,9 +193,8 @@ func TestResolveCodexLegacyAccountKeyAcceptsOnlyLeadingWeakIdentityPrefix(t *tes
 		{
 			name: "valid marked prefix followed by direct workspace",
 			buildEvents: func() []usage.Event {
-				marked := identityTestEvent("marked-prefix", 1, "codex-a.json", "auth-a", "codex", "")
-				marked.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
-				strong := identityTestEvent("strong-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				marked := identityChronologyEvent("marked-prefix", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				strong := identityChronologyEvent("strong-anchor", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
 				return []usage.Event{marked, strong}
 			},
 			wantAllowed: true,
@@ -202,15 +202,15 @@ func TestResolveCodexLegacyAccountKeyAcceptsOnlyLeadingWeakIdentityPrefix(t *tes
 		{
 			name: "weak identity without direct anchor",
 			buildEvents: func() []usage.Event {
-				return []usage.Event{identityTestEvent("weak-only", 1, "codex-a.json", "auth-a", "codex", "")}
+				return []usage.Event{identityChronologyEvent("weak-only", 1000, "codex-a.json", "auth-a", "codex", "", "")}
 			},
 			wantAllowed: false,
 		},
 		{
 			name: "weak identity after direct anchor",
 			buildEvents: func() []usage.Event {
-				strong := identityTestEvent("strong-anchor", 1, "codex-a.json", "auth-a", "codex", "account-a")
-				weak := identityTestEvent("weak-tail", 2, "codex-a.json", "auth-a", "codex", "")
+				strong := identityChronologyEvent("strong-anchor", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				weak := identityChronologyEvent("weak-tail", 2000, "codex-a.json", "auth-a", "codex", "", "")
 				return []usage.Event{strong, weak}
 			},
 			wantAllowed: false,
@@ -218,9 +218,8 @@ func TestResolveCodexLegacyAccountKeyAcceptsOnlyLeadingWeakIdentityPrefix(t *tes
 		{
 			name: "malformed provenance prefix",
 			buildEvents: func() []usage.Event {
-				invalid := identityTestEvent("invalid-prefix", 1, "codex-a.json", "auth-a", "codex", "")
-				invalid.AuthProjectIDSnapshot = "codex-account-id:v1:"
-				strong := identityTestEvent("strong-anchor", 2, "codex-a.json", "auth-a", "codex", "account-a")
+				invalid := identityChronologyEvent("invalid-prefix", 1000, "codex-a.json", "auth-a", "codex", "", "codex-account-id:v1:")
+				strong := identityChronologyEvent("strong-anchor", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
 				return []usage.Event{invalid, strong}
 			},
 			wantAllowed: false,
@@ -385,4 +384,583 @@ func identityTestEvent(hash string, offset int64, file, authIndex, provider, acc
 		TotalTokens:           2,
 		CreatedAtMS:           timestampMS,
 	}
+}
+
+func identityChronologyEvent(hash string, createdAtMS int64, file, authIndex, provider, accountID, projectID string) usage.Event {
+	event := identityTestEvent(hash, 0, file, authIndex, provider, accountID)
+	event.AuthProjectIDSnapshot = projectID
+	event.CreatedAtMS = createdAtMS
+	event.TimestampMS = createdAtMS
+	return event
+}
+
+func TestResolveCodexLegacyAccountKeyAcceptsValidMarkerOnlyHistory(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		buildEvents func() []usage.Event
+		wantAllowed bool
+	}{
+		{
+			name: "Case 1: matching marker only",
+			buildEvents: func() []usage.Event {
+				event := identityChronologyEvent("marker-1", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				return []usage.Event{event}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "Case 2: multiple matching markers only",
+			buildEvents: func() []usage.Event {
+				e1 := identityChronologyEvent("marker-1", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				e2 := identityChronologyEvent("marker-2", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				e3 := identityChronologyEvent("marker-3", 3000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				return []usage.Event{e1, e2, e3}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "Case 3: marker-only conflicting workspace",
+			buildEvents: func() []usage.Event {
+				event := identityChronologyEvent("marker-b", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-b"))
+				return []usage.Event{event}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "Case 4: malformed marker-only",
+			buildEvents: func() []usage.Event {
+				event := identityChronologyEvent("marker-invalid", 1000, "codex-a.json", "auth-a", "codex", "", "codex-account-id:v1:")
+				return []usage.Event{event}
+			},
+			wantAllowed: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			if _, err := repo.InsertBatch(context.Background(), test.buildEvents()); err != nil {
+				t.Fatalf("insert identity events: %v", err)
+			}
+
+			key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), usageidentity.Fields{
+				AuthFileSnapshot:      "codex-a.json",
+				AuthIndex:             "auth-a",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "account-a",
+				AccountSnapshot:       "same@example.com",
+				Source:                "codex-a.json",
+			})
+			if err != nil {
+				t.Fatalf("resolve legacy identity: %v", err)
+			}
+			if allowed != test.wantAllowed {
+				t.Fatalf("allowed = %v, want %v (key=%q)", allowed, test.wantAllowed, key)
+			}
+		})
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyStateMachine(t *testing.T) {
+	tests := []struct {
+		name        string
+		events      func() []usage.Event
+		wantAllowed bool
+	}{
+		{
+			name: "marker-only",
+			events: func() []usage.Event {
+				m1 := identityChronologyEvent("m1", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				m2 := identityChronologyEvent("m2", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				return []usage.Event{m1, m2}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "direct-only",
+			events: func() []usage.Event {
+				d1 := identityChronologyEvent("d1", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				d2 := identityChronologyEvent("d2", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				return []usage.Event{d1, d2}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "marker then direct",
+			events: func() []usage.Event {
+				m := identityChronologyEvent("m", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				d := identityChronologyEvent("d", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				return []usage.Event{m, d}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "direct then marker",
+			events: func() []usage.Event {
+				d := identityChronologyEvent("d", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				m := identityChronologyEvent("m", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				return []usage.Event{d, m}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "weak-only",
+			events: func() []usage.Event {
+				w1 := identityChronologyEvent("w1", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				w2 := identityChronologyEvent("w2", 2000, "codex-a.json", "auth-a", "codex", "", "")
+				return []usage.Event{w1, w2}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "weak then direct",
+			events: func() []usage.Event {
+				w := identityChronologyEvent("w", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				d := identityChronologyEvent("d", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				return []usage.Event{w, d}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "weak then weak then direct",
+			events: func() []usage.Event {
+				w1 := identityChronologyEvent("w1", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				w2 := identityChronologyEvent("w2", 1500, "codex-a.json", "auth-a", "codex", "", "")
+				d := identityChronologyEvent("d", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				return []usage.Event{w1, w2, d}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "weak then marker then direct",
+			events: func() []usage.Event {
+				w := identityChronologyEvent("w", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				m := identityChronologyEvent("m", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				d := identityChronologyEvent("d", 3000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				return []usage.Event{w, m, d}
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "weak then marker",
+			events: func() []usage.Event {
+				w := identityChronologyEvent("w", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				m := identityChronologyEvent("m", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				return []usage.Event{w, m}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "weak then marker then marker",
+			events: func() []usage.Event {
+				w := identityChronologyEvent("w", 1000, "codex-a.json", "auth-a", "codex", "", "")
+				m1 := identityChronologyEvent("m1", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				m2 := identityChronologyEvent("m2", 3000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				return []usage.Event{w, m1, m2}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "direct then weak",
+			events: func() []usage.Event {
+				d := identityChronologyEvent("d", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				w := identityChronologyEvent("w", 2000, "codex-a.json", "auth-a", "codex", "", "")
+				return []usage.Event{d, w}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "marker then weak",
+			events: func() []usage.Event {
+				m := identityChronologyEvent("m", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				w := identityChronologyEvent("w", 2000, "codex-a.json", "auth-a", "codex", "", "")
+				return []usage.Event{m, w}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "marker then weak then direct",
+			events: func() []usage.Event {
+				m := identityChronologyEvent("m", 1000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				w := identityChronologyEvent("w", 2000, "codex-a.json", "auth-a", "codex", "", "")
+				d := identityChronologyEvent("d", 3000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				return []usage.Event{m, w, d}
+			},
+			wantAllowed: false,
+		},
+		{
+			name: "direct then marker then weak",
+			events: func() []usage.Event {
+				d := identityChronologyEvent("d", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+				m := identityChronologyEvent("m", 2000, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+				w := identityChronologyEvent("w", 3000, "codex-a.json", "auth-a", "codex", "", "")
+				return []usage.Event{d, m, w}
+			},
+			wantAllowed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			evs := test.events()
+			if _, err := repo.InsertBatch(context.Background(), evs); err != nil {
+				t.Fatalf("insert identity events: %v", err)
+			}
+
+			key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), usageidentity.Fields{
+				AuthFileSnapshot:      "codex-a.json",
+				AuthIndex:             "auth-a",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "account-a",
+				AccountSnapshot:       "same@example.com",
+				Source:                "codex-a.json",
+			})
+			if err != nil {
+				t.Fatalf("resolve legacy identity: %v", err)
+			}
+			if allowed != test.wantAllowed {
+				t.Fatalf("allowed = %v, want %v (key=%q)", allowed, test.wantAllowed, key)
+			}
+		})
+
+		t.Run(test.name+"_reverse_insert", func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			evs := test.events()
+			reversed := make([]usage.Event, len(evs))
+			for i, ev := range evs {
+				reversed[len(evs)-1-i] = ev
+			}
+			if _, err := repo.InsertBatch(context.Background(), reversed); err != nil {
+				t.Fatalf("insert identity events reversed: %v", err)
+			}
+
+			key, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), usageidentity.Fields{
+				AuthFileSnapshot:      "codex-a.json",
+				AuthIndex:             "auth-a",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "account-a",
+				AccountSnapshot:       "same@example.com",
+				Source:                "codex-a.json",
+			})
+			if err != nil {
+				t.Fatalf("resolve legacy identity: %v", err)
+			}
+			if allowed != test.wantAllowed {
+				t.Fatalf("reverse insert allowed = %v, want %v (key=%q)", allowed, test.wantAllowed, key)
+			}
+		})
+	}
+}
+
+func TestResolveCodexLegacyAccountKeyTimeFallback(t *testing.T) {
+	fields := usageidentity.Fields{
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "same@example.com",
+		Source:                "codex-a.json",
+	}
+
+	t.Run("Case A: auth_snapshot_at_ms takes precedence over created_at_ms", func(t *testing.T) {
+		db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		repo := New(db)
+
+		// If CreatedAtMS were used: weak (3000) > direct (1500) => DENY
+		// But AuthSnapshotAtMS: weak (1000) < direct (2000) => ALLOW
+		weak := identityChronologyEvent("weak-precedence", 3000, "codex-a.json", "auth-a", "codex", "", "")
+		weak.AuthSnapshotAtMS = 1000
+		direct := identityChronologyEvent("direct-precedence", 1500, "codex-a.json", "auth-a", "codex", "account-a", "")
+		direct.AuthSnapshotAtMS = 2000
+
+		if _, err := repo.InsertBatch(context.Background(), []usage.Event{weak, direct}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		_, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !allowed {
+			t.Fatal("expected allowed when auth_snapshot_at_ms establishes weak < direct")
+		}
+	})
+
+	t.Run("Case B: auth_snapshot_at_ms is 0 falls back to created_at_ms", func(t *testing.T) {
+		db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		repo := New(db)
+
+		weak := identityChronologyEvent("weak-fallback", 1000, "codex-a.json", "auth-a", "codex", "", "")
+		weak.AuthSnapshotAtMS = 0
+		direct := identityChronologyEvent("direct-fallback", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+		direct.AuthSnapshotAtMS = 0
+
+		if _, err := repo.InsertBatch(context.Background(), []usage.Event{weak, direct}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		_, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !allowed {
+			t.Fatal("expected allowed when created_at_ms establishes weak < direct")
+		}
+	})
+
+	t.Run("Case C: weak history with both timestamps 0 fails closed", func(t *testing.T) {
+		db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		repo := New(db)
+
+		weak := identityChronologyEvent("weak-zero-time", 0, "codex-a.json", "auth-a", "codex", "", "")
+		weak.AuthSnapshotAtMS = 0
+		direct := identityChronologyEvent("direct-anchor", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+
+		if _, err := repo.InsertBatch(context.Background(), []usage.Event{weak, direct}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		_, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if allowed {
+			t.Fatal("expected denied when weak event lacks evidence time")
+		}
+	})
+
+	t.Run("Case D: marker-only history with both timestamps 0 succeeds", func(t *testing.T) {
+		db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		repo := New(db)
+
+		marker := identityChronologyEvent("marker-zero-time", 0, "codex-a.json", "auth-a", "codex", "", usageidentity.CodexAccountIDSnapshot("account-a"))
+		marker.AuthSnapshotAtMS = 0
+
+		if _, err := repo.InsertBatch(context.Background(), []usage.Event{marker}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		_, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !allowed {
+			t.Fatal("expected allowed for marker-only history even when timestamp is 0")
+		}
+	})
+}
+
+func TestResolveCodexLegacyAccountKeyJSONLRoundTrip(t *testing.T) {
+	fields := usageidentity.Fields{
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "same@example.com",
+		Source:                "codex-a.json",
+	}
+
+	t.Run("Round-trip Case A: weak to direct preserves ALLOW across export/import", func(t *testing.T) {
+		dbA, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-a.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbA: %v", err)
+		}
+		t.Cleanup(func() { _ = dbA.Close() })
+		repoA := New(dbA)
+
+		weak := identityChronologyEvent("rt-weak", 1000, "codex-a.json", "auth-a", "codex", "", "")
+		direct := identityChronologyEvent("rt-direct", 2000, "codex-a.json", "auth-a", "codex", "account-a", "")
+
+		if _, err := repoA.InsertBatch(context.Background(), []usage.Event{weak, direct}); err != nil {
+			t.Fatalf("insert dbA: %v", err)
+		}
+
+		keyA, allowedA, err := repoA.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbA: %v", err)
+		}
+		if !allowedA {
+			t.Fatalf("expected allowed in dbA, key=%q", keyA)
+		}
+
+		var exportBuf bytes.Buffer
+		if err := repoA.WriteExportJSONL(context.Background(), &exportBuf, 100); err != nil {
+			t.Fatalf("export dbA: %v", err)
+		}
+
+		dbB, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-b.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbB: %v", err)
+		}
+		t.Cleanup(func() { _ = dbB.Close() })
+		repoB := New(dbB)
+
+		streamResult, err := usage.StreamImportPayload(&exportBuf, 256, func(events []usage.Event) error {
+			_, err := repoB.InsertBatch(context.Background(), events)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("import into dbB: %v", err)
+		}
+		if streamResult.Failed != 0 || streamResult.Total != 2 {
+			t.Fatalf("stream import result = %#v, want 2 total 0 failed", streamResult)
+		}
+
+		keyB, allowedB, err := repoB.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbB: %v", err)
+		}
+		if !allowedB || keyB != keyA {
+			t.Fatalf("dbB result: allowed=%v, key=%q; want allowed=true, key=%q", allowedB, keyB, keyA)
+		}
+
+		// Verify inverted insertion order in DB C (direct inserted before weak, so direct gets lower row ID)
+		dbC, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-c.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbC: %v", err)
+		}
+		t.Cleanup(func() { _ = dbC.Close() })
+		repoC := New(dbC)
+
+		if _, err := repoC.InsertBatch(context.Background(), []usage.Event{direct, weak}); err != nil {
+			t.Fatalf("insert dbC reversed: %v", err)
+		}
+		keyC, allowedC, err := repoC.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbC: %v", err)
+		}
+		if !allowedC || keyC != keyA {
+			t.Fatalf("dbC (inverted SQLite ID) result: allowed=%v, key=%q; want allowed=true, key=%q", allowedC, keyC, keyA)
+		}
+	})
+
+	t.Run("Round-trip Case B: direct to weak preserves DENY across export/import", func(t *testing.T) {
+		dbA, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-a.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbA: %v", err)
+		}
+		t.Cleanup(func() { _ = dbA.Close() })
+		repoA := New(dbA)
+
+		direct := identityChronologyEvent("rt-b-direct", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+		weak := identityChronologyEvent("rt-b-weak", 2000, "codex-a.json", "auth-a", "codex", "", "")
+
+		if _, err := repoA.InsertBatch(context.Background(), []usage.Event{direct, weak}); err != nil {
+			t.Fatalf("insert dbA: %v", err)
+		}
+
+		_, allowedA, err := repoA.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbA: %v", err)
+		}
+		if allowedA {
+			t.Fatal("expected denied in dbA for direct -> weak")
+		}
+
+		var exportBuf bytes.Buffer
+		if err := repoA.WriteExportJSONL(context.Background(), &exportBuf, 100); err != nil {
+			t.Fatalf("export dbA: %v", err)
+		}
+
+		dbB, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-b.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbB: %v", err)
+		}
+		t.Cleanup(func() { _ = dbB.Close() })
+		repoB := New(dbB)
+
+		_, err = usage.StreamImportPayload(&exportBuf, 256, func(events []usage.Event) error {
+			_, err := repoB.InsertBatch(context.Background(), events)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("import into dbB: %v", err)
+		}
+
+		_, allowedB, err := repoB.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbB: %v", err)
+		}
+		if allowedB {
+			t.Fatal("expected denied in dbB for direct -> weak after export/import")
+		}
+	})
+
+	t.Run("Round-trip Case C: same evidence time fails closed across export/import", func(t *testing.T) {
+		dbA, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-a.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbA: %v", err)
+		}
+		t.Cleanup(func() { _ = dbA.Close() })
+		repoA := New(dbA)
+
+		weak := identityChronologyEvent("rt-c-weak", 1000, "codex-a.json", "auth-a", "codex", "", "")
+		direct := identityChronologyEvent("rt-c-direct", 1000, "codex-a.json", "auth-a", "codex", "account-a", "")
+
+		if _, err := repoA.InsertBatch(context.Background(), []usage.Event{weak, direct}); err != nil {
+			t.Fatalf("insert dbA: %v", err)
+		}
+
+		_, allowedA, err := repoA.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbA: %v", err)
+		}
+		if allowedA {
+			t.Fatal("expected denied in dbA for same evidence timestamp")
+		}
+
+		var exportBuf bytes.Buffer
+		if err := repoA.WriteExportJSONL(context.Background(), &exportBuf, 100); err != nil {
+			t.Fatalf("export dbA: %v", err)
+		}
+
+		dbB, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage-b.sqlite"))
+		if err != nil {
+			t.Fatalf("open dbB: %v", err)
+		}
+		t.Cleanup(func() { _ = dbB.Close() })
+		repoB := New(dbB)
+
+		_, err = usage.StreamImportPayload(&exportBuf, 256, func(events []usage.Event) error {
+			_, err := repoB.InsertBatch(context.Background(), events)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("import into dbB: %v", err)
+		}
+
+		_, allowedB, err := repoB.ResolveCodexLegacyAccountKey(context.Background(), fields)
+		if err != nil {
+			t.Fatalf("resolve dbB: %v", err)
+		}
+		if allowedB {
+			t.Fatal("expected denied in dbB for same evidence timestamp after export/import")
+		}
+	})
 }

--- a/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/repository_test.go
@@ -450,7 +450,7 @@ func TestCodexAccountWindowKeepsHistoryAcrossSameAccountReauth(t *testing.T) {
 
 	projectedEvents := []usage.Event{
 		makeEvent("previous-old-credential", previousFromMS+1_000, "codex-a-free.json", "auth-1", "account-a", 10),
-		makeEvent("previous-new-credential", previousFromMS+2_000, "codex-a-pro.json", "auth-2", "account-a", 20),
+		makeEvent("previous-new-credential-before-workspace", previousFromMS+2_000, "codex-a-pro.json", "auth-2", "", 20),
 		makeEvent("current-old-credential", currentFromMS+1_000, "codex-a-free.json", "auth-1", "account-a", 30),
 		makeEvent("different-space-same-email", currentFromMS+2_000, "codex-b.json", "auth-3", "account-b", 9_000),
 	}

--- a/apps/manager-server/internal/service/monitoring/service_test.go
+++ b/apps/manager-server/internal/service/monitoring/service_test.go
@@ -2282,17 +2282,16 @@ func TestAccountHistoryAutoMergesSafeCodexLegacyFileIndex(t *testing.T) {
 	db := newMonitoringTestStore(t)
 	ctx := context.Background()
 	baseMS := int64(1_700_006_000_000)
-	stable := monitoringEvent("history-codex-stable", baseMS+1_000, "gpt-codex", "auth-a", "codex-a.json", false, 10, 2, 0, 0, 12, nil)
+	legacy := monitoringEvent("history-codex-legacy", baseMS+1_000, "gpt-codex", "auth-a", "codex-a.json", false, 10, 2, 0, 0, 12, nil)
+	legacy.AuthFileSnapshot = "codex-a.json"
+	legacy.AuthProviderSnapshot = "codex"
+	legacy.AccountSnapshot = "same@example.com"
+	stable := monitoringEvent("history-codex-stable", baseMS+2_000, "gpt-codex", "auth-a", "codex-a.json", false, 20, 3, 0, 0, 23, nil)
 	stable.AuthFileSnapshot = "codex-a.json"
 	stable.AuthProviderSnapshot = "codex"
 	stable.AuthAccountIDSnapshot = "account-a"
 	stable.AccountSnapshot = "same@example.com"
-	legacy := monitoringEvent("history-codex-legacy", baseMS+2_000, "gpt-codex", "auth-a", "codex-a.json", false, 20, 3, 0, 0, 23, nil)
-	legacy.AuthFileSnapshot = "codex-a.json"
-	legacy.AuthProviderSnapshot = "codex"
-	legacy.AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
-	legacy.AccountSnapshot = "same@example.com"
-	if _, err := db.InsertEvents(ctx, []usage.Event{stable, legacy}); err != nil {
+	if _, err := db.InsertEvents(ctx, []usage.Event{legacy, stable}); err != nil {
 		t.Fatalf("insert Codex history events: %v", err)
 	}
 

--- a/apps/manager-server/internal/service/quotasnapshot/service.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service.go
@@ -36,6 +36,7 @@ var (
 	validAccuracy       = stringSet("exact", "derived", "estimated", "unknown")
 	validInventoryModes = stringSet("complete", "partial", "delta")
 	validRelationships  = stringSet("concurrent_subwindow")
+	codexPersonalPlans  = stringSet("free", "plus", "pro", "go")
 )
 
 type Service struct {
@@ -524,6 +525,16 @@ func (s *Service) Query(ctx context.Context, req QueryRequest) (QueryResponse, e
 		if err != nil {
 			return QueryResponse{}, err
 		}
+		if legacyAccountKey, bridgeEligible := legacyCodexWorkspaceQuotaKey(account.Account, provider); bridgeEligible {
+			legacyStates, legacyErr := s.store.QuotaSnapshots.ListLegacyCodexWorkspaceWindowStates(ctx, legacyAccountKey, provider)
+			if legacyErr != nil {
+				return QueryResponse{}, legacyErr
+			}
+			states, legacyErr = bridgeLegacyCodexWorkspacePreviousCycles(ctx, s.store.QuotaSnapshots, states, legacyStates)
+			if legacyErr != nil {
+				return QueryResponse{}, legacyErr
+			}
+		}
 		stateByID := make(map[int64]model.AccountQuotaWindowState, len(states))
 		for _, state := range states {
 			stateByID[state.ID] = state
@@ -596,6 +607,173 @@ func (s *Service) Query(ctx context.Context, req QueryRequest) (QueryResponse, e
 		})
 	}
 	return QueryResponse{GeneratedAtMS: nowMS, Items: items}, nil
+}
+
+type legacyCodexPreviousCycleBridgeCandidate struct {
+	stateIndex int
+	cycleIDs   [3]int64
+	previous   model.AccountQuotaCycle
+}
+
+func legacyCodexWorkspaceQuotaKey(account AccountTarget, provider string) (string, bool) {
+	if normalizeProvider(provider) != "codex" || strings.Trim(account.AuthAccountIDSnapshot, " ") == "" {
+		return "", false
+	}
+	fields := account.identityFields(provider)
+	workspace, workspaceOK := usageidentity.ResolveCodexWorkspace(fields)
+	_, memberOK := usageidentity.NormalizeCodexMemberSnapshot(fields.AccountSnapshot)
+	if !workspaceOK || !memberOK {
+		return "", false
+	}
+	return usageidentity.LegacyCodexWorkspaceAccountKey(provider, workspace)
+}
+
+func bridgeLegacyCodexWorkspacePreviousCycles(
+	ctx context.Context,
+	repository quotasnapshotrepo.Repository,
+	states, legacyStates []model.AccountQuotaWindowState,
+) ([]model.AccountQuotaWindowState, error) {
+	if len(states) == 0 || len(legacyStates) == 0 {
+		return states, nil
+	}
+	legacyByWindow := make(map[string][]model.AccountQuotaWindowState, len(legacyStates))
+	for _, legacyState := range legacyStates {
+		normalized := legacyState
+		normalizeCodexWindowStateForQuery(&normalized)
+		key := legacyCodexQuotaBridgeWindowKey(normalized)
+		legacyByWindow[key] = append(legacyByWindow[key], normalized)
+	}
+
+	candidates := make([]legacyCodexPreviousCycleBridgeCandidate, 0)
+	cycleIDs := make([]int64, 0)
+	for stateIndex := range states {
+		if states[stateIndex].PreviousCycle != nil {
+			continue
+		}
+		current := states[stateIndex]
+		normalizeCodexWindowStateForQuery(&current)
+		matches := make([]model.AccountQuotaWindowState, 0, 1)
+		for _, legacyState := range legacyByWindow[legacyCodexQuotaBridgeWindowKey(current)] {
+			if legacyCodexQuotaBridgeCyclesMatch(current, legacyState) {
+				matches = append(matches, legacyState)
+			}
+		}
+		if len(matches) != 1 {
+			continue
+		}
+		legacyState := matches[0]
+		candidate := legacyCodexPreviousCycleBridgeCandidate{
+			stateIndex: stateIndex,
+			cycleIDs: [3]int64{
+				current.CurrentCycle.ID,
+				legacyState.CurrentCycle.ID,
+				legacyState.PreviousCycle.ID,
+			},
+			previous: *legacyState.PreviousCycle,
+		}
+		candidates = append(candidates, candidate)
+		cycleIDs = append(cycleIDs, candidate.cycleIDs[:]...)
+	}
+	if len(candidates) == 0 {
+		return states, nil
+	}
+	evidenceByCycle, err := repository.ListCyclePlanEvidence(ctx, cycleIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, candidate := range candidates {
+		if !legacyCodexQuotaBridgeHasPersonalPlan(evidenceByCycle, candidate.cycleIDs) {
+			continue
+		}
+		previous := candidate.previous
+		states[candidate.stateIndex].PreviousCycle = &previous
+	}
+	return states, nil
+}
+
+func legacyCodexQuotaBridgeWindowKey(state model.AccountQuotaWindowState) string {
+	return strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(state.Provider)),
+		state.ProviderWindowID,
+		state.WindowKind,
+		state.WindowMode,
+		state.ModelScopeKind,
+		state.ModelScopeKey,
+		state.ModelIDsJSON,
+		state.ScopeFingerprint,
+		state.InventoryScopeKey,
+		state.RelationshipKind,
+		state.ContainerProviderWindowID,
+	}, "\x00")
+}
+
+func legacyCodexQuotaBridgeCyclesMatch(
+	current, legacy model.AccountQuotaWindowState,
+) bool {
+	if current.Availability != "active" || legacy.Availability != "active" ||
+		(current.WindowMode != "fixed" && current.WindowMode != "calendar") ||
+		current.CurrentCycle == nil || legacy.CurrentCycle == nil || legacy.PreviousCycle == nil {
+		return false
+	}
+	currentCycle := current.CurrentCycle
+	legacyCurrent := legacy.CurrentCycle
+	legacyPrevious := legacy.PreviousCycle
+	if currentCycle.State != "active" || legacyCurrent.State != "active" ||
+		currentCycle.ActualEndMS != nil || legacyCurrent.ActualEndMS != nil ||
+		!reliableQuotaCycleBoundary(currentCycle) ||
+		!reliableQuotaCycleBoundary(legacyCurrent) ||
+		!reliableQuotaCycleBoundary(legacyPrevious) ||
+		currentCycle.ActualStartMS != legacyCurrent.ActualStartMS ||
+		!equalOptionalInt64(currentCycle.ScheduledStartMS, legacyCurrent.ScheduledStartMS) ||
+		!equalOptionalInt64(currentCycle.ScheduledEndMS, legacyCurrent.ScheduledEndMS) ||
+		!equalOptionalInt64(currentCycle.DurationSeconds, legacyCurrent.DurationSeconds) ||
+		currentCycle.DurationSeconds == nil || *currentCycle.DurationSeconds <= 0 {
+		return false
+	}
+	if legacyPrevious.State != "closed" || legacyPrevious.ActualEndMS == nil ||
+		legacyPrevious.ActualStartMS >= *legacyPrevious.ActualEndMS ||
+		*legacyPrevious.ActualEndMS > legacyCurrent.ActualStartMS {
+		return false
+	}
+	switch legacyPrevious.EndReason {
+	case "scheduled", "provider_reset", "early_reset":
+		return true
+	default:
+		return false
+	}
+}
+
+func reliableQuotaCycleBoundary(cycle *model.AccountQuotaCycle) bool {
+	return cycle != nil && (cycle.BoundaryAccuracy == "exact" || cycle.BoundaryAccuracy == "derived")
+}
+
+func equalOptionalInt64(left, right *int64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func legacyCodexQuotaBridgeHasPersonalPlan(
+	evidenceByCycle map[int64]quotasnapshotrepo.CyclePlanEvidence,
+	cycleIDs [3]int64,
+) bool {
+	planType := ""
+	for _, cycleID := range cycleIDs {
+		evidence, ok := evidenceByCycle[cycleID]
+		if !ok || evidence.SnapshotCount == 0 || evidence.MissingPlanCount != 0 || len(evidence.PlanTypes) != 1 {
+			return false
+		}
+		candidate := evidence.PlanTypes[0]
+		if _, personal := codexPersonalPlans[candidate]; !personal {
+			return false
+		}
+		if planType != "" && candidate != planType {
+			return false
+		}
+		planType = candidate
+	}
+	return planType != ""
 }
 
 // normalizeCodexSnapshotForQuery is the read-side compatibility shield for

--- a/apps/manager-server/internal/service/quotasnapshot/service_test.go
+++ b/apps/manager-server/internal/service/quotasnapshot/service_test.go
@@ -46,6 +46,62 @@ func quotaSnapshotTestAccount() AccountTarget {
 	}
 }
 
+func writeQuotaLifecycleSnapshotForKey(
+	t *testing.T,
+	service *Service,
+	accountKey, observationID string,
+	observedAtMS, cycleStartMS, cycleEndMS, durationSeconds int64,
+	usedPercent float64,
+	planType string,
+) {
+	t.Helper()
+	entry := WriteEntry{
+		Provider: "codex",
+		Observation: &ObservationInput{
+			Source:              "api_query",
+			SourceObservationID: observationID,
+			ObservedAtMS:        observedAtMS,
+			InventoryScopeKey:   "codex:rate-limits",
+			InventoryMode:       "partial",
+		},
+		Windows: []WindowInput{{
+			ProviderWindowID:    "weekly",
+			WindowKind:          "weekly",
+			WindowMode:          "fixed",
+			ModelScopeKind:      "family",
+			ModelScopeKey:       "codex_main",
+			Source:              "api_query",
+			SourceObservationID: observationID,
+			ObservedAtMS:        observedAtMS,
+			BoundaryAccuracy:    "exact",
+			CycleStartMS:        &cycleStartMS,
+			CycleEndMS:          &cycleEndMS,
+			DurationSeconds:     &durationSeconds,
+			UsedPercent:         &usedPercent,
+			PlanType:            planType,
+		}},
+	}
+	observation, err := normalizeObservationInput(accountKey, "codex", entry, service.now().UnixMilli())
+	if err != nil {
+		t.Fatalf("normalize quota observation: %v", err)
+	}
+	snapshot, err := normalizeWindowInput(accountKey, "codex", entry.Windows[0], service.now().UnixMilli())
+	if err != nil {
+		t.Fatalf("normalize quota snapshot: %v", err)
+	}
+	snapshot.InventoryScopeKey = observation.InventoryScopeKey
+	write := model.AccountQuotaObservationWrite{
+		Observation: observation,
+		Snapshots:   []model.AccountQuotaSnapshot{snapshot},
+	}
+	write.Observation.WindowCount = len(write.Snapshots)
+	write.Snapshots[0].ContentHash = snapshotContentHash(write.Snapshots[0])
+	write.Observation.ObservationHash = observationHash(write)
+	if err := service.store.QuotaSnapshots.InsertObservationWrites(context.Background(), []model.AccountQuotaObservationWrite{write}); err != nil {
+		t.Fatalf("write quota lifecycle snapshot: %v", err)
+	}
+}
+
 func TestWriteQuerySelectsLatestCompleteObservationAndMergesCodexResetCredits(t *testing.T) {
 	service := newQuotaSnapshotTestService(t, 20_000)
 	cycleStart := int64(10_000)
@@ -201,6 +257,202 @@ func TestCodexQuotaSnapshotsStayMemberScopedAndIgnoreLegacyWorkspaceKey(t *testi
 	}
 	if aliceRows != 1 || bobRows != 1 || legacyRows != 1 {
 		t.Fatalf("quota snapshot rows were migrated/fanned out: Alice=%d Bob=%d legacy=%d", aliceRows, bobRows, legacyRows)
+	}
+}
+
+func TestQueryBridgesLegacyCodexPreviousCycleOnlyForConsistentPersonalPlan(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		previousPlan      string
+		legacyCurrentPlan string
+		memberCurrentPlan string
+		mixedMemberPlan   string
+		memberStartOffset int64
+		wantBridge        bool
+	}{
+		{name: "Plus", previousPlan: "plus", legacyCurrentPlan: "plus", memberCurrentPlan: "plus", wantBridge: true},
+		{name: "Free", previousPlan: "free", legacyCurrentPlan: "free", memberCurrentPlan: "free", wantBridge: true},
+		{name: "Pro", previousPlan: "pro", legacyCurrentPlan: "pro", memberCurrentPlan: "pro", wantBridge: true},
+		{name: "Go", previousPlan: "go", legacyCurrentPlan: "go", memberCurrentPlan: "go", wantBridge: true},
+		{name: "normalized personal plan", previousPlan: " Plus ", legacyCurrentPlan: "PLUS", memberCurrentPlan: "plus", wantBridge: true},
+		{name: "Team", previousPlan: "team", legacyCurrentPlan: "team", memberCurrentPlan: "team"},
+		{name: "Business", previousPlan: "business", legacyCurrentPlan: "business", memberCurrentPlan: "business"},
+		{name: "Enterprise", previousPlan: "enterprise", legacyCurrentPlan: "enterprise", memberCurrentPlan: "enterprise"},
+		{name: "Edu", previousPlan: "edu", legacyCurrentPlan: "edu", memberCurrentPlan: "edu"},
+		{name: "unknown plan", previousPlan: "", legacyCurrentPlan: "", memberCurrentPlan: ""},
+		{name: "future plan", previousPlan: "starter", legacyCurrentPlan: "starter", memberCurrentPlan: "starter"},
+		{name: "plan changed", previousPlan: "free", legacyCurrentPlan: "plus", memberCurrentPlan: "plus"},
+		{name: "mixed member cycle", previousPlan: "plus", legacyCurrentPlan: "plus", memberCurrentPlan: "plus", mixedMemberPlan: "team"},
+		{name: "current boundary mismatch", previousPlan: "plus", legacyCurrentPlan: "plus", memberCurrentPlan: "plus", memberStartOffset: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service, path := newQuotaSnapshotTestServiceWithPath(t, 250_000)
+			account := AccountTarget{
+				AuthFileSnapshot:      "member.json",
+				AuthProviderSnapshot:  "codex",
+				AuthAccountIDSnapshot: "workspace-1",
+				AuthIndex:             "auth-member",
+				AccountSnapshot:       "member@example.com",
+				Source:                "member.json",
+			}
+			memberKey, memberOK := usageidentity.AccountKey(account.identityFields("codex"))
+			legacyKey, legacyOK := usageidentity.LegacyCodexWorkspaceAccountKey("codex", "workspace-1")
+			if !memberOK || !legacyOK || memberKey == legacyKey {
+				t.Fatalf("quota bridge keys = member:%q/%v legacy:%q/%v", memberKey, memberOK, legacyKey, legacyOK)
+			}
+
+			const durationSeconds = int64(100)
+			const previousStartMS = int64(100_000)
+			const currentStartMS = int64(200_000)
+			const currentEndMS = int64(300_000)
+			writeQuotaLifecycleSnapshotForKey(t, service, legacyKey, "legacy-previous", 150_000,
+				previousStartMS, currentStartMS, durationSeconds, 70, test.previousPlan)
+			writeQuotaLifecycleSnapshotForKey(t, service, legacyKey, "legacy-current", 220_000,
+				currentStartMS, currentEndMS, durationSeconds, 90, test.legacyCurrentPlan)
+			memberStartMS := currentStartMS + test.memberStartOffset
+			memberEndMS := currentEndMS + test.memberStartOffset
+			writeQuotaLifecycleSnapshotForKey(t, service, memberKey, "member-current", 221_000,
+				memberStartMS, memberEndMS, durationSeconds, 11, test.memberCurrentPlan)
+			if test.mixedMemberPlan != "" {
+				writeQuotaLifecycleSnapshotForKey(t, service, memberKey, "member-current-mixed", 222_000,
+					memberStartMS, memberEndMS, durationSeconds, 12, test.mixedMemberPlan)
+			}
+
+			result, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+				RowKey: "member", Provider: "codex", Account: account,
+			}}, NowMS: 250_000})
+			if err != nil {
+				t.Fatalf("query bridged quota lifecycle: %v", err)
+			}
+			if len(result.Items) != 1 || len(result.Items[0].Windows) != 1 {
+				t.Fatalf("quota bridge result = %#v", result)
+			}
+			window := result.Items[0].Windows[0]
+			wantUsedPercent := 11.0
+			if test.mixedMemberPlan != "" {
+				wantUsedPercent = 12
+			}
+			if window.UsedPercent == nil || *window.UsedPercent != wantUsedPercent {
+				t.Fatalf("member current usage was replaced by legacy workspace data: %#v", window)
+			}
+			if gotBridge := window.PreviousCycle != nil; gotBridge != test.wantBridge {
+				t.Fatalf("previous cycle bridged = %v, want %v: %#v", gotBridge, test.wantBridge, window.PreviousCycle)
+			}
+			if test.wantBridge {
+				if window.CurrentCycle == nil || window.PreviousCycle.ActualStartMS != previousStartMS ||
+					window.PreviousCycle.ActualEndMS == nil || *window.PreviousCycle.ActualEndMS != currentStartMS ||
+					window.PreviousCycle.EndReason != "scheduled" ||
+					window.PreviousCycle.ActivationID == window.CurrentCycle.ActivationID {
+					t.Fatalf("bridged previous cycle = %#v current=%#v", window.PreviousCycle, window.CurrentCycle)
+				}
+			}
+
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatalf("open quota bridge database: %v", err)
+			}
+			defer db.Close()
+			var legacySnapshots, memberSnapshots int
+			if err := db.QueryRow(`select count(*) from account_quota_snapshots where account_key = ?`, legacyKey).Scan(&legacySnapshots); err != nil {
+				t.Fatalf("count legacy quota snapshots: %v", err)
+			}
+			if err := db.QueryRow(`select count(*) from account_quota_snapshots where account_key = ?`, memberKey).Scan(&memberSnapshots); err != nil {
+				t.Fatalf("count member quota snapshots: %v", err)
+			}
+			wantMemberSnapshots := 1
+			if test.mixedMemberPlan != "" {
+				wantMemberSnapshots = 2
+			}
+			if legacySnapshots != 2 || memberSnapshots != wantMemberSnapshots {
+				t.Fatalf("quota query rewrote snapshots: legacy=%d member=%d", legacySnapshots, memberSnapshots)
+			}
+		})
+	}
+}
+
+func TestQueryKeepsMemberPreviousCycleInsteadOfLegacyWorkspaceCycle(t *testing.T) {
+	service := newQuotaSnapshotTestService(t, 250_000)
+	account := AccountTarget{
+		AuthFileSnapshot:      "member.json",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "workspace-1",
+		AuthIndex:             "auth-member",
+		AccountSnapshot:       "member@example.com",
+		Source:                "member.json",
+	}
+	memberKey, _ := usageidentity.AccountKey(account.identityFields("codex"))
+	legacyKey, _ := usageidentity.LegacyCodexWorkspaceAccountKey("codex", "workspace-1")
+	for _, accountKey := range []string{legacyKey, memberKey} {
+		writeQuotaLifecycleSnapshotForKey(t, service, accountKey, accountKey+"-previous", 150_000,
+			100_000, 200_000, 100, 70, "plus")
+		writeQuotaLifecycleSnapshotForKey(t, service, accountKey, accountKey+"-current", 220_000,
+			200_000, 300_000, 100, 10, "plus")
+	}
+
+	result, err := service.Query(context.Background(), QueryRequest{Accounts: []QueryAccount{{
+		RowKey: "member", Provider: "codex", Account: account,
+	}}, NowMS: 250_000})
+	if err != nil {
+		t.Fatalf("query member lifecycle: %v", err)
+	}
+	if len(result.Items) != 1 || len(result.Items[0].Windows) != 1 {
+		t.Fatalf("member lifecycle result = %#v", result)
+	}
+	window := result.Items[0].Windows[0]
+	if window.CurrentCycle == nil || window.PreviousCycle == nil ||
+		window.PreviousCycle.ActivationID != window.CurrentCycle.ActivationID {
+		t.Fatalf("member previous cycle was replaced by legacy workspace cycle: current=%#v previous=%#v", window.CurrentCycle, window.PreviousCycle)
+	}
+}
+
+func TestLegacyCodexQuotaBridgeAcceptsOnlyReliableClosedCycleReasons(t *testing.T) {
+	currentStartMS := int64(200_000)
+	currentEndMS := int64(300_000)
+	previousEndMS := currentStartMS
+	durationSeconds := int64(100)
+	cycle := func(id, activationID int64, state, endReason string, startMS int64, endMS *int64) *model.AccountQuotaCycle {
+		return &model.AccountQuotaCycle{
+			ID:               id,
+			ActivationID:     activationID,
+			State:            state,
+			ScheduledStartMS: &startMS,
+			ScheduledEndMS:   endMS,
+			ActualStartMS:    startMS,
+			ActualEndMS:      endMS,
+			DurationSeconds:  &durationSeconds,
+			BoundaryAccuracy: "exact",
+			EndReason:        endReason,
+		}
+	}
+	for _, test := range []struct {
+		endReason string
+		want      bool
+	}{
+		{endReason: "scheduled", want: true},
+		{endReason: "provider_reset", want: true},
+		{endReason: "early_reset", want: true},
+		{endReason: "mode_changed"},
+		{endReason: "window_removed"},
+		{endReason: ""},
+	} {
+		t.Run(test.endReason, func(t *testing.T) {
+			current := model.AccountQuotaWindowState{
+				WindowMode:   "fixed",
+				Availability: "active",
+				CurrentCycle: cycle(3, 2, "active", "", currentStartMS, nil),
+			}
+			legacy := model.AccountQuotaWindowState{
+				WindowMode:    "fixed",
+				Availability:  "active",
+				CurrentCycle:  cycle(2, 1, "active", "", currentStartMS, nil),
+				PreviousCycle: cycle(1, 1, "closed", test.endReason, 100_000, &previousEndMS),
+			}
+			current.CurrentCycle.ScheduledEndMS = &currentEndMS
+			legacy.CurrentCycle.ScheduledEndMS = &currentEndMS
+			if got := legacyCodexQuotaBridgeCyclesMatch(current, legacy); got != test.want {
+				t.Fatalf("legacyCodexQuotaBridgeCyclesMatch(%q) = %v, want %v", test.endReason, got, test.want)
+			}
+		})
 	}
 }
 

--- a/apps/manager-server/internal/usageidentity/identity.go
+++ b/apps/manager-server/internal/usageidentity/identity.go
@@ -45,6 +45,28 @@ func CodexAccountIDFromSnapshot(snapshot string) string {
 	return accountID
 }
 
+// HasCodexAccountIDSnapshotMarker reports whether a historical project
+// snapshot claims Codex account-id provenance, including malformed markers.
+// Callers use this to distinguish missing legacy evidence from invalid
+// evidence that must fail closed.
+func HasCodexAccountIDSnapshotMarker(snapshot string) bool {
+	return strings.HasPrefix(strings.Trim(snapshot, " "), codexAccountIDSnapshotPrefix)
+}
+
+// LegacyCodexWorkspaceAccountKey returns the v3 Workspace-only Codex key used
+// before member-aware identity was introduced. It is intentionally separate
+// from AccountKey: new writes must always remain member-aware when strong
+// member evidence is available, while narrow compatibility readers may use
+// this key to inspect orphaned legacy derived data.
+func LegacyCodexWorkspaceAccountKey(provider, workspace string) (string, bool) {
+	provider = normalizeProvider(provider)
+	workspace, workspaceOK := NormalizeCodexWorkspaceSnapshot(workspace)
+	if provider != "codex" || !workspaceOK {
+		return "", false
+	}
+	return encodeCodexKey("codex-account", provider, workspace), true
+}
+
 // ProjectIDSnapshot returns only a real provider project snapshot. The
 // pre-v3 Codex account marker is retained in immutable history for audit but
 // must never be exposed as a project identifier again.

--- a/apps/manager-server/internal/usageidentity/identity_test.go
+++ b/apps/manager-server/internal/usageidentity/identity_test.go
@@ -98,6 +98,41 @@ func TestAccountKeyUsesCodexWorkspaceAndMemberAcrossMutableCredentialIdentity(t 
 	}
 }
 
+func TestLegacyCodexWorkspaceAccountKeyIsExplicitAndStable(t *testing.T) {
+	key, ok := LegacyCodexWorkspaceAccountKey(" Codex ", " workspace-1 ")
+	const want = "usage-account-history:3:codex-account:636F646578:776F726B73706163652D31"
+	if !ok || key != want {
+		t.Fatalf("LegacyCodexWorkspaceAccountKey() = %q, %v; want %q, true", key, ok, want)
+	}
+	for _, test := range []struct {
+		provider  string
+		workspace string
+	}{
+		{provider: "openai", workspace: "workspace-1"},
+		{provider: "codex", workspace: "   "},
+	} {
+		if got, valid := LegacyCodexWorkspaceAccountKey(test.provider, test.workspace); valid || got != "" {
+			t.Fatalf("LegacyCodexWorkspaceAccountKey(%q, %q) = %q, %v; want empty, false", test.provider, test.workspace, got, valid)
+		}
+	}
+}
+
+func TestHasCodexAccountIDSnapshotMarkerIncludesMalformedEvidence(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  bool
+	}{
+		{value: CodexAccountIDSnapshot("workspace-1"), want: true},
+		{value: " codex-account-id:v1: ", want: true},
+		{value: "workspace-1", want: false},
+		{value: "", want: false},
+	} {
+		if got := HasCodexAccountIDSnapshotMarker(test.value); got != test.want {
+			t.Fatalf("HasCodexAccountIDSnapshotMarker(%q) = %v; want %v", test.value, got, test.want)
+		}
+	}
+}
+
 func TestAccountKeyFallsBackWhenCodexMemberEvidenceIsMissingOrWeak(t *testing.T) {
 	for _, snapshot := range []string{"", "Alice", "alice@example.com@duplicate"} {
 		fields := Fields{


### PR DESCRIPTION
## Summary

Restore accurate Codex previous-window usage history for legacy events while keeping ambiguous identity evidence fail-closed.

The fix bridges only validated personal-plan cycles and preserves the immutable usage event history used for recovery.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Accept legacy Codex weak-identity events only as a leading prefix followed by a direct Workspace identity anchor.
- Reject provider, Workspace, member, malformed-marker, and post-anchor weak-identity conflicts.
- Restore guarded legacy previous-cycle evidence for matching window, scope, inventory, mode, duration, and reset boundaries.
- Bridge only consistent personal plans: free, plus, pro, and go.
- Exclude Team, Business, Enterprise, Edu, unknown, future, mixed, or changed plan evidence.
- Preserve member-owned previous cycles and do not rewrite usage_events or quota snapshots.

## User Impact

Codex personal accounts can recover the correct previous-window request, token, and cost history from compatible legacy data. Ambiguous or Team-scoped data remains excluded rather than being attributed to the wrong account or member.

## Compatibility / Runtime Notes

- CPA panel mode: No CPA code or protocol changes.
- Manager Server mode: Applies to Codex usage-event attribution and quota-history reads.
- Full Docker / native packages: No configuration or packaging changes; existing usage.sqlite data remains usable.

## Data / Security Notes

- usage_events remains the authoritative, immutable recovery input.
- No raw events, quota snapshots, credentials, admin keys, or CPA Management Keys are rewritten.
- Identity recovery fails closed when strong Workspace/member evidence is missing or inconsistent.

## Risk / Rollback

Risk level: Medium

Rollback notes:

Revert the four commits or deploy the previous Manager Server image. The raw usage event history remains untouched, so the derived history behavior can be re-evaluated after rollback.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm run manager-server:test
cd apps/manager-server && go test -race ./...
npm run type-check
npm run lint
npm run test
npm run build
git diff --check
```

All commands passed. Lint reported zero errors and one pre-existing Fast Refresh warning. The full frontend/repository test run passed with 217 files and 3072 tests.

Real database recovery evidence:

- 5,895 previous-window requests
- 763,129,136 tokens
- $39.20323592 total cost
- matched: true
- scope_match_status: complete
- unmatched_requests: 0

The local Docker image built from this branch started healthy and returned {"ok":true,"service":"cpa-manager-plus"}.

## Screenshots / Recordings

N/A — backend-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — backend-only change; no configuration or public API changes.

Docs decision:

No documentation changes are required for this internal history-recovery correction.

## Related

N/A