### PR TITLE
docs(release): prepare v1.12.9

### DIFF
--- a/docs/release-notes/v1.12.9-en.md
+++ b/docs/release-notes/v1.12.9-en.md
@@ -1,0 +1,43 @@
+# CPA Manager Plus v1.12.9
+
+> 61 commits · 144 files changed · +21457 / -1691
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.9/docs/release-notes/v1.12.9-zh.md)
+
+## Overview
+
+v1.12.9 focuses on correct Codex multi-member identity and quota-history attribution, fixes account health after OAuth reauthentication, and improves Accounts quota lifecycle, forecast, and fallback presentation. It also adds per-model Thinking Levels configuration for OpenAI Compatible Provider models.
+
+## Highlights
+
+### Features
+
+- OpenAI Compatible Provider model editors support per-model Thinking Levels configuration while preserving the unconfigured state and unknown or future fields. (Web)
+
+### Fixes
+
+- Codex usage, cost, quota, and credential actions are now isolated by Workspace plus strong member evidence; same-member reauthentication preserves history continuity, while missing or conflicting member evidence is not merged across accounts. (Manager Server / Web)
+- After confirmed Codex OAuth reauthentication, pre-reauthentication 401 evidence no longer keeps an account in needs re-login; new authentication failures remain actionable. (Web)
+- Compatible legacy Codex personal-plan data can now restore previous-window request, token, and cost history; inconsistent identity, plan, or window evidence remains unattributed. (Manager Server)
+- Accounts stops showing a forecast when current usage is ahead of trusted quota progress and resumes it automatically after a fresh progress observation catches up, avoiding projections based on stale progress. (Web)
+- Codex quota cycles and snapshots now respect cycle, observation-time, and field-freshness evidence; an older snapshot cannot roll newer quota backward, and remaining-only evidence cannot fabricate used values or progress provenance. (Web / Manager Server)
+- Codex quota windows recognize more five-hour, weekly, and monthly cycle identifiers and reject zero-only placeholder responses without reliable evidence. (Web)
+- Accounts continues to separate provider-specific quota information in list and detail views: Antigravity model-family matrices, Claude model-scoped quota, xAI billing and PAYG, and Kimi summaries remain visible with lifecycle-aware status. (Web)
+- Credential-file, monitoring, and automatic status actions remain isolated or pending when credential locator or ownership evidence conflicts, preventing mutations against another Codex credential. (Web / Manager Server)
+- Non-Codex historical observation-time compatibility is restored so valid Claude, Antigravity, Kimi, and xAI quota state is not lost during fallback reads. (Web)
+- Escape in the OpenAI Thinking Levels UI closes only the tooltip instead of accidentally closing its parent Drawer or Modal. (Web)
+
+## Upgrade Notes
+
+- This release adds no SQLite tables or columns; `usage_events` remains immutable. Codex identity-related history, monitoring, and pricing-derived projections may refresh through the existing background maintenance path, and legacy Workspace-only data is not fanned out to multiple members.
+- When provider quota progress lags behind current usage, Accounts temporarily hides the forecast until fresh trusted progress arrives; this is a data-protection state, not a quota reset.
+- Newly discovered OpenAI Compatible Provider models leave Thinking Levels unconfigured by default. Configure levels only after confirming upstream model support; unknown fields are preserved.
+- Compatible legacy Codex previous-window recovery is limited to evidence-consistent personal plans (free, plus, pro, and go); Team, Business, Enterprise, Edu, unknown, and mixed evidence remain excluded.
+
+## Acknowledgements
+
+- [@riba2534](https://github.com/riba2534) - Restored the Antigravity model-family quota matrix and improved compact layout readability so users can inspect 5H/7D quota without opening details.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.8...v1.12.9

--- a/docs/release-notes/v1.12.9-zh.md
+++ b/docs/release-notes/v1.12.9-zh.md
@@ -1,0 +1,43 @@
+# CPA Manager Plus v1.12.9
+
+> 61 commits · 144 files changed · +21457 / -1691
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.9/docs/release-notes/v1.12.9-en.md)
+
+## Overview
+
+v1.12.9 聚焦 Codex 多成员身份与配额历史的正确归属，修复 OAuth 重认证后的账户健康状态，并完善 Accounts 配额生命周期、预测和回退展示；同时为 OpenAI Compatible Provider 增加按模型配置 Thinking Levels 的能力。
+
+## Highlights
+
+### Features
+
+- OpenAI Compatible Provider 模型编辑器支持按模型配置 Thinking Levels，可保持未配置状态并保留未知或未来配置字段。（Web）
+
+### Fixes
+
+- Codex 用量、成本、配额和凭证操作现在按 Workspace 与强成员证据隔离，同一成员重认证保持历史连续；成员证据缺失或冲突时不跨账户合并。（Manager Server / Web）
+- 确认完成 Codex OAuth 重认证后，重认证前的 401 证据不再继续将账户标记为需要重新登录；新的认证失败仍可被识别。（Web）
+- 兼容的 Codex 个人计划旧数据现在可恢复上一配额窗口的请求、Token 和成本历史；身份、计划或窗口证据不一致时保持不归属。（Manager Server）
+- Accounts 在当前用量领先可信配额进度时停止显示预测，待进度观测追上后自动恢复，避免使用过期进度计算结果。（Web）
+- Codex 配额周期和快照现在按周期、观测时间与字段新鲜度判断，旧快照不能回滚更新配额，剩余量证据也不会伪造已用量或进度来源。（Web / Manager Server）
+- Codex 配额窗口可识别更多五小时、周和月周期标识，并拒绝缺少可靠证据的零值占位响应。（Web）
+- Accounts 凭证列表与详情继续按 Provider 区分配额信息：Antigravity 模型族矩阵、Claude 模型级额度、xAI 计费与 PAYG、Kimi 汇总等回退数据保持可见，并按刷新生命周期显示对应状态。（Web）
+- 认证文件、监控检查和自动状态操作在凭证定位或所有权证据冲突时保持独立或待确认，避免误操作其他 Codex 凭证。（Web / Manager Server）
+- 非 Codex Provider 的历史观测时间兼容性得到恢复，Claude、Antigravity、Kimi 和 xAI 的有效配额状态不会因回退读取而丢失。（Web）
+- OpenAI 配置界面的 Thinking Levels 提示框在按下 Escape 时只关闭提示框，不再误关闭父级 Drawer 或 Modal。（Web）
+
+## Upgrade Notes
+
+- 本版本不新增 SQLite 表或列；`usage_events` 保持不可变，升级后 Codex 身份相关的历史、监控和定价派生投影可能通过现有后台维护流程刷新；旧 Workspace-only 数据不会自动分摊给多个成员。
+- 当 Provider 配额进度落后当前用量时，Accounts 会暂时隐藏预测，直到新的可信进度到达；这表示数据保护状态，不是配额被清零。
+- OpenAI Compatible Provider 新发现的模型默认保持 Thinking Levels 未配置；为模型配置级别前，请确认上游模型实际支持这些级别，已有未知字段会被保留。
+- 旧 Codex 上一窗口历史的兼容恢复只适用于证据一致的 free、plus、pro、go 个人计划；Team、Business、Enterprise、Edu、未知或混合证据继续排除。
+
+## Acknowledgements
+
+- [@riba2534](https://github.com/riba2534) - 贡献 Antigravity 凭证列表中的模型族配额矩阵恢复与布局可读性修正，让用户无需打开详情即可查看 5H/7D 额度。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.8...v1.12.9

--- a/docs/release-posts/v1.12.9-telegram.html
+++ b/docs/release-posts/v1.12.9-telegram.html
@@ -1,0 +1,26 @@
+🚀 <b>9 月 5 日 · v1.12.9</b>
+
+✨ <b>更新内容</b>
+
+• OpenAI Compatible Provider 的模型编辑器现在支持按模型配置 Thinking Levels，并保留未配置状态与未知配置。
+• Accounts 现在按 Workspace 与成员隔离 Codex 的用量、成本、配额和凭证操作，同一成员重认证仍能延续历史。
+• 确认 Codex OAuth 重认证后，旧的 401 证据不再持续把账户标记为需要重新登录。
+• Codex 个人账户可以从兼容的旧数据恢复上一配额窗口的请求、Token 和成本历史，身份不明确时仍保持不归属。
+• Accounts 在当前用量领先可信配额进度时暂不显示预测，等新进度到达后自动恢复。
+• Accounts 配额周期和快照按观测新鲜度处理，避免旧数据回滚新配额或混合已用量与剩余量。
+• Accounts 配额列表和详情按 Provider 保留 Antigravity 模型族、Claude 模型级额度、xAI 计费/PAYG 与 Kimi 汇总等信息，并按刷新状态显示对应颜色。
+• Codex 可识别更多五小时、周和月配额周期，缺乏证据的零值占位数据不再影响周期判断。
+• 凭证定位或所有权证据冲突时，Accounts、监控与自动状态操作会保持待确认，避免误触另一 Codex 凭证。
+• Claude、Antigravity、Kimi 和 xAI 的有效配额状态在兼容回退读取时继续保留正确的观测时间。
+• OpenAI 配置界面的 Thinking Levels 提示框按下 Escape 时只关闭提示框，不再误关闭父级编辑窗口。
+
+⚠️ <b>注意事项</b>
+
+• 本版本不新增 SQLite 表或列；usage_events 保持不可变，升级后 Codex 历史投影可能由现有后台维护流程刷新，旧 Workspace-only 数据不会自动分摊给多个成员。
+• OpenAI Compatible Provider 新发现的模型默认保持 Thinking Levels 未配置；请只为确认得到上游支持的模型配置级别。
+• 当配额进度落后当前用量时，Accounts 会暂时不显示预测，直到新的可信进度到达。
+• 兼容旧 Codex 上一窗口历史的恢复只适用于证据一致的 free、plus、pro、go 个人计划；Team、Business、Enterprise、Edu 或证据冲突的数据会继续排除。
+
+🤝 <b>致谢</b>
+
+• <a href="https://github.com/riba2534">@riba2534</a> - 贡献 Antigravity 凭证列表中的模型族配额矩阵恢复与布局可读性修正，让用户无需打开详情即可查看 5H/7D 额度。


### PR DESCRIPTION
## Summary

Prepare the reviewed v1.12.9 release notes and Actions-only Telegram announcement for the protected release flow.

> Community and maintenance PRs must target `dev`. Repository automation retargets other pull requests to `dev`; this can change the diff and make existing review comments outdated. `main` accepts only a promotion PR whose source is this repository's `dev` branch.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add the Chinese and English v1.12.9 release notes with reciprocal tag-pinned links.
- Add the reviewed v1.12.9 Telegram HTML post for the GitHub Actions notification.
- Keep the release content aligned with the frozen 61-commit v1.12.9 scope.

## User Impact

The release record documents Codex workspace-member identity isolation and legacy history recovery, OAuth reauthentication health correction, provider-aware quota lifecycle and forecast safeguards, OpenAI Thinking Levels configuration, and restored Antigravity quota visibility for users upgrading to v1.12.9.

## Compatibility / Runtime Notes

- CPA panel mode: N/A; this PR contains release documentation only.
- Manager Server mode: N/A; this PR contains release documentation only.
- Full Docker / native packages: The release workflow consumes these files when building and publishing v1.12.9 artifacts.

## Data / Security Notes

N/A; this PR adds documentation and a reviewed notification body only. It adds no schema, migration, backfill, secret, credential, or runtime data.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert this release-only merge before promotion if the reviewed content is found to be incorrect. No runtime code or data is changed.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Docs/link check
- [x] Not applicable, docs-only

Commands / evidence:

```text
npm run --silent release:validate -- --tag v1.12.9 --content-only  # passed
git diff --check                                                   # passed

Frozen source dev: abcfdc1724c6c22ec2bea0f98bb8f8e0a1e32bc4
Release range: 7c4cbeadaa801613e98ea6874b902844f09e59c6..abcfdc1724c6c22ec2bea0f98bb8f8e0a1e32bc4
Release scope: 61 commits, 144 files changed, +21457 / -1691

UTF-8 SHA-256 digests:
  docs/release-notes/v1.12.9-zh.md
  c654f0d0b5f023186177d10830e51b353e517c34700d64418fdfa09808de216d
  docs/release-notes/v1.12.9-en.md
  e4273ef278e6efe51b570dc78313de1163985519592b1177b58b8487cb742ad1
  docs/release-posts/v1.12.9-telegram.html
  4dfca4776333da2841851d61dab9d1781fc69d23defc9b1c6ee77609e60a2a7c
```

## Screenshots / Recordings

N/A; this PR contains release documentation and a notification body only.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [x] Release notes needed
- [ ] Not needed — explanation included below

Docs decision:

The versioned release notes and reviewed Telegram post are required release artifacts for v1.12.9.

## Related

N/A