### PR TITLE
perf(manager-server): compact legacy identity evidence reads

### DIFF
--- a/apps/manager-server/cmd/cpa-manager-plus/codex_legacy_identity_test.go
+++ b/apps/manager-server/cmd/cpa-manager-plus/codex_legacy_identity_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+)
+
+func TestCodexLegacyIdentityBackfillServesHTTPBeforeCompletionAndResumes(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("100k external-process migration timing is verified by the normal suite")
+	}
+	const rowCount int64 = 100_001
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "usage.sqlite")
+	db, err := sqliterepo.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`with recursive ids(id) as (
+		select 1 union all select id + 1 from ids where id < ?
+	) insert into usage_events (
+		id, event_hash, timestamp_ms, timestamp, model, created_at_ms,
+		provider, auth_provider_snapshot, auth_file_snapshot, source,
+		auth_index, auth_account_id_snapshot, account_snapshot, raw_json
+	) select id, 'identity-' || id, id, cast(id as text), 'gpt-test', id,
+		'codex', 'codex', 'codex-a.json', 'codex-a.json', 'auth-a',
+		case when id <= ? then '' else 'account-a' end,
+		'same@example.com', null from ids`, rowCount, rowCount/2); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	// Reproduce an upgrade from a database that has no evidence derivation.
+	if _, err := db.Exec("drop table usage_codex_legacy_identity_evidence_v1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("delete from usage_monitoring_rollup_state where rollup_name = 'codex_legacy_identity_v1'"); err != nil {
+		t.Fatal(err)
+	}
+	before := readUsageEventsSummaryFromDB(t, db)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	first := startManagerServerProcess(t, tempDir, dbPath)
+	firstStopped := false
+	t.Cleanup(func() {
+		if !firstStopped {
+			first.stop(t)
+		}
+	})
+	assertManagerEndpoint(t, first.addr, "/management.html")
+	assertManagerEndpoint(t, first.addr, "/usage-service/info")
+	assertManagerEndpoint(t, first.addr, "/health")
+	observer := openMigrationObserver(t, dbPath)
+	t.Cleanup(func() { _ = observer.Close() })
+	initial := readCodexIdentityCoverage(t, observer)
+	if initial >= rowCount {
+		t.Fatalf("identity evidence completed before initial HTTP acceptance: %d", initial)
+	}
+	waitForCodexIdentityCoverage(t, observer, initial)
+	first.stop(t)
+	firstStopped = true
+	checkpoint := readCodexIdentityCoverage(t, observer)
+	if checkpoint <= 0 || checkpoint >= rowCount {
+		t.Fatalf("interrupted identity coverage = %d", checkpoint)
+	}
+	if after := readUsageEventsSummaryFromDB(t, observer); after != before {
+		t.Fatalf("identity backfill changed raw events: before=%+v after=%+v", before, after)
+	}
+
+	second := startManagerServerProcess(t, tempDir, dbPath)
+	secondStopped := false
+	t.Cleanup(func() {
+		if !secondStopped {
+			second.stop(t)
+		}
+	})
+	assertManagerEndpoint(t, second.addr, "/management.html")
+	assertManagerEndpoint(t, second.addr, "/usage-service/info")
+	assertManagerEndpoint(t, second.addr, "/health")
+	waitForCodexIdentityCoverage(t, observer, checkpoint)
+	second.stop(t)
+	secondStopped = true
+	if after := readUsageEventsSummaryFromDB(t, observer); after != before {
+		t.Fatalf("resumed identity backfill changed raw events: before=%+v after=%+v", before, after)
+	}
+}
+
+func readCodexIdentityCoverage(t testing.TB, db *sql.DB) int64 {
+	t.Helper()
+	var coverage int64
+	if err := db.QueryRow(`select coverage_event_id from usage_monitoring_rollup_state
+		where rollup_name = 'codex_legacy_identity_v1'`).Scan(&coverage); err != nil {
+		t.Fatal(err)
+	}
+	return coverage
+}
+
+func waitForCodexIdentityCoverage(t testing.TB, db *sql.DB, previous int64) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if readCodexIdentityCoverage(t, db) > previous {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("identity evidence did not advance past %d", previous)
+}

--- a/apps/manager-server/internal/repository/sqlite/codex_legacy_identity.go
+++ b/apps/manager-server/internal/repository/sqlite/codex_legacy_identity.go
@@ -1,0 +1,29 @@
+package sqlite
+
+const (
+	usageCodexLegacyIdentityEvidenceTable  = "usage_codex_legacy_identity_evidence_v1"
+	usageCodexLegacyIdentityRollupName     = "codex_legacy_identity_v1"
+	usageCodexLegacyIdentityEvidenceLegacy = "usage_codex_legacy_identity_evidence_v1_legacy_recovery"
+
+	// This table and its primary key are created empty. Historical evidence is
+	// populated by the post-listener worker, never by startup migrations.
+	createUsageCodexLegacyIdentityEvidenceTable = `create table if not exists usage_codex_legacy_identity_evidence_v1 (
+		structure_revision text not null,
+		physical_kind integer not null,
+		physical_file text collate nocase not null,
+		auth_index text collate nocase not null,
+		provider text not null,
+		auth_provider_snapshot text not null,
+		auth_account_id_snapshot text not null,
+		auth_project_id_snapshot text not null,
+		account_snapshot text not null,
+		min_evidence_at_ms integer not null,
+		max_evidence_at_ms integer not null,
+		chronology_unknown integer not null,
+		primary key (
+			structure_revision, physical_kind, physical_file, auth_index,
+			provider, auth_provider_snapshot, auth_account_id_snapshot,
+			auth_project_id_snapshot, account_snapshot
+		)
+	)`
+)

--- a/apps/manager-server/internal/repository/sqlite/derived_cleanup.go
+++ b/apps/manager-server/internal/repository/sqlite/derived_cleanup.go
@@ -42,6 +42,7 @@ var derivedLegacyTables = []string{
 	usageCacheChangesSourceLegacy,
 	usageAccountModelSourceLegacy,
 	usagePricingAccountSourceLegacy,
+	usageCodexLegacyIdentityEvidenceLegacy,
 }
 
 type OfflineCleanupResult struct {

--- a/apps/manager-server/internal/repository/sqlite/migrate.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate.go
@@ -558,6 +558,12 @@ func Migrate(db *sql.DB) error {
 			finished_at_ms integer,
 			last_error text
 		)`,
+		createUsageCodexLegacyIdentityEvidenceTable,
+		`insert or ignore into usage_monitoring_rollup_state (
+			rollup_name, schema_version, status, target_event_id, updated_at_ms
+		) select 'codex_legacy_identity_v1', 1,
+			case when exists (select 1 from usage_events limit 1) then 'pending' else 'ready' end,
+			coalesce((select max(id) from usage_events), 0), 0`,
 		`insert or ignore into usage_monitoring_rollup_state (
 			rollup_name, schema_version, status, target_event_id, updated_at_ms
 		) select 'stats_v1', 1,
@@ -1197,10 +1203,11 @@ func inspectUsageMonitoringMigrationSnapshot(db *sql.DB) (usageMonitoringMigrati
 		usageMonitoringHeaderLatestTable,
 		usageMonitoringRollupStateTable,
 		usageMonitoringSearchStateTable,
+		usageCodexLegacyIdentityEvidenceTable,
 	}
 	snapshot := usageMonitoringMigrationSnapshot{
 		tables:       make(map[string]bool, len(tableNames)),
-		rollupStates: make(map[string]bool, 3),
+		rollupStates: make(map[string]bool, 4),
 	}
 	rows, err := db.Query(`select name from sqlite_master where type = 'table' and name in (
 		'usage_events',
@@ -1211,7 +1218,8 @@ func inspectUsageMonitoringMigrationSnapshot(db *sql.DB) (usageMonitoringMigrati
 		'usage_monitoring_event_search_v1',
 		'usage_monitoring_header_latest_v1',
 		'usage_monitoring_rollup_state',
-		'usage_monitoring_search_index_state'
+		'usage_monitoring_search_index_state',
+		'usage_codex_legacy_identity_evidence_v1'
 	)`)
 	if err != nil {
 		return usageMonitoringMigrationSnapshot{}, fmt.Errorf("inspect usage monitoring tables: %w", err)
@@ -1239,10 +1247,11 @@ func inspectUsageMonitoringMigrationSnapshot(db *sql.DB) (usageMonitoringMigrati
 	if !snapshot.tables[usageMonitoringRollupStateTable] {
 		return snapshot, nil
 	}
-	stateRows, err := db.Query(`select rollup_name from usage_monitoring_rollup_state where rollup_name in (?, ?, ?)`,
+	stateRows, err := db.Query(`select rollup_name from usage_monitoring_rollup_state where rollup_name in (?, ?, ?, ?)`,
 		usageMonitoringStatsRollupName,
 		usageMonitoringMetadataRollupName,
 		usageMonitoringProjectionRollupName,
+		usageCodexLegacyIdentityRollupName,
 	)
 	if err != nil {
 		return usageMonitoringMigrationSnapshot{}, fmt.Errorf("inspect usage monitoring rollup states: %w", err)
@@ -1276,7 +1285,10 @@ func resetDamagedUsageMonitoringDerivations(db *sql.DB, snapshot usageMonitoring
 	projectionDamaged := snapshot.sourceTableMissing() ||
 		!snapshot.rollupStates[usageMonitoringProjectionRollupName] ||
 		!snapshot.tables[usageprojection.EventTable]
-	if !statsDamaged && !metadataDamaged && !projectionDamaged {
+	identityEvidenceDamaged := snapshot.sourceTableMissing() ||
+		!snapshot.rollupStates[usageCodexLegacyIdentityRollupName] ||
+		!snapshot.tables[usageCodexLegacyIdentityEvidenceTable]
+	if !statsDamaged && !metadataDamaged && !projectionDamaged && !identityEvidenceDamaged {
 		return nil
 	}
 	if snapshot.sourceTableMissing() {
@@ -1320,6 +1332,16 @@ func resetDamagedUsageMonitoringDerivations(db *sql.DB, snapshot usageMonitoring
 			}
 		}
 		if err := resetUsageMonitoringRollupState(tx, snapshot, usageMonitoringMetadataRollupName); err != nil {
+			return err
+		}
+	}
+	if identityEvidenceDamaged {
+		if snapshot.tables[usageCodexLegacyIdentityEvidenceTable] {
+			if err := parkDerivedTable(tx, usageCodexLegacyIdentityEvidenceTable, usageCodexLegacyIdentityEvidenceLegacy); err != nil {
+				return err
+			}
+		}
+		if err := resetUsageMonitoringRollupState(tx, snapshot, usageCodexLegacyIdentityRollupName); err != nil {
 			return err
 		}
 	}

--- a/apps/manager-server/internal/repository/sqlite/migrate_test.go
+++ b/apps/manager-server/internal/repository/sqlite/migrate_test.go
@@ -454,6 +454,13 @@ func TestMigrateClearsDerivedUsageWhenSourceTableWasLost(t *testing.T) {
 			structure_revision = 'revision-1', status = 'ready',
 			backfill_last_event_id = 1, coverage_event_id = 1,
 			target_event_id = 1, processed_events = 1`,
+		`insert into usage_codex_legacy_identity_evidence_v1 (
+			structure_revision, physical_kind, physical_file, auth_index,
+			provider, auth_provider_snapshot, auth_account_id_snapshot,
+			auth_project_id_snapshot, account_snapshot,
+			min_evidence_at_ms, max_evidence_at_ms, chronology_unknown
+		) values ('1', 0, 'codex-a.json', 'auth-a', 'codex', 'codex', 'account-a',
+			'', 'same@example.com', 1, 1, 0)`,
 		`update usage_monitoring_search_index_state set ready = 1, updated_at_ms = 1
 		where id = 1`,
 		`update usage_data_migrations set
@@ -500,6 +507,7 @@ func TestMigrateClearsDerivedUsageWhenSourceTableWasLost(t *testing.T) {
 		"usage_monitoring_event_search_v1",
 		"usage_monitoring_header_latest_v1",
 		"usage_cache_accounting_v2_changes",
+		usageCodexLegacyIdentityEvidenceTable,
 	} {
 		assertTableCount(t, db, table, 0)
 	}
@@ -1044,7 +1052,8 @@ func TestUsageMonitoringModelFormatUpgradeRebuildsDerivedDataOnce(t *testing.T) 
 		`update usage_monitoring_rollup_state set
 			structure_revision = 'legacy', status = 'ready',
 			backfill_last_event_id = 1, coverage_event_id = 1,
-			target_event_id = 1, processed_events = 1, updated_at_ms = 1`,
+			target_event_id = 1, processed_events = 1, updated_at_ms = 1
+			where rollup_name in ('stats_v1', 'metadata_v1', 'projection_v1')`,
 		`update usage_monitoring_search_index_state set ready = 1, updated_at_ms = 1 where id = 1`,
 		`delete from settings where key = 'usage_monitoring_model_format_version'`,
 	} {
@@ -1085,7 +1094,8 @@ func TestUsageMonitoringModelFormatUpgradeRebuildsDerivedDataOnce(t *testing.T) 
 	}
 	rows, err := db.Query(`select rollup_name, structure_revision, status,
 		coverage_event_id, target_event_id, processed_events
-		from usage_monitoring_rollup_state order by rollup_name`)
+		from usage_monitoring_rollup_state
+		where rollup_name in ('stats_v1', 'metadata_v1', 'projection_v1') order by rollup_name`)
 	if err != nil {
 		t.Fatalf("read rebuilt monitoring states: %v", err)
 	}
@@ -3471,8 +3481,8 @@ func assertEmptyUsageDerivedState(t *testing.T, db *sql.DB) {
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate reset monitoring state: %v", err)
 	}
-	if monitoringStates != 3 {
-		t.Fatalf("reset monitoring state rows = %d, want 3", monitoringStates)
+	if monitoringStates != 4 {
+		t.Fatalf("reset monitoring state rows = %d, want 4", monitoringStates)
 	}
 	var searchReady int
 	if err := db.QueryRow(`select ready from usage_monitoring_search_index_state where id = 1`).Scan(&searchReady); err != nil {

--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -35,13 +35,18 @@ func ResolveCodexLegacyAccountKey(
 		return "", false, nil
 	}
 
-	evidenceGroups := make([]legacyAccountIdentityEvidence, 0)
-	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
-		predicateEvidence, err := queryLegacyAccountIdentityEvidence(ctx, queryer, predicate)
-		if err != nil {
-			return "", false, err
+	evidenceGroups, available, err := queryStoredCodexLegacyIdentityEvidence(ctx, queryer, authFile, authIndex)
+	if err != nil {
+		return "", false, err
+	}
+	if !available {
+		for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
+			predicateEvidence, err := queryLegacyAccountIdentityEvidence(ctx, queryer, predicate)
+			if err != nil {
+				return "", false, err
+			}
+			evidenceGroups = append(evidenceGroups, predicateEvidence...)
 		}
-		evidenceGroups = append(evidenceGroups, predicateEvidence...)
 	}
 	if !legacyAccountIdentityAllowed(evidenceGroups, targetAccountID, targetMember) {
 		return "", false, nil
@@ -128,7 +133,7 @@ func legacySourceIdentityGuards() string {
 		and (e.auth_label_snapshot is null or lower(trim(e.source)) <> lower(trim(e.auth_label_snapshot)))`
 }
 
-const legacyAccountIdentityEvidenceSelect = `select
+const legacyAccountIdentityEvidenceColumns = `
 	coalesce(e.provider, ''),
 	coalesce(e.auth_provider_snapshot, ''),
 	coalesce(e.auth_account_id_snapshot, ''),
@@ -155,7 +160,9 @@ const legacyAccountIdentityEvidenceSelect = `select
 			or coalesce(e.created_at_ms, 0) > 0 then 0
 		else 1
 	end) as chronology_unknown
-from usage_events e
+`
+
+const legacyAccountIdentityEvidenceSelect = `select ` + legacyAccountIdentityEvidenceColumns + `from usage_events e
 where `
 
 const legacyAccountIdentityEvidenceGroupBy = `

--- a/apps/manager-server/internal/repository/usageevent/account_identity.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity.go
@@ -35,28 +35,15 @@ func ResolveCodexLegacyAccountKey(
 		return "", false, nil
 	}
 
-	events := make([]legacyAccountIdentityEvent, 0)
+	evidenceGroups := make([]legacyAccountIdentityEvidence, 0)
 	for _, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
-		rows, err := queryer.QueryContext(ctx, `select
-			coalesce(e.provider, ''),
-			coalesce(e.auth_provider_snapshot, ''),
-			coalesce(e.auth_account_id_snapshot, ''),
-			coalesce(e.auth_project_id_snapshot, ''),
-			coalesce(e.account_snapshot, ''),
-			coalesce(e.auth_snapshot_at_ms, 0),
-			coalesce(e.created_at_ms, 0)
-		from usage_events e
-		where `+predicate.sql, predicate.args...)
+		predicateEvidence, err := queryLegacyAccountIdentityEvidence(ctx, queryer, predicate)
 		if err != nil {
 			return "", false, err
 		}
-		predicateEvents, err := scanLegacyAccountIdentityRows(rows)
-		if err != nil {
-			return "", false, err
-		}
-		events = append(events, predicateEvents...)
+		evidenceGroups = append(evidenceGroups, predicateEvidence...)
 	}
-	if !legacyAccountIdentityAllowed(events, targetAccountID, targetMember) {
+	if !legacyAccountIdentityAllowed(evidenceGroups, targetAccountID, targetMember) {
 		return "", false, nil
 	}
 	return legacyKey, true, nil
@@ -141,52 +128,96 @@ func legacySourceIdentityGuards() string {
 		and (e.auth_label_snapshot is null or lower(trim(e.source)) <> lower(trim(e.auth_label_snapshot)))`
 }
 
-type legacyAccountIdentityEvent struct {
-	provider         string
-	authProvider     string
-	accountID        string
-	projectID        string
-	accountSnapshot  string
-	authSnapshotAtMS int64
-	createdAtMS      int64
+const legacyAccountIdentityEvidenceSelect = `select
+	coalesce(e.provider, ''),
+	coalesce(e.auth_provider_snapshot, ''),
+	coalesce(e.auth_account_id_snapshot, ''),
+	coalesce(e.auth_project_id_snapshot, ''),
+	coalesce(e.account_snapshot, ''),
+	coalesce(
+		min(case
+			when coalesce(e.auth_snapshot_at_ms, 0) > 0 then e.auth_snapshot_at_ms
+			when coalesce(e.created_at_ms, 0) > 0 then e.created_at_ms
+			else null
+		end),
+		0
+	) as min_evidence_at_ms,
+	coalesce(
+		max(case
+			when coalesce(e.auth_snapshot_at_ms, 0) > 0 then e.auth_snapshot_at_ms
+			when coalesce(e.created_at_ms, 0) > 0 then e.created_at_ms
+			else null
+		end),
+		0
+	) as max_evidence_at_ms,
+	max(case
+		when coalesce(e.auth_snapshot_at_ms, 0) > 0
+			or coalesce(e.created_at_ms, 0) > 0 then 0
+		else 1
+	end) as chronology_unknown
+from usage_events e
+where `
+
+const legacyAccountIdentityEvidenceGroupBy = `
+	group by
+		coalesce(e.provider, ''),
+		coalesce(e.auth_provider_snapshot, ''),
+		coalesce(e.auth_account_id_snapshot, ''),
+		coalesce(e.auth_project_id_snapshot, ''),
+		coalesce(e.account_snapshot, '')`
+
+type legacyAccountIdentityEvidence struct {
+	provider          string
+	authProvider      string
+	accountID         string
+	projectID         string
+	accountSnapshot   string
+	minEvidenceAtMS   int64
+	maxEvidenceAtMS   int64
+	chronologyUnknown bool
 }
 
-func scanLegacyAccountIdentityRows(rows *sql.Rows) ([]legacyAccountIdentityEvent, error) {
+func queryLegacyAccountIdentityEvidence(
+	ctx context.Context,
+	queryer SQLQueryer,
+	predicate legacyAccountIdentityPredicate,
+) ([]legacyAccountIdentityEvidence, error) {
+	rows, err := queryer.QueryContext(ctx, legacyAccountIdentityEvidenceSelect+predicate.sql+legacyAccountIdentityEvidenceGroupBy, predicate.args...)
+	if err != nil {
+		return nil, err
+	}
+	return scanLegacyAccountIdentityEvidenceRows(rows)
+}
+
+func scanLegacyAccountIdentityEvidenceRows(rows *sql.Rows) ([]legacyAccountIdentityEvidence, error) {
 	defer rows.Close()
-	events := make([]legacyAccountIdentityEvent, 0)
+	evidenceGroups := make([]legacyAccountIdentityEvidence, 0)
 	for rows.Next() {
-		var event legacyAccountIdentityEvent
+		var evidence legacyAccountIdentityEvidence
+		var chronologyUnknown int64
 		if err := rows.Scan(
-			&event.provider,
-			&event.authProvider,
-			&event.accountID,
-			&event.projectID,
-			&event.accountSnapshot,
-			&event.authSnapshotAtMS,
-			&event.createdAtMS,
+			&evidence.provider,
+			&evidence.authProvider,
+			&evidence.accountID,
+			&evidence.projectID,
+			&evidence.accountSnapshot,
+			&evidence.minEvidenceAtMS,
+			&evidence.maxEvidenceAtMS,
+			&chronologyUnknown,
 		); err != nil {
 			return nil, err
 		}
-		events = append(events, event)
+		evidence.chronologyUnknown = chronologyUnknown != 0
+		evidenceGroups = append(evidenceGroups, evidence)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return events, nil
-}
-
-func legacyIdentityEvidenceAtMS(event legacyAccountIdentityEvent) (int64, bool) {
-	if event.authSnapshotAtMS > 0 {
-		return event.authSnapshotAtMS, true
-	}
-	if event.createdAtMS > 0 {
-		return event.createdAtMS, true
-	}
-	return 0, false
+	return evidenceGroups, nil
 }
 
 func legacyAccountIdentityAllowed(
-	events []legacyAccountIdentityEvent,
+	evidenceGroups []legacyAccountIdentityEvidence,
 	targetAccountID, targetMember string,
 ) bool {
 	trustedWorkspaceFound := false
@@ -201,9 +232,9 @@ func legacyAccountIdentityAllowed(
 	hasWeakEvidenceAt := false
 	weakChronologyKnown := true
 
-	for _, event := range events {
+	for _, evidence := range evidenceGroups {
 		hasProvider := false
-		for _, value := range []string{event.provider, event.authProvider} {
+		for _, value := range []string{evidence.provider, evidence.authProvider} {
 			normalized := normalizeIdentityProvider(value)
 			if normalized == "" {
 				continue
@@ -217,17 +248,17 @@ func legacyAccountIdentityAllowed(
 			return false
 		}
 
-		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(event.accountSnapshot)
+		member, memberOK := usageidentity.NormalizeCodexMemberSnapshot(evidence.accountSnapshot)
 		if !memberOK || member != targetMember {
 			return false
 		}
 
-		directWorkspacePresent := strings.Trim(event.accountID, " ") != ""
-		markedWorkspacePresent := usageidentity.HasCodexAccountIDSnapshotMarker(event.projectID)
+		directWorkspacePresent := strings.Trim(evidence.accountID, " ") != ""
+		markedWorkspacePresent := usageidentity.HasCodexAccountIDSnapshotMarker(evidence.projectID)
 		workspace, workspaceOK := usageidentity.ResolveCodexWorkspace(usageidentity.Fields{
-			AuthAccountIDSnapshot: event.accountID,
-			AuthProjectIDSnapshot: event.projectID,
-			AccountSnapshot:       event.accountSnapshot,
+			AuthAccountIDSnapshot: evidence.accountID,
+			AuthProjectIDSnapshot: evidence.projectID,
+			AccountSnapshot:       evidence.accountSnapshot,
 		})
 		if directWorkspacePresent || markedWorkspacePresent {
 			if !workspaceOK || workspace != targetAccountID {
@@ -237,22 +268,20 @@ func legacyAccountIdentityAllowed(
 			if directWorkspacePresent {
 				directWorkspaceFound = true
 			}
-			evidenceTime, timeOK := legacyIdentityEvidenceAtMS(event)
-			if !timeOK {
+			if evidence.chronologyUnknown {
 				trustedChronologyKnown = false
-			} else if !hasTrustedEvidenceAt || evidenceTime < minTrustedEvidenceAt {
-				minTrustedEvidenceAt = evidenceTime
+			} else if !hasTrustedEvidenceAt || evidence.minEvidenceAtMS < minTrustedEvidenceAt {
+				minTrustedEvidenceAt = evidence.minEvidenceAtMS
 				hasTrustedEvidenceAt = true
 			}
 			continue
 		}
 
 		weakFound = true
-		evidenceTime, timeOK := legacyIdentityEvidenceAtMS(event)
-		if !timeOK {
+		if evidence.chronologyUnknown {
 			weakChronologyKnown = false
-		} else if !hasWeakEvidenceAt || evidenceTime > maxWeakEvidenceAt {
-			maxWeakEvidenceAt = evidenceTime
+		} else if !hasWeakEvidenceAt || evidence.maxEvidenceAtMS > maxWeakEvidenceAt {
+			maxWeakEvidenceAt = evidence.maxEvidenceAtMS
 			hasWeakEvidenceAt = true
 		}
 	}

--- a/apps/manager-server/internal/repository/usageevent/account_identity_evidence.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_evidence.go
@@ -1,0 +1,182 @@
+package usageevent
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+const (
+	CodexLegacyIdentityEvidenceTable = "usage_codex_legacy_identity_evidence_v1"
+	CodexLegacyIdentityRollupName    = "codex_legacy_identity_v1"
+	// Bump when the stored fields, physical predicates, or chronology projection
+	// change. Account-key/model revisions do not change this raw evidence.
+	CodexLegacyIdentityEvidenceRevision = "1"
+	codexLegacyIdentityTailLimit        = 1000
+)
+
+// UpsertCodexLegacyIdentityEvidenceRange compacts only the requested event-ID
+// range. The caller commits these rows and its coverage checkpoint together.
+// Keep all providers and identity values: contradictory evidence must survive
+// compaction and reach the same authority check as the raw reader.
+func UpsertCodexLegacyIdentityEvidenceRange(ctx context.Context, tx *sql.Tx, revision string, afterID, throughID int64) error {
+	if throughID <= afterID {
+		return nil
+	}
+	physicalPredicates := []struct {
+		column string
+		filter string
+	}{
+		{"e.auth_file_snapshot", "e.auth_file_snapshot is not null and e.auth_file_snapshot <> ''"},
+		{"e.source", "e.auth_file_snapshot is null" + legacySourceIdentityGuards()},
+		{"e.source", "e.auth_file_snapshot = ''" + legacySourceIdentityGuards()},
+	}
+	for kind, physical := range physicalPredicates {
+		query := `insert into ` + CodexLegacyIdentityEvidenceTable + ` (
+			structure_revision, physical_kind, physical_file, auth_index,
+			provider, auth_provider_snapshot, auth_account_id_snapshot,
+			auth_project_id_snapshot, account_snapshot,
+			min_evidence_at_ms, max_evidence_at_ms, chronology_unknown
+		) select ?, ?, ` + physical.column + `, e.auth_index, ` + legacyAccountIdentityEvidenceColumns + `
+		from usage_events e not indexed
+		where e.id > ? and e.id <= ?
+			and coalesce(e.auth_index, '') <> ''
+			and coalesce(` + physical.column + `, '') <> ''
+			and ` + physical.filter + legacyAccountIdentityEvidenceGroupBy + `,
+			` + physical.column + ` collate nocase, e.auth_index collate nocase
+		on conflict do update set
+			min_evidence_at_ms = case
+				when min_evidence_at_ms = 0 then excluded.min_evidence_at_ms
+				when excluded.min_evidence_at_ms = 0 then min_evidence_at_ms
+				else min(min_evidence_at_ms, excluded.min_evidence_at_ms)
+			end,
+			max_evidence_at_ms = max(max_evidence_at_ms, excluded.max_evidence_at_ms),
+			chronology_unknown = max(chronology_unknown, excluded.chronology_unknown)`
+		if _, err := tx.ExecContext(ctx, query, revision, kind, afterID, throughID); err != nil {
+			return fmt.Errorf("compact Codex legacy identity evidence: %w", err)
+		}
+	}
+	return nil
+}
+
+// ClearCodexLegacyIdentityEvidenceBatch removes a previous evidence revision
+// in bounded transactions before a new revision starts rebuilding.
+func ClearCodexLegacyIdentityEvidenceBatch(ctx context.Context, tx *sql.Tx, limit int) (bool, error) {
+	if _, err := tx.ExecContext(ctx, `delete from `+CodexLegacyIdentityEvidenceTable+` where rowid in (
+		select rowid from `+CodexLegacyIdentityEvidenceTable+` limit ?
+	)`, limit); err != nil {
+		return false, err
+	}
+	var pending bool
+	err := tx.QueryRowContext(ctx, `select exists(select 1 from `+CodexLegacyIdentityEvidenceTable+` limit 1)`).Scan(&pending)
+	return pending, err
+}
+
+func queryStoredCodexLegacyIdentityEvidence(ctx context.Context, queryer SQLQueryer, authFile, authIndex string) ([]legacyAccountIdentityEvidence, bool, error) {
+	coverageID, latestID, available, err := codexLegacyIdentityEvidenceReadState(ctx, queryer)
+	if err != nil || !available {
+		return nil, false, err
+	}
+	groups := make([]legacyAccountIdentityEvidence, 0)
+	for kind, predicate := range legacyAccountIdentityPredicates(authFile, authIndex) {
+		rows, err := queryer.QueryContext(ctx, `select
+			provider, auth_provider_snapshot, auth_account_id_snapshot,
+			auth_project_id_snapshot, account_snapshot,
+			min_evidence_at_ms, max_evidence_at_ms, chronology_unknown
+		from `+CodexLegacyIdentityEvidenceTable+`
+		where structure_revision = ? and physical_kind = ?
+			and physical_file = ? collate nocase and auth_index = ? collate nocase`,
+			CodexLegacyIdentityEvidenceRevision, kind, authFile, authIndex)
+		if err != nil {
+			return nil, false, err
+		}
+		stored, err := scanLegacyAccountIdentityEvidenceRows(rows)
+		if err != nil {
+			return nil, false, err
+		}
+		groups = append(groups, stored...)
+		if coverageID == latestID {
+			continue
+		}
+		// NOT INDEXED retains the bounded rowid range instead of letting SQLite
+		// revisit the credential's entire historical file/source index range.
+		query := `select ` + legacyAccountIdentityEvidenceColumns + `from usage_events e not indexed
+		where e.id > ? and e.id <= ? and ` + predicate.sql + legacyAccountIdentityEvidenceGroupBy
+		args := append([]any{coverageID, latestID}, predicate.args...)
+		rows, err = queryer.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, false, err
+		}
+		tail, err := scanLegacyAccountIdentityEvidenceRows(rows)
+		if err != nil {
+			return nil, false, err
+		}
+		groups = append(groups, tail...)
+	}
+	return groups, true, nil
+}
+
+func codexLegacyIdentityEvidenceReadState(ctx context.Context, queryer SQLQueryer) (int64, int64, bool, error) {
+	rows, err := queryer.QueryContext(ctx, `select
+		s.schema_version, s.structure_revision, s.status, s.coverage_event_id,
+		coalesce((select max(id) from usage_events), 0)
+	from usage_monitoring_rollup_state s
+	where s.rollup_name = ? and exists (
+		select 1 from sqlite_master where type = 'table' and name = ?
+	)`, CodexLegacyIdentityRollupName, CodexLegacyIdentityEvidenceTable)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	var version int
+	var revision, status string
+	var coverageID, latestID int64
+	if !rows.Next() {
+		err := rows.Err()
+		_ = rows.Close()
+		return 0, 0, false, err
+	}
+	if err := rows.Scan(&version, &revision, &status, &coverageID, &latestID); err != nil {
+		_ = rows.Close()
+		return 0, 0, false, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, 0, false, err
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, false, err
+	}
+	if version != 1 || revision != CodexLegacyIdentityEvidenceRevision || coverageID < 0 || coverageID > latestID {
+		return 0, 0, false, nil
+	}
+	if status != "ready" && status != "catching_up" && status != "rebuilding" {
+		return 0, 0, false, nil
+	}
+	if coverageID != latestID {
+		rows, err := queryer.QueryContext(ctx, `select count(*) from (
+			select id from usage_events where id > ? order by id limit ?
+		)`, coverageID, codexLegacyIdentityTailLimit+1)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		var count int
+		if !rows.Next() {
+			err := rows.Err()
+			_ = rows.Close()
+			return 0, 0, false, err
+		}
+		if err := rows.Scan(&count); err != nil {
+			_ = rows.Close()
+			return 0, 0, false, err
+		}
+		if err := rows.Close(); err != nil {
+			return 0, 0, false, err
+		}
+		if err := rows.Err(); err != nil {
+			return 0, 0, false, err
+		}
+		if count > codexLegacyIdentityTailLimit {
+			return 0, 0, false, nil
+		}
+	}
+	return coverageID, latestID, true, nil
+}

--- a/apps/manager-server/internal/repository/usageevent/account_identity_evidence_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_evidence_test.go
@@ -1,0 +1,318 @@
+package usageevent
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
+)
+
+func TestStoredCodexLegacyEvidencePreservesAuthorityAcrossBatches(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mutate  func([]usage.Event) []usage.Event
+		prepare string
+		allowed bool
+	}{
+		{name: "leading weak prefix", allowed: true},
+		{name: "case variants", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			events[0].AuthFileSnapshot = "CODEX-A.JSON"
+			events[0].AuthIndex = "AUTH-A"
+			events[1].AccountSnapshot = " SAME@EXAMPLE.COM "
+			return events
+		}},
+		{name: "null file source prefix", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			events[0].AuthFileSnapshot = ""
+			return events
+		}},
+		{name: "empty file source prefix", allowed: true, prepare: "update usage_events set auth_file_snapshot = '' where id = 1"},
+		{name: "source is only display text", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			events[0].AuthFileSnapshot = ""
+			events[0].AuthLabelSnapshot = "codex-a.json"
+			events[0].Provider = "openai"
+			return events
+		}},
+		{name: "unrelated source beside explicit file", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			extra := identityChronologyEvent("unrelated", 4000, "other.json", "auth-a", "openai", "other", "")
+			extra.Source = "codex-a.json"
+			return append(events, extra)
+		}},
+		{name: "foreign provider", mutate: func(events []usage.Event) []usage.Event {
+			events[0].Provider = "openai"
+			return events
+		}},
+		{name: "missing provider", mutate: func(events []usage.Event) []usage.Event {
+			events[0].Provider, events[0].AuthProviderSnapshot = "", ""
+			return events
+		}},
+		{name: "different member", mutate: func(events []usage.Event) []usage.Event {
+			events[0].AccountSnapshot = "other@example.com"
+			return events
+		}},
+		{name: "missing member", mutate: func(events []usage.Event) []usage.Event {
+			events[0].AccountSnapshot = ""
+			return events
+		}},
+		{name: "different workspace", mutate: func(events []usage.Event) []usage.Event {
+			events[0].AuthAccountIDSnapshot = "other-workspace"
+			return events
+		}},
+		{name: "invalid marker", mutate: func(events []usage.Event) []usage.Event {
+			events[0].AuthProjectIDSnapshot = "codex-account-id:v1:"
+			return events
+		}},
+		{name: "conflicting marker", mutate: func(events []usage.Event) []usage.Event {
+			events[1].AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("other-workspace")
+			return events
+		}},
+		{name: "valid marker", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			events[0].AuthProjectIDSnapshot = usageidentity.CodexAccountIDSnapshot("account-a")
+			return events
+		}},
+		{name: "late weak evidence", mutate: func(events []usage.Event) []usage.Event {
+			events[0].CreatedAtMS = 4000
+			return events
+		}},
+		{name: "weak maximum survives repeated groups", mutate: func(events []usage.Event) []usage.Event {
+			return append(events, identityChronologyEvent("late-weak", 4000, "codex-a.json", "auth-a", "codex", "", ""))
+		}},
+		{name: "trusted minimum survives repeated groups", mutate: func(events []usage.Event) []usage.Event {
+			return append(events, identityChronologyEvent("early-trusted", 500, "codex-a.json", "auth-a", "codex", "account-a", ""))
+		}},
+		{name: "unknown duplicate weak chronology", prepare: "update usage_events set auth_snapshot_at_ms = null, created_at_ms = 0 where id = 3", mutate: func(events []usage.Event) []usage.Event {
+			return append(events, identityChronologyEvent("unknown-weak", 2000, "codex-a.json", "auth-a", "codex", "", ""))
+		}},
+		{name: "unknown duplicate trusted chronology", prepare: "update usage_events set auth_snapshot_at_ms = null, created_at_ms = 0 where id = 3", mutate: func(events []usage.Event) []usage.Event {
+			return append(events, identityChronologyEvent("unknown-trusted", 4000, "codex-a.json", "auth-a", "codex", "account-a", ""))
+		}},
+		{name: "repeated trusted group", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			return append(events, identityChronologyEvent("later-trusted", 4000, "codex-a.json", "auth-a", "codex", "account-a", ""))
+		}},
+		{name: "equal chronology", mutate: func(events []usage.Event) []usage.Event {
+			events[0].CreatedAtMS = events[1].CreatedAtMS
+			return events
+		}},
+		{name: "unknown weak chronology", prepare: "update usage_events set auth_snapshot_at_ms = null, created_at_ms = 0 where id = 1"},
+		{name: "unknown trusted chronology", prepare: "update usage_events set auth_snapshot_at_ms = null, created_at_ms = 0 where id = 2"},
+		{name: "snapshot time overrides insertion time", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			events[0].CreatedAtMS = 9000
+			events[0].AuthSnapshotAtMS = 1000
+			return events
+		}},
+		{name: "old weak evidence imported after anchor", allowed: true, mutate: func(events []usage.Event) []usage.Event {
+			return []usage.Event{events[1], events[0]}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db := openIdentityEvidenceTestDB(t)
+			events := []usage.Event{
+				identityChronologyEvent("weak", 1000, "codex-a.json", "auth-a", "codex", "", ""),
+				identityChronologyEvent("trusted", 3000, "codex-a.json", "auth-a", "codex", "account-a", ""),
+			}
+			if test.mutate != nil {
+				events = test.mutate(events)
+			}
+			if _, err := New(db).InsertBatch(context.Background(), events); err != nil {
+				t.Fatal(err)
+			}
+			if test.prepare != "" {
+				if _, err := db.Exec(test.prepare); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertIdentityEvidenceAllowed(t, db, test.allowed)
+			// Every split is tested: evidence on either side of the checkpoint
+			// must be combined before authorizing a historical alias.
+			for through := int64(1); through <= int64(len(events)); through++ {
+				commitIdentityEvidenceTestBatch(t, db, through-1, through)
+				assertIdentityEvidenceAllowed(t, db, test.allowed)
+			}
+		})
+	}
+}
+
+func TestStoredCodexLegacyEvidenceReadsNewConflictBeforeWorkerCatchUp(t *testing.T) {
+	db := openIdentityEvidenceTestDB(t)
+	repo := New(db)
+	ctx := context.Background()
+	if _, err := repo.InsertBatch(ctx, []usage.Event{identityTestEvent("trusted", 1, "codex-a.json", "auth-a", "codex", "account-a")}); err != nil {
+		t.Fatal(err)
+	}
+	commitIdentityEvidenceTestBatch(t, db, 0, 1)
+	assertIdentityEvidenceAllowed(t, db, true)
+	if _, err := repo.InsertBatch(ctx, []usage.Event{identityTestEvent("new-conflict", 2, "codex-a.json", "auth-a", "codex", "other")}); err != nil {
+		t.Fatal(err)
+	}
+	assertIdentityEvidenceAllowed(t, db, false)
+	commitIdentityEvidenceTestBatch(t, db, 1, 2)
+	assertIdentityEvidenceAllowed(t, db, false)
+}
+
+func TestStoredCodexLegacyEvidenceBoundsRawTailAndUsesRowID(t *testing.T) {
+	for _, count := range []int{1, codexLegacyIdentityTailLimit, codexLegacyIdentityTailLimit + 1} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			db := openIdentityEvidenceTestDB(t)
+			ctx := context.Background()
+			events := []usage.Event{identityTestEvent("anchor", 1, "codex-a.json", "auth-a", "codex", "account-a")}
+			if _, err := New(db).InsertBatch(ctx, events); err != nil {
+				t.Fatal(err)
+			}
+			commitIdentityEvidenceTestBatch(t, db, 0, 1)
+			events = events[:0]
+			for i := 0; i < count; i++ {
+				events = append(events, identityTestEvent(fmt.Sprint("tail-", i), int64(i+2), "codex-a.json", "auth-a", "codex", "account-a"))
+			}
+			// A conflict at the end must never be hidden by a LIMIT.
+			events[len(events)-1].AuthAccountIDSnapshot = "other"
+			if _, err := New(db).InsertBatch(ctx, events); err != nil {
+				t.Fatal(err)
+			}
+			if count == 1 {
+				if _, err := db.Exec("update usage_events set id = 1000000 where id = 2"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback()
+			spy := &identityEvidenceQuerySpy{SQLQueryer: tx}
+			_, allowed, err := ResolveCodexLegacyAccountKey(ctx, spy, identityEvidenceTestTarget())
+			if err != nil || allowed {
+				t.Fatalf("conflicting tail allowed=%v err=%v", allowed, err)
+			}
+			if spy.fullHistoryReads != 0 && count <= codexLegacyIdentityTailLimit {
+				t.Fatal("bounded tail unexpectedly rescanned historical credential rows")
+			}
+			if spy.fullHistoryReads == 0 && count > codexLegacyIdentityTailLimit {
+				t.Fatal("oversized tail did not fall back to complete evidence")
+			}
+			for _, statement := range spy.tailQueries {
+				rows, err := tx.QueryContext(ctx, "explain query plan "+statement.query, statement.args...)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var details []string
+				for rows.Next() {
+					var id, parent, unused int
+					var detail string
+					if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+						t.Fatal(err)
+					}
+					details = append(details, detail)
+				}
+				if err := rows.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(strings.Join(details, "\n"), "SEARCH e USING INTEGER PRIMARY KEY") {
+					t.Fatalf("tail is not bounded by rowid: %v", details)
+				}
+			}
+		})
+	}
+}
+
+func TestStoredCodexLegacyEvidenceFallsBackWhenUnavailable(t *testing.T) {
+	for name, statement := range map[string]string{
+		"missing state":     "delete from usage_monitoring_rollup_state where rollup_name = 'codex_legacy_identity_v1'",
+		"missing table":     "drop table usage_codex_legacy_identity_evidence_v1",
+		"old revision":      "update usage_monitoring_rollup_state set structure_revision = 'old' where rollup_name = 'codex_legacy_identity_v1'",
+		"old schema":        "update usage_monitoring_rollup_state set schema_version = 0 where rollup_name = 'codex_legacy_identity_v1'",
+		"pending":           "update usage_monitoring_rollup_state set status = 'pending' where rollup_name = 'codex_legacy_identity_v1'",
+		"clearing":          "update usage_monitoring_rollup_state set status = 'clearing' where rollup_name = 'codex_legacy_identity_v1'",
+		"failed":            "update usage_monitoring_rollup_state set status = 'failed' where rollup_name = 'codex_legacy_identity_v1'",
+		"invalid coverage":  "update usage_monitoring_rollup_state set coverage_event_id = 100 where rollup_name = 'codex_legacy_identity_v1'",
+		"negative coverage": "update usage_monitoring_rollup_state set coverage_event_id = -1 where rollup_name = 'codex_legacy_identity_v1'",
+	} {
+		t.Run(name, func(t *testing.T) {
+			db := openIdentityEvidenceTestDB(t)
+			if _, err := New(db).InsertBatch(context.Background(), []usage.Event{identityTestEvent("trusted", 1, "codex-a.json", "auth-a", "codex", "account-a")}); err != nil {
+				t.Fatal(err)
+			}
+			commitIdentityEvidenceTestBatch(t, db, 0, 1)
+			if _, err := db.Exec("update usage_codex_legacy_identity_evidence_v1 set auth_account_id_snapshot = 'stale-conflict'"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(statement); err != nil {
+				t.Fatal(err)
+			}
+			assertIdentityEvidenceAllowed(t, db, true)
+		})
+	}
+}
+
+type identityEvidenceQuerySpy struct {
+	SQLQueryer
+	fullHistoryReads int
+	tailQueries      []struct {
+		query string
+		args  []any
+	}
+}
+
+func (s *identityEvidenceQuerySpy) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if strings.Contains(query, legacyAccountIdentityEvidenceSelect) {
+		s.fullHistoryReads++
+	}
+	if strings.Contains(query, "from usage_events e not indexed") {
+		s.tailQueries = append(s.tailQueries, struct {
+			query string
+			args  []any
+		}{query, append([]any(nil), args...)})
+	}
+	return s.SQLQueryer.QueryContext(ctx, query, args...)
+}
+
+func openIdentityEvidenceTestDB(t testing.TB) *sql.DB {
+	t.Helper()
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func identityEvidenceTestTarget() usageidentity.Fields {
+	return usageidentity.Fields{
+		AuthFileSnapshot: "codex-a.json", AuthIndex: "auth-a", AuthProviderSnapshot: "codex",
+		AuthAccountIDSnapshot: "account-a", AccountSnapshot: "same@example.com", Source: "codex-a.json",
+	}
+}
+
+func assertIdentityEvidenceAllowed(t testing.TB, db *sql.DB, want bool) {
+	t.Helper()
+	key, allowed, err := New(db).ResolveCodexLegacyAccountKey(context.Background(), identityEvidenceTestTarget())
+	if err != nil || allowed != want || (key != "") != want {
+		t.Fatalf("legacy identity = key:%q allowed:%v err:%v, want allowed:%v", key, allowed, err, want)
+	}
+}
+
+func commitIdentityEvidenceTestBatch(t testing.TB, db *sql.DB, afterID, throughID int64) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	if err := UpsertCodexLegacyIdentityEvidenceRange(ctx, tx, CodexLegacyIdentityEvidenceRevision, afterID, throughID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`update usage_monitoring_rollup_state set
+		structure_revision = ?, status = 'rebuilding', coverage_event_id = ?,
+		target_event_id = (select max(id) from usage_events)
+		where rollup_name = ?`, CodexLegacyIdentityEvidenceRevision, throughID, CodexLegacyIdentityRollupName); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/apps/manager-server/internal/repository/usageevent/account_identity_test.go
+++ b/apps/manager-server/internal/repository/usageevent/account_identity_test.go
@@ -3,6 +3,7 @@ package usageevent
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -392,6 +393,168 @@ func identityChronologyEvent(hash string, createdAtMS int64, file, authIndex, pr
 	event.CreatedAtMS = createdAtMS
 	event.TimestampMS = createdAtMS
 	return event
+}
+
+func TestGroupedLegacyAccountIdentityEvidenceCompactsDuplicateRowsAndPreservesConflicts(t *testing.T) {
+	const repeatedRows = 100
+	fields := usageidentity.Fields{
+		AuthFileSnapshot:      "codex-a.json",
+		AuthIndex:             "auth-a",
+		AuthProviderSnapshot:  "codex",
+		AuthAccountIDSnapshot: "account-a",
+		AccountSnapshot:       "same@example.com",
+		Source:                "codex-a.json",
+	}
+
+	tests := []struct {
+		name              string
+		buildEvents       func() []usage.Event
+		wantGroups        int
+		wantAllowed       bool
+		wantMinEvidenceAt int64
+		wantMaxEvidenceAt int64
+		wantUnknownGroup  bool
+	}{
+		{
+			name: "identical trusted evidence compacts to one group",
+			buildEvents: func() []usage.Event {
+				return repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "account-a", "same@example.com", "")
+			},
+			wantGroups:        1,
+			wantAllowed:       true,
+			wantMinEvidenceAt: 1000,
+			wantMaxEvidenceAt: 1099,
+		},
+		{
+			name: "weak and trusted evidence remain separate groups",
+			buildEvents: func() []usage.Event {
+				events := repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "", "same@example.com", "")
+				return append(events, repeatedIdentityEvidenceEvents(repeatedRows, 2000, "codex", "account-a", "same@example.com", "")...)
+			},
+			wantGroups:  2,
+			wantAllowed: true,
+		},
+		{
+			name: "unknown weak chronology is retained in its group",
+			buildEvents: func() []usage.Event {
+				events := repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "", "same@example.com", "")
+				unknown := repeatedIdentityEvidenceEvents(1, 0, "codex", "", "same@example.com", "")
+				unknown[0].AuthSnapshotAtMS = 0
+				unknown[0].CreatedAtMS = 0
+				events = append(events, unknown...)
+				return append(events, repeatedIdentityEvidenceEvents(repeatedRows, 2000, "codex", "account-a", "same@example.com", "")...)
+			},
+			wantGroups:       2,
+			wantAllowed:      false,
+			wantUnknownGroup: true,
+		},
+		{
+			name: "unknown trusted chronology is retained in its group",
+			buildEvents: func() []usage.Event {
+				events := repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "", "same@example.com", "")
+				unknown := repeatedIdentityEvidenceEvents(1, 0, "codex", "account-a", "same@example.com", "")
+				unknown[0].AuthSnapshotAtMS = 0
+				unknown[0].CreatedAtMS = 0
+				return append(events, unknown...)
+			},
+			wantGroups:       2,
+			wantAllowed:      false,
+			wantUnknownGroup: true,
+		},
+		{
+			name: "one conflicting member is not aggregated away",
+			buildEvents: func() []usage.Event {
+				events := repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "account-a", "same@example.com", "")
+				return append(events, repeatedIdentityEvidenceEvents(1, 2000, "codex", "account-a", "other@example.com", "")...)
+			},
+			wantGroups:  2,
+			wantAllowed: false,
+		},
+		{
+			name: "one conflicting workspace is not aggregated away",
+			buildEvents: func() []usage.Event {
+				events := repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "account-a", "same@example.com", "")
+				return append(events, repeatedIdentityEvidenceEvents(1, 2000, "codex", "account-b", "same@example.com", "")...)
+			},
+			wantGroups:  2,
+			wantAllowed: false,
+		},
+		{
+			name: "one foreign provider is not aggregated away",
+			buildEvents: func() []usage.Event {
+				events := repeatedIdentityEvidenceEvents(repeatedRows, 1000, "codex", "account-a", "same@example.com", "")
+				return append(events, repeatedIdentityEvidenceEvents(1, 2000, "openai", "account-a", "same@example.com", "")...)
+			},
+			wantGroups:  2,
+			wantAllowed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			repo := New(db)
+			if _, err := repo.InsertBatch(context.Background(), test.buildEvents()); err != nil {
+				t.Fatalf("insert identity events: %v", err)
+			}
+
+			predicates := legacyAccountIdentityPredicates(fields.AuthFileSnapshot, fields.AuthIndex)
+			evidence, err := queryLegacyAccountIdentityEvidence(context.Background(), db, predicates[0])
+			if err != nil {
+				t.Fatalf("query grouped identity evidence: %v", err)
+			}
+			if len(evidence) != test.wantGroups {
+				t.Fatalf("grouped evidence count = %d, want %d: %#v", len(evidence), test.wantGroups, evidence)
+			}
+			if test.wantMinEvidenceAt != 0 {
+				if len(evidence) != 1 || evidence[0].minEvidenceAtMS != test.wantMinEvidenceAt || evidence[0].maxEvidenceAtMS != test.wantMaxEvidenceAt || evidence[0].chronologyUnknown {
+					t.Fatalf("grouped chronology = %#v, want min=%d max=%d known", evidence, test.wantMinEvidenceAt, test.wantMaxEvidenceAt)
+				}
+			}
+			if test.wantUnknownGroup {
+				found := false
+				for _, group := range evidence {
+					if group.chronologyUnknown {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("grouped chronology = %#v, want an unknown chronology group", evidence)
+				}
+			}
+
+			_, allowed, err := repo.ResolveCodexLegacyAccountKey(context.Background(), fields)
+			if err != nil {
+				t.Fatalf("resolve grouped identity: %v", err)
+			}
+			if allowed != test.wantAllowed {
+				t.Fatalf("allowed = %v, want %v", allowed, test.wantAllowed)
+			}
+		})
+	}
+}
+
+func repeatedIdentityEvidenceEvents(count int, startMS int64, provider, accountID, member, projectID string) []usage.Event {
+	events := make([]usage.Event, 0, count)
+	for i := 0; i < count; i++ {
+		event := identityChronologyEvent(
+			fmt.Sprintf("grouped-%s-%s-%s-%s-%d-%d", provider, accountID, member, projectID, startMS, i),
+			startMS+int64(i),
+			"codex-a.json",
+			"auth-a",
+			provider,
+			accountID,
+			projectID,
+		)
+		event.AccountSnapshot = member
+		events = append(events, event)
+	}
+	return events
 }
 
 func TestResolveCodexLegacyAccountKeyAcceptsValidMarkerOnlyHistory(t *testing.T) {

--- a/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
@@ -20,13 +20,13 @@ func (r *repository) LoadAccountWindowStats(ctx context.Context, windows []Accou
 		return nil, State{}, false, err
 	}
 	defer func() { _ = tx.Rollback() }()
-	windows, err = usageevent.ResolveAccountWindowLegacyKeys(ctx, tx, windows)
-	if err != nil {
-		return nil, State{}, false, err
-	}
 	state, available, projectionComplete, err := projectionReadState(ctx, tx)
 	if err != nil || !available {
 		return nil, state, available, err
+	}
+	windows, err = usageevent.ResolveAccountWindowLegacyKeys(ctx, tx, windows)
+	if err != nil {
+		return nil, state, false, err
 	}
 	statsState, revision, dailyAvailable, err := statsReadState(ctx, tx)
 	if err != nil {

--- a/apps/manager-server/internal/repository/usagemonitoring/codex_legacy_identity_test.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/codex_legacy_identity_test.go
@@ -1,0 +1,203 @@
+package usagemonitoring_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageevent"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
+)
+
+func TestCodexLegacyIdentityEvidenceRollupResumesAndIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+	db, st := openMonitoringRepositoryStore(t, dbPath)
+	defer func() { _ = db.Close() }()
+	seedCodexLegacyIdentityEvents(t, db, 2001)
+	result, err := st.CatchUpCodexLegacyIdentityEvidence(ctx, 100_000, 1)
+	if err != nil || result.Processed != 1000 || result.CoverageEventID != 1000 || !result.Pending {
+		t.Fatalf("first bounded batch = %+v err=%v", result, err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, st = openMonitoringRepositoryStore(t, dbPath)
+	state, err := st.UsageMonitoringState(ctx, usageevent.CodexLegacyIdentityRollupName)
+	if err != nil || state.CoverageEventID != 1000 || state.ProcessedEvents != 1000 {
+		t.Fatalf("reopened checkpoint = %+v err=%v", state, err)
+	}
+	result, err = st.CatchUpCodexLegacyIdentityEvidence(ctx, 1000, 2)
+	if err != nil || result.Processed != 1000 || result.CoverageEventID != 2000 {
+		t.Fatalf("resumed batch = %+v err=%v", result, err)
+	}
+	assertCodexEvidenceAlias(t, st, true)
+	result, err = st.CatchUpCodexLegacyIdentityEvidence(ctx, 1000, 3)
+	if err != nil || result.Processed != 1 || result.Pending || result.CoverageEventID != 2001 {
+		t.Fatalf("final batch = %+v err=%v", result, err)
+	}
+	result, err = st.CatchUpCodexLegacyIdentityEvidence(ctx, 1000, 4)
+	if err != nil || result.Processed != 0 || result.Pending {
+		t.Fatalf("idempotent catch-up = %+v err=%v", result, err)
+	}
+	assertCodexEvidenceAlias(t, st, true)
+	var groups int
+	if err := db.QueryRow("select count(*) from " + usageevent.CodexLegacyIdentityEvidenceTable).Scan(&groups); err != nil || groups != 6 {
+		t.Fatalf("compacted groups = %d err=%v, want 6", groups, err)
+	}
+	assertCodexEvidenceRawEvents(t, db, 2001)
+}
+
+func TestCodexLegacyIdentityEvidenceRollupCommitsCheckpointAtomically(t *testing.T) {
+	ctx := context.Background()
+	db, st := newMonitoringRepositoryStore(t)
+	seedCodexLegacyIdentityEvents(t, db, 3)
+	if _, err := db.Exec(`create trigger fail_identity_checkpoint before update of coverage_event_id on usage_monitoring_rollup_state
+		when new.rollup_name = 'codex_legacy_identity_v1' and new.coverage_event_id > 0
+		begin select raise(abort, 'checkpoint failure'); end`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CatchUpCodexLegacyIdentityEvidence(ctx, 1000, 1); err == nil {
+		t.Fatal("expected checkpoint failure")
+	}
+	state, err := st.UsageMonitoringState(ctx, usageevent.CodexLegacyIdentityRollupName)
+	if err != nil || state.CoverageEventID != 0 || state.ProcessedEvents != 0 {
+		t.Fatalf("failed checkpoint = %+v err=%v", state, err)
+	}
+	var groups int
+	if err := db.QueryRow("select count(*) from " + usageevent.CodexLegacyIdentityEvidenceTable).Scan(&groups); err != nil || groups != 0 {
+		t.Fatalf("uncommitted evidence survived = %d err=%v", groups, err)
+	}
+	if _, err := db.Exec("drop trigger fail_identity_checkpoint"); err != nil {
+		t.Fatal(err)
+	}
+	finishCodexEvidenceRollup(t, st, 1)
+	assertCodexEvidenceAlias(t, st, true)
+	assertCodexEvidenceRawEvents(t, db, 3)
+}
+
+func TestCodexLegacyIdentityEvidenceRevisionClearsInBoundedBatches(t *testing.T) {
+	ctx := context.Background()
+	db, st := newMonitoringRepositoryStore(t)
+	seedCodexLegacyIdentityEvents(t, db, 5)
+	finishCodexEvidenceRollup(t, st, 1000)
+	if _, err := db.Exec("update " + usageevent.CodexLegacyIdentityEvidenceTable + " set structure_revision = 'old', auth_account_id_snapshot = auth_account_id_snapshot || '-conflict'"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("update usage_monitoring_rollup_state set structure_revision = 'old' where rollup_name = 'codex_legacy_identity_v1'"); err != nil {
+		t.Fatal(err)
+	}
+	var before int
+	if err := db.QueryRow("select count(*) from " + usageevent.CodexLegacyIdentityEvidenceTable).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	result, err := st.CatchUpCodexLegacyIdentityEvidence(ctx, 1, 1)
+	if err != nil || result.Processed != 0 || !result.Pending || !result.ContinueSoon {
+		t.Fatalf("clearing batch = %+v err=%v", result, err)
+	}
+	var after int
+	if err := db.QueryRow("select count(*) from " + usageevent.CodexLegacyIdentityEvidenceTable).Scan(&after); err != nil || after != before-1 {
+		t.Fatalf("bounded clearing = before:%d after:%d err:%v", before, after, err)
+	}
+	assertCodexEvidenceAlias(t, st, true)
+	finishCodexEvidenceRollup(t, st, 1)
+	var stale int
+	if err := db.QueryRow("select count(*) from " + usageevent.CodexLegacyIdentityEvidenceTable + " where structure_revision <> '1'").Scan(&stale); err != nil || stale != 0 {
+		t.Fatalf("stale revision rows = %d err=%v", stale, err)
+	}
+	assertCodexEvidenceAlias(t, st, true)
+	assertCodexEvidenceRawEvents(t, db, 5)
+}
+
+func TestCodexLegacyIdentityEvidenceMigrationRecoversMissingDerivation(t *testing.T) {
+	for _, missing := range []string{"table", "state"} {
+		t.Run(missing, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "usage.sqlite")
+			db, st := openMonitoringRepositoryStore(t, dbPath)
+			defer func() { _ = db.Close() }()
+			seedCodexLegacyIdentityEvents(t, db, 5)
+			finishCodexEvidenceRollup(t, st, 1000)
+			query := "drop table " + usageevent.CodexLegacyIdentityEvidenceTable
+			if missing == "state" {
+				query = "delete from usage_monitoring_rollup_state where rollup_name = 'codex_legacy_identity_v1'"
+			}
+			if _, err := db.Exec(query); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			db, st = openMonitoringRepositoryStore(t, dbPath)
+			state, err := st.UsageMonitoringState(context.Background(), usageevent.CodexLegacyIdentityRollupName)
+			if err != nil || state.CoverageEventID != 0 || state.TargetEventID != 5 {
+				t.Fatalf("recovered state = %+v err=%v", state, err)
+			}
+			assertCodexEvidenceAlias(t, st, true)
+			finishCodexEvidenceRollup(t, st, 1)
+			if err := sqliterepo.Migrate(db); err != nil {
+				t.Fatal(err)
+			}
+			state, err = st.UsageMonitoringState(context.Background(), usageevent.CodexLegacyIdentityRollupName)
+			if err != nil || state.CoverageEventID != 5 || state.ProcessedEvents != 5 {
+				t.Fatalf("repeated migration reset valid evidence = %+v err=%v", state, err)
+			}
+			assertCodexEvidenceAlias(t, st, true)
+			assertCodexEvidenceRawEvents(t, db, 5)
+		})
+	}
+}
+
+func seedCodexLegacyIdentityEvents(t testing.TB, db *sql.DB, count int64) {
+	t.Helper()
+	_, err := db.Exec(`with recursive ids(id) as (
+		select 1 union all select id + 1 from ids where id < ?
+	) insert into usage_events (
+		id, event_hash, timestamp_ms, timestamp, model, created_at_ms,
+		provider, auth_provider_snapshot, auth_file_snapshot, source,
+		auth_index, auth_account_id_snapshot, account_snapshot
+	) select id, 'identity-' || id, id, cast(id as text), 'gpt-test', id,
+		'codex', 'codex', case id % 3 when 0 then 'codex-a.json' when 1 then null else '' end,
+		'codex-a.json', 'auth-a', case when id <= ? then '' else 'account-a' end,
+		'same@example.com' from ids`, count, count/2)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func finishCodexEvidenceRollup(t testing.TB, st *store.Store, limit int) {
+	t.Helper()
+	for i := int64(1); i <= 1000; i++ {
+		result, err := st.CatchUpCodexLegacyIdentityEvidence(context.Background(), limit, i)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result.Pending {
+			return
+		}
+	}
+	t.Fatal("identity evidence backfill did not complete")
+}
+
+func assertCodexEvidenceAlias(t testing.TB, st *store.Store, want bool) {
+	t.Helper()
+	_, allowed, err := st.UsageEvents.ResolveCodexLegacyAccountKey(context.Background(), usageidentity.Fields{
+		AuthFileSnapshot: "codex-a.json", AuthIndex: "auth-a", Source: "codex-a.json",
+		AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: "account-a", AccountSnapshot: "same@example.com",
+	})
+	if err != nil || allowed != want {
+		t.Fatalf("identity allowed=%v err=%v, want %v", allowed, err, want)
+	}
+}
+
+func assertCodexEvidenceRawEvents(t testing.TB, db *sql.DB, count int64) {
+	t.Helper()
+	var rows, sumIDs, sumCreated, strong int64
+	err := db.QueryRow(`select count(*), sum(id), sum(created_at_ms),
+		sum(case when auth_account_id_snapshot = 'account-a' then 1 else 0 end) from usage_events`).Scan(&rows, &sumIDs, &sumCreated, &strong)
+	if err != nil || rows != count || sumIDs != count*(count+1)/2 || sumCreated != sumIDs || strong != count-count/2 {
+		t.Fatalf("raw identity events changed: rows=%d ids=%d created=%d strong=%d err=%v", rows, sumIDs, sumCreated, strong, err)
+	}
+}

--- a/apps/manager-server/internal/repository/usagemonitoring/repository.go
+++ b/apps/manager-server/internal/repository/usagemonitoring/repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageevent"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageprojection"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usageidentity"
 )
@@ -24,6 +25,7 @@ type Repository interface {
 	CatchUpProjection(ctx context.Context, limit int, nowMS int64) (CatchUpResult, error)
 	CatchUpStats(ctx context.Context, limit int, nowMS int64) (CatchUpResult, error)
 	CatchUpMetadata(ctx context.Context, limit int, nowMS int64) (CatchUpResult, error)
+	CatchUpCodexLegacyIdentityEvidence(ctx context.Context, limit int, nowMS int64) (CatchUpResult, error)
 	RecordFailure(ctx context.Context, rollupName string, rollupErr error, nowMS int64) error
 	State(ctx context.Context, rollupName string) (State, error)
 	LoadAggregate(ctx context.Context, filter AnalyticsFilter) (Aggregate, State, bool, error)
@@ -96,6 +98,15 @@ func (r *repository) CatchUpMetadata(ctx context.Context, limit int, nowMS int64
 	})
 }
 
+func (r *repository) CatchUpCodexLegacyIdentityEvidence(ctx context.Context, limit int, nowMS int64) (CatchUpResult, error) {
+	if limit <= 0 || limit > defaultBatchLimit {
+		limit = defaultBatchLimit
+	}
+	return r.catchUp(ctx, usageevent.CodexLegacyIdentityRollupName, limit, nowMS, func(ctx context.Context, tx *sql.Tx, revision string, afterID, throughID, _ int64) error {
+		return usageevent.UpsertCodexLegacyIdentityEvidenceRange(ctx, tx, revision, afterID, throughID)
+	})
+}
+
 type batchUpserter func(context.Context, *sql.Tx, string, int64, int64, int64) error
 
 func (r *repository) catchUp(
@@ -145,13 +156,16 @@ func (r *repository) catchUp(
 		revision, err = currentStructureRevision(ctx, tx)
 	} else if rollupName == ProjectionRollupName {
 		revision = usageidentity.MonitoringProjectionStructureRevision()
+	} else if rollupName == usageevent.CodexLegacyIdentityRollupName {
+		revision = usageevent.CodexLegacyIdentityEvidenceRevision
 	} else {
 		revision = usageidentity.ModelFormatVersion
 	}
 	if err != nil {
 		return CatchUpResult{}, err
 	}
-	if state.StructureRevision != revision {
+	if state.StructureRevision != revision ||
+		(rollupName == usageevent.CodexLegacyIdentityRollupName && latestID < state.CoverageEventID) {
 		if err := resetForRevision(ctx, tx, rollupName, revision, latestID, nowMS); err != nil {
 			return CatchUpResult{}, err
 		}
@@ -166,7 +180,13 @@ func (r *repository) catchUp(
 		rebuilt = true
 	}
 	if state.Status == "clearing" {
-		pending, err := clearStatsRevisionRowsBatch(ctx, tx, revision, limit)
+		var pending bool
+		var err error
+		if rollupName == usageevent.CodexLegacyIdentityRollupName {
+			pending, err = usageevent.ClearCodexLegacyIdentityEvidenceBatch(ctx, tx, limit)
+		} else {
+			pending, err = clearStatsRevisionRowsBatch(ctx, tx, revision, limit)
+		}
 		if err != nil {
 			return CatchUpResult{}, err
 		}
@@ -286,7 +306,7 @@ func (r *repository) RecordFailure(ctx context.Context, rollupName string, rollu
 	if rollupErr == nil || nowMS <= 0 {
 		return nil
 	}
-	if rollupName != StatsRollupName && rollupName != MetadataRollupName && rollupName != ProjectionRollupName {
+	if rollupName != StatsRollupName && rollupName != MetadataRollupName && rollupName != ProjectionRollupName && rollupName != usageevent.CodexLegacyIdentityRollupName {
 		return fmt.Errorf("unknown usage monitoring rollup %q", rollupName)
 	}
 	_, err := r.db.ExecContext(ctx, `update usage_monitoring_rollup_state set
@@ -400,7 +420,7 @@ func resetForRevision(ctx context.Context, tx *sql.Tx, rollupName, revision stri
 }
 
 func revisionResetStatus(rollupName string) string {
-	if rollupName == StatsRollupName {
+	if rollupName == StatsRollupName || rollupName == usageevent.CodexLegacyIdentityRollupName {
 		return "clearing"
 	}
 	return "rebuilding"

--- a/apps/manager-server/internal/service/monitoring/codex_legacy_identity_test.go
+++ b/apps/manager-server/internal/service/monitoring/codex_legacy_identity_test.go
@@ -1,0 +1,240 @@
+package monitoring
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	sqliterepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/sqlite"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
+)
+
+func TestCodexLegacyEvidencePreservesHistoryAndWindowResponses(t *testing.T) {
+	db, st, historyRequest, windowRequest := newCodexLegacyServiceFixture(t, 12, "")
+	service := New(st)
+	ctx := context.Background()
+	wantHistory, err := service.AccountHistory(ctx, historyRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantWindow, err := service.AccountWindowUsage(ctx, windowRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, count := range []int64{3, 5} {
+		if wantHistory.Items[index].TotalRequests != count || wantWindow.Items[index].TotalRequests != count {
+			t.Fatalf("fixture target %d lost historical usage: history=%+v window=%+v", index, wantHistory.Items[index], wantWindow.Items[index])
+		}
+	}
+	for _, batchSize := range []int{1, 1000} {
+		if _, err := st.CatchUpCodexLegacyIdentityEvidence(ctx, batchSize, time.Now().UnixMilli()); err != nil {
+			t.Fatal(err)
+		}
+		history, err := service.AccountHistory(ctx, historyRequest)
+		if err != nil || !reflect.DeepEqual(history.Items, wantHistory.Items) || history.Checkpoint != wantHistory.Checkpoint {
+			t.Fatalf("history changed with evidence batch %d: response=%+v err=%v", batchSize, history, err)
+		}
+		window, err := service.AccountWindowUsage(ctx, windowRequest)
+		if err != nil || !reflect.DeepEqual(window.Items, wantWindow.Items) {
+			t.Fatalf("window changed with evidence batch %d: response=%+v err=%v", batchSize, window, err)
+		}
+	}
+	// The same evidence reader must also serve the raw analytics fallback.
+	if _, err := db.Exec("update usage_monitoring_rollup_state set structure_revision = 'unavailable' where rollup_name = 'projection_v1'"); err != nil {
+		t.Fatal(err)
+	}
+	window, err := service.AccountWindowUsage(ctx, windowRequest)
+	if err != nil || !reflect.DeepEqual(window.Items, wantWindow.Items) {
+		t.Fatalf("raw account-window fallback changed: response=%+v err=%v", window, err)
+	}
+}
+
+// BenchmarkCodexLegacyIdentityServices reproduces the issue's 154k/296k
+// credential histories in a 610k-event database. Existing monitoring benchmark
+// environment variables can change row count and raw payload size.
+func BenchmarkCodexLegacyIdentityServices(b *testing.B) {
+	count := monitoringBenchmarkEventCount(610_000)
+	payload := monitoringBenchmarkRawPayload()
+	b.Logf("preparing events=%d credential_a=%d credential_b=%d raw_payload_bytes=%d", count, count*154/610, count*296/610, len(payload))
+	preparedAt := time.Now()
+	db, st, historyRequest, windowRequest := newCodexLegacyServiceFixture(b, count, payload)
+	service := New(st)
+	ctx := context.Background()
+	wantRequests := []int64{int64(count * 154 / 610), int64(count * 296 / 610)}
+	var databaseBytes int64
+	if err := db.QueryRow("select page_count * page_size from pragma_page_count(), pragma_page_size()").Scan(&databaseBytes); err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("fixture prepared elapsed=%s database_bytes=%d", time.Since(preparedAt), databaseBytes)
+	for _, evidence := range []string{"raw_evidence", "stored_evidence"} {
+		if evidence == "stored_evidence" {
+			started := time.Now()
+			var longestBatch time.Duration
+			batches := 0
+			for {
+				batchStarted := time.Now()
+				result, err := st.CatchUpCodexLegacyIdentityEvidence(ctx, 1000, time.Now().UnixMilli())
+				if err != nil {
+					b.Fatal(err)
+				}
+				longestBatch = max(longestBatch, time.Since(batchStarted))
+				batches++
+				if !result.Pending {
+					break
+				}
+			}
+			var groups int64
+			if err := db.QueryRow("select count(*) from usage_codex_legacy_identity_evidence_v1").Scan(&groups); err != nil {
+				b.Fatal(err)
+			}
+			b.Logf("identity evidence backfill elapsed=%s batches=%d longest_batch=%s groups=%d", time.Since(started), batches, longestBatch, groups)
+		}
+		for _, cache := range []string{"warm", "fresh_sqlite_connection"} {
+			for _, operation := range []string{"history", "window"} {
+				b.Run(evidence+"/"+cache+"/"+operation, func(b *testing.B) {
+					samples := make([]time.Duration, 0, b.N)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						if cache == "fresh_sqlite_connection" {
+							b.StopTimer()
+							db.SetMaxIdleConns(0)
+							db.SetMaxIdleConns(1)
+							b.StartTimer()
+						}
+						started := time.Now()
+						if operation == "history" {
+							response, err := service.AccountHistory(ctx, historyRequest)
+							if err != nil || len(response.Items) != 2 {
+								b.Fatalf("history response=%+v err=%v", response, err)
+							}
+							for i, item := range response.Items {
+								if item.TotalRequests != wantRequests[i] {
+									b.Fatalf("history target %d requests=%d, want %d", i, item.TotalRequests, wantRequests[i])
+								}
+							}
+						} else {
+							response, err := service.AccountWindowUsage(ctx, windowRequest)
+							if err != nil || len(response.Items) != 2 {
+								b.Fatalf("window response=%+v err=%v", response, err)
+							}
+							for i, item := range response.Items {
+								if item.TotalRequests != wantRequests[i] {
+									b.Fatalf("window target %d requests=%d, want %d", i, item.TotalRequests, wantRequests[i])
+								}
+							}
+						}
+						samples = append(samples, time.Since(started))
+					}
+					b.StopTimer()
+					sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+					b.ReportMetric(float64(samples[len(samples)/2])/float64(time.Millisecond), "p50-ms")
+					b.ReportMetric(float64(samples[(len(samples)*95-1)/100])/float64(time.Millisecond), "p95-ms")
+				})
+			}
+		}
+	}
+}
+
+func newCodexLegacyServiceFixture(t testing.TB, count int, payload string) (*sql.DB, *store.Store, AccountHistoryRequest, AccountWindowUsageRequest) {
+	t.Helper()
+	if count < 12 {
+		t.Fatal("identity service fixture requires at least 12 events")
+	}
+	db, err := sqliterepo.Open(filepath.Join(t.TempDir(), "usage.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+	if err := sqliterepo.RunDerivedStartupMaintenance(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	const fromMS int64 = 1_700_000_000_000
+	toMS := fromMS + int64(count)*1000 + 1
+	aCount, bCount := count*154/610, count*296/610
+	if _, err := db.Exec(`with recursive ids(id) as (
+		select 1 union all select id + 1 from ids where id < @rows
+	), credentials as (
+		select id, case when id <= @a then 0 when id <= @a + @b then 1 else 2 end as credential
+		from ids
+	) insert into usage_events (
+		id, event_hash, timestamp_ms, timestamp, model, requested_model, created_at_ms,
+		provider, auth_provider_snapshot, auth_file_snapshot, source, auth_index,
+		auth_account_id_snapshot, account_snapshot, input_tokens, output_tokens, total_tokens, raw_json
+	) select id, 'identity-' || id, @base + id * 1000, cast(@base + id * 1000 as text),
+		'gpt-test', 'gpt-test', @base + id * 1000, 'codex', 'codex',
+		'codex-' || credential || '.json', 'codex-' || credential || '.json', 'auth-' || credential,
+		case when id > case credential
+			when 0 then @a / 2 when 1 then @a + @b / 2
+			else @a + @b + (@rows - @a - @b) / 2 end
+		then 'workspace-' || credential else '' end,
+		'member-' || credential || '@example.com', 100, 20, 120, @payload
+	from credentials`, sql.Named("rows", count), sql.Named("a", aCount), sql.Named("b", bCount),
+		sql.Named("base", fromMS), sql.Named("payload", payload)); err != nil {
+		t.Fatal(err)
+	}
+	st := store.New(db)
+	if err := st.SaveModelPrices(ctx, map[string]store.ModelPrice{"gpt-test": {Prompt: 1, Completion: 2}}); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		result, err := st.CatchUpAccountHistoryRollups(ctx, 5000, toMS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Processed == 0 {
+			break
+		}
+	}
+	for {
+		result, err := st.CatchUpUsagePricing(ctx, 5000, toMS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result.Pending {
+			break
+		}
+	}
+	for _, catchUp := range []func(context.Context, int, int64) (store.UsageMonitoringCatchUpResult, error){
+		st.CatchUpUsageMonitoringProjection, st.CatchUpUsageMonitoringStats,
+	} {
+		for {
+			result, err := catchUp(ctx, 5000, toMS)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.Pending {
+				break
+			}
+		}
+	}
+	// Bulk fixture creation can leave a multi-GB WAL. Measure steady-state
+	// queries after checkpointing that setup work, with the same database for
+	// both evidence readers. Reopening a connection does not clear OS caches.
+	var busy, logFrames, checkpointed int
+	if err := db.QueryRow("pragma wal_checkpoint(truncate)").Scan(&busy, &logFrames, &checkpointed); err != nil || busy != 0 {
+		t.Fatalf("checkpoint identity fixture: busy=%d err=%v", busy, err)
+	}
+	history := AccountHistoryRequest{}
+	windows := AccountWindowUsageRequest{}
+	for i := 0; i < 2; i++ {
+		history.Accounts = append(history.Accounts, AccountHistoryTarget{
+			RowKey: fmt.Sprint(i), AuthFileSnapshot: fmt.Sprintf("codex-%d.json", i),
+			AuthIndex: fmt.Sprintf("auth-%d", i), AuthProviderSnapshot: "codex",
+			AuthAccountIDSnapshot: fmt.Sprintf("workspace-%d", i), AccountSnapshot: fmt.Sprintf("member-%d@example.com", i),
+		})
+		windows.Windows = append(windows.Windows, AccountWindowUsageTarget{
+			RowKey: fmt.Sprint(i), WindowKey: "window", FromMS: fromMS, ToMS: toMS,
+			AuthFileSnapshot: fmt.Sprintf("codex-%d.json", i), AuthIndex: fmt.Sprintf("auth-%d", i),
+			AuthProviderSnapshot: "codex", AuthAccountIDSnapshot: fmt.Sprintf("workspace-%d", i),
+			AccountSnapshot: fmt.Sprintf("member-%d@example.com", i),
+		})
+	}
+	return db, st, history, windows
+}

--- a/apps/manager-server/internal/store/store.go
+++ b/apps/manager-server/internal/store/store.go
@@ -539,6 +539,10 @@ func (s *Store) CatchUpUsageMonitoringMetadata(ctx context.Context, limit int, n
 	return s.UsageMonitoring.CatchUpMetadata(ctx, limit, nowMS)
 }
 
+func (s *Store) CatchUpCodexLegacyIdentityEvidence(ctx context.Context, limit int, nowMS int64) (UsageMonitoringCatchUpResult, error) {
+	return s.UsageMonitoring.CatchUpCodexLegacyIdentityEvidence(ctx, limit, nowMS)
+}
+
 func (s *Store) RecordUsageMonitoringFailure(ctx context.Context, rollupName string, rollupErr error, nowMS int64) error {
 	return s.UsageMonitoring.RecordFailure(ctx, rollupName, rollupErr, nowMS)
 }

--- a/apps/manager-server/internal/worker/usage_pricing_rollup.go
+++ b/apps/manager-server/internal/worker/usage_pricing_rollup.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	collectorpkg "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/collector"
+	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usageevent"
 	monitoringrepo "github.com/seakee/cpa-manager-plus/apps/manager-server/internal/repository/usagemonitoring"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/store"
 	"github.com/seakee/cpa-manager-plus/apps/manager-server/internal/usage"
@@ -36,6 +37,7 @@ const (
 	usageDerivedMonitoringProjectionTask
 	usageDerivedMonitoringMetadataTask
 	usageDerivedMonitoringStatsTask
+	usageDerivedCodexLegacyIdentityTask
 	usageDerivedTaskCount
 )
 
@@ -160,6 +162,9 @@ func (w *UsagePricingRollupWorker) catchUpTask(ctx context.Context, task int, no
 	case usageDerivedMonitoringStatsTask:
 		result, err := w.store.CatchUpUsageMonitoringStats(ctx, w.batchLimit, nowMS)
 		return usageDerivedCatchUpResult{Processed: result.Processed, CoverageEventID: result.CoverageEventID, TargetEventID: result.TargetEventID, Pending: result.Pending, Rebuilt: result.Rebuilt, ContinueSoon: result.ContinueSoon}, err
+	case usageDerivedCodexLegacyIdentityTask:
+		result, err := w.store.CatchUpCodexLegacyIdentityEvidence(ctx, w.batchLimit, nowMS)
+		return usageDerivedCatchUpResult{Processed: result.Processed, CoverageEventID: result.CoverageEventID, TargetEventID: result.TargetEventID, Pending: result.Pending, Rebuilt: result.Rebuilt, ContinueSoon: result.ContinueSoon}, err
 	default:
 		result, err := w.store.CatchUpUsagePricing(ctx, w.batchLimit, nowMS)
 		return usageDerivedCatchUpResult{Processed: result.Processed, CoverageEventID: result.CoverageEventID, TargetEventID: result.TargetEventID, Pending: result.Pending, Rebuilt: result.Rebuilt, ContinueSoon: result.ContinueSoon}, err
@@ -196,6 +201,8 @@ func (w *UsagePricingRollupWorker) recordTaskFailure(ctx context.Context, task i
 		return w.store.RecordUsageMonitoringFailure(ctx, monitoringrepo.MetadataRollupName, rollupErr, nowMS)
 	case usageDerivedMonitoringStatsTask:
 		return w.store.RecordUsageMonitoringFailure(ctx, monitoringrepo.StatsRollupName, rollupErr, nowMS)
+	case usageDerivedCodexLegacyIdentityTask:
+		return w.store.RecordUsageMonitoringFailure(ctx, usageevent.CodexLegacyIdentityRollupName, rollupErr, nowMS)
 	default:
 		return w.store.RecordUsagePricingFailure(ctx, rollupErr, nowMS)
 	}
@@ -209,6 +216,8 @@ func usageDerivedTaskName(task int) string {
 		return "monitoring metadata"
 	case usageDerivedMonitoringStatsTask:
 		return "monitoring stats"
+	case usageDerivedCodexLegacyIdentityTask:
+		return "Codex legacy identity evidence"
 	default:
 		return "pricing"
 	}

--- a/apps/manager-server/internal/worker/usage_pricing_rollup_test.go
+++ b/apps/manager-server/internal/worker/usage_pricing_rollup_test.go
@@ -37,7 +37,7 @@ func TestUsagePricingRollupWorkerCatchUp(t *testing.T) {
 
 	worker := NewUsagePricingRollupWorker(db)
 	worker.batchLimit = 10
-	worker.maxBatches = 4
+	worker.maxBatches = usageDerivedTaskCount
 	if pending := worker.catchUp(ctx); pending {
 		t.Fatal("completed catch-up reported pending work")
 	}
@@ -56,7 +56,7 @@ func TestUsagePricingRollupWorkerCatchUp(t *testing.T) {
 	if len(rows) != 1 || rows[0].Calls != 1 || rows[0].InputTokens != 150 || rows[0].ContextThresholdTokens != 100 {
 		t.Fatalf("pricing rows = %#v", rows)
 	}
-	for _, rollupName := range []string{"projection_v1", "metadata_v1", "stats_v1"} {
+	for _, rollupName := range []string{"projection_v1", "metadata_v1", "stats_v1", "codex_legacy_identity_v1"} {
 		monitoringState, err := db.UsageMonitoringState(ctx, rollupName)
 		if err != nil {
 			t.Fatalf("monitoring state %s: %v", rollupName, err)


### PR DESCRIPTION
## Summary

Fix Issue #701 by avoiding per-event Go materialization during Codex legacy identity validation. SQLite now compacts matching evidence into grouped identity records while preserving the existing fail-closed authority and chronology rules.

## Scope

- [ ] Frontend panel
- [x] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Group matching legacy identity evidence in SQLite with min/max chronology bounds and an unknown-chronology flag before scanning into Go.
- Keep provider, member, workspace, marker, physical-predicate, and chronology decisions in the existing Go authority path.
- Check projection availability before running the expensive account-window legacy resolver.
- Add grouped-evidence, conflict, and chronology regression coverage.

## User Impact

Large Codex histories no longer transfer every matching identity event into Go during account-history and account-window reads. Identity attribution and fail-closed behavior remain unchanged.

## Compatibility / Runtime Notes

- CPA panel mode: No identity contract or frontend behavior changes.
- Manager Server mode: Legacy identity reads use grouped evidence; unavailable account-window projections return before legacy validation and preserve raw fallback semantics.
- Full Docker / native packages: No packaging or deployment changes.

## Data / Security Notes

No schema migration, new index, identity revision change, cache, or historical data rewrite. `usage_events` remains read-only input. Provider, member, workspace, marker, and chronology conflicts continue to fail closed.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `e11f26c5ecfaaaaf71b9185e1de633054cdb5aaa`.

## Verification

- [ ] Type check
- [ ] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
go test ./internal/repository/usageevent
go test ./internal/repository/usagemonitoring
go test ./...
go test -race ./internal/repository/usageevent ./internal/repository/usagemonitoring
gofmt -d apps/manager-server/internal/repository/usageevent/account_identity.go apps/manager-server/internal/repository/usageevent/account_identity_test.go apps/manager-server/internal/repository/usagemonitoring/account_window_read.go
git diff --check
```

## Screenshots / Recordings

N/A — backend-only change.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: No user-facing API, configuration, or documentation contract changed.

## Related

Fixes #701