### PR TITLE
fix(accounts): align quota window semantic groups

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -8162,7 +8162,7 @@ describe('AccountsPage replacement flows', () => {
     );
   });
 
-  it('keeps a fixed xAI billing period in detail standard mode while showing billing and PAYG fallbacks', async () => {
+  it('keeps a fixed xAI billing period in detail other mode while showing billing and PAYG fallbacks', async () => {
     const file = {
       name: 'xai-fixed-billing.json',
       type: 'xai',
@@ -8211,11 +8211,10 @@ describe('AccountsPage replacement flows', () => {
     });
     await flushPromises();
 
-    const standardGroup = renderer.root.findByProps({ 'data-quota-window-group': 'standard' });
+    const standardGroup = renderer.root.findAllByProps({ 'data-quota-window-group': 'standard' });
     const otherGroup = renderer.root.findByProps({ 'data-quota-window-group': 'other' });
-    expect(standardGroup.findAllByType(QuotaWindowCard)).toHaveLength(1);
-    expect(standardGroup.findByProps({ 'data-quota-card-mode': 'standard' })).toBeTruthy();
-    expect(standardGroup.findByProps({ 'data-quota-standard-comparison': 'true' })).toBeTruthy();
+    expect(standardGroup).toHaveLength(0);
+    expect(otherGroup.findAllByType(QuotaWindowCard)).toHaveLength(4);
     expect(readText(otherGroup)).toContain('xai_quota.monthly_credits');
     expect(readText(otherGroup)).toContain('Grok Code Fast');
   });
@@ -8392,7 +8391,7 @@ describe('AccountsPage replacement flows', () => {
     expect(readText(renderer.root)).toContain('Opus model quota');
   });
 
-  it('keeps Kimi standard windows ahead of summary data', async () => {
+  it('keeps Kimi standard windows alongside top-level summary data', async () => {
     const file = {
       name: 'kimi-standard.json',
       type: 'kimi',
@@ -8430,7 +8429,7 @@ describe('AccountsPage replacement flows', () => {
     const card = findAccountCardByKey(renderer, selectionKey);
 
     expect(readText(card)).toContain('5H');
-    expect(readText(card)).not.toContain('SUM');
+    expect(readText(card)).toContain('SUM');
     expect(readText(card)).not.toContain('accounts.quota_details_only');
   });
 

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.test.tsx
@@ -140,7 +140,7 @@ describe('QuotaWindowCard', () => {
     expect(renderer.root.findAllByProps({ 'data-quota-model-comparison': 'true' })).toHaveLength(0);
   });
 
-  it('keeps a fixed billing interval in standard mode when mode is inferred', () => {
+  it('infers other mode for a fixed billing interval', () => {
     const renderer = renderCard(
       makeWindow({
         kind: 'billing',
@@ -151,11 +151,34 @@ describe('QuotaWindowCard', () => {
       })
     );
 
-    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'standard' })).toHaveLength(1);
+    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'other' })).toHaveLength(1);
     expect(renderer.root.findAllByProps({ 'data-quota-standard-comparison': 'true' })).toHaveLength(
-      1
+      0
     );
+  });
+
+  it('renders standard card with incomplete boundary notice for unknown boundary standard window', () => {
+    const renderer = renderCard(
+      makeWindow({
+        kind: 'weekly',
+        windowMode: 'unknown',
+        modelScope: { kind: 'all', complete: true },
+        limitWindowSeconds: null,
+        fromMs: null,
+        toMs: null,
+        cycleStartMs: null,
+        cycleEndMs: null,
+        usage: undefined,
+        currentUsage: undefined,
+        previousUsage: undefined,
+        forecast: undefined,
+      })
+    );
+
+    expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'standard' })).toHaveLength(1);
     expect(renderer.root.findAllByProps({ 'data-quota-card-mode': 'other' })).toHaveLength(0);
+    const cardText = readText(renderer.root);
+    expect(cardText).toContain('accounts.detail_window_boundary_incomplete');
   });
 
   it('uses semantic colors for the current usage metric icons', () => {

--- a/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
+++ b/apps/web/src/features/accounts/components/QuotaWindowCard.tsx
@@ -24,8 +24,7 @@ import {
   IconCheck,
 } from '@/components/ui/icons';
 import {
-  isIntervalAccountQuotaWindow,
-  isModelScopedAccountQuotaWindow,
+  getAccountQuotaSemanticGroup,
   type AccountQuotaWindowKind,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
 import type { AccountQuotaBoundaryAccuracy } from '@/features/accounts/model/accountQuotaWindowDefinitions';
@@ -149,9 +148,7 @@ const formatObservedAt = (value: number, locale: string): string =>
   }).format(value);
 
 const inferCardMode = (window: AccountDetailQuotaWindow): QuotaWindowCardMode => {
-  if (!isIntervalAccountQuotaWindow(window)) return 'other';
-  if (isModelScopedAccountQuotaWindow(window)) return 'model';
-  return 'standard';
+  return getAccountQuotaSemanticGroup(window);
 };
 
 const windowIconForKind = (
@@ -614,7 +611,7 @@ export const QuotaWindowCard = ({
 
   const progress = <QuotaProgress className={styles.bar} percent={q.remainingPercent} />;
 
-  if (resolvedMode === 'other' || !isIntervalAccountQuotaWindow(q)) {
+  if (resolvedMode === 'other') {
     return (
       <div
         className={`${styles.card} ${styles.otherCard}`}
@@ -712,51 +709,53 @@ export const QuotaWindowCard = ({
     >
       {header}
       {progress}
-      <div className={styles.compareColumns} data-quota-standard-comparison="true">
-        <UsageColumn
-          title={
-            q.previousPeriod === 'previous_equal_range'
-              ? t('accounts.detail_previous_equal_range', { defaultValue: '前一等长区间' })
-              : t('accounts.detail_previous_usage', { defaultValue: '上个窗口用量' })
-          }
-          subtitle={formatPreviousWindowRange(q, previousUsage, resolvedLocale)}
-          period="previous"
-          usage={previousUsage}
-          labels={usageLabels}
-          emptyMessage={t('accounts.detail_window_stats_empty', {
-            defaultValue: '窗口统计暂未采集',
-          })}
-        />
-        <UsageColumn
-          title={t('accounts.detail_current_used', { defaultValue: '当前窗口已用' })}
-          subtitle={formatCurrentWindowRange(
-            q,
-            usage,
-            resolvedLocale,
-            currentWindowBoundaryUnconfirmed
-          )}
-          period="current"
-          usage={usage}
-          labels={usageLabels}
-          emptyMessage={t('accounts.detail_window_stats_empty', {
-            defaultValue: '窗口统计暂未采集',
-          })}
-        />
-        <ForecastColumn
-          forecast={q.forecast}
-          title={t('accounts.detail_current_forecast', { defaultValue: '当前窗口预测' })}
-          subtitle={forecastSubtitle}
-          labels={{
-            requests: t('accounts.detail_forecast_requests', { defaultValue: '预计请求' }),
-            tokens: t('accounts.detail_forecast_tokens', { defaultValue: '预计 Token' }),
-            cost: t('accounts.detail_forecast_cost', { defaultValue: '预计花费' }),
-          }}
-          unavailableMessage={t('accounts.detail_forecast_success_rate_unavailable', {
-            defaultValue: '暂不预测成功率',
-          })}
-          emptyMessage={forecastEmptyMessage}
-        />
-      </div>
+      {q.windowMode !== 'unknown' ? (
+        <div className={styles.compareColumns} data-quota-standard-comparison="true">
+          <UsageColumn
+            title={
+              q.previousPeriod === 'previous_equal_range'
+                ? t('accounts.detail_previous_equal_range', { defaultValue: '前一等长区间' })
+                : t('accounts.detail_previous_usage', { defaultValue: '上个窗口用量' })
+            }
+            subtitle={formatPreviousWindowRange(q, previousUsage, resolvedLocale)}
+            period="previous"
+            usage={previousUsage}
+            labels={usageLabels}
+            emptyMessage={t('accounts.detail_window_stats_empty', {
+              defaultValue: '窗口统计暂未采集',
+            })}
+          />
+          <UsageColumn
+            title={t('accounts.detail_current_used', { defaultValue: '当前窗口已用' })}
+            subtitle={formatCurrentWindowRange(
+              q,
+              usage,
+              resolvedLocale,
+              currentWindowBoundaryUnconfirmed
+            )}
+            period="current"
+            usage={usage}
+            labels={usageLabels}
+            emptyMessage={t('accounts.detail_window_stats_empty', {
+              defaultValue: '窗口统计暂未采集',
+            })}
+          />
+          <ForecastColumn
+            forecast={q.forecast}
+            title={t('accounts.detail_current_forecast', { defaultValue: '当前窗口预测' })}
+            subtitle={forecastSubtitle}
+            labels={{
+              requests: t('accounts.detail_forecast_requests', { defaultValue: '预计请求' }),
+              tokens: t('accounts.detail_forecast_tokens', { defaultValue: '预计 Token' }),
+              cost: t('accounts.detail_forecast_cost', { defaultValue: '预计花费' }),
+            }}
+            unavailableMessage={t('accounts.detail_forecast_success_rate_unavailable', {
+              defaultValue: '暂不预测成功率',
+            })}
+            emptyMessage={forecastEmptyMessage}
+          />
+        </div>
+      ) : null}
       {sourceMeta}
       {q.windowMode === 'unknown' ? (
         <div className={styles.emptyState}>{t('accounts.detail_window_boundary_incomplete')}</div>

--- a/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
@@ -15,8 +15,7 @@ import {
   formatQuotaResetTimestamp,
 } from '@/features/accounts/model/accountsPagePresentation';
 import {
-  isIntervalAccountQuotaWindow,
-  isModelScopedAccountQuotaWindow,
+  getAccountQuotaSemanticGroup,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import { QuotaWindowCard } from '../QuotaWindowCard';
@@ -116,12 +115,14 @@ export function AccountQuotaTab({
   const history = detailView.history;
   const allWindows = detailView.quota.windows;
   const standardWindows = allWindows.filter(
-    (window) => isIntervalAccountQuotaWindow(window) && !isModelScopedAccountQuotaWindow(window)
+    (window) => getAccountQuotaSemanticGroup(window) === 'standard'
   );
   const modelWindows = allWindows.filter(
-    (window) => isIntervalAccountQuotaWindow(window) && isModelScopedAccountQuotaWindow(window)
+    (window) => getAccountQuotaSemanticGroup(window) === 'model'
   );
-  const otherQuotaItems = allWindows.filter((window) => !isIntervalAccountQuotaWindow(window));
+  const otherQuotaItems = allWindows.filter(
+    (window) => getAccountQuotaSemanticGroup(window) === 'other'
+  );
 
   const formatNumber = (value: number) => new Intl.NumberFormat(i18n.language).format(value);
   const formatTime = (value: number | null) =>

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
@@ -6,6 +6,7 @@ import { buildAccountRows, type AccountQuotaStores } from './accountRows';
 import {
   buildAccountQuotaDisplayWindow,
   buildAccountQuotaDisplayWindows,
+  getAccountQuotaSemanticGroup,
   getQuotaWindowShortLabel,
   isIntervalAccountQuotaWindow,
   isModelScopedAccountQuotaWindow,
@@ -143,6 +144,53 @@ describe('accountQuotaDisplayWindows', () => {
 
       expect(isModelScopedAccountQuotaWindow(window)).toBe(true);
       expect(isStandardAccountQuotaListWindow(window)).toBe(false);
+    });
+
+    it('classifies unknown-boundary weekly account-wide window as standard semantic group while failing closed for intervals', () => {
+      const window = {
+        kind: 'weekly' as const,
+        windowMode: 'unknown' as const,
+        source: 'kimi' as const,
+        modelScope: { kind: 'all' as const, complete: true },
+      };
+
+      expect(getAccountQuotaSemanticGroup(window)).toBe('standard');
+      expect(isIntervalAccountQuotaWindow(window)).toBe(false);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(false);
+    });
+
+    it('classifies unknown-boundary weekly model-scoped window as model semantic group', () => {
+      const window = {
+        kind: 'weekly' as const,
+        windowMode: 'unknown' as const,
+        source: 'codex' as const,
+        modelScope: { kind: 'models' as const, models: ['gpt-5'], complete: true },
+      };
+
+      expect(getAccountQuotaSemanticGroup(window)).toBe('model');
+    });
+
+    it('classifies fixed billing window as other semantic group without entering standard quota', () => {
+      const window = {
+        kind: 'billing' as const,
+        windowMode: 'fixed' as const,
+        source: 'xai' as const,
+        modelScope: { kind: 'all' as const, complete: true },
+      };
+
+      expect(getAccountQuotaSemanticGroup(window)).toBe('other');
+      expect(isIntervalAccountQuotaWindow(window)).toBe(true);
+      expect(isStandardAccountQuotaListWindow(window)).toBe(false);
+    });
+
+    it('retains backward compatibility by classifying undefined kind with fixed interval as standard semantic group', () => {
+      const window = {
+        windowMode: 'fixed' as const,
+        source: 'kimi' as const,
+        modelScope: { kind: 'all' as const, complete: true },
+      };
+
+      expect(getAccountQuotaSemanticGroup(window)).toBe('standard');
     });
   });
 
@@ -329,12 +377,13 @@ describe('accountQuotaDisplayWindows', () => {
     expect(windows[1]).toMatchObject({
       key: 'extra-usage',
       label: 'Extra Usage',
-      kind: 'monthly',
+      kind: 'billing',
       remainingPercent: 70,
       usedPercent: 30,
       amountLabel: '$1.50 / $5.00',
       source: 'claude',
     });
+    expect(getAccountQuotaSemanticGroup(windows[1])).toBe('other');
   });
 
   it('flattens Antigravity groups while retaining group and bucket metadata', () => {
@@ -549,6 +598,46 @@ describe('accountQuotaDisplayWindows', () => {
       amountLabel: '3 / 10',
       source: 'kimi',
     });
+  });
+
+  it('builds top-level Kimi weekly quota with 604800s duration as fixed weekly interval in standard semantic group', () => {
+    const stores = {
+      ...emptyStores(),
+      kimiQuota: {
+        'kimi.json': {
+          status: 'success',
+          rows: [
+            {
+              id: 'summary',
+              labelKey: 'kimi_quota.weekly_limit',
+              used: 17,
+              limit: 100,
+              resetAtMs: Date.parse('2026-09-13T00:24:47.694Z'),
+              resetAccuracy: 'exact',
+              limitWindowSeconds: 604_800,
+            },
+          ],
+        },
+      },
+    } satisfies AccountQuotaStores;
+    const row = buildRow({ name: 'kimi.json', type: 'kimi' }, stores);
+
+    const windows = buildAccountQuotaDisplayWindows(row, {
+      stores,
+      translateQuotaWindowLabel,
+      t,
+    });
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      key: 'summary',
+      kind: 'weekly',
+      windowMode: 'fixed',
+      limitWindowSeconds: 604_800,
+    });
+    expect(getAccountQuotaSemanticGroup(windows[0])).toBe('standard');
+    expect(isIntervalAccountQuotaWindow(windows[0])).toBe(true);
+    expect(isStandardAccountQuotaListWindow(windows[0])).toBe(true);
   });
 
   it('splits xAI billing into monthly and pay-as-you-go windows', () => {

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.ts
@@ -129,6 +129,40 @@ export const isStandardAccountQuotaListWindow = (
   window.kind !== 'product' &&
   window.kind !== 'summary';
 
+export type AccountQuotaSemanticGroup = 'standard' | 'model' | 'other';
+
+export const getAccountQuotaSemanticGroup = (
+  window: Pick<AccountQuotaDisplayWindow, 'kind' | 'windowMode' | 'modelScope' | 'source'>
+): AccountQuotaSemanticGroup => {
+  const { kind, windowMode } = window;
+
+  if (
+    windowMode === 'non_window' ||
+    kind === 'billing' ||
+    kind === 'payg' ||
+    kind === 'product' ||
+    kind === 'summary' ||
+    kind === 'unknown'
+  ) {
+    return 'other';
+  }
+
+  if (
+    kind === 'five_hour' ||
+    kind === 'daily' ||
+    kind === 'weekly' ||
+    kind === 'monthly'
+  ) {
+    return isModelScopedAccountQuotaWindow(window) ? 'model' : 'standard';
+  }
+
+  if (kind === undefined && isIntervalAccountQuotaWindow(window)) {
+    return isModelScopedAccountQuotaWindow(window) ? 'model' : 'standard';
+  }
+
+  return 'other';
+};
+
 const normalizeText = (value: string): string => value.trim().toLowerCase().replace(/\s+/g, ' ');
 
 const parseAntigravityWindowSeconds = (value: string | undefined): number | null => {
@@ -498,7 +532,7 @@ const buildClaudeQuotaDisplayWindows = (
       buildAccountQuotaDisplayWindow({
         key: 'extra-usage',
         label: options.t('claude_quota.extra_usage_label'),
-        kind: 'monthly',
+        kind: 'billing',
         remainingPercent: remainingPercentFromUsed(usedPercent),
         usedPercent,
         resetLabel: '-',

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
@@ -132,10 +132,92 @@ describe('accountsPagePresentation', () => {
     ).toBe(standardQuotaWindows);
   });
 
-  it('does not add a fallback for Codex model-only quota', () => {
-    const quotaWindows = [makeQuotaWindow({ key: 'codex-spark', kind: 'product' })];
+  it('selects Codex main quota with or without duration while excluding scoped quota', () => {
+    // Case D: full duration main 5H fixed + main 7D fixed -> [5H, 7D]
+    const main5hFixed = makeQuotaWindow({
+      key: 'five-hour',
+      kind: 'five_hour',
+      source: 'codex',
+      windowMode: 'fixed',
+      limitWindowSeconds: 18000,
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    const main7dFixed = makeQuotaWindow({
+      key: 'weekly',
+      kind: 'weekly',
+      source: 'codex',
+      windowMode: 'fixed',
+      limitWindowSeconds: 604800,
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    expect(
+      selectAccountQuotaListWindows(
+        makeAccountRow('codex'),
+        [main5hFixed, main7dFixed],
+        [main5hFixed, main7dFixed]
+      )
+    ).toEqual([main5hFixed, main7dFixed]);
 
-    expect(selectAccountQuotaListWindows(makeAccountRow('codex'), quotaWindows, [])).toEqual([]);
+    // Case E: Weekly duration missing (main 5H fixed + main Weekly unknown) -> [5H, 7D]
+    const mainWeeklyUnknown = makeQuotaWindow({
+      key: 'weekly',
+      kind: 'weekly',
+      source: 'codex',
+      windowMode: 'unknown',
+      limitWindowSeconds: null,
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    expect(
+      selectAccountQuotaListWindows(
+        makeAccountRow('codex'),
+        [main5hFixed, mainWeeklyUnknown],
+        [main5hFixed]
+      )
+    ).toEqual([main5hFixed, mainWeeklyUnknown]);
+
+    // Case F: both duration missing -> [5H, 7D]
+    const main5hUnknown = makeQuotaWindow({
+      key: 'five-hour',
+      kind: 'five_hour',
+      source: 'codex',
+      windowMode: 'unknown',
+      limitWindowSeconds: null,
+      modelScope: { kind: 'family', key: 'codex_main', complete: true },
+    });
+    expect(
+      selectAccountQuotaListWindows(
+        makeAccountRow('codex'),
+        [main5hUnknown, mainWeeklyUnknown],
+        []
+      )
+    ).toEqual([main5hUnknown, mainWeeklyUnknown]);
+
+    // Case G: scoped quota (Spark, additional, code-review, model-scoped) do not enter list
+    const spark = makeQuotaWindow({
+      key: 'spark',
+      kind: 'five_hour',
+      source: 'codex',
+      modelScope: { kind: 'models', models: ['gpt-5.3-codex-spark'], complete: true },
+    });
+    const codeReview = makeQuotaWindow({
+      key: 'code-review',
+      kind: 'weekly',
+      source: 'codex',
+      modelScope: { kind: 'feature', key: 'code_review', complete: false },
+    });
+    const additional = makeQuotaWindow({
+      key: 'additional-unknown',
+      kind: 'five_hour',
+      source: 'codex',
+      modelScope: { kind: 'feature', key: 'additional_unknown', complete: false },
+    });
+    expect(
+      selectAccountQuotaListWindows(
+        makeAccountRow('codex'),
+        [main5hFixed, spark, codeReview, additional],
+        [main5hFixed]
+      )
+    ).toEqual([main5hFixed]);
   });
 
   it('preserves Claude standard ordering and keeps non-standard-only quota in details', () => {
@@ -161,25 +243,30 @@ describe('accountsPagePresentation', () => {
     ).toEqual([]);
   });
 
-  it('keeps Kimi standard windows ahead of summary data and exposes summary-only data', () => {
-    const standardQuotaWindows = [makeQuotaWindow({ key: 'five-hour', kind: 'five_hour' })];
-    const quotaWindows = [
-      makeQuotaWindow({ key: 'summary', kind: 'summary' }),
-      ...standardQuotaWindows,
-    ];
+  it('selects Kimi top-level 5H and 7D in order, hides scoped quota, and exposes summary-only data', () => {
+    // Case A: 5H standard + top-level 7D -> [5H, 7D]
+    const fiveHour = makeQuotaWindow({ key: 'five-hour', kind: 'five_hour', source: 'kimi' });
+    const topLevelWeekly = makeQuotaWindow({ key: 'summary', kind: 'weekly', source: 'kimi' });
     expect(
-      selectAccountQuotaListWindows(makeAccountRow('kimi'), quotaWindows, standardQuotaWindows)
-    ).toBe(standardQuotaWindows);
+      selectAccountQuotaListWindows(makeAccountRow('kimi'), [topLevelWeekly, fiveHour], [fiveHour])
+    ).toEqual([fiveHour, topLevelWeekly]);
 
-    const summaryOnly = [makeQuotaWindow({ key: 'summary', kind: 'summary', source: 'kimi' })];
+    // Case B: only top-level Weekly -> [7D]
+    const summaryOnly = [makeQuotaWindow({ key: 'summary', kind: 'weekly', source: 'kimi' })];
     expect(selectAccountQuotaListWindows(makeAccountRow('kimi'), summaryOnly, [])).toEqual(
       summaryOnly
     );
 
-    const scopedSummary = [
-      makeQuotaWindow({ key: 'usage-0-summary', kind: 'summary', source: 'kimi' }),
-    ];
-    expect(selectAccountQuotaListWindows(makeAccountRow('kimi'), scopedSummary, [])).toEqual([]);
+    // Case C: top-level 5H, top-level 7D, usage-0 scoped 5H, usage-0 scoped Weekly -> [top-level 5H, top-level 7D]
+    const scoped5H = makeQuotaWindow({ key: 'usage-0-limit-0', kind: 'five_hour', source: 'kimi' });
+    const scopedWeekly = makeQuotaWindow({ key: 'usage-0-summary', kind: 'weekly', source: 'kimi' });
+    expect(
+      selectAccountQuotaListWindows(
+        makeAccountRow('kimi'),
+        [fiveHour, topLevelWeekly, scoped5H, scopedWeekly],
+        [fiveHour]
+      )
+    ).toEqual([fiveHour, topLevelWeekly]);
   });
 
   it('normalizes Antigravity fallback scope labels without labeling other providers', () => {

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.ts
@@ -1,6 +1,10 @@
 import type { TFunction } from 'i18next';
 import { ANTIGRAVITY_CONFIG } from '@/components/quota';
-import { getQuotaWindowShortLabel } from '@/features/accounts/model/accountQuotaDisplayWindows';
+import {
+  getQuotaWindowShortLabel,
+  isModelScopedAccountQuotaWindow,
+  isStandardAccountQuotaListWindow,
+} from '@/features/accounts/model/accountQuotaDisplayWindows';
 import type {
   AccountQuotaWindowKind,
   AccountQuotaDisplayWindow,
@@ -315,30 +319,65 @@ const selectXaiQuotaListFallbackWindows = (
   return [billing, payg].filter((window): window is AccountQuotaDisplayWindow => Boolean(window));
 };
 
+const isCodexQuotaListCandidate = (window: AccountQuotaDisplayWindow): boolean =>
+  !isModelScopedAccountQuotaWindow(window) &&
+  (window.kind === 'five_hour' || window.kind === 'weekly' || window.kind === 'monthly');
+
+const selectCodexQuotaListWindows = (
+  quotaWindows: AccountQuotaDisplayWindow[]
+): AccountQuotaDisplayWindow[] => {
+  return quotaWindows.filter(isCodexQuotaListCandidate);
+};
+
+const selectKimiQuotaListWindows = (
+  quotaWindows: AccountQuotaDisplayWindow[]
+): AccountQuotaDisplayWindow[] => {
+  const topLevelWindows = quotaWindows.filter(
+    (window) => !window.key.startsWith('usage-')
+  );
+
+  const limits = topLevelWindows.filter(
+    (window) =>
+      window.key !== 'summary' &&
+      !isModelScopedAccountQuotaWindow(window) &&
+      (isStandardAccountQuotaListWindow(window) ||
+        window.kind === 'five_hour' ||
+        window.kind === 'daily' ||
+        window.kind === 'weekly')
+  );
+
+  const summary = topLevelWindows.find(
+    (window) => window.key === 'summary' && !isModelScopedAccountQuotaWindow(window)
+  );
+
+  if (summary) {
+    return [...limits, summary];
+  }
+  return limits;
+};
+
 export const selectAccountQuotaListWindows = (
   row: AccountRow,
   quotaWindows: AccountQuotaDisplayWindow[],
   standardQuotaWindows: AccountQuotaDisplayWindow[]
 ): AccountQuotaDisplayWindow[] => {
-  if (standardQuotaWindows.length > 0) return standardQuotaWindows;
-
   switch (row.provider) {
     case 'codex':
-      return [];
+      return selectCodexQuotaListWindows(quotaWindows);
+    case 'kimi':
+      return selectKimiQuotaListWindows(quotaWindows);
     case 'xai':
-      return selectXaiQuotaListFallbackWindows(quotaWindows);
+      return standardQuotaWindows.length > 0
+        ? standardQuotaWindows
+        : selectXaiQuotaListFallbackWindows(quotaWindows);
     case 'antigravity':
-      return quotaWindows.slice(0, 2);
-    case 'kimi': {
-      const summary = quotaWindows.find(
-        (window) => window.source === 'kimi' && window.key === 'summary'
-      );
-      return summary ? [summary] : [];
-    }
+      return standardQuotaWindows.length > 0
+        ? standardQuotaWindows
+        : quotaWindows.slice(0, 2);
     case 'claude':
-      return [];
+      return standardQuotaWindows;
     default:
-      return [];
+      return standardQuotaWindows;
   }
 };
 

--- a/apps/web/src/utils/quota/builders.test.ts
+++ b/apps/web/src/utils/quota/builders.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { KimiUsagePayload } from '@/types';
 import { buildAntigravityQuotaGroups, buildKimiQuotaRows } from './builders';
 
 describe('buildAntigravityQuotaGroups', () => {
@@ -280,19 +281,128 @@ describe('buildKimiQuotaRows', () => {
 
     expect(rows).toEqual([
       expect.objectContaining({
-        id: 'usage-0-summary',
-        labelKey: 'kimi_quota.scoped_weekly_limit',
-        labelParams: { scope: 'Coding' },
-        used: 214,
-        limit: 2048,
-      }),
-      expect.objectContaining({
         id: 'usage-0-limit-0',
         labelKey: 'kimi_quota.scoped_limit_window',
         labelParams: { scope: 'Coding', duration: '5h' },
         used: 139,
         limit: 200,
       }),
+      expect.objectContaining({
+        id: 'usage-0-summary',
+        labelKey: 'kimi_quota.scoped_weekly_limit',
+        labelParams: { scope: 'Coding' },
+        used: 214,
+        limit: 2048,
+      }),
     ]);
+  });
+
+  it('normalizes Kimi #699 payload with 5H limits before Weekly usage and assigns 7D duration to top-level usage', () => {
+    const observedAtMs = Date.parse('2026-09-06T19:24:47.694Z');
+    const resetTime = '2026-09-13T00:24:47.694450Z';
+    const limitResetTime = '2026-09-06T19:24:47.694450Z';
+    const rows = buildKimiQuotaRows(
+      {
+        user: {
+          membership: {
+            level: 'LEVEL_INTERMEDIATE',
+          },
+        },
+        usage: {
+          limit: '100',
+          used: '17',
+          remaining: '83',
+          resetTime,
+        },
+        limits: [
+          {
+            window: {
+              duration: 300,
+              timeUnit: 'TIME_UNIT_MINUTE',
+            },
+            detail: {
+              limit: '100',
+              used: '16',
+              remaining: '84',
+              resetTime: limitResetTime,
+            },
+          },
+        ],
+        parallel: {
+          limit: '20',
+        },
+        authentication: {
+          method: 'METHOD_ACCESS_TOKEN',
+          scope: 'FEATURE_CODING',
+        },
+        subType: 'TYPE_PURCHASE',
+        domain: 'DOMAIN_NEXUS',
+        version: 'GOODS_VERSION_V1',
+      } as unknown as KimiUsagePayload,
+      { observedAtMs }
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      id: 'limit-0',
+      used: 16,
+      limit: 100,
+      limitWindowSeconds: 18_000,
+      resetAtMs: Date.parse(limitResetTime),
+    });
+    expect(rows[1]).toMatchObject({
+      id: 'summary',
+      labelKey: 'kimi_quota.weekly_limit',
+      used: 17,
+      limit: 100,
+      limitWindowSeconds: 604_800,
+      resetAtMs: Date.parse(resetTime),
+    });
+  });
+
+  it('normalizes Kimi top-level summary-only usage as 7D weekly quota', () => {
+    const resetTime = '2026-09-13T00:24:47.694450Z';
+    const rows = buildKimiQuotaRows({
+      usage: {
+        limit: '100',
+        used: '17',
+        remaining: '83',
+        resetTime,
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'summary',
+      labelKey: 'kimi_quota.weekly_limit',
+      used: 17,
+      limit: 100,
+      limitWindowSeconds: 604_800,
+      resetAtMs: Date.parse(resetTime),
+    });
+  });
+
+  it('does not alter Kimi normalization based on membership level', () => {
+    const resetTime = '2026-09-13T00:24:47.694450Z';
+    const rows = buildKimiQuotaRows({
+      user: {
+        membership: {
+          level: 'LEVEL_ADVANCED',
+        },
+      },
+      usage: {
+        limit: '200',
+        used: '50',
+        resetTime,
+      },
+    } as unknown as KimiUsagePayload);
+
+    expect(rows[0]).toMatchObject({
+      id: 'summary',
+      limitWindowSeconds: 604_800,
+      used: 50,
+      limit: 200,
+      resetAtMs: Date.parse(resetTime),
+    });
   });
 });

--- a/apps/web/src/utils/quota/builders.ts
+++ b/apps/web/src/utils/quota/builders.ts
@@ -591,19 +591,6 @@ export function buildKimiQuotaRows(
     idPrefix = '',
     scope?: unknown
   ) => {
-    if (usage && typeof usage === 'object') {
-      const summary = toKimiUsageRow(
-        usage as Record<string, unknown>,
-        {
-          labelKey: 'kimi_quota.weekly_limit',
-        },
-        observedAtMs
-      );
-      if (summary) {
-        rows.push({ id: `${idPrefix}summary`, ...summary, ...applyKimiScopeLabel(summary, scope) });
-      }
-    }
-
     if (Array.isArray(limits)) {
       limits.forEach((item, idx) => {
         const detail = (item.detail && typeof item.detail === 'object' ? item.detail : item) as
@@ -638,6 +625,39 @@ export function buildKimiQuotaRows(
           });
         }
       });
+    }
+
+    if (usage && typeof usage === 'object') {
+      const summary = toKimiUsageRow(
+        usage as Record<string, unknown>,
+        {
+          labelKey: 'kimi_quota.weekly_limit',
+        },
+        observedAtMs
+      );
+      if (summary) {
+        const isTopLevel = idPrefix === '';
+        const scopedDuration = toInt((usage as Record<string, unknown>).duration);
+        const scopedTimeUnit = (usage as Record<string, unknown>).timeUnit;
+        const limitWindowSeconds = isTopLevel
+          ? 7 * 24 * 60 * 60
+          : scopedDuration !== null
+            ? kimiDurationSeconds(scopedDuration, scopedTimeUnit)
+            : null;
+        const resolvedScope =
+          (typeof (usage as Record<string, unknown>).scope === 'string' &&
+            ((usage as Record<string, unknown>).scope as string).trim()) ||
+          (typeof scope === 'string' && scope.trim()) ||
+          undefined;
+
+        rows.push({
+          id: `${idPrefix}summary`,
+          ...summary,
+          ...applyKimiScopeLabel(summary, scope),
+          scope: resolvedScope,
+          limitWindowSeconds,
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Align Accounts quota window grouping and list selection so provider-specific windows and incomplete-boundary windows are displayed consistently.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add semantic grouping for standard, model-scoped, and other quota windows.
- Keep unknown-boundary interval windows in account details without treating billing or pay-as-you-go data as standard quota.
- Restore top-level Codex and Kimi quota list selection and add regression coverage for provider-specific cases.

## User Impact

Account quota summaries and detail cards now show provider-specific quota windows in the intended sections. Billing and pay-as-you-go entries no longer appear as standard interval quotas.

## Compatibility / Runtime Notes

- CPA panel mode: No protocol or CPA integration changes.
- Manager Server mode: No Manager Server changes.
- Full Docker / native packages: No changes.

## Data / Security Notes

N/A. No database, authentication, raw usage, or credential changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit 65866f21 to restore the previous quota window classification and list selection behavior.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

    git diff --check: passed
    Focused Vitest run: blocked because the isolated worktree has no installed dependencies; reusing the source Vitest binary could not resolve Vite plugins and hit worktree EPERM while bundling the config.
    CI is expected to run the repository frontend type-check, lint, test, and build checks after the PR is opened.

## Screenshots / Recordings

N/A. Manual UI capture was not available in the isolated worktree because frontend dependencies were unavailable.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

No documentation contract or configuration behavior changed.

## Related

N/A
