### PR TITLE
feat(accounts): improve quota refresh and expiry display

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -10081,6 +10081,63 @@ describe('AccountsPage replacement flows', () => {
     expect(mocks.getAccountHistory).not.toHaveBeenCalled();
   });
 
+  it('allows different credential quota refreshes to run concurrently', async () => {
+    const first = makeCodexFile('codex-first.json', 'auth-first', 'first@example.com');
+    const second = makeCodexFile('codex-second.json', 'auth-second', 'second@example.com');
+    mocks.files = [first, second];
+    const firstQuota = createDeferred<CodexQuotaData>();
+    const secondQuota = createDeferred<CodexQuotaData>();
+    const quotaFetch = vi
+      .spyOn(CODEX_CONFIG, 'fetchQuota')
+      .mockReturnValueOnce(firstQuota.promise)
+      .mockReturnValueOnce(secondQuota.promise);
+    const renderer = await renderAccountsPage();
+
+    await act(async () => {
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(first),
+        'accounts.refresh_quota'
+      ).props.onClick();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(first),
+        'accounts.refresh_quota'
+      ).props.onClick();
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(second),
+        'accounts.refresh_quota'
+      ).props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(quotaFetch).toHaveBeenCalledTimes(2);
+    expect(
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(first),
+        'accounts.refresh_quota'
+      ).props.disabled
+    ).toBe(true);
+    expect(
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(second),
+        'accounts.refresh_quota'
+      ).props.disabled
+    ).toBe(true);
+
+    firstQuota.resolve(makeCodexQuotaData());
+    secondQuota.resolve(makeCodexQuotaData());
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
   it('allows a disabled credential to request its latest quota', async () => {
     const file = {
       ...makeCodexFile('codex-disabled.json', 'auth-disabled', 'disabled@example.com'),
@@ -13315,7 +13372,7 @@ describe('AccountsPage replacement flows', () => {
     );
     expect(
       readText(renderer.root.findByProps({ 'data-quota-reset-credit-expiry': 'reset-credit-1' }))
-    ).toBe(formatQuotaResetTimestamp(resetCreditExpiresAtMs, 'en'));
+    ).toContain(formatQuotaResetTimestamp(resetCreditExpiresAtMs, 'en'));
     expect(
       renderer.root.findAllByProps({ 'data-account-quota-reset-records': 'true' })
     ).toHaveLength(1);
@@ -13328,6 +13385,7 @@ describe('AccountsPage replacement flows', () => {
     expect(treeText(renderer)).toContain('codex_quota.reset_credits_available_label');
     expect(treeText(renderer)).toContain('codex_quota.reset_credits_unit');
     expect(treeText(renderer)).toContain('codex_quota.reset_credits_expected_expiry_label');
+    expect(treeText(renderer)).toContain('codex_quota.reset_credit_expiry_remaining_days');
 
     const resetAction = renderer.root.findByProps({ 'data-quota-reset-action': 'true' });
     expect(resetAction.props.disabled).toBe(false);

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -386,6 +386,9 @@ const CREDENTIAL_EVIDENCE_UNIQUE_FILE_NAME_BOUNDARY_PREFIX = 'unique-file-name\u
 const CREDENTIAL_EVIDENCE_SOURCE_FILE_BOUNDARY_PREFIX = 'source-file\u0000';
 const CREDENTIAL_EVIDENCE_PROVIDER_BOUNDARY_PREFIX = 'provider\u0000';
 
+const getAccountQuotaRefreshKey = (row: AccountRow): string =>
+  `${row.provider}:${getQuotaCredentialStoreKey(row.raw)}`;
+
 type AccountQuotaRefreshOutcome =
   | { status: 'success' }
   | { status: 'error'; error: string }
@@ -1294,6 +1297,9 @@ export function AccountsPage() {
   const inspectionSnapshotRef = useRef(inspectionSnapshot);
   inspectionSnapshotRef.current = inspectionSnapshot;
   const [quotaRefreshing, setQuotaRefreshing] = useState(false);
+  const [manualQuotaRefreshingKeys, setManualQuotaRefreshingKeys] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
   const [historyRefreshing, setHistoryRefreshing] = useState(false);
   const [accountHistoryRefreshRevision, setAccountHistoryRefreshRevision] = useState(0);
   const [accountHistoryAutoRefreshRevision, setAccountHistoryAutoRefreshRevision] = useState(0);
@@ -1510,6 +1516,7 @@ export function AccountsPage() {
     promise: Promise<void>;
   } | null>(null);
   const quotaRefreshGenerationRef = useRef(0);
+  const manualQuotaRefreshingKeysRef = useRef<Set<string>>(new Set());
   const accountHistoryRefreshRequestIdRef = useRef(0);
   const accountHistoryRefreshPromiseRef = useRef<{
     key: string;
@@ -1608,6 +1615,8 @@ export function AccountsPage() {
     credentialMutationMarkerExhaustedRef.current.clear();
     quotaRefreshGenerationRef.current += 1;
     quotaRefreshBatchRef.current = null;
+    manualQuotaRefreshingKeysRef.current.clear();
+    setManualQuotaRefreshingKeys(new Set());
     quotaRequestVersionsRef.current.forEach((version, key) => {
       quotaRequestVersionsRef.current.set(key, version + 1);
     });
@@ -5994,13 +6003,57 @@ export function AccountsPage() {
 
   const refreshAccountQuota = useCallback(
     async (row: AccountRow): Promise<void> => {
-      await refreshQuotaRows([row]);
-      if (selectedRowKeyRef.current === row.selectionKey) {
-        setAccountQuotaRefreshRevision((current) => current + 1);
+      if (row.runtimeOnly) return;
+      const refreshKey = getAccountQuotaRefreshKey(row);
+      if (manualQuotaRefreshingKeysRef.current.has(refreshKey)) return;
+
+      manualQuotaRefreshingKeysRef.current.add(refreshKey);
+      setManualQuotaRefreshingKeys((current) => {
+        const next = new Set(current);
+        next.add(refreshKey);
+        return next;
+      });
+
+      const generation = quotaRefreshGenerationRef.current;
+      const isCurrentContext = () =>
+        quotaRefreshGenerationRef.current === generation &&
+        oauthEditorConnectionFingerprintRef.current === connectionFingerprint;
+
+      try {
+        const result = await refreshQuotaForRow(row);
+        if (!isCurrentContext() || result.status === 'ignored') return;
+
+        const rawName = row.accountLabel || row.fileName;
+        const name = accountDisplayMode === 'full' ? rawName : maskQuotaAccountText(rawName);
+        if (result.status === 'error') {
+          showNotification(
+            t('accounts.quota_refresh_failed', { name, message: result.error }),
+            'error'
+          );
+        } else {
+          showNotification(t('accounts.quota_refresh_success', { name }), 'success');
+        }
+
+        if (selectedRowKeyRef.current === row.selectionKey) {
+          setAccountQuotaRefreshRevision((current) => current + 1);
+        }
+      } finally {
+        if (isCurrentContext()) {
+          manualQuotaRefreshingKeysRef.current.delete(refreshKey);
+          setManualQuotaRefreshingKeys((current) => {
+            if (!current.has(refreshKey)) return current;
+            const next = new Set(current);
+            next.delete(refreshKey);
+            return next;
+          });
+        }
       }
     },
-    [refreshQuotaRows]
+    [accountDisplayMode, connectionFingerprint, refreshQuotaForRow, showNotification, t]
   );
+
+  const isManualQuotaRefreshing = (row: AccountRow): boolean =>
+    manualQuotaRefreshingKeys.has(getAccountQuotaRefreshKey(row));
 
   const refreshAccountHistory = useCallback(
     (row: AccountRow): Promise<void> => {
@@ -7142,7 +7195,10 @@ export function AccountsPage() {
           iconOnly
           className={`${styles.accountIconButton} ${styles.accountIconButtonRefresh}`}
           onClick={() => void refreshAccountQuota(row)}
-          disabled={disableControls || quotaRefreshing || row.runtimeOnly}
+          disabled={
+            disableControls || quotaRefreshing || isManualQuotaRefreshing(row) || row.runtimeOnly
+          }
+          loading={isManualQuotaRefreshing(row)}
           title={t('accounts.refresh_quota')}
           aria-label={t('accounts.refresh_quota')}
         >
@@ -7854,6 +7910,7 @@ export function AccountsPage() {
     };
     const selectedCredentialRefreshing =
       credentialRefreshing[getAuthFileSelectionKey(selectedRow.raw)] === true;
+    const selectedQuotaRefreshing = isManualQuotaRefreshing(selectedRow);
     const drawerMoreItems: DropdownMenuItem[] = [
       {
         key: 'models',
@@ -7967,10 +8024,10 @@ export function AccountsPage() {
             <Button
               variant="secondary"
               onClick={() => void refreshAccountQuota(selectedRow)}
-              loading={quotaRefreshing}
-              disabled={disableControls || selectedRow.runtimeOnly}
+              loading={quotaRefreshing || selectedQuotaRefreshing}
+              disabled={disableControls || selectedQuotaRefreshing || selectedRow.runtimeOnly}
             >
-              {!quotaRefreshing ? <IconRefreshCw size={16} /> : null}
+              {!quotaRefreshing && !selectedQuotaRefreshing ? <IconRefreshCw size={16} /> : null}
               {t('accounts.refresh_quota')}
             </Button>
             <Button

--- a/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
+++ b/apps/web/src/features/accounts/components/accountDetail/AccountQuotaTab.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { JSX } from 'react';
 import { Button } from '@/components/ui/Button';
@@ -13,10 +13,12 @@ import type { AccountDetailViewModel } from '@/features/accounts/model/accountDe
 import {
   formatPercent,
   formatQuotaResetTimestamp,
+  getQuotaResetRemainingDays,
 } from '@/features/accounts/model/accountsPagePresentation';
 import {
   getAccountQuotaSemanticGroup,
 } from '@/features/accounts/model/accountQuotaDisplayWindows';
+import { useInterval } from '@/hooks/useInterval';
 import { formatCompactNumber, formatUsd } from '@/utils/usage';
 import { QuotaWindowCard } from '../QuotaWindowCard';
 import styles from '@/features/accounts/AccountsPage.module.scss';
@@ -140,6 +142,8 @@ export function AccountQuotaTab({
     detailView.quota.resetCreditsAvailableCount !== null ||
     detailView.quota.resetCreditExpiries.length > 0;
   const shouldShowResetRecords = detailView.identity.provider === 'codex' && hasResetRecords;
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useInterval(() => setNowMs(Date.now()), shouldShowResetRecords ? 60_000 : null);
 
   return (
     <div className={styles.quotaTab} data-account-quota-tab="true">
@@ -341,7 +345,10 @@ export function AccountQuotaTab({
                     >
                       <span>{t('codex_quota.reset_credit_expiry_item', { index: index + 1 })}</span>
                       <strong data-quota-reset-credit-expiry={item.id}>
-                        {formatQuotaResetTimestamp(item.expiresAtMs, i18n.language)}
+                        {t('codex_quota.reset_credit_expiry_remaining_days', {
+                          days: getQuotaResetRemainingDays(item.expiresAtMs, nowMs) ?? 0,
+                        })}{' '}
+                        · {formatQuotaResetTimestamp(item.expiresAtMs, i18n.language)}
                       </strong>
                     </div>
                   ))}

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
@@ -6,6 +6,7 @@ import {
   formatHistorySuccessRate,
   formatMoney,
   formatQuotaResetDisplay,
+  getQuotaResetRemainingDays,
   formatQuotaResetTimestamp,
   formatQuotaResetTooltipParams,
   formatTimestamp,
@@ -112,6 +113,15 @@ describe('accountsPagePresentation', () => {
         recoverAtMs
       )
     ).toEqual({ resetAt: '07/30 10:05', recoverAt: '07/31 11:15' });
+  });
+
+  it('calculates reset-credit remaining days with an inclusive countdown boundary', () => {
+    const nowMs = new Date(2026, 8, 11, 6, 33).getTime();
+
+    expect(getQuotaResetRemainingDays(nowMs + 10 * 24 * 60 * 60 * 1000, nowMs)).toBe(10);
+    expect(getQuotaResetRemainingDays(nowMs + 10 * 24 * 60 * 60 * 1000 - 1, nowMs)).toBe(10);
+    expect(getQuotaResetRemainingDays(nowMs - 1, nowMs)).toBe(0);
+    expect(getQuotaResetRemainingDays(null, nowMs)).toBeNull();
   });
 
   it('keeps standard quota windows as the only list selection when available', () => {

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.ts
@@ -161,6 +161,8 @@ const formatNumericTimestamp = (date: Date, includeSeconds = false) => {
   return includeSeconds ? `${base}:${padTimestampPart(date.getSeconds())}` : base;
 };
 
+const QUOTA_RESET_DAY_MS = 24 * 60 * 60 * 1000;
+
 export const formatTimestamp = (value: number | null, _locale: string, includeSeconds = false) => {
   const date = resolveValidTimestampDate(value);
   if (!date) return '-';
@@ -188,6 +190,21 @@ export const formatQuotaResetTimestamp = (value: number | null | undefined, _loc
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '-';
   return formatNumericTimestamp(date);
+};
+
+export const getQuotaResetRemainingDays = (
+  expiresAtMs: number | null | undefined,
+  nowMs = Date.now()
+): number | null => {
+  if (
+    typeof expiresAtMs !== 'number' ||
+    !Number.isFinite(expiresAtMs) ||
+    expiresAtMs <= 0 ||
+    !Number.isFinite(nowMs)
+  ) {
+    return null;
+  }
+  return Math.max(0, Math.ceil((expiresAtMs - nowMs) / QUOTA_RESET_DAY_MS));
 };
 
 export const formatQuotaResetDisplay = (

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1739,6 +1739,7 @@
     "reset_credits_expiry_label": "Reset credit expiry",
     "reset_credits_invalid_payload": "The reset credits service returned an invalid response",
     "reset_credit_expiry_item": "Credit {{index}}",
+    "reset_credit_expiry_remaining_days": "Remaining {{days}} days",
     "active_limit_label": "Active limit",
     "credits_label": "Credits",
     "credits_balance": "Balance",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -1740,6 +1740,7 @@
     "reset_credits_expiry_label": "Срок действия сбросов квоты",
     "reset_credits_invalid_payload": "Endpoint сбросов квоты вернул неверный payload",
     "reset_credit_expiry_item": "Сброс {{index}}",
+    "reset_credit_expiry_remaining_days": "Осталось {{days}} дн.",
     "active_limit_label": "Активный лимит",
     "credits_label": "Credits",
     "credits_balance": "Баланс",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -1737,6 +1737,7 @@
     "reset_credits_expiry_label": "重置过期时间",
     "reset_credits_invalid_payload": "主动重置次数接口返回格式无效",
     "reset_credit_expiry_item": "第 {{index}} 次",
+    "reset_credit_expiry_remaining_days": "剩余 {{days}} 天",
     "active_limit_label": "生效限额",
     "credits_label": "Credits",
     "credits_balance": "余额",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -1737,6 +1737,7 @@
     "reset_credits_expiry_label": "重置過期時間",
     "reset_credits_invalid_payload": "主動重置次數介面回傳格式無效",
     "reset_credit_expiry_item": "第 {{index}} 次",
+    "reset_credit_expiry_remaining_days": "剩餘 {{days}} 天",
     "active_limit_label": "生效限額",
     "credits_label": "Credits",
     "credits_balance": "餘額",


### PR DESCRIPTION
## Summary

Allow credential-level quota refreshes to run concurrently and add remaining-day countdowns to Codex reset-credit expiry records.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Keep the existing overall quota refresh behavior while allowing different credential refresh buttons to run independently.
- Deduplicate repeated manual refreshes for the same credential and preserve context/request-generation safeguards.
- Display localized remaining days before reset-credit expiry timestamps and refresh the countdown periodically.
- Add regression coverage for refresh concurrency, countdown calculation, and locale resources.

## User Impact

Users can refresh multiple credentials from the credential list at the same time. Reset-credit records now show the remaining duration, for example `Remaining 10 days · 09/21 06:33`.

## Compatibility / Runtime Notes

- CPA panel mode: Frontend-only behavior is preserved.
- Manager Server mode: No backend or API contract changes.
- Full Docker / native packages: Embedded frontend behavior remains compatible; native packaging is not changed.

## Data / Security Notes

N/A. No data schema, credential, authentication, or security behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `943435f2` or merge the PR without changing backend data.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Focused frontend tests: 294/294 passed
Full frontend/repository tests: 218 files, 3185 tests passed
npm run type-check: passed
npm run lint: passed with one pre-existing warning and 0 errors
Production build: passed
git diff --check: passed
```

## Screenshots / Recordings

Not attached; the visible behavior is covered by the focused and full frontend regression suites.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a small inline account-panel behavior improvement; existing documentation does not describe the refresh control or reset-credit record formatting.

## Related

N/A
