### PR TITLE
fix(accounts): hide duplicate refresh icon while loading

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -52,6 +52,7 @@ import { AccountModelsTab } from './components/accountDetail/AccountModelsTab';
 import { AccountOverviewTab } from './components/accountDetail/AccountOverviewTab';
 import { AccountQuotaTab } from './components/accountDetail/AccountQuotaTab';
 import { QuotaWindowCard } from './components/QuotaWindowCard';
+import { IconRefreshCw } from '@/components/ui/icons';
 import { formatQuotaResetTimestamp } from './model/accountsPagePresentation';
 import { buildAccountQuotaDisplayWindow } from './model/accountQuotaDisplayWindows';
 import type { AccountQuotaDisplayWindow } from './model/accountQuotaDisplayWindows';
@@ -10130,6 +10131,20 @@ describe('AccountsPage replacement flows', () => {
         'accounts.refresh_quota'
       ).props.disabled
     ).toBe(true);
+    expect(
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(first),
+        'accounts.refresh_quota'
+      ).findAllByType(IconRefreshCw)
+    ).toHaveLength(0);
+    expect(
+      findAccountCardButtonByAriaLabel(
+        renderer,
+        getAuthFileSelectionKey(second),
+        'accounts.refresh_quota'
+      ).findAllByType(IconRefreshCw)
+    ).toHaveLength(0);
 
     firstQuota.resolve(makeCodexQuotaData());
     secondQuota.resolve(makeCodexQuotaData());

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -7202,7 +7202,7 @@ export function AccountsPage() {
           title={t('accounts.refresh_quota')}
           aria-label={t('accounts.refresh_quota')}
         >
-          <IconRefreshCw size={15} />
+          {!isManualQuotaRefreshing(row) ? <IconRefreshCw size={15} /> : null}
         </Button>
         <Button
           variant="secondary"


### PR DESCRIPTION
## Summary

Fix the credential-list quota refresh button showing both a loading spinner and the static refresh icon during refresh.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Hide the static refresh glyph while an individual credential quota request is loading.
- Keep the shared loading spinner and existing per-credential concurrent refresh behavior.
- Add regression assertions for both concurrently refreshing credential buttons.

## User Impact

The refresh button now shows a single clear loading indicator instead of two overlapping icons.

## Compatibility / Runtime Notes

- CPA panel mode: Frontend-only presentation fix; manual credential refresh behavior is unchanged.
- Manager Server mode: No backend or API contract changes.
- Full Docker / native packages: Embedded panel behavior remains compatible; packaging is unchanged.

## Data / Security Notes

N/A. No data, credential, authentication, or security behavior changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `10a83bb6`.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Focused AccountsPage tests: 272/272 passed
npm run type-check: passed
npm run lint: passed with 0 errors and 1 pre-existing warning
npm run build: passed
git diff --check: passed
Demo browser DOM check: idle refresh buttons contain one SVG and no loading spinner
```

## Screenshots / Recordings

Not attached. The user-provided screenshot identifies the regression, and the loading-state DOM assertion is covered by the focused regression test.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a small visual correction to an existing account refresh control and does not change documented behavior.

## Related

N/A
