### PR TITLE
fix(xai): preserve unknown weekly usage and separate billing reset boundaries

### DIFF
--- a/apps/manager-server/internal/service/codexinspection/service_test.go
+++ b/apps/manager-server/internal/service/codexinspection/service_test.go
@@ -1538,32 +1538,32 @@ func TestParseXAIBillingSummaryDoesNotCreateMonthlyWindowFromWeeklyZeroOnDemandD
 	if summary == nil {
 		t.Fatal("summary is nil")
 	}
+	if !summary.HasWeeklyData || summary.UsagePercent != nil {
+		t.Fatalf("weekly zero on-demand summary = %#v, want weekly data with unknown usage", summary)
+	}
+	if summary.BillingPeriodEnd != "" {
+		t.Fatalf("billing period end = %q, want absent", summary.BillingPeriodEnd)
+	}
 	windows := xaiSummaryWindows(summary)
 	if len(windows) != 1 || windows[0].ID != "xai-weekly" {
 		t.Fatalf("weekly zero on-demand windows = %#v, want weekly only", windows)
 	}
 }
 
-func TestParseXAIBillingSummaryTreatsOmittedWeeklyPercentAsResetZeroOnlyForValidPeriod(t *testing.T) {
-	valid := parseXAIBillingSummary(map[string]any{
+func TestParseXAIBillingSummaryKeepsOmittedWeeklyPercentUnknown(t *testing.T) {
+	summary := parseXAIBillingSummary(map[string]any{
 		"currentPeriod": map[string]any{
 			"type":  "USAGE_PERIOD_TYPE_WEEKLY",
 			"start": "2026-08-13T00:00:00Z",
 			"end":   "2026-08-20T00:00:00Z",
 		},
 	})
-	if valid == nil || valid.UsagePercent == nil || *valid.UsagePercent != 0 {
-		t.Fatalf("valid weekly reset summary = %#v, want zero usage", valid)
+	if summary == nil || !summary.HasWeeklyData || summary.UsagePercent != nil || summary.PeriodEnd != "2026-08-20T00:00:00Z" {
+		t.Fatalf("weekly summary = %#v, want unknown usage and weekly reset", summary)
 	}
-
-	incomplete := parseXAIBillingSummary(map[string]any{
-		"currentPeriod": map[string]any{
-			"type": "USAGE_PERIOD_TYPE_WEEKLY",
-			"end":  "2026-08-20T00:00:00Z",
-		},
-	})
-	if incomplete == nil || incomplete.UsagePercent != nil {
-		t.Fatalf("incomplete weekly period summary = %#v, want unknown usage", incomplete)
+	windows := xaiSummaryWindows(summary)
+	if len(windows) != 1 || windows[0].ID != "xai-weekly" || windows[0].UsedPercent != nil || windows[0].ResetLabel != summary.PeriodEnd {
+		t.Fatalf("weekly windows = %#v, want unknown usage with weekly reset", windows)
 	}
 }
 
@@ -1582,7 +1582,7 @@ func TestParseXAIBillingSummaryTreatsNestedEmptyCentValuesAsPlaceholders(t *test
 		},
 		"billingPeriodEnd": "2026-09-01T00:00:00Z",
 	})
-	if summary == nil || summary.UsagePercent == nil || *summary.UsagePercent != 0 {
+	if summary == nil || summary.UsagePercent != nil {
 		t.Fatalf("nested weekly summary = %#v", summary)
 	}
 	for name, value := range map[string]*float64{
@@ -1693,7 +1693,7 @@ func TestMergeXAIBillingSummaryUsesLegacyBillingGroupsOverWeeklyPlaceholders(t *
 	})
 
 	merged := mergeXAIBillingSummary(weekly, legacy)
-	if merged == nil || merged.UsagePercent == nil || *merged.UsagePercent != 0 {
+	if merged == nil || merged.UsagePercent != nil {
 		t.Fatalf("merged weekly summary = %#v", merged)
 	}
 	for name, value := range map[string]struct {
@@ -1714,6 +1714,46 @@ func TestMergeXAIBillingSummaryUsesLegacyBillingGroupsOverWeeklyPlaceholders(t *
 	}
 	if merged.BillingPeriodEnd != "2026-09-01T00:00:00Z" {
 		t.Fatalf("billing period end = %q", merged.BillingPeriodEnd)
+	}
+}
+
+func TestMergeXAIBillingSummaryKeepsWeeklyAndMonthlyResetBoundariesSeparate(t *testing.T) {
+	weekly := parseXAIBillingSummary(map[string]any{
+		"currentPeriod": map[string]any{
+			"type":  "USAGE_PERIOD_TYPE_WEEKLY",
+			"start": "2026-09-05T00:00:00Z",
+			"end":   "2026-09-12T00:00:00Z",
+		},
+		"onDemandCap":      map[string]any{"val": 0},
+		"onDemandUsed":     map[string]any{"val": 0},
+		"billingPeriodEnd": "2026-09-12T00:00:00Z",
+	})
+	monthly := parseXAIBillingSummary(map[string]any{
+		"monthlyLimit":     map[string]any{"val": 0},
+		"used":             map[string]any{"val": 0},
+		"billingPeriodEnd": "2026-10-01T00:00:00Z",
+	})
+
+	merged := mergeXAIBillingSummary(weekly, monthly)
+	if merged == nil || merged.UsagePercent != nil || merged.PeriodEnd != "2026-09-12T00:00:00Z" {
+		t.Fatalf("merged weekly summary = %#v", merged)
+	}
+	if merged.MonthlyLimitCents == nil || *merged.MonthlyLimitCents != 0 {
+		t.Fatalf("merged monthly limit = %#v, want zero evidence", merged.MonthlyLimitCents)
+	}
+	if merged.BillingPeriodEnd != "2026-10-01T00:00:00Z" {
+		t.Fatalf("merged billing period end = %q", merged.BillingPeriodEnd)
+	}
+
+	windows := xaiSummaryWindows(merged)
+	if len(windows) != 2 {
+		t.Fatalf("merged windows = %#v, want weekly and monthly", windows)
+	}
+	if windows[0].ID != "xai-weekly" || windows[0].UsedPercent != nil || windows[0].ResetLabel != "2026-09-12T00:00:00Z" {
+		t.Fatalf("weekly window = %#v", windows[0])
+	}
+	if windows[1].ID != "xai-monthly" || windows[1].UsedPercent != nil || windows[1].ResetLabel != "2026-10-01T00:00:00Z" {
+		t.Fatalf("monthly window = %#v", windows[1])
 	}
 }
 

--- a/apps/manager-server/internal/service/codexinspection/xai_probe.go
+++ b/apps/manager-server/internal/service/codexinspection/xai_probe.go
@@ -930,13 +930,8 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 	}
 	period := readMap(config, "current_period", "currentPeriod")
 	periodType := strings.ToLower(readString(period, "type"))
-	periodStart := readString(period, "start")
 	periodEnd := readString(period, "end")
 	usage := readNullableFloat(config, "credit_usage_percent", "creditUsagePercent")
-	if usage == nil && strings.Contains(periodType, "weekly") && validXAIPeriodWindow(periodStart, periodEnd) {
-		zero := float64(0)
-		usage = &zero
-	}
 	monthlyLimit, hasMonthlyLimitEvidence := readXAICentFloatWithEvidence(config, "monthly_limit", "monthlyLimit")
 	nestedUsage := readMap(config, "usage")
 	nestedIncludedUsed, hasNestedIncludedEvidence := readXAICentFloatWithEvidence(nestedUsage, "included_used", "includedUsed")
@@ -987,6 +982,8 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 		onDemandUsedPercent = &value
 	}
 	hasOnDemandData := hasOnDemandCapEvidence || hasOnDemandUsedEvidence || positiveXAIFloat(onDemandUsed)
+	hasMeaningfulOnDemandData := positiveXAIFloat(onDemandCap) || positiveXAIFloat(onDemandUsed)
+	hasBillingPeriodData := hasMonthlyData || hasMeaningfulOnDemandData
 	if !hasMonthlyData {
 		monthlyLimit = nil
 		includedUsed = nil
@@ -1013,10 +1010,13 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 		}
 	}
 	billingCycle := readMap(config, "billing_cycle", "billingCycle")
-	billingPeriodEnd := firstNonEmpty(
-		readString(config, "billing_period_end", "billingPeriodEnd"),
-		readString(billingCycle, "billing_period_end", "billingPeriodEnd"),
-	)
+	billingPeriodEnd := ""
+	if hasBillingPeriodData {
+		billingPeriodEnd = firstNonEmpty(
+			readString(config, "billing_period_end", "billingPeriodEnd"),
+			readString(billingCycle, "billing_period_end", "billingPeriodEnd"),
+		)
+	}
 	hasWeeklyData := usage != nil || len(productUsage) > 0 || strings.Contains(periodType, "weekly")
 	if !hasWeeklyData && !hasMonthlyData && !hasOnDemandData {
 		return nil
@@ -1041,12 +1041,6 @@ func parseXAIBillingSummary(config map[string]any) *xaiBillingSummary {
 		BillingPeriodEnd:    billingPeriodEnd,
 		ProductUsage:        productUsage,
 	}
-}
-
-func validXAIPeriodWindow(start, end string) bool {
-	startAt, startErr := time.Parse(time.RFC3339, start)
-	endAt, endErr := time.Parse(time.RFC3339, end)
-	return startErr == nil && endErr == nil && endAt.After(startAt)
 }
 
 func xaiSummaryUsedPercent(summary *xaiBillingSummary) *float64 {

--- a/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
+++ b/apps/web/src/features/accounts/model/accountQuotaDisplayWindows.test.ts
@@ -918,6 +918,63 @@ describe('accountQuotaDisplayWindows', () => {
     expect(windows.map((window) => window.key)).toEqual(['credits-period']);
   });
 
+  it('keeps unknown weekly xAI usage separate from the monthly billing reset', () => {
+    const weeklyResetMs = Date.parse('2026-09-12T00:00:00Z');
+    const monthlyResetMs = Date.parse('2026-10-01T00:00:00Z');
+    const stores = {
+      ...emptyStores(),
+      xaiQuota: {
+        'xai.json': {
+          status: 'success',
+          billing: {
+            periodType: 'weekly',
+            usagePercent: null,
+            periodStart: '2026-09-05T00:00:00Z',
+            periodEnd: '2026-09-12T00:00:00Z',
+            productUsage: [],
+            monthlyLimitCents: 0,
+            usedCents: 0,
+            includedUsedCents: 0,
+            onDemandCapCents: 0,
+            onDemandUsedCents: 0,
+            onDemandUsedPercent: null,
+            billingPeriodStart: '2026-09-01T00:00:00Z',
+            billingPeriodEnd: '2026-10-01T00:00:00Z',
+            usedPercent: null,
+          },
+        },
+      },
+    } satisfies AccountQuotaStores;
+    const row = buildRow({ name: 'xai.json', type: 'xai' }, stores);
+
+    const windows = buildAccountQuotaDisplayWindows(row, {
+      stores,
+      translateQuotaWindowLabel,
+      t,
+    });
+    const weekly = windows.find((window) => window.key === 'credits-period');
+    const billing = windows.find((window) => window.key === 'billing');
+
+    expect(weekly).toMatchObject({
+      key: 'credits-period',
+      kind: 'weekly',
+      usedPercent: null,
+      remainingPercent: null,
+      resetAtMs: weeklyResetMs,
+      limitWindowSeconds: 7 * 24 * 60 * 60,
+      windowMode: 'fixed',
+      cycleStartMs: Date.parse('2026-09-05T00:00:00Z'),
+      cycleEndMs: weeklyResetMs,
+    });
+    expect(billing).toMatchObject({
+      key: 'billing',
+      usedPercent: null,
+      remainingPercent: null,
+      resetAtMs: monthlyResetMs,
+    });
+    expect(windows.some((window) => window.key === 'pay-as-you-go')).toBe(false);
+  });
+
   it('does not create a monthly window when usage exists without limit evidence', () => {
     const stores = {
       ...emptyStores(),

--- a/apps/web/src/utils/quota/providerRequests.test.ts
+++ b/apps/web/src/utils/quota/providerRequests.test.ts
@@ -1961,7 +1961,7 @@ describe('buildXaiBillingSummary', () => {
     });
   });
 
-  it('treats an omitted weekly percentage as zero only for a complete valid period', () => {
+  it('keeps omitted weekly usage unknown even when the period window is valid', () => {
     expect(
       buildXaiBillingSummary({
         currentPeriod: {
@@ -1970,7 +1970,7 @@ describe('buildXaiBillingSummary', () => {
           end: '2026-08-20T00:00:00Z',
         },
       })
-    ).toMatchObject({ periodType: 'weekly', usagePercent: 0 });
+    ).toMatchObject({ periodType: 'weekly', usagePercent: null });
 
     expect(
       buildXaiBillingSummary({
@@ -1980,6 +1980,17 @@ describe('buildXaiBillingSummary', () => {
         },
       })
     ).toMatchObject({ periodType: 'weekly', usagePercent: null });
+
+    expect(
+      buildXaiBillingSummary({
+        currentPeriod: {
+          type: 'USAGE_PERIOD_TYPE_WEEKLY',
+          start: '2026-08-13T00:00:00Z',
+          end: '2026-08-20T00:00:00Z',
+        },
+        creditUsagePercent: 0,
+      })
+    ).toMatchObject({ periodType: 'weekly', usagePercent: 0 });
   });
 
   it('treats nested protobuf zero placeholders as absent billing evidence', () => {
@@ -1999,7 +2010,7 @@ describe('buildXaiBillingSummary', () => {
     });
 
     expect(summary).toMatchObject({
-      usagePercent: 0,
+      usagePercent: null,
       usedCents: null,
       includedUsedCents: null,
       onDemandCapCents: null,
@@ -2106,6 +2117,30 @@ describe('buildXaiBillingSummary', () => {
       billingPeriodEnd: '2026-08-01T00:00:00Z',
     });
   });
+
+  it('does not treat zero on-demand evidence as a billing boundary', () => {
+    const summary = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'USAGE_PERIOD_TYPE_WEEKLY',
+        start: '2026-09-05T00:00:00Z',
+        end: '2026-09-12T00:00:00Z',
+      },
+      onDemandCap: { val: 0 },
+      onDemandUsed: { val: 0 },
+      billingPeriodStart: '2026-09-05T00:00:00Z',
+      billingPeriodEnd: '2026-09-12T00:00:00Z',
+    });
+
+    expect(summary).toMatchObject({
+      periodType: 'weekly',
+      usagePercent: null,
+      onDemandCapCents: 0,
+      onDemandUsedCents: 0,
+      usedCents: null,
+    });
+    expect(summary?.billingPeriodStart).toBeUndefined();
+    expect(summary?.billingPeriodEnd).toBeUndefined();
+  });
 });
 
 describe('mergeXaiBillingSummaries', () => {
@@ -2162,7 +2197,7 @@ describe('mergeXaiBillingSummaries', () => {
 
     expect(mergeXaiBillingSummaries(weekly, legacy)).toMatchObject({
       periodType: 'weekly',
-      usagePercent: 0,
+      usagePercent: null,
       monthlyLimitCents: 10_000,
       usedCents: 12_500,
       includedUsedCents: 10_000,
@@ -2171,6 +2206,37 @@ describe('mergeXaiBillingSummaries', () => {
       onDemandUsedCents: 2_500,
       onDemandUsedPercent: 50,
       billingPeriodEnd: '2026-09-01T00:00:00Z',
+    });
+  });
+
+  it('keeps weekly and monthly billing reset boundaries separate', () => {
+    const weekly = buildXaiBillingSummary({
+      currentPeriod: {
+        type: 'USAGE_PERIOD_TYPE_WEEKLY',
+        start: '2026-09-05T00:00:00Z',
+        end: '2026-09-12T00:00:00Z',
+      },
+      onDemandCap: { val: 0 },
+      onDemandUsed: { val: 0 },
+      billingPeriodStart: '2026-09-05T00:00:00Z',
+      billingPeriodEnd: '2026-09-12T00:00:00Z',
+    });
+    const monthly = buildXaiBillingSummary({
+      monthlyLimit: { val: 0 },
+      used: { val: 0 },
+      billingPeriodStart: '2026-09-01T00:00:00Z',
+      billingPeriodEnd: '2026-10-01T00:00:00Z',
+    });
+
+    expect(mergeXaiBillingSummaries(weekly, monthly)).toMatchObject({
+      periodType: 'weekly',
+      usagePercent: null,
+      periodStart: '2026-09-05T00:00:00Z',
+      periodEnd: '2026-09-12T00:00:00Z',
+      monthlyLimitCents: 0,
+      billingPeriodStart: '2026-09-01T00:00:00Z',
+      billingPeriodEnd: '2026-10-01T00:00:00Z',
+      usedPercent: null,
     });
   });
 

--- a/apps/web/src/utils/quota/providerRequests.ts
+++ b/apps/web/src/utils/quota/providerRequests.ts
@@ -1118,13 +1118,6 @@ const resolveXaiCentCandidate = (...values: unknown[]) => {
 const normalizeXaiPeriodTimestamp = (value: unknown): string | undefined =>
   normalizeStringValue(value) ?? undefined;
 
-const hasValidXaiPeriodWindow = (start?: string, end?: string): boolean => {
-  if (!start || !end) return false;
-  const startMs = Date.parse(start);
-  const endMs = Date.parse(end);
-  return Number.isFinite(startMs) && Number.isFinite(endMs) && endMs > startMs;
-};
-
 const resolveXaiBillingConfig = (payload: XaiBillingPayload | null): XaiBillingConfig | null => {
   if (!payload || typeof payload !== 'object') return null;
   return payload.config ?? (payload as XaiBillingConfig);
@@ -1198,9 +1191,7 @@ export const buildXaiBillingSummary = (
   );
   const periodStart = normalizeXaiPeriodTimestamp(currentPeriod?.start);
   const periodEnd = normalizeXaiPeriodTimestamp(currentPeriod?.end);
-  const creditUsagePercent =
-    rawCreditUsagePercent ??
-    (periodType === 'weekly' && hasValidXaiPeriodWindow(periodStart, periodEnd) ? 0 : null);
+  const creditUsagePercent = rawCreditUsagePercent;
   const billingCycle = config.billingCycle ?? config.billing_cycle ?? null;
   const nestedUsage = config.usage ?? null;
   const productUsage = normalizeXaiProductUsage(
@@ -1279,7 +1270,10 @@ export const buildXaiBillingSummary = (
     onDemandCap.hasEvidence ||
     explicitOnDemandUsed.hasEvidence ||
     (derivedOnDemandUsedCents !== null && derivedOnDemandUsedCents > 0);
-  const hasBillingPeriodData = hasMonthlyData || hasOnDemandData;
+  const hasMeaningfulOnDemandData =
+    (onDemandCapCents !== null && onDemandCapCents > 0) ||
+    (onDemandUsedCents !== null && onDemandUsedCents > 0);
+  const hasBillingPeriodData = hasMonthlyData || hasMeaningfulOnDemandData;
 
   if (!hasWeeklyData && !hasMonthlyData && !hasOnDemandData) return null;
 


### PR DESCRIPTION
## Summary

Preserve unknown xAI weekly usage and keep weekly quota resets separate from monthly billing resets.
Align Web and Manager Server parsing so explicit zero values remain evidence without authorizing a billing boundary.

## Scope

- [x] Frontend panel
- [x] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Keep omitted `creditUsagePercent` as unknown while preserving explicit zero values.
- Retain billing boundaries only for monthly evidence or positive on-demand billing data.
- Add Web, Manager Server, merge, and Accounts display regressions for independent weekly/monthly reset clocks.

## User Impact

Weekly xAI quota windows with omitted usage no longer display synthetic 0% used / 100% remaining. Zero-valued on-demand placeholders no longer overwrite a real monthly billing reset, while positive PAYG data remains supported.

## Compatibility / Runtime Notes

- CPA panel mode: Web xAI quota normalization preserves unknown usage and separate reset boundaries.
- Manager Server mode: xAI inspection parsing and quota windows use the same semantics.
- Full Docker / native packages: Full Docker Manager Server behavior is covered; no native package changes.

## Data / Security Notes

N/A — no schema, migration, persistence, or security changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert the two module-scoped fix commits.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/utils/quota/providerRequests.test.ts src/features/accounts/model/accountQuotaDisplayWindows.test.ts src/features/monitoring/model/xaiInspectionProbe.test.ts
# 3 files, 164 tests passed
cd apps/manager-server && go test ./internal/service/codexinspection
# passed
npm run type-check
# passed
npm run lint
# passed; one existing react-refresh warning in AccountHealthBadge.tsx
npm test
# 218 files, 3188 tests passed
npm run manager-server:test
# all packages passed
git diff --check
# passed
```

## Screenshots / Recordings

N/A — no production UI components changed.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — bugfix with no new capability or documentation change

Docs decision:

No documentation or release-note change is needed for this focused parser correction.

## Related

N/A