### PR TITLE
feat(oauth): add per-login proxy on OAuth page

### DIFF
--- a/apps/web/src/features/oauth/OAuthPage.module.scss
+++ b/apps/web/src/features/oauth/OAuthPage.module.scss
@@ -36,6 +36,10 @@
   gap: $spacing-xl;
 }
 
+.proxyBar {
+  max-width: 640px;
+}
+
 .cardContent {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/features/oauth/OAuthPage.tsx
+++ b/apps/web/src/features/oauth/OAuthPage.tsx
@@ -58,6 +58,12 @@ import iconVertex from '@/assets/icons/vertex.svg';
 import iconGrok from '@/assets/icons/grok.svg';
 import iconGrokDark from '@/assets/icons/grok-dark.svg';
 
+// Per-login OAuth proxy, shown at the top of the page. When set it is sent as
+// `proxy-url` on the auth-url start request so the whole CPA-side OAuth flow
+// (code -> token exchange etc.) uses this proxy instead of the global proxy-url,
+// without leaking the CPA host's direct egress.
+const OAUTH_PROXY_STORAGE_KEY = 'oauth.login.proxy-url';
+
 interface ProviderState {
   url?: string;
   state?: string;
@@ -272,6 +278,26 @@ export function OAuthPage() {
   );
   const [states, setStates] = useState<Record<string, ProviderState>>({});
   const [pluginOAuthPlugins, setPluginOAuthPlugins] = useState<PluginListEntry[]>([]);
+  const [oauthProxyUrl, setOauthProxyUrl] = useState<string>(() => {
+    try {
+      return window.localStorage.getItem(OAUTH_PROXY_STORAGE_KEY) ?? '';
+    } catch {
+      return '';
+    }
+  });
+  const updateOauthProxyUrl = (value: string) => {
+    setOauthProxyUrl(value);
+    try {
+      const trimmed = value.trim();
+      if (trimmed) {
+        window.localStorage.setItem(OAUTH_PROXY_STORAGE_KEY, trimmed);
+      } else {
+        window.localStorage.removeItem(OAUTH_PROXY_STORAGE_KEY);
+      }
+    } catch {
+      // storage may be unavailable; the in-memory value still applies this session
+    }
+  };
   const [vertexState, setVertexState] = useState<VertexImportState>({
     fileName: '',
     location: '',
@@ -684,7 +710,10 @@ export function OAuthPage() {
         if (!isProviderAttemptCurrent(provider, attempt)) return;
         // OAuth remains available, but completion will fail closed without a mutation marker.
       }
-      const res = await oauthApi.startAuth(provider, attempt.requestScope);
+      const trimmedProxyUrl = oauthProxyUrl.trim();
+      const res = trimmedProxyUrl
+        ? await oauthApi.startAuth(provider, attempt.requestScope, trimmedProxyUrl)
+        : await oauthApi.startAuth(provider, attempt.requestScope);
       if (!isProviderAttemptCurrent(provider, attempt)) return;
       if (!res.state) {
         const message = t('auth_login.missing_state');
@@ -929,6 +958,18 @@ export function OAuthPage() {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
+        <div className={styles.proxyBar}>
+          <Input
+            type="text"
+            label={t('auth_login.oauth_proxy_label')}
+            hint={t('auth_login.oauth_proxy_hint')}
+            value={oauthProxyUrl}
+            onChange={(event) => updateOauthProxyUrl(event.target.value)}
+            placeholder={t('auth_login.oauth_proxy_placeholder')}
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
         {providers.map((provider) => {
           const state = states[provider.id] || {};
           const canSubmitCallback = provider.supportsCallback && Boolean(state.url);

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2007,7 +2007,10 @@
     "upgrade_required_desc": "The current server does not support the OAuth model aliases API. Please upgrade to the latest CLI Proxy API (CPA) version."
   },
   "auth_login": {
-    "codex_oauth_title": "Codex OAuth",
+    "oauth_proxy_label": "OAuth proxy URL (optional)",
+    "oauth_proxy_hint": "Applied only to OAuth logins on this page. CPA outbound (e.g. codex code→token exchange) uses this proxy; leave empty to use the global proxy-url.",
+    "oauth_proxy_placeholder": "socks5://user:pass@host:port",
+        "codex_oauth_title": "Codex OAuth",
     "codex_oauth_button": "Start Codex Login",
     "codex_oauth_hint": "Login to Codex service through OAuth flow, automatically obtain and save authentication files.",
     "codex_oauth_url_label": "Authorization URL:",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -2008,7 +2008,10 @@
     "upgrade_required_desc": "Текущая версия сервера не поддерживает API псевдонимов моделей OAuth. Обновите CLI Proxy API (CPA) до последней версии."
   },
   "auth_login": {
-    "codex_oauth_title": "Codex OAuth",
+    "oauth_proxy_label": "Прокси для OAuth (необязательно)",
+    "oauth_proxy_hint": "Только для OAuth-входа на этой странице. Исходящие запросы CPA (напр. обмен code→token для codex) идут через этот прокси; пусто — глобальный proxy-url.",
+    "oauth_proxy_placeholder": "socks5://user:pass@host:port",
+        "codex_oauth_title": "Codex OAuth",
     "codex_oauth_button": "Начать вход Codex",
     "codex_oauth_hint": "Выполните вход в сервис Codex через OAuth и автоматически получите/сохраните файлы авторизации.",
     "codex_oauth_url_label": "URL авторизации:",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -2005,7 +2005,10 @@
     "upgrade_required_desc": "当前服务器版本不支持 OAuth 模型别名功能，请升级到最新版本的 CPA（CLI Proxy API）后重试。"
   },
   "auth_login": {
-    "codex_oauth_title": "Codex OAuth",
+    "oauth_proxy_label": "登录代理地址（可选）",
+    "oauth_proxy_hint": "仅本页 OAuth 登录有效：codex 的 code 换 token 等 CPA 出站将走此代理；留空使用全局 proxy-url",
+    "oauth_proxy_placeholder": "socks5://user:pass@host:port",
+        "codex_oauth_title": "Codex OAuth",
     "codex_oauth_button": "开始 Codex 登录",
     "codex_oauth_hint": "通过 OAuth 流程登录 Codex 服务，自动获取并保存认证文件。",
     "codex_oauth_url_label": "授权链接:",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -2005,7 +2005,10 @@
     "upgrade_required_desc": "目前伺服器版本不支援 OAuth 模型別名功能，請升級到最新版本的 CPA（CLI Proxy API）後重試。"
   },
   "auth_login": {
-    "codex_oauth_title": "Codex OAuth",
+    "oauth_proxy_label": "登入代理位址（可選）",
+    "oauth_proxy_hint": "僅本頁 OAuth 登入有效：codex 的 code 換 token 等 CPA 出站將走此代理；留空使用全域 proxy-url",
+    "oauth_proxy_placeholder": "socks5://user:pass@host:port",
+        "codex_oauth_title": "Codex OAuth",
     "codex_oauth_button": "開始 Codex 登入",
     "codex_oauth_hint": "透過 OAuth 流程登入 Codex 服務，自動取得並儲存驗證檔案。",
     "codex_oauth_url_label": "授權連結:",

--- a/apps/web/src/services/api/oauth.ts
+++ b/apps/web/src/services/api/oauth.ts
@@ -19,10 +19,18 @@ export interface OAuthCallbackResponse {
 const WEBUI_SUPPORTED: string[] = ['codex', 'anthropic', 'antigravity', 'xai'];
 
 export const oauthApi = {
-  startAuth: (provider: OAuthProvider, requestScope?: ApiClientRequestScope) => {
+  startAuth: (
+    provider: OAuthProvider,
+    requestScope?: ApiClientRequestScope,
+    proxyUrl?: string
+  ) => {
     const params: Record<string, string | boolean> = {};
     if (WEBUI_SUPPORTED.includes(provider)) {
       params.is_webui = true;
+    }
+    const trimmedProxy = (proxyUrl ?? '').trim();
+    if (trimmedProxy) {
+      params['proxy-url'] = trimmedProxy;
     }
     return apiClient.get<OAuthStartResponse>(`/${provider}-auth-url`, {
       ...(requestScope ? createScopedApiRequestConfig(requestScope) : {}),


### PR DESCRIPTION
Adds a proxy URL input at the top of the OAuth login page. When set, it is sent as \proxy-url\ on the \<provider>-auth-url\ start request, so the CPA-side OAuth flow (code -> token exchange etc.) uses this proxy instead of the global proxy-url — without leaking the CPA host's direct egress and without editing the global config per login.