### PR TITLE
fix(release): notify after update channel publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,7 +473,7 @@ jobs:
             --header "X-GitHub-Api-Version: 2022-11-28" \
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}")"
           if [ "${http_code}" != "200" ]; then
-            echo "GitHub Release lookup after asset upload failed with HTTP ${http_code} for id ${RELEASE_ID}." >&2
+            echo "Published GitHub Release lookup after asset upload failed with HTTP ${http_code} for id ${RELEASE_ID}." >&2
             exit 1
           fi
           node bin/release/verify-published-release.mjs \
@@ -749,6 +749,7 @@ jobs:
     needs:
       - preflight
       - publish_github_release
+      - publish_update_index
     if: needs.preflight.outputs.dry_run != 'true' && github.run_attempt == 1
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Ensure normal release Telegram notifications are sent only after the verified update-channel publication succeeds.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Add `publish_update_index` to the `notify_telegram` job dependencies in `.github/workflows/release.yml`.
- Keep GitHub Release publication and update-channel reconciliation unchanged.
- This prevents announcing a release before `latest`, stable channel metadata, and update-index publication have completed successfully.

## User Impact

Release announcements now represent a fully published update path rather than only a successfully created GitHub Release.

## Compatibility / Runtime Notes

No runtime application behavior changes.

## Data / Security Notes

No data, credentials, schema, or permission changes.

## Risk / Rollback

Risk level: Low.

Rollback by reverting this workflow-only change.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [x] Not applicable, workflow-only

The repository PR workflow is the verification gate for this dependency-only change.

## Screenshots / Recordings

N/A.

## Docs

- [x] Not needed — workflow ordering only.

## Related

- Refs #720