### PR TITLE
docs(release): prepare v1.12.11

### DIFF
--- a/docs/release-notes/v1.12.11-en.md
+++ b/docs/release-notes/v1.12.11-en.md
@@ -1,0 +1,39 @@
+# CPA Manager Plus v1.12.11
+
+> 18 commits · 61 files changed · +6346 / -199
+
+> [中文 ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.11/docs/release-notes/v1.12.11-zh.md)
+
+## Overview
+
+v1.12.11 establishes CPAMP's verified release update-check and channel system, and fixes stale CPA routing cooldown after a Codex reset credit is successfully consumed. This release provides update discovery, notifications, and upgrade guidance only; it does not automatically install or replace existing deployments.
+
+## Highlights
+
+### Features
+
+- Manager Server now supports release update checks with `auto`, `stable`, `rc`, and `beta` channels. Update state is stored in existing settings, with bounded background checks, manual checks, and explicit stale/error states. (Manager Server)
+- A new System Information → Software Updates page and Dashboard entry show the target version, summary, check status, migration/compatibility guidance, and exact-version upgrade instructions for Docker and native deployments. (Web)
+- Each Manager instance proactively notifies at most once for each exact release tag. Viewing, dismissing, refreshing, or restarting does not repeat the prompt, while the version card continues to provide access to the update page. (Web / Manager Server)
+- Releases now publish verified `release-info.json` metadata and a validated Update Channel index. The release pipeline verifies the immutable Release, asset digests, source commit, and images in both registries before advancing Stable/Beta pointers, Docker aliases, and GitHub Latest. (Release)
+- CPA-hosted / external panels keep a lightweight Stable-update compatibility path without the full Manager Server update state or prerelease channels. (Web)
+
+### Fixes
+
+- After a Codex reset credit is successfully consumed, CPAMP now synchronizes CPA quota reset state to clear obsolete routing cooldown. Only explicit successful business outcomes trigger local recovery; failures preserve cooldown state and surface partial-success feedback, preventing recovered quota from remaining blocked by stale local 429 state. (Web)
+- Telegram release notifications now wait for Update Channel publication to succeed, preventing announcements from being sent while `latest`, Stable channel metadata, or the update index still point to an older release. (Release)
+
+## Upgrade Notes
+
+- This is the first release to enable the verified Update Channel. Historical releases are not backfilled with `release-info.json`; the initial channel index starts from v1.12.11 and later releases that provide the new metadata.
+- In v1, update support is informational only: it checks, notifies, and provides upgrade guidance, but does not automatically modify Docker images, native binaries, or the running version.
+- Set `CPAMP_UPDATE_CHECK_ENABLED=false` to disable Manager Server background update checks. Manual checks and explicit channel changes remain available.
+- No database schema migration is required and usage history is not modified.
+
+## Acknowledgements
+
+- [@212duo](https://github.com/212duo) - contributed the fix and regression coverage that synchronize CPA routing cooldown after Codex reset-credit redemption.
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.10...v1.12.11

--- a/docs/release-notes/v1.12.11-zh.md
+++ b/docs/release-notes/v1.12.11-zh.md
@@ -1,0 +1,57 @@
+# CPA Manager Plus v1.12.11
+
+> 18 commits · 61 files changed · +6346 / -199
+
+> [English ->](https://github.com/seakee/CPA-Manager-Plus/blob/v1.12.11/docs/release-notes/v1.12.11-en.md)
+
+<!-- cpamp-update
+{
+  "summary": {
+    "zh": "新增可信版本更新检查与发布通道，并修复 Codex 重置额度后 CPA 路由冷却未同步清除的问题。",
+    "en": "Adds verified release update checks and channels, and fixes stale CPA routing cooldown after Codex reset-credit redemption."
+  },
+  "update": {
+    "breaking": false,
+    "migration_required": false,
+    "minimum_direct_upgrade_version": null,
+    "upgrade_guide_url": "https://github.com/seakee/CPA-Manager-Plus/releases/tag/v1.12.11"
+  },
+  "compatibility": {
+    "minimum_cpa_version": null
+  }
+}
+-->
+
+## Overview
+
+v1.12.11 建立 CPAMP 自身的可信版本更新检查与发布通道体系，并修复 Codex reset credit 成功消费后 CPA 仍保留旧路由冷却的问题。本版本只提供更新发现、通知与升级指引，不会自动安装或替换现有部署。
+
+## Highlights
+
+### Features
+
+- 新增 Manager Server 版本更新检查，支持 `auto`、`stable`、`rc`、`beta` 通道；更新状态保存在现有 settings 中，并提供后台周期检查、手动检查和明确的缓存/失败状态。（Manager Server）
+- 新增「系统信息 → 软件更新」页面与 Dashboard 更新入口，可展示目标版本、版本摘要、检查状态、迁移/兼容性提示，并针对 Docker 与原生部署提供精确版本升级指引。（Web）
+- 每个 Manager 实例对同一精确版本最多主动提示一次更新；查看、关闭、刷新或重启不会重复弹出，同一版本仍可从版本卡片重新进入更新页。（Web / Manager Server）
+- 新增经过校验的 `release-info.json` 与 Update Channel 发布链路；发布流程会验证 Release、资产摘要、源提交和双 Registry 镜像，再推进 Stable/Beta 指针、Docker aliases 与 GitHub Latest。（Release）
+- CPA-hosted / external panel 保留轻量 Stable 更新提示兼容路径，不引入完整 Manager Server 更新状态或预发布通道。（Web）
+
+### Fixes
+
+- Codex reset credit 成功消费后会同步调用 CPA 的 quota reset，清除已经失效的路由 cooldown；只有明确的成功业务结果才触发本地恢复，失败时保留 cooldown 并提示 partial success，避免额度已恢复但请求仍被旧 429 状态阻塞。（Web）
+- Release Telegram 通知现在等待 Update Channel 发布成功后再发送，避免社区公告已经发出但 `latest`、Stable channel 或 update-index 仍停留在旧版本。（Release）
+
+## Upgrade Notes
+
+- 本版本首次启用新的可信 Update Channel。历史 Release 不会回填 `release-info.json`，首次 Channel 索引将从具备新元数据的 v1.12.11 开始建立。
+- 更新功能在 v1 中仅负责检查、通知和提供升级指引，不会自动修改 Docker 镜像、原生二进制或当前运行版本。
+- 可通过 `CPAMP_UPDATE_CHECK_ENABLED=false` 关闭 Manager Server 后台更新检查；手动检查和显式切换更新通道仍可使用。
+- 无数据库 schema 迁移，也不会修改 usage 历史数据。
+
+## Acknowledgements
+
+- [@212duo](https://github.com/212duo) - 贡献 Codex reset credit 消费后同步清理 CPA 路由冷却的修复及回归测试。
+
+---
+
+**Full Changelog**: https://github.com/seakee/CPA-Manager-Plus/compare/v1.12.10...v1.12.11

--- a/docs/release-posts/v1.12.11-telegram.html
+++ b/docs/release-posts/v1.12.11-telegram.html
@@ -1,0 +1,22 @@
+🚀 <b>9 月 10 日 · v1.12.11</b>
+
+✨ <b>更新内容</b>
+
+• 新增可信版本更新检查，支持 <code>auto</code>、<code>stable</code>、<code>rc</code>、<code>beta</code> 更新通道，并提供后台检查与手动检查。
+• 新增「系统信息 → 软件更新」页面，可查看目标版本、更新摘要、兼容性与迁移提示，并获得 Docker / 原生部署的精确版本升级指引。
+• 同一 Manager 实例对同一精确版本最多主动提示一次；关闭、查看、刷新或重启不会重复弹出。
+• 发布流程新增经过校验的 <code>release-info.json</code> 与 Update Channel，同步验证 Release、资产、源提交和双 Registry 镜像后再推进 Stable/Beta、Docker aliases 与 GitHub Latest。
+• 修复 Codex reset credit 成功消费后 CPA 仍保留旧路由 cooldown 的问题，避免额度恢复后继续被旧 429 状态阻塞。
+• Release Telegram 通知现在会等待 Update Channel 发布成功后再发送，避免公告与实际可升级版本状态不一致。
+
+⚠️ <b>注意事项</b>
+
+• 本版本首次启用新的可信 Update Channel；历史 Release 不回填新元数据，首次索引从 v1.12.11 开始建立。
+• v1 的更新功能仅负责检查、通知和提供升级指引，不会自动替换 Docker 镜像或原生二进制。
+• 如需关闭后台更新检查，可设置 <code>CPAMP_UPDATE_CHECK_ENABLED=false</code>；手动检查仍可使用。
+
+🤝 <b>致谢</b>
+
+感谢 <a href="https://github.com/212duo">@212duo</a> 贡献 Codex reset credit 后同步清理 CPA 路由冷却的修复与回归测试。
+
+<a href="https://github.com/seakee/CPA-Manager-Plus/releases/tag/v1.12.11">GitHub Release</a>


### PR DESCRIPTION
## Summary

Prepare the frozen v1.12.11 release content.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [x] Native packages / release
- [x] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add `docs/release-notes/v1.12.11-zh.md` with the required reviewed `cpamp-update` metadata block.
- Add `docs/release-notes/v1.12.11-en.md`.
- Add `docs/release-posts/v1.12.11-telegram.html`.
- Freeze release content against dev SHA `2ca1676db8c89e37007dcdd9c7709d1e130bff90`.
- Release baseline versus v1.12.10: 18 commits, 61 files changed, +6346 / -199.

## User Impact

v1.12.11 introduces verified release update checks and update channels, a dedicated Software Updates page and one-time update notifications, and fixes stale CPA routing cooldown after Codex reset-credit redemption.

## Compatibility / Runtime Notes

- Update support in v1 is informational only; it does not automatically install or replace deployments.
- Background update checks can be disabled with `CPAMP_UPDATE_CHECK_ENABLED=false`; manual checks remain available.
- No database schema migration is required.

## Data / Security Notes

No usage-history migration or credential-storage change is introduced by this release-content PR. Release metadata explicitly declares no breaking change and no required migration.

## Risk / Rollback

Risk level: Low. This PR contains release content only.

Rollback by reverting the release-content merge before promotion/tagging.

## Verification

- PR changes exactly the three required versioned release files.
- Chinese release notes contain exactly one `cpamp-update` metadata block.
- Reciprocal language links are tag-pinned.
- Release baseline is frozen against `2ca1676db8c89e37007dcdd9c7709d1e130bff90`.
- Branch protection and release-content validation must pass before merge.

## Screenshots / Recordings

Not applicable to this release-content PR.

## Docs

- [x] Release notes needed
- [x] Chinese release notes added
- [x] English release notes added
- [x] Telegram release post added

## Related

- Refs #700
- Refs #720
- Refs #727