### PR TITLE
✨ feat(accounts): expand table quota window layout

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -370,7 +370,7 @@
 .accountCardList {
   display: grid;
   gap: 8px;
-  min-width: 1040px;
+  min-width: 1100px;
   padding: 10px 12px;
 }
 
@@ -380,7 +380,7 @@
   grid-template-columns:
     minmax(140px, 1.1fr)
     76px
-    minmax(150px, 0.45fr)
+    minmax(180px, 0.45fr)
     minmax(124px, 0.3fr)
     minmax(280px, 3fr)
     146px;
@@ -1083,7 +1083,7 @@
     grid-template-columns:
       minmax(150px, 1.1fr)
       78px
-      minmax(160px, 0.45fr)
+      minmax(190px, 0.45fr)
       minmax(132px, 0.3fr)
       minmax(300px, 3fr)
       175px;
@@ -1103,7 +1103,7 @@
     grid-template-columns:
       minmax(180px, 1.3fr)
       88px
-      minmax(176px, 0.45fr)
+      minmax(200px, 0.45fr)
       minmax(144px, 0.3fr)
       minmax(380px, 3fr)
       182px;
@@ -1426,6 +1426,9 @@
     min-height: 24px;
     padding-inline: 10px;
     font-size: 13px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   small {

--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -370,7 +370,7 @@
 .accountCardList {
   display: grid;
   gap: 8px;
-  min-width: 960px;
+  min-width: 1040px;
   padding: 10px 12px;
 }
 
@@ -380,9 +380,9 @@
   grid-template-columns:
     minmax(140px, 1.1fr)
     76px
-    84px
-    116px
-    minmax(280px, 2fr)
+    minmax(150px, 0.45fr)
+    minmax(124px, 0.3fr)
+    minmax(280px, 3fr)
     146px;
   column-gap: clamp(8px, 0.8vw, 12px);
   min-width: 0;
@@ -1083,9 +1083,9 @@
     grid-template-columns:
       minmax(150px, 1.1fr)
       78px
-      84px
-      118px
-      minmax(280px, 2fr)
+      minmax(160px, 0.45fr)
+      minmax(132px, 0.3fr)
+      minmax(300px, 3fr)
       175px;
     column-gap: clamp(10px, 0.85vw, 14px);
   }
@@ -1103,9 +1103,9 @@
     grid-template-columns:
       minmax(180px, 1.3fr)
       88px
-      90px
-      130px
-      minmax(380px, 2.5fr)
+      minmax(176px, 0.45fr)
+      minmax(144px, 0.3fr)
+      minmax(380px, 3fr)
       182px;
     column-gap: 16px;
   }
@@ -1879,6 +1879,11 @@
   position: relative;
   height: 100%;
   min-width: 0;
+}
+
+.quotaWindowGrid > .quotaWindowCard:only-child,
+.quotaWindowGrid > .quotaWindowCard:nth-child(3):last-child {
+  grid-column: 1 / -1;
 }
 
 .quotaWindowCard {

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -17102,6 +17102,230 @@ describe('AccountsPage replacement flows', () => {
       expect(queriedPairs).toContain('monthly/current');
     });
 
+    it('synchronizes rendered quota windows and list usage targets across Table -> Grid -> Table transitions', async () => {
+      const file = {
+        name: 'antigravity-pro-matrix.json',
+        type: 'antigravity',
+        provider: 'antigravity',
+        authIndex: 'antigravity-pro-matrix-04',
+        account: 'AG Pro Matrix',
+        label: 'Antigravity Pro Matrix',
+        priority: 0,
+        disabled: false,
+      } as AuthFileItem;
+      mocks.files = [file];
+      mocks.panelFeatureAvailability = {
+        checking: false,
+        managerServiceBase: 'http://manager.local:18317',
+        requestMonitoringAvailable: true,
+        serverCodexInspectionAvailable: false,
+      };
+
+      const now = Date.now();
+      mocks.quotaState.antigravityQuota = buildCredentialScopedQuotaRecord(file, {
+        status: 'success',
+        subscription: { plan: 'pro', tierName: 'Pro', tierId: 'g1-pro' },
+        groups: [
+          {
+            id: 'gemini-models',
+            label: 'Gemini Models',
+            description: 'Models within this group: Gemini Flash, Gemini Pro',
+            models: ['gemini-2.5-flash', 'gemini-2.5-pro'],
+            buckets: [
+              {
+                id: 'gemini-5h',
+                label: 'Five Hour Limit',
+                window: '5h',
+                remainingFraction: 0.96,
+                resetTime: new Date(now + 3 * 3600 * 1000).toISOString(),
+              },
+              {
+                id: 'gemini-weekly',
+                label: 'Weekly Limit',
+                window: 'weekly',
+                remainingFraction: 0.04,
+                resetTime: new Date(now + 4 * 86400 * 1000).toISOString(),
+              },
+            ],
+          },
+          {
+            id: 'claude-gpt-models',
+            label: 'Claude and GPT models',
+            description: 'Models within this group: Claude Sonnet, GPT-OSS',
+            models: ['claude-sonnet-4-5', 'gpt-oss-120b-medium'],
+            buckets: [
+              {
+                id: '3p-5h',
+                label: 'Five Hour Limit',
+                window: '5h',
+                remainingFraction: 0.11,
+                resetTime: new Date(now + 2 * 3600 * 1000).toISOString(),
+              },
+              {
+                id: '3p-weekly',
+                label: 'Weekly Limit',
+                window: 'weekly',
+                remainingFraction: 0.19,
+                resetTime: new Date(now + 5 * 86400 * 1000).toISOString(),
+              },
+            ],
+          },
+        ],
+      });
+
+      mocks.getAccountWindowUsage.mockImplementation(async (_base, _key, request) => {
+        return {
+          generated_at_ms: Date.now(),
+          items: request.windows.map((w) => ({
+            request_key: w.request_key,
+            row_key: w.row_key,
+            window_key: w.window_key,
+            provider_window_id: w.provider_window_id,
+            period: w.period,
+            from_ms: w.from_ms,
+            to_ms: w.to_ms,
+            matched: true,
+            total_requests: 10,
+            success_calls: 10,
+            failure_calls: 0,
+            total_tokens: 20_000,
+            total_cost: 0.2,
+            success_rate: 1,
+            last_seen_ms: Date.now() - 1000,
+            scope_match_status: 'complete',
+            unmatched_requests: 0,
+            sync_status: 'ready',
+          })),
+        };
+      });
+
+      const renderer = await renderAccountsPage();
+      await flushPromises();
+
+      const selectionKey = getAuthFileSelectionKey(file);
+
+      // 1. Initial Table mode: 4 rendered quota windows & 4 logical usage target windows
+      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(1);
+      const initialTableRequest = mocks.getAccountWindowUsage.mock.calls[0]?.[2] as {
+        windows: Array<{ provider_window_id?: string; window_key?: string; period: string }>;
+      };
+      expect(initialTableRequest).toBeDefined();
+      const initialTableSelectedWindowIds = new Set(
+        initialTableRequest.windows.map((w) => w.provider_window_id || w.window_key)
+      );
+      expect(initialTableSelectedWindowIds.size).toBe(4);
+      expect(Array.from(initialTableSelectedWindowIds)).toEqual(
+        expect.arrayContaining([
+          'claude-gpt-models:3p-5h',
+          'gemini-models:gemini-5h',
+          'claude-gpt-models:3p-weekly',
+          'gemini-models:gemini-weekly',
+        ])
+      );
+
+      const initialCard = findAccountCardByKey(renderer, selectionKey);
+      const initialWindows = initialCard.findAll(
+        (node) => typeof node.props['data-account-quota-window'] === 'string'
+      );
+      expect(initialWindows).toHaveLength(4);
+      expect(initialWindows.map((w) => w.props['data-account-quota-window'])).toEqual([
+        'claude-gpt-models:3p-5h',
+        'gemini-models:gemini-5h',
+        'claude-gpt-models:3p-weekly',
+        'gemini-models:gemini-weekly',
+      ]);
+      const initialText = readText(initialCard);
+      expect(initialText).toContain('Claude');
+      expect(initialText).toContain('Gemini');
+      expect(initialText).toContain('5h');
+      expect(initialText).toMatch(/Weekly|7d/);
+
+      // 2. Switch to Grid mode: 2 rendered quota windows & 2 logical usage target windows
+      const gridButton = renderer.root.find(
+        (node) => node.type === 'button' && node.props['aria-label'] === 'accounts.view_mode_grid'
+      );
+      await act(async () => {
+        gridButton.props.onClick();
+        await Promise.resolve();
+      });
+      await flushPromises();
+
+      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(2);
+      const gridRequest = mocks.getAccountWindowUsage.mock.calls[1]?.[2] as {
+        windows: Array<{ provider_window_id?: string; window_key?: string; period: string }>;
+      };
+      expect(gridRequest).toBeDefined();
+      const gridSelectedWindowIds = new Set(
+        gridRequest.windows.map((w) => w.provider_window_id || w.window_key)
+      );
+      expect(gridSelectedWindowIds.size).toBe(2);
+      expect(Array.from(gridSelectedWindowIds)).toEqual(
+        expect.arrayContaining(['claude-gpt-models:3p-5h', 'gemini-models:gemini-5h'])
+      );
+      expect(gridSelectedWindowIds.has('claude-gpt-models:3p-weekly')).toBe(false);
+      expect(gridSelectedWindowIds.has('gemini-models:gemini-weekly')).toBe(false);
+
+      const gridCard = findAccountCardByKey(renderer, selectionKey);
+      const gridWindows = gridCard.findAll(
+        (node) => typeof node.props['data-account-quota-window'] === 'string'
+      );
+      expect(gridWindows).toHaveLength(2);
+      expect(gridWindows.map((w) => w.props['data-account-quota-window'])).toEqual([
+        'claude-gpt-models:3p-5h',
+        'gemini-models:gemini-5h',
+      ]);
+      const gridText = readText(gridCard);
+      expect(gridText).toContain('Claude');
+      expect(gridText).toContain('Gemini');
+      expect(gridText).toContain('5h');
+      expect(gridWindows.some((w) => /Weekly|7d/.test(readText(w)))).toBe(false);
+
+      // 3. Switch back to Table mode: restores 4 rendered quota windows & 4 logical usage target windows
+      const tableButton = renderer.root.find(
+        (node) => node.type === 'button' && node.props['aria-label'] === 'accounts.view_mode_table'
+      );
+      await act(async () => {
+        tableButton.props.onClick();
+        await Promise.resolve();
+      });
+      await flushPromises();
+
+      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(3);
+      const restoredTableRequest = mocks.getAccountWindowUsage.mock.calls[2]?.[2] as {
+        windows: Array<{ provider_window_id?: string; window_key?: string; period: string }>;
+      };
+      expect(restoredTableRequest).toBeDefined();
+      const restoredSelectedWindowIds = new Set(
+        restoredTableRequest.windows.map((w) => w.provider_window_id || w.window_key)
+      );
+      expect(restoredSelectedWindowIds.size).toBe(4);
+      expect(Array.from(restoredSelectedWindowIds)).toEqual(
+        expect.arrayContaining([
+          'claude-gpt-models:3p-5h',
+          'gemini-models:gemini-5h',
+          'claude-gpt-models:3p-weekly',
+          'gemini-models:gemini-weekly',
+        ])
+      );
+
+      const restoredCard = findAccountCardByKey(renderer, selectionKey);
+      const restoredWindows = restoredCard.findAll(
+        (node) => typeof node.props['data-account-quota-window'] === 'string'
+      );
+      expect(restoredWindows).toHaveLength(4);
+      expect(restoredWindows.map((w) => w.props['data-account-quota-window'])).toEqual([
+        'claude-gpt-models:3p-5h',
+        'gemini-models:gemini-5h',
+        'claude-gpt-models:3p-weekly',
+        'gemini-models:gemini-weekly',
+      ]);
+      const restoredText = readText(restoredCard);
+      expect(restoredText).toContain('Claude');
+      expect(restoredText).toContain('Gemini');
+      expect(restoredText).toContain('5h');
+      expect(restoredText).toMatch(/Weekly|7d/);
+    });
+
     it('refreshes list window usage on passive 60s evidence refresh interval', async () => {
       vi.useFakeTimers();
       const file = makeCodexFile('codex-passive.json', 'auth-passive', 'passive@example.com');

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -8691,7 +8691,7 @@ describe('AccountsPage replacement flows', () => {
     );
     expect(
       card.findAll((node) => typeof node.props['data-account-quota-window'] === 'string')
-    ).toHaveLength(2);
+    ).toHaveLength(4);
     expect(readText(card)).not.toContain('accounts.quota_details_only');
     expect(readText(card)).toContain('Gemini');
     expect(readText(card)).toContain('Claude');
@@ -8856,7 +8856,7 @@ describe('AccountsPage replacement flows', () => {
 
     expect(
       card.findAll((node) => typeof node.props['data-account-quota-window'] === 'string')
-    ).toHaveLength(2);
+    ).toHaveLength(4);
     expect(readText(card)).toContain('5h');
     expect(readText(card)).toContain('Gemini');
     expect(readText(card)).toContain('Claude');
@@ -9463,7 +9463,7 @@ describe('AccountsPage replacement flows', () => {
     const cardText = getAccountCardText(renderer, selectionKey);
     expect(cardText).toContain('5h');
     expect(cardText).toContain('Weekly');
-    expect(cardText).not.toContain('Monthly');
+    expect(cardText).toContain('Monthly');
     expect(cardText).not.toContain('Spark model quota');
     expect(cardText).not.toContain('Billing credits');
 
@@ -16996,7 +16996,7 @@ describe('AccountsPage replacement flows', () => {
       expect(noteRow.props.title).not.toContain('accounts.note_edit');
     });
 
-    it('queries list window usage only for the selected main list quota windows (max 2)', async () => {
+    it('queries list window usage only for the selected main list quota windows (max 4 in Table)', async () => {
       const file = makeCodexFile('codex-multi.json', 'auth-multi', 'multi@example.com');
       mocks.files = [file];
       mocks.panelFeatureAvailability = {
@@ -17094,11 +17094,12 @@ describe('AccountsPage replacement flows', () => {
       const monthlyEntries = listRequest.windows.filter(
         (w) => w.provider_window_id === 'monthly' || w.window_key === 'monthly'
       );
-      expect(monthlyEntries).toHaveLength(0);
+      expect(monthlyEntries).toHaveLength(2);
 
       const queriedPairs = listRequest.windows.map((w) => `${w.provider_window_id}/${w.period}`);
       expect(queriedPairs).toContain('five-hour/current');
       expect(queriedPairs).toContain('weekly/current');
+      expect(queriedPairs).toContain('monthly/current');
     });
 
     it('refreshes list window usage on passive 60s evidence refresh interval', async () => {

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -1563,6 +1563,7 @@ export function AccountsPage() {
   );
   const isCompactScreen = useMediaQuery('(max-width: 1024px)');
   const effectiveLayoutMode = isCompactScreen ? 'grid' : layoutMode;
+  const mainListQuotaWindowLimit = effectiveLayoutMode === 'table' ? 4 : 2;
   const [copiedIdentityKey, setCopiedIdentityKey] = useState<string | null>(null);
   const detailEventsRequestIdRef = useRef(0);
   const detailEventsAutoLoadKeyRef = useRef<string | null>(null);
@@ -4756,7 +4757,11 @@ export function AccountsPage() {
       const quotaWindows =
         quotaDisplayWindowsByRowKey.get(row.selectionKey) ??
         buildQuotaDisplayWindows(row);
-      const mainListWindows = selectAccountQuotaMainListWindows(row, quotaWindows);
+      const mainListWindows = selectAccountQuotaMainListWindows(
+        row,
+        quotaWindows,
+        mainListQuotaWindowLimit
+      );
       const existingDefinitions = quotaWindowDefinitionsByRowKey.get(row.selectionKey);
       let definitions: AccountQuotaWindowDefinition[];
       if (existingDefinitions && existingDefinitions.length > 0) {
@@ -4775,6 +4780,7 @@ export function AccountsPage() {
     pageRows,
     quotaDisplayWindowsByRowKey,
     quotaWindowDefinitionsByRowKey,
+    mainListQuotaWindowLimit,
   ]);
   const isListQueryContextMatching = useMemo(() => {
     if (!listWindowUsageQueryContext) return false;
@@ -8388,7 +8394,11 @@ export function AccountsPage() {
     const quotaWindows =
       quotaDisplayWindowsByRowKey.get(row.selectionKey) ?? buildQuotaDisplayWindows(row);
     const quotaLifecycleBarOverride = getAccountQuotaLifecycleBarOverride(row.quota.status);
-    const mainListWindows = selectAccountQuotaMainListWindows(row, quotaWindows);
+    const mainListWindows = selectAccountQuotaMainListWindows(
+      row,
+      quotaWindows,
+      mainListQuotaWindowLimit
+    );
     const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
     const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
     const item = buildAccountListItem(row, {

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.test.ts
@@ -513,7 +513,7 @@ describe('accountsPagePresentation', () => {
       expect(selected).toEqual([fiveHour]);
     });
 
-    it('always caps selection at maximum 2 windows', () => {
+    it('defaults main-list selection to maximum 2 windows', () => {
       const w1 = makeQuotaWindow({
         key: 'w1',
         kind: 'five_hour',
@@ -546,6 +546,105 @@ describe('accountsPagePresentation', () => {
       const selected = selectAccountQuotaMainListWindows(makeRow('claude'), [w4, w3, w2, w1]);
       expect(selected).toHaveLength(2);
       expect(selected).toEqual([w1, w2]);
+    });
+
+    it('supports an explicit maximum of 4 windows while preserving duration order', () => {
+      const fiveHour = makeQuotaWindow({
+        key: '5h',
+        kind: 'five_hour',
+        limitWindowSeconds: 18000,
+        remainingPercent: 95,
+        windowMode: 'fixed',
+        source: 'claude',
+      });
+      const daily = makeQuotaWindow({
+        key: '24h',
+        kind: 'daily',
+        limitWindowSeconds: 86400,
+        remainingPercent: 5,
+        windowMode: 'fixed',
+        source: 'claude',
+      });
+      const weekly = makeQuotaWindow({
+        key: '7d',
+        kind: 'weekly',
+        limitWindowSeconds: 604800,
+        remainingPercent: 80,
+        windowMode: 'fixed',
+        source: 'claude',
+      });
+      const monthly = makeQuotaWindow({
+        key: '30d',
+        kind: 'monthly',
+        limitWindowSeconds: 2592000,
+        remainingPercent: 10,
+        windowMode: 'fixed',
+        source: 'claude',
+      });
+      const longer = makeQuotaWindow({
+        key: '90d',
+        kind: 'monthly',
+        limitWindowSeconds: 7776000,
+        remainingPercent: 99,
+        windowMode: 'fixed',
+        source: 'claude',
+      });
+
+      const selected = selectAccountQuotaMainListWindows(
+        makeRow('claude'),
+        [longer, weekly, monthly, fiveHour, daily],
+        4
+      );
+
+      expect(selected).toHaveLength(4);
+      expect(selected).toEqual([fiveHour, daily, weekly, monthly]);
+    });
+
+    it('orders Antigravity windows by duration and stable model group rank', () => {
+      const claude5h = makeQuotaWindow({
+        key: 'claude-5h',
+        kind: 'five_hour',
+        limitWindowSeconds: 18000,
+        source: 'antigravity',
+        windowMode: 'fixed',
+        groupLabel: 'Claude and GPT models',
+        modelScope: { kind: 'family', key: 'claude_gpt', complete: true },
+      });
+      const gemini5h = makeQuotaWindow({
+        key: 'gemini-5h',
+        kind: 'five_hour',
+        limitWindowSeconds: 18000,
+        source: 'antigravity',
+        windowMode: 'fixed',
+        groupLabel: 'Gemini models',
+        modelScope: { kind: 'family', key: 'gemini', complete: true },
+      });
+      const claude7d = makeQuotaWindow({
+        key: 'claude-7d',
+        kind: 'weekly',
+        limitWindowSeconds: 604800,
+        source: 'antigravity',
+        windowMode: 'fixed',
+        groupLabel: 'Claude and GPT models',
+        modelScope: { kind: 'family', key: 'claude_gpt', complete: true },
+      });
+      const gemini7d = makeQuotaWindow({
+        key: 'gemini-7d',
+        kind: 'weekly',
+        limitWindowSeconds: 604800,
+        source: 'antigravity',
+        windowMode: 'fixed',
+        groupLabel: 'Gemini models',
+        modelScope: { kind: 'family', key: 'gemini', complete: true },
+      });
+
+      const selected = selectAccountQuotaMainListWindows(
+        makeRow('antigravity'),
+        [gemini7d, claude5h, claude7d, gemini5h],
+        4
+      );
+
+      expect(selected).toEqual([claude5h, gemini5h, claude7d, gemini7d]);
     });
 
     it('prioritizes known duration over unknown duration', () => {

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.ts
@@ -719,7 +719,8 @@ export const getQuotaWindowReadableLabel = (
 
 export const selectAccountQuotaMainListWindows = (
   row: AccountRow,
-  quotaWindows: AccountQuotaDisplayWindow[]
+  quotaWindows: AccountQuotaDisplayWindow[],
+  maxWindows = 2
 ): AccountQuotaDisplayWindow[] => {
   const standardQuotaWindows = quotaWindows.filter(isStandardAccountQuotaListWindow);
   let candidates: AccountQuotaDisplayWindow[];
@@ -767,13 +768,21 @@ export const selectAccountQuotaMainListWindows = (
     if (a.duration !== b.duration) {
       return a.duration - b.duration;
     }
+    if (row.provider === 'antigravity') {
+      const groupRankDiff =
+        getAntigravityGroupRank(a.w.groupLabel ?? '') -
+        getAntigravityGroupRank(b.w.groupLabel ?? '');
+      if (groupRankDiff !== 0) {
+        return groupRankDiff;
+      }
+    }
     if (a.index !== b.index) {
       return a.index - b.index;
     }
     return a.w.key.localeCompare(b.w.key);
   });
 
-  return indexed.slice(0, 2).map((item) => item.w);
+  return indexed.slice(0, maxWindows).map((item) => item.w);
 };
 
 export const selectAccountQuotaListWindows = (


### PR DESCRIPTION
## Summary

Expand Accounts Table mode to show up to four quota windows and improve responsive column allocation without changing provider quota parsing or quota detail views.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Add a configurable main-list quota window limit: four in Table mode and two in Grid/Card mode.
- Keep list rendering and account-window-usage targets aligned with the same selected quota windows.
- Preserve duration-first ordering and stabilize Antigravity equal-duration groups with Claude/GPT before Gemini.
- Widen the responsive Table columns, raise the table minimum width, and support one-, two-, three-, and four-window quota layouts.
- Add regression coverage for selection limits, Antigravity ordering, rendered windows, and usage targets.

## User Impact

Table/List mode can display up to four quota windows. A single quota window uses the full Quota column; three windows use a full-width third row; four windows use a 2x2 layout. Grid/Card mode remains capped at two windows. Availability and Recent Requests receive more readable space while Quota absorbs most extra width. Existing status text and tooltips are unchanged.

## Compatibility / Runtime Notes

- CPA panel mode: No mode-specific runtime changes.
- Manager Server mode: Uses the existing account-window-usage API contract; no server changes.
- Full Docker / native packages: No changes.

## Data / Security Notes

N/A — frontend-only presentation and selection changes; no database, credential, usage-event, or API contract changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `a8e7f225f0ea2d5f31086dadef83c8f00ceb90c2`.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/features/accounts/model/accountsPagePresentation.test.ts (42/42)
npm --workspace apps/web run test -- src/features/accounts/AccountsPage.test.tsx src/features/accounts/model/accountsPagePresentation.test.ts (362/362)
npm run test:web (225 files, 3369 tests)
npm run type-check (passed)
npm run lint (0 errors; 5 pre-existing warnings)
npm run build (passed)
git diff --check (passed)
```

Manual UI note: The dedicated browser runtime was unavailable in this environment, so no browser screenshot/layout check was recorded.

## Screenshots / Recordings

N/A — the dedicated browser runtime was unavailable; automated tests, type-check, lint, and production build passed.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — this is a focused frontend layout fix with no documentation or release-note requirement.

Docs decision:

Documentation updates are not needed for this internal Accounts layout behavior.

## Related

N/A
