### PR TITLE
fix(ci): support v2 pull request targets

### DIFF
--- a/.github/workflows/main-promotion.yml
+++ b/.github/workflows/main-promotion.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v2
     types:
       - opened
       - edited
@@ -13,6 +14,7 @@ on:
   pull_request_target:
     branches-ignore:
       - dev
+      - v2
     types:
       - opened
       - edited
@@ -29,6 +31,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.base.ref != 'dev' &&
+      github.event.pull_request.base.ref != 'v2' &&
       (github.event.pull_request.base.ref != 'main' ||
        github.event.pull_request.head.repo.full_name != github.repository ||
        github.event.pull_request.head.ref != 'dev')
@@ -77,13 +80,14 @@ jobs:
             });
 
             const targetsDev = current.base.ref === "dev";
+            const targetsV2 = current.base.ref === "v2";
             const isDevPromotion =
               current.base.ref === "main" &&
               current.head.repo?.full_name === repository &&
               current.head.ref === "dev";
 
-            if (targetsDev || isDevPromotion) {
-              core.info("Pull request target already satisfies the dev integration policy.");
+            if (targetsDev || targetsV2 || isDevPromotion) {
+              core.info("Pull request target already satisfies the integration policy.");
               return;
             }
 
@@ -108,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Require the repository dev branch
+      - name: Verify protected target source policy
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -118,8 +122,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ "${BASE_REF}" = "v2" ]; then
+            echo "v2 is an allowed development target."
+            exit 0
+          fi
+
           if [ "${BASE_REF}" != "main" ]; then
-            echo "Expected a pull request targeting main, got ${BASE_REF}." >&2
+            echo "Expected a pull request targeting main or v2, got ${BASE_REF}." >&2
             exit 1
           fi
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - v2
     types:
       - opened
       - edited

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - v2
     types:
       - opened
       - edited


### PR DESCRIPTION
## Summary

Allow `v2` to operate as a first-class pull request target without being retargeted to `dev`, while preserving the existing `dev -> main` promotion restriction.

This fixes the protection deadlock exposed by #734, where `v2` required checks that its workflows never produced.

## Scope

- [ ] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [x] CI / build / tooling

## Changes

- Run PR checks and PR template validation for pull requests targeting `v2`.
- Treat `v2` as an allowed development target while keeping `main` restricted to promotions from this repository's `dev` branch.

## User Impact

No user-facing behavior change.

## Compatibility / Runtime Notes

- CPA panel mode: N/A
- Manager Server mode: N/A
- Full Docker / native packages: N/A

## Data / Security Notes

N/A. This PR changes GitHub Actions branch policy only.

## Risk / Rollback

Risk level: Low

Rollback notes:

Revert this PR to restore the previous PR target policy. Doing so would reintroduce the `v2` required-check deadlock.

## Verification

- [ ] Type check
- [ ] Lint
- [ ] Tests
- [ ] Build
- [ ] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
Pending CI.
```

## Screenshots / Recordings

N/A

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision:

Internal repository workflow policy only; no user-facing documentation change is required.

## Related

Refs #734
