### PR TITLE
✨ feat(accounts): complete card usage and quota windows

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.module.scss
+++ b/apps/web/src/features/accounts/AccountsPage.module.scss
@@ -370,7 +370,7 @@
 .accountCardList {
   display: grid;
   gap: 8px;
-  min-width: 1100px;
+  min-width: 1240px;
   padding: 10px 12px;
 }
 
@@ -380,11 +380,12 @@
   grid-template-columns:
     minmax(140px, 1.1fr)
     76px
-    minmax(180px, 0.45fr)
+    96px
     minmax(124px, 0.3fr)
+    minmax(160px, 0.35fr)
     minmax(280px, 3fr)
     146px;
-  column-gap: clamp(8px, 0.8vw, 12px);
+  column-gap: 8px;
   min-width: 0;
   box-sizing: border-box;
 }
@@ -407,7 +408,8 @@
 
   > span:nth-child(2),
   > span:nth-child(3),
-  > span:nth-child(4) {
+  > span:nth-child(4),
+  > span:nth-child(5) {
     justify-content: center;
     text-align: center;
   }
@@ -415,12 +417,11 @@
   > span:last-child {
     justify-content: center;
     text-align: center;
-    padding-left: 10px;
     box-sizing: border-box;
   }
 
   > span:first-child,
-  > span:nth-child(5) {
+  > span:nth-child(6) {
     justify-content: flex-start;
     text-align: left;
   }
@@ -460,7 +461,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  gap: 8px;
+  gap: 15px;
   min-width: 0;
   min-height: 250px;
   padding: 14px 16px;
@@ -884,9 +885,21 @@
   gap: 8px;
   width: 100%;
 
-  .quotaWindowCard + .quotaWindowCard {
+  > .quotaWindowCard + .quotaWindowCard {
     padding-top: 7px;
     border-top: 1px dashed color-mix(in srgb, var(--accounts-border) 65%, transparent);
+  }
+
+  .accountGridCardQuotaGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .accountGridCardQuotaGroup + .accountGridCardQuotaGroup {
+    padding-top: 8px;
+    border-top: 1px dashed color-mix(in srgb, var(--accounts-border) 52%, transparent);
   }
 }
 
@@ -1078,16 +1091,21 @@
 }
 
 @media (min-width: 1360px) {
+  .accountCardList {
+    min-width: 1320px;
+  }
+
   .accountCardHeader,
   .accountCard {
     grid-template-columns:
       minmax(150px, 1.1fr)
-      78px
-      minmax(190px, 0.45fr)
-      minmax(132px, 0.3fr)
+      70px
+      96px
+      minmax(112px, 0.3fr)
+      minmax(178px, 0.35fr)
       minmax(300px, 3fr)
       175px;
-    column-gap: clamp(10px, 0.85vw, 14px);
+    column-gap: 10px;
   }
 
   .rowActions {
@@ -1098,16 +1116,21 @@
 }
 
 @media (min-width: 1680px) {
+  .accountCardList {
+    min-width: 1500px;
+  }
+
   .accountCardHeader,
   .accountCard {
     grid-template-columns:
       minmax(180px, 1.3fr)
-      88px
-      minmax(200px, 0.45fr)
-      minmax(144px, 0.3fr)
+      80px
+      96px
+      minmax(124px, 0.3fr)
+      minmax(186px, 0.35fr)
       minmax(380px, 3fr)
       182px;
-    column-gap: 16px;
+    column-gap: 12px;
   }
 
   .rowActions {
@@ -1126,13 +1149,6 @@
     display: none;
   }
 
-  .accountCardPlan::before,
-  .accountCardHealth::before,
-  .accountCardLatestRequest::before,
-  .accountCardBusiness::before,
-  .accountCardRecommendation::before {
-    display: none;
-  }
 }
 
 .accountCardSelected {
@@ -1164,45 +1180,6 @@
   box-sizing: border-box;
   align-self: stretch;
   min-width: 0;
-}
-
-.accountCardIdentity,
-.accountCardPlan,
-.accountCardHealth,
-.accountCardLatestRequest,
-.accountCardBusiness {
-  padding-right: 6px;
-}
-
-.accountCardPlan,
-.accountCardHealth,
-.accountCardLatestRequest,
-.accountCardBusiness,
-.accountCardRecommendation {
-  position: relative;
-  padding-left: 10px;
-}
-
-.accountCardPlan::before,
-.accountCardHealth::before,
-.accountCardLatestRequest::before,
-.accountCardBusiness::before,
-.accountCardRecommendation::before {
-  position: absolute;
-  top: 6px;
-  bottom: 6px;
-  left: 0;
-  width: 1px;
-  border-radius: $radius-full;
-  background: linear-gradient(
-    180deg,
-    transparent,
-    color-mix(in srgb, var(--accounts-strong-border) 68%, transparent),
-    transparent
-  );
-  content: '';
-  opacity: 0.68;
-  pointer-events: none;
 }
 
 .accountCardIdentity {
@@ -1425,8 +1402,12 @@
   .badge {
     min-height: 24px;
     padding-inline: 10px;
+    padding-block: 3px;
     font-size: 13px;
+    line-height: 1.25;
     max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -1465,20 +1446,11 @@
   cursor: pointer;
   transition: background-color 0.14s ease;
 
-  &:hover {
-    background: color-mix(in srgb, var(--primary-color) 4%, transparent);
-  }
-
   &:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--primary-color) 48%, transparent);
     outline-offset: -2px;
     border-radius: 6px;
   }
-}
-
-.accountCardDetailTrigger.accountCardEvidence,
-.accountCardDetailTrigger.accountCardBusiness {
-  padding: 0 6px 0 10px;
 }
 
 .accountHistoryGrid {
@@ -1488,6 +1460,63 @@
   justify-content: stretch;
   gap: 10px 8px;
   min-width: 0;
+}
+
+.accountGridCardHistory {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  height: auto;
+  padding-top: 8px;
+  border-top: 1px solid color-mix(in srgb, var(--accounts-border) 65%, transparent);
+
+  .accountHistoryGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .accountHistoryMetric {
+    display: grid;
+    grid-template-columns: 17px minmax(0, 1fr);
+    gap: 1px 3px;
+    min-height: 48px;
+    padding: 7px 4px;
+    border: 1px solid color-mix(in srgb, var(--accounts-border) 72%, transparent);
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--accounts-surface) 42%, transparent);
+    box-sizing: border-box;
+
+    strong {
+      grid-column: 1 / -1;
+      text-align: left;
+      font-size: 12px;
+    }
+
+    .accountHistoryMetricLabel {
+      font-size: 10px;
+      line-height: 1.15;
+    }
+  }
+
+  .accountHistoryFootnote {
+    max-width: 100%;
+  }
+}
+
+.accountGridCardHistoryTitle,
+.accountHistoryMetricLabel {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--accounts-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.accountGridCardHistoryTitle {
+  font-weight: 700;
 }
 
 .accountHistoryMetric {
@@ -1722,6 +1751,26 @@
   .rowActions {
     align-self: center;
     justify-content: center;
+  }
+}
+
+@media (min-width: 1025px) {
+  .accountCardRecommendation::before {
+    content: '';
+    position: absolute;
+    left: -5px;
+    top: 6px;
+    bottom: 6px;
+    width: 1px;
+    border-radius: $radius-full;
+    background: linear-gradient(
+      180deg,
+      transparent,
+      color-mix(in srgb, var(--accounts-strong-border) 68%, transparent),
+      transparent
+    );
+    opacity: 0.68;
+    pointer-events: none;
   }
 }
 

--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -1093,6 +1093,17 @@ const findAccountDetailRegion = (
   return region;
 };
 
+const findGridQuotaRegion = (renderer: ReactTestRenderer, selectionKey: string) => {
+  const region = findAccountCardByKey(renderer, selectionKey).findAll(
+    (node) =>
+      node.props.role === 'button' &&
+      node.findAll((child) => typeof child.props['data-account-quota-window'] === 'string')
+        .length > 0
+  )[0];
+  if (!region) throw new Error('Grid quota region not found');
+  return region;
+};
+
 const findAccountCardInputByAriaLabel = (
   renderer: ReactTestRenderer,
   selectionKey: string,
@@ -8166,7 +8177,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('xai_quota.pay_as_you_go_label');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
 
     const otherQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'other' });
@@ -8291,7 +8302,7 @@ describe('AccountsPage replacement flows', () => {
     expect(findQuotaBarByWindow(card, 'pay-as-you-go').props.className).toContain('quotaBarGood');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
     await flushPromises();
 
@@ -8346,7 +8357,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('xai_quota.pay_as_you_go_label');
 
     await act(async () => {
-      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick();
+      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick({ stopPropagation: vi.fn() });
     });
     await flushPromises();
 
@@ -8436,7 +8447,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('Weekly');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
     await flushPromises();
 
@@ -8480,7 +8491,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('accounts.quota_details_only');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
     await flushPromises();
 
@@ -8523,7 +8534,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('accounts.quota_details_only');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
     await flushPromises();
 
@@ -8625,6 +8636,7 @@ describe('AccountsPage replacement flows', () => {
   });
 
   it('renders Antigravity Pro model groups in the quota matrix and keeps them in quota details', async () => {
+    mocks.location = { pathname: '/accounts', search: '?layout=grid' };
     mocks.files = [
       {
         name: 'antigravity-pro-matrix.json',
@@ -8690,26 +8702,29 @@ describe('AccountsPage replacement flows', () => {
 
     const renderer = await renderAccountsPage();
     const card = findAccountCardByKey(renderer, getAuthFileSelectionKey(mocks.files[0]));
-    const quotaRegion = findAccountDetailRegion(
-      renderer,
-      getAuthFileSelectionKey(mocks.files[0]),
-      'quota'
+    const quotaRegion = findGridQuotaRegion(renderer, getAuthFileSelectionKey(mocks.files[0]));
+    const cardWindows = card.findAll(
+      (node) => typeof node.props['data-account-quota-window'] === 'string'
     );
-    expect(
-      card.findAll((node) => typeof node.props['data-account-quota-window'] === 'string')
-    ).toHaveLength(4);
+    expect(cardWindows).toHaveLength(4);
+    expect(cardWindows.map((window) => window.props['data-account-quota-window'])).toEqual([
+      'claude-gpt-models:3p-5h',
+      'claude-gpt-models:3p-weekly',
+      'gemini-models:gemini-5h',
+      'gemini-models:gemini-weekly',
+    ]);
+    expect(card.findAll((node) => typeof node.props['data-account-quota-group'] === 'string'))
+      .toHaveLength(2);
     expect(readText(card)).not.toContain('accounts.quota_details_only');
     expect(readText(card)).toContain('Gemini');
     expect(readText(card)).toContain('Claude');
-    expect(quotaRegion.props['aria-label']).toContain('Claude');
-    expect(quotaRegion.props['aria-label']).toContain('Gemini');
+    expect(quotaRegion.props.title).toContain('Claude');
+    expect(quotaRegion.props.title).toContain('Gemini');
 
     await act(async () => {
-      findAccountDetailRegion(
-        renderer,
-        getAuthFileSelectionKey(mocks.files[0]),
-        'quota'
-      ).props.onClick();
+      findGridQuotaRegion(renderer, getAuthFileSelectionKey(mocks.files[0])).props.onClick({
+        stopPropagation: vi.fn(),
+      });
     });
 
     const modelQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
@@ -8720,6 +8735,7 @@ describe('AccountsPage replacement flows', () => {
   });
 
   it('renders Antigravity Free model groups in the quota matrix and keeps them in quota details', async () => {
+    mocks.location = { pathname: '/accounts', search: '?layout=grid' };
     mocks.files = [
       {
         name: 'antigravity-free-weekly.json',
@@ -8779,11 +8795,9 @@ describe('AccountsPage replacement flows', () => {
     expect(readText(card)).toContain('Claude');
 
     await act(async () => {
-      findAccountDetailRegion(
-        renderer,
-        getAuthFileSelectionKey(mocks.files[0]),
-        'quota'
-      ).props.onClick();
+      findGridQuotaRegion(renderer, getAuthFileSelectionKey(mocks.files[0])).props.onClick({
+        stopPropagation: vi.fn(),
+      });
     });
 
     const modelQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
@@ -8878,7 +8892,7 @@ describe('AccountsPage replacement flows', () => {
     });
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
     await flushPromises();
 
@@ -8932,7 +8946,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('76%');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
 
     expect(renderer.root.findByProps({ 'data-quota-window-group': 'model' })).toBeTruthy();
@@ -9005,7 +9019,7 @@ describe('AccountsPage replacement flows', () => {
     );
 
     await act(async () => {
-      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick();
+      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick({ stopPropagation: vi.fn() });
     });
 
     const modelQuotaGroup = renderer.root.findByProps({ 'data-quota-window-group': 'model' });
@@ -9082,7 +9096,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('Weekly');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
     });
 
     expect(
@@ -9194,7 +9208,7 @@ describe('AccountsPage replacement flows', () => {
     expect(findHostButtonByText(renderer, 'accounts.view_mode_grid')).toBeDefined();
   });
 
-  it('renders the six localized credential list headers', async () => {
+  it('renders the seven localized credential list headers', async () => {
     const renderer = await renderAccountsPage();
     const header = renderer.root.findByProps({ 'data-account-list-header': 'true' });
 
@@ -9203,6 +9217,7 @@ describe('AccountsPage replacement flows', () => {
       'accounts.list_header_plan',
       'accounts.list_header_availability',
       'accounts.list_header_recent_requests',
+      'accounts.list_header_historical_usage',
       'accounts.list_header_quota',
       'accounts.list_header_actions',
     ]);
@@ -9213,7 +9228,7 @@ describe('AccountsPage replacement flows', () => {
     expect(treeText(renderer)).not.toContain('SUM');
   });
 
-  it('does not render historical usage trigger on main list cards but keeps quota trigger', async () => {
+  it('renders historical usage alongside the quota trigger', async () => {
     const file = mocks.files[0];
     const selectionKey = getAuthFileSelectionKey(file);
     mocks.panelFeatureAvailability = {
@@ -9244,10 +9259,146 @@ describe('AccountsPage replacement flows', () => {
     const renderer = await renderAccountsPage();
     await flushPromises();
 
-    expect(() => findAccountDetailRegion(renderer, selectionKey, 'history')).toThrow();
+    const history = findAccountDetailRegion(renderer, selectionKey, 'history');
+    expect(history.type).toBe('button');
+    expect(history.props['aria-label']).toContain('accounts.history_title:12:1,200:$0.12:83.33%');
+    expect(history.findAllByType('strong').map(readText)).toEqual(['12', '1.2K', '$0.12', '83.3%']);
     const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
     expect(quotaRegion.type).toBe('button');
     expect(quotaRegion.props['data-account-detail-trigger']).toBe('quota');
+  });
+
+  describe.each(['table', 'grid'] as const)('historical usage in %s layout', (layout) => {
+    const selectionKey = 'history.json\u0000auth-history';
+    const item = {
+      row_key: selectionKey,
+      account_key: 'history@example.com',
+      matched: true,
+      total_requests: 1_234_567,
+      success_calls: 1_218_000,
+      failure_calls: 16_567,
+      total_tokens: 1_000_190_000,
+      total_cost: 12_345.67,
+      success_rate: 0.98321,
+      first_seen_ms: 1,
+      last_seen_ms: 2,
+      sync_status: 'ready' as const,
+    };
+
+    beforeEach(() => {
+      mocks.location = { pathname: '/accounts', search: `?layout=${layout}` };
+      mocks.files = [{
+        ...makeCodexFile('history.json', 'auth-history', 'history@example.com'),
+        success: 9,
+        failed: 1,
+        recent_requests: [{ success: 9, failed: 1 }],
+      }];
+      mocks.panelFeatureAvailability = {
+        checking: false,
+        managerServiceBase: 'http://manager.local:18317',
+        requestMonitoringAvailable: true,
+        serverCodexInspectionAvailable: false,
+      };
+      mocks.getAccountHistory.mockResolvedValue(makeAccountHistoryResponse([item]));
+    });
+
+    it('renders compact historical metrics with exact accessible values and opens quota without bubbling', async () => {
+      const renderer = await renderAccountsPage();
+      await flushPromises();
+      const region = findAccountDetailRegion(renderer, selectionKey, 'history');
+      expect(region.type).toBe('button');
+      expect(region.props.type).toBe('button');
+      expect(region.props['aria-label']).toContain('accounts.detail_tab_quota');
+      expect(region.findAllByType('strong').map(readText)).toEqual([
+        '1.2M', '1.0B', '$12.35K', '98.3%',
+      ]);
+      expect(region.findAll((node) => node.type === 'span' && node.props['aria-label'])
+        .map((node) => node.props['aria-label'])).toEqual([
+        'accounts.history_requests: 1,234,567',
+        'accounts.history_tokens: 1,000,190,000',
+        'accounts.history_cost: $12,345.67',
+        'accounts.history_success: 98.32%',
+      ]);
+      // The trigger contains phrasing content and has no interactive ancestor or descendants.
+      expect(region.findAll((node) => node !== region &&
+        (node.type === 'button' || node.type === 'a' || node.props.role === 'button' ||
+          node.props.tabIndex !== undefined || node.type === 'div'))).toHaveLength(0);
+      for (let parent = region.parent; parent; parent = parent.parent) {
+        expect(parent.type).not.toBe('button');
+        expect(parent.props.role).not.toBe('button');
+      }
+      const stopPropagation = vi.fn();
+      mocks.navigate.mockClear();
+      await act(async () => region.props.onClick({ stopPropagation }));
+      await flushPromises();
+      expect(stopPropagation).toHaveBeenCalledTimes(1);
+      expect(renderer.root.findByType(AccountQuotaTab)).toBeTruthy();
+      expect(mocks.navigate).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: expect.stringContaining('tab=quota') }),
+        { replace: true }
+      );
+    });
+
+    it.each(['unmatched', 'error'] as const)('uses only recent requests and success for %s history', async (state) => {
+      if (state === 'error') mocks.getAccountHistory.mockRejectedValue(new Error('offline'));
+      else mocks.getAccountHistory.mockResolvedValue(makeAccountHistoryResponse([]));
+      const renderer = await renderAccountsPage();
+      await flushPromises();
+      const region = findAccountDetailRegion(renderer, selectionKey, 'history');
+      expect(region.findAllByType('strong').map(readText)).toEqual(['10', '-', '-', '90.0%']);
+      if (state === 'error') expect(readText(region)).toContain('accounts.history_recent_fallback');
+    });
+
+    it('shows unavailable without inventing zero metrics when no fallback exists', async () => {
+      mocks.files = [makeCodexFile('history.json', 'auth-history', 'history@example.com')];
+      mocks.getAccountHistory.mockRejectedValue(new Error('offline'));
+      const renderer = await renderAccountsPage();
+      await flushPromises();
+      const region = findAccountDetailRegion(renderer, selectionKey, 'history');
+      expect(region.findAllByType('strong').map(readText)).toEqual(['-', '-', '-', '-']);
+      expect(readText(region)).toContain('accounts.history_unavailable');
+    });
+
+    it('shows loading followed by syncing using the same history request', async () => {
+      const pending = createDeferred<AccountHistoryResponseForTest>();
+      mocks.getAccountHistory.mockReturnValue(pending.promise);
+      const renderer = await renderAccountsPage();
+      await flushPromises();
+      expect(readText(findAccountDetailRegion(renderer, selectionKey, 'history')))
+        .toContain('accounts.history_loading');
+      pending.resolve(makeAccountHistoryResponse([{ ...item, sync_status: 'pending' }]));
+      await flushPromises();
+      expect(readText(findAccountDetailRegion(renderer, selectionKey, 'history')))
+        .toContain('accounts.history_syncing');
+      expect(mocks.getAccountHistory).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not request history when Request Monitoring is unavailable', async () => {
+      mocks.files = [makeCodexFile('history.json', 'auth-history', 'history@example.com')];
+      mocks.panelFeatureAvailability.requestMonitoringAvailable = false;
+      const renderer = await renderAccountsPage();
+      await flushPromises();
+      expect(mocks.getAccountHistory).not.toHaveBeenCalled();
+      expect(findAccountDetailRegion(renderer, selectionKey, 'history').findAllByType('strong')
+        .map(readText)).toEqual(['-', '-', '-', '-']);
+    });
+
+    it('leaves history non-interactive in selection mode and preserves row selection', async () => {
+      const renderer = await renderAccountsPage();
+      await act(async () => {
+        findHostButtonByText(renderer, 'accounts.selection_mode_enter').props.onClick();
+      });
+      const region = findAccountDetailRegion(renderer, selectionKey, 'history');
+      expect(region.type).toBe('div');
+      expect(region.props.onClick).toBeUndefined();
+      expect(region.props.tabIndex).toBeUndefined();
+      expect(region.props['data-account-detail-trigger']).toBeUndefined();
+      mocks.navigate.mockClear();
+      await act(async () => findAccountCardByKey(renderer, selectionKey).props.onClick());
+      expect(mocks.toggleSelect).toHaveBeenCalledWith(selectionKey);
+      expect(mocks.navigate).not.toHaveBeenCalled();
+      expect(renderer.root.findAllByType(AccountQuotaTab)).toHaveLength(0);
+    });
   });
 
   it('opens the quota detail from the full quota information region', async () => {
@@ -9277,7 +9428,7 @@ describe('AccountsPage replacement flows', () => {
     expect(readText(quotaRegion)).toContain('5h');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
       await Promise.resolve();
     });
     await flushPromises();
@@ -9333,7 +9484,7 @@ describe('AccountsPage replacement flows', () => {
     expect(quotaRegion.props['aria-label']).toContain('accounts.quota_details_only');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
       await Promise.resolve();
     });
     await flushPromises();
@@ -9378,7 +9529,7 @@ describe('AccountsPage replacement flows', () => {
     const quotaRegion = findAccountDetailRegion(renderer, selectionKey, 'quota');
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
       await Promise.resolve();
     });
 
@@ -9400,7 +9551,7 @@ describe('AccountsPage replacement flows', () => {
     expect(renderer.root.findAllByType(AccountQuotaTab)).toHaveLength(0);
 
     await act(async () => {
-      quotaRegion.props.onClick();
+      quotaRegion.props.onClick({ stopPropagation: vi.fn() });
       await Promise.resolve();
     });
     const secondConfirmation = mocks.showConfirmation.mock.calls[1]?.[0] as {
@@ -9474,7 +9625,7 @@ describe('AccountsPage replacement flows', () => {
     expect(cardText).not.toContain('Billing credits');
 
     await act(async () => {
-      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick();
+      findAccountDetailRegion(renderer, selectionKey, 'quota').props.onClick({ stopPropagation: vi.fn() });
       await Promise.resolve();
     });
     await flushPromises();
@@ -16537,7 +16688,7 @@ describe('AccountsPage replacement flows', () => {
         'data-account-detail-trigger': 'quota',
       });
       await act(async () => {
-        quotaTrigger.props.onClick();
+        quotaTrigger.props.onClick({ stopPropagation: vi.fn() });
         await Promise.resolve();
       });
       await flushPromises();
@@ -16767,7 +16918,7 @@ describe('AccountsPage replacement flows', () => {
       });
 
       await act(async () => {
-        quotaTrigger.props.onClick();
+        quotaTrigger.props.onClick({ stopPropagation: vi.fn() });
         await Promise.resolve();
       });
       await flushPromises();
@@ -16898,6 +17049,12 @@ describe('AccountsPage replacement flows', () => {
         'data-account-grid-recent-status': getAuthFileSelectionKey(mocks.files[0]),
       });
       expect(recentStatusSection).toBeTruthy();
+      const historySection = cards[0].findByProps({
+        'data-account-detail-trigger': 'history',
+      });
+      expect(cards[0].children.indexOf(historySection)).toBeLessThan(
+        cards[0].children.indexOf(recentStatusSection)
+      );
       expect(readText(recentStatusSection)).toContain('accounts.detail_overview_recent_status_title');
       const recentStatusBar = recentStatusSection.findByType(ProviderStatusBar);
       expect(recentStatusBar.props.statusData.totalSuccess).toBe(12);
@@ -17111,6 +17268,22 @@ describe('AccountsPage replacement flows', () => {
     });
 
     it('synchronizes rendered quota windows and list usage targets across Table -> Grid -> Table transitions', async () => {
+      mocks.getAccountHistory.mockImplementation(async () =>
+        makeAccountHistoryResponse([{
+          row_key: getAuthFileSelectionKey(mocks.files[0]),
+          account_key: 'antigravity-history',
+          matched: true,
+          total_requests: 12_400,
+          success_calls: 12_300,
+          failure_calls: 100,
+          total_tokens: 8_700_000,
+          total_cost: 18.42,
+          success_rate: 0.997,
+          first_seen_ms: 1,
+          last_seen_ms: 2,
+          sync_status: 'ready',
+        }])
+      );
       const file = {
         name: 'antigravity-pro-matrix.json',
         type: 'antigravity',
@@ -17232,6 +17405,12 @@ describe('AccountsPage replacement flows', () => {
       );
 
       const initialCard = findAccountCardByKey(renderer, selectionKey);
+      const assertHistory = () => {
+        expect(findAccountDetailRegion(renderer, selectionKey, 'history').findAllByType('strong')
+          .map(readText)).toEqual(['12.4K', '8.7M', '$18.42', '99.7%']);
+        expect(mocks.getAccountHistory).toHaveBeenCalledTimes(1);
+      };
+      assertHistory();
       const initialWindows = initialCard.findAll(
         (node) => typeof node.props['data-account-quota-window'] === 'string'
       );
@@ -17248,7 +17427,7 @@ describe('AccountsPage replacement flows', () => {
       expect(initialText).toContain('5h');
       expect(initialText).toMatch(/Weekly|7d/);
 
-      // 2. Switch to Grid mode: 2 rendered quota windows & 2 logical usage target windows
+      // 2. Switch to Grid mode: Pro keeps all 4 rendered quota windows & logical usage targets
       const gridButton = renderer.root.find(
         (node) => node.type === 'button' && node.props['aria-label'] === 'accounts.view_mode_grid'
       );
@@ -17258,37 +17437,31 @@ describe('AccountsPage replacement flows', () => {
       });
       await flushPromises();
 
-      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(2);
+      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(1);
       const gridRequest = mocks.getAccountWindowUsage.mock.calls[1]?.[2] as {
         windows: Array<{ provider_window_id?: string; window_key?: string; period: string }>;
       };
-      expect(gridRequest).toBeDefined();
-      const gridSelectedWindowIds = new Set(
-        gridRequest.windows.map((w) => w.provider_window_id || w.window_key)
-      );
-      expect(gridSelectedWindowIds.size).toBe(2);
-      expect(Array.from(gridSelectedWindowIds)).toEqual(
-        expect.arrayContaining(['claude-gpt-models:3p-5h', 'gemini-models:gemini-5h'])
-      );
-      expect(gridSelectedWindowIds.has('claude-gpt-models:3p-weekly')).toBe(false);
-      expect(gridSelectedWindowIds.has('gemini-models:gemini-weekly')).toBe(false);
+      expect(gridRequest).toBeUndefined();
 
       const gridCard = findAccountCardByKey(renderer, selectionKey);
+      assertHistory();
       const gridWindows = gridCard.findAll(
         (node) => typeof node.props['data-account-quota-window'] === 'string'
       );
-      expect(gridWindows).toHaveLength(2);
+      expect(gridWindows).toHaveLength(4);
       expect(gridWindows.map((w) => w.props['data-account-quota-window'])).toEqual([
         'claude-gpt-models:3p-5h',
+        'claude-gpt-models:3p-weekly',
         'gemini-models:gemini-5h',
+        'gemini-models:gemini-weekly',
       ]);
       const gridText = readText(gridCard);
       expect(gridText).toContain('Claude');
       expect(gridText).toContain('Gemini');
       expect(gridText).toContain('5h');
-      expect(gridWindows.some((w) => /Weekly|7d/.test(readText(w)))).toBe(false);
+      expect(gridWindows.some((w) => /Weekly|7d/.test(readText(w)))).toBe(true);
 
-      // 3. Switch back to Table mode: restores 4 rendered quota windows & 4 logical usage target windows
+      // 3. Switch back to Table mode: keeps 4 rendered quota windows & logical usage targets
       const tableButton = renderer.root.find(
         (node) => node.type === 'button' && node.props['aria-label'] === 'accounts.view_mode_table'
       );
@@ -17298,25 +17471,14 @@ describe('AccountsPage replacement flows', () => {
       });
       await flushPromises();
 
-      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(3);
+      expect(mocks.getAccountWindowUsage).toHaveBeenCalledTimes(1);
       const restoredTableRequest = mocks.getAccountWindowUsage.mock.calls[2]?.[2] as {
         windows: Array<{ provider_window_id?: string; window_key?: string; period: string }>;
       };
-      expect(restoredTableRequest).toBeDefined();
-      const restoredSelectedWindowIds = new Set(
-        restoredTableRequest.windows.map((w) => w.provider_window_id || w.window_key)
-      );
-      expect(restoredSelectedWindowIds.size).toBe(4);
-      expect(Array.from(restoredSelectedWindowIds)).toEqual(
-        expect.arrayContaining([
-          'claude-gpt-models:3p-5h',
-          'gemini-models:gemini-5h',
-          'claude-gpt-models:3p-weekly',
-          'gemini-models:gemini-weekly',
-        ])
-      );
+      expect(restoredTableRequest).toBeUndefined();
 
       const restoredCard = findAccountCardByKey(renderer, selectionKey);
+      assertHistory();
       const restoredWindows = restoredCard.findAll(
         (node) => typeof node.props['data-account-quota-window'] === 'string'
       );

--- a/apps/web/src/features/accounts/AccountsPage.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.tsx
@@ -20,6 +20,9 @@ import { SegmentedTabs, type SegmentedTabItem } from '@/components/ui/SegmentedT
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
 import {
   IconCheck,
+  IconBinary,
+  IconDollarSign,
+  IconSend,
   IconChartLine,
   IconArrowDownWideNarrow,
   IconArrowUpNarrowWide,
@@ -197,6 +200,9 @@ import {
   DETAIL_EVENTS_LIMIT,
   DETAIL_EVENTS_RANGE_MS,
   PAGE_SIZE_OPTIONS,
+  formatHistoryNumber,
+  formatHistorySuccessRate,
+  getAccountHistoryTitle,
   formatPercent,
   formatQuotaRemainingPercentDisplay,
   formatQuotaRemainingPercentParts,
@@ -208,6 +214,7 @@ import {
   getProviderLabel,
   getQuotaWindowReadableLabel,
   parsePriorityValue,
+  resolveWindowDurationSeconds,
   selectAccountQuotaMainListWindows,
   toAuthFileCodexInspectionSnapshot,
   type AccountSortFieldValue,
@@ -217,7 +224,7 @@ import {
 } from '@/features/accounts/model/accountsPagePresentation';
 import { buildAccountSubscriptionPresentation } from '@/features/accounts/model/accountSubscriptionPresentation';
 import { resolveAccountQuotaWindowUsageAndForecast } from '@/features/accounts/model/accountQuotaWindowUsagePresentation';
-import { formatCompactNumber, formatCompactUsd } from '@/utils/usage';
+import { formatCompactNumber, formatCompactUsd, formatUsd } from '@/utils/usage';
 import {
   getAuthFileCodexInspectionKeyForFile,
   getAuthFileCodexInspectionKeyForIdentity,
@@ -383,7 +390,10 @@ const renderAccountDetailTrigger = ({
       aria-label={ariaLabel}
       data-account-detail-region={kind}
       data-account-detail-trigger={kind}
-      onClick={onOpen}
+      onClick={(event) => {
+        event.stopPropagation();
+        onOpen();
+      }}
     >
       {children}
     </button>
@@ -396,11 +406,50 @@ const PASSIVE_ACCOUNTS_EVIDENCE_REFRESH_MS = 60_000;
 const CREDENTIAL_EVIDENCE_UNIQUE_FILE_NAME_BOUNDARY_PREFIX = 'unique-file-name\u0000';
 const CREDENTIAL_EVIDENCE_SOURCE_FILE_BOUNDARY_PREFIX = 'source-file\u0000';
 const CREDENTIAL_EVIDENCE_PROVIDER_BOUNDARY_PREFIX = 'provider\u0000';
+const ANTIGRAVITY_MULTI_WINDOW_PLAN_TYPES = new Set(['pro', 'ultra', 'ultra-lite']);
 
 type AccountQuotaRefreshMode = 'summary' | 'detail';
 
 const getAccountQuotaRefreshKey = (row: AccountRow): string =>
   `${row.provider}:${getQuotaCredentialStoreKey(row.raw)}`;
+
+const getMainListQuotaWindowLimit = (
+  layoutMode: AccountsLayoutMode,
+  row: AccountRow
+): number => {
+  if (layoutMode === 'table') return 4;
+  return row.provider === ANTIGRAVITY_CONFIG.type &&
+    ANTIGRAVITY_MULTI_WINDOW_PLAN_TYPES.has(row.canonicalPlanType ?? '')
+    ? 4
+    : 2;
+};
+
+const getCardQuotaWindowGroups = (
+  row: AccountRow,
+  windows: AccountQuotaDisplayWindow[]
+): Array<{ key: string; windows: AccountQuotaDisplayWindow[] }> => {
+  if (row.provider !== ANTIGRAVITY_CONFIG.type) return [{ key: 'all', windows }];
+
+  const grouped = new Map<string, AccountQuotaDisplayWindow[]>();
+  windows.forEach((window) => {
+    const key = window.groupLabel?.trim() || window.modelScope?.key || window.key;
+    const group = grouped.get(key) ?? [];
+    group.push(window);
+    grouped.set(key, group);
+  });
+
+  return [...grouped.entries()].map(([key, groupWindows]) => ({
+    key,
+    windows: groupWindows
+      .map((window, index) => ({ window, index }))
+      .sort((left, right) => {
+        const durationDiff =
+          resolveWindowDurationSeconds(left.window) - resolveWindowDurationSeconds(right.window);
+        return durationDiff !== 0 ? durationDiff : left.index - right.index;
+      })
+      .map(({ window }) => window),
+  }));
+};
 
 type AccountQuotaRefreshOutcome =
   | { status: 'success'; rateLimited?: boolean }
@@ -1563,7 +1612,6 @@ export function AccountsPage() {
   );
   const isCompactScreen = useMediaQuery('(max-width: 1024px)');
   const effectiveLayoutMode = isCompactScreen ? 'grid' : layoutMode;
-  const mainListQuotaWindowLimit = effectiveLayoutMode === 'table' ? 4 : 2;
   const [copiedIdentityKey, setCopiedIdentityKey] = useState<string | null>(null);
   const detailEventsRequestIdRef = useRef(0);
   const detailEventsAutoLoadKeyRef = useRef<string | null>(null);
@@ -4760,7 +4808,7 @@ export function AccountsPage() {
       const mainListWindows = selectAccountQuotaMainListWindows(
         row,
         quotaWindows,
-        mainListQuotaWindowLimit
+        getMainListQuotaWindowLimit(effectiveLayoutMode, row)
       );
       const existingDefinitions = quotaWindowDefinitionsByRowKey.get(row.selectionKey);
       let definitions: AccountQuotaWindowDefinition[];
@@ -4780,7 +4828,7 @@ export function AccountsPage() {
     pageRows,
     quotaDisplayWindowsByRowKey,
     quotaWindowDefinitionsByRowKey,
-    mainListQuotaWindowLimit,
+    effectiveLayoutMode,
   ]);
   const isListQueryContextMatching = useMemo(() => {
     if (!listWindowUsageQueryContext) return false;
@@ -8397,7 +8445,7 @@ export function AccountsPage() {
     const mainListWindows = selectAccountQuotaMainListWindows(
       row,
       quotaWindows,
-      mainListQuotaWindowLimit
+      getMainListQuotaWindowLimit(effectiveLayoutMode, row)
     );
     const quotaCooldown = quotaCooldownsByRowKey.get(row.selectionKey)?.[0] ?? null;
     const codexStatus = codexStatusBySelectionKey.get(row.selectionKey) ?? null;
@@ -8480,6 +8528,110 @@ export function AccountsPage() {
     };
   };
 
+  const renderAccountHistory = (
+    row: AccountRow,
+    ctx: ReturnType<typeof resolveAccountRowContext>,
+    card = false
+  ) => {
+    const { accountHistory, accountHistoryError } = ctx;
+    const matched = accountHistory?.matched === true;
+    const recentRequestCount = row.usage.success + row.usage.failure;
+    const title = getAccountHistoryTitle(
+      t,
+      accountHistory,
+      accountHistoryLoading,
+      accountHistoryError,
+      i18n.language
+    );
+    const footnote = accountHistoryError
+      ? recentRequestCount > 0
+        ? t('accounts.history_recent_fallback')
+        : t('accounts.history_unavailable')
+      : accountHistoryLoading && !accountHistory
+        ? t('accounts.history_loading')
+        : accountHistory?.sync_status === 'pending'
+          ? t('accounts.history_syncing')
+          : null;
+    const requests = matched
+      ? accountHistory.total_requests
+      : recentRequestCount > 0
+        ? recentRequestCount
+        : null;
+    const metrics = [
+      {
+        key: 'requests',
+        icon: <IconSend size={13} />,
+        className: styles.accountHistoryMetricRequests,
+        value: requests !== null ? formatCompactNumber(requests) : '-',
+        exact: requests !== null ? formatHistoryNumber(requests, i18n.language) : '-',
+      },
+      {
+        key: 'tokens',
+        icon: <IconBinary size={13} />,
+        className: styles.accountHistoryMetricTokens,
+        value: matched ? formatCompactNumber(accountHistory.total_tokens) : '-',
+        exact: matched ? formatHistoryNumber(accountHistory.total_tokens, i18n.language) : '-',
+      },
+      {
+        key: 'cost',
+        icon: <IconDollarSign size={13} />,
+        className: styles.accountHistoryMetricCost,
+        value: matched ? formatCompactUsd(accountHistory.total_cost) : '-',
+        exact: matched ? formatUsd(accountHistory.total_cost) : '-',
+      },
+      {
+        key: 'success',
+        icon: <IconCheck size={13} />,
+        className: styles.accountHistoryMetricSuccess,
+        value: matched
+          ? formatHistorySuccessRate(accountHistory.success_rate)
+          : formatPercent(row.usage.successRate, 1),
+        exact: matched
+          ? formatHistorySuccessRate(accountHistory.success_rate, 2)
+          : formatPercent(row.usage.successRate, 2),
+      },
+    ];
+
+    return renderAccountDetailTrigger({
+      isSelectionMode,
+      className: card ? styles.accountGridCardHistory : styles.accountCardEvidence,
+      title,
+      ariaLabel: `${t('accounts.list_header_historical_usage')}: ${title}. ${t(
+        'accounts.open_detail',
+        { name: row.fileName }
+      )}: ${t('accounts.detail_tab_quota')}`,
+      kind: 'history',
+      onOpen: () => void openAccountDetail(row, 'quota'),
+      children: (
+        <>
+          {card ? (
+            <span className={styles.accountGridCardHistoryTitle}>
+              {t('accounts.list_header_historical_usage')}
+            </span>
+          ) : null}
+          <span className={styles.accountHistoryGrid}>
+            {metrics.map((metric) => (
+              <span
+                key={metric.key}
+                className={`${styles.accountHistoryMetric} ${metric.className}`}
+                aria-label={`${t(`accounts.history_${metric.key}`)}: ${metric.exact}`}
+              >
+                <span className={styles.accountHistoryIcon} aria-hidden="true">{metric.icon}</span>
+                {card ? (
+                  <span className={styles.accountHistoryMetricLabel}>
+                    {t(`accounts.history_${metric.key}`)}
+                  </span>
+                ) : null}
+                <strong>{metric.value}</strong>
+              </span>
+            ))}
+          </span>
+          {footnote ? <span className={styles.accountHistoryFootnote}>{footnote}</span> : null}
+        </>
+      ),
+    });
+  };
+
   const renderAccountCards = (rowsToRender = pageRows, paged = true) => (
     <section className={styles.tablePanel}>
       {paged ? renderBatchBar() : null}
@@ -8488,6 +8640,7 @@ export function AccountsPage() {
           <div className={styles.accountGridList}>
             {rowsToRender.map((row) => {
               const ctx = resolveAccountRowContext(row);
+              const quotaWindowGroups = getCardQuotaWindowGroups(row, ctx.mainListWindows);
               return (
                 <article
                   key={row.selectionKey}
@@ -8843,6 +8996,8 @@ export function AccountsPage() {
                   )}
                 </div>
 
+                  {renderAccountHistory(row, ctx, true)}
+
                   <div
                     className={styles.accountGridCardRecentStatus}
                     data-account-grid-recent-status={row.selectionKey}
@@ -8942,16 +9097,35 @@ export function AccountsPage() {
                   >
                     {ctx.mainListWindows.length > 0 ? (
                       <div className={styles.accountGridCardQuotaList}>
-                        {ctx.mainListWindows.map((window, idx) =>
-                          renderSingleQuotaWindowCard(
-                            row,
-                            window,
-                            idx,
-                            null,
-                            false,
-                            ctx.quotaLifecycleBarOverride
-                          )
-                        )}
+                        {row.provider === ANTIGRAVITY_CONFIG.type
+                          ? quotaWindowGroups.map((group) => (
+                              <div
+                                key={group.key}
+                                className={styles.accountGridCardQuotaGroup}
+                                data-account-quota-group={group.key}
+                              >
+                                {group.windows.map((window, idx) =>
+                                  renderSingleQuotaWindowCard(
+                                    row,
+                                    window,
+                                    idx,
+                                    null,
+                                    false,
+                                    ctx.quotaLifecycleBarOverride
+                                  )
+                                )}
+                              </div>
+                            ))
+                          : ctx.mainListWindows.map((window, idx) =>
+                              renderSingleQuotaWindowCard(
+                                row,
+                                window,
+                                idx,
+                                null,
+                                false,
+                                ctx.quotaLifecycleBarOverride
+                              )
+                            )}
                       </div>
                     ) : (
                       <span className={styles.quotaEmptyState} data-account-quota-empty="true">
@@ -8978,6 +9152,7 @@ export function AccountsPage() {
                 <span>{t('accounts.list_header_plan')}</span>
                 <span>{t('accounts.list_header_availability')}</span>
                 <span>{t('accounts.list_header_recent_requests')}</span>
+                <span>{t('accounts.list_header_historical_usage')}</span>
                 <span>{t('accounts.list_header_quota')}</span>
                 <span>{t('accounts.list_header_actions')}</span>
               </div>
@@ -9162,6 +9337,8 @@ export function AccountsPage() {
                       onCopy={copyTextWithNotification}
                     />
                   </div>
+
+                  {renderAccountHistory(row, ctx)}
 
                   {(() => {
                     const resetCreditsAriaSuffix =


### PR DESCRIPTION
## Summary

The Accounts page now keeps historical usage complete and readable in both table and card layouts. Antigravity Pro and higher plans show all model-group quota windows in card mode.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [ ] CPA panel mode
- [ ] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- Added the four historical usage metrics to account cards and table rows with compact display values, exact accessible values, left-aligned amounts, independent metric borders, and taller card spacing.
- Show all four Antigravity `5h` and `7d` windows for `Pro`, `Ultra`, and `Ultra Lite` cards; keep other card providers and Free Antigravity cards capped at two windows.
- Group Antigravity card windows by model family so each family's `5h` and `7d` windows stay adjacent, with a weak separator between groups.

## User Impact

Users can see complete historical usage and all four Antigravity paid-plan quota windows directly in card mode without opening the detail view.

## Compatibility / Runtime Notes

- CPA panel mode: Frontend-only presentation change.
- Manager Server mode: No changes.
- Full Docker / native packages: No changes.

## Data / Security Notes

N/A — no backend, database, credential, or raw usage changes.

## Risk / Rollback

Risk level: Low

Rollback notes: Revert commit `dac3c442`.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
npm --workspace apps/web run test -- src/features/accounts/AccountsPage.test.tsx src/features/accounts/model/accountsPagePresentation.test.ts (377 passed)
npm run test:web (225 files, 3411 tests passed)
npm run type-check (passed)
npm run lint (0 errors; 5 existing warnings)
npm run build (passed)
git diff --check (passed)
Headless Chrome demo DOM and screenshot verified four Pro windows grouped as Claude 5h/7d and Gemini 5h/7d.
```

## Screenshots / Recordings

Local visual check completed with headless Chrome at desktop card width; no repository screenshot asset added.

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: This is a focused frontend presentation fix with no user workflow or configuration documentation changes.

## Related

N/A
