### PR TITLE
fix(accounts): sort Codex rows by plan remaining time

### DIFF
--- a/apps/web/src/features/accounts/AccountsPage.test.tsx
+++ b/apps/web/src/features/accounts/AccountsPage.test.tsx
@@ -8136,6 +8136,51 @@ describe('AccountsPage replacement flows', () => {
     expect(getAccountListItemTexts(renderer)[0]).toContain('high.json');
   });
 
+  it('sorts Codex account cards by paid subscription remaining time', async () => {
+    const now = Date.now();
+    mocks.files = [
+      makeCodexFile('later.json', 'auth-later', 'later@example.com'),
+      makeCodexFile('sooner.json', 'auth-sooner', 'sooner@example.com'),
+      makeCodexFile('unknown.json', 'auth-unknown', 'unknown@example.com'),
+    ];
+    mocks.quotaState.codexQuota = {
+      ...buildCredentialScopedQuotaRecord(mocks.files[0], {
+        status: 'success',
+        planType: 'plus',
+        windows: [{ id: 'weekly', label: 'Weekly', usedPercent: 10, resetLabel: '2026-01-10' }],
+        subscriptionActiveUntil: now + 20 * 86_400_000,
+      }),
+      ...buildCredentialScopedQuotaRecord(mocks.files[1], {
+        status: 'success',
+        planType: 'plus',
+        windows: [{ id: 'weekly', label: 'Weekly', usedPercent: 10, resetLabel: '2026-01-10' }],
+        subscriptionActiveUntil: now + 3 * 86_400_000,
+      }),
+      ...buildCredentialScopedQuotaRecord(mocks.files[2], {
+        status: 'success',
+        planType: 'plus',
+        windows: [{ id: 'weekly', label: 'Weekly', usedPercent: 10, resetLabel: '2026-01-10' }],
+      }),
+    };
+
+    const renderer = await renderAccountsPage();
+
+    await act(async () => {
+      findHostButtonByAriaLabel(
+        renderer,
+        'accounts.sort_label: accounts.col_recent'
+      ).props.onClick();
+    });
+    await act(async () => {
+      findHostButtonByText(renderer, 'accounts.sort_remaining').props.onClick();
+    });
+
+    const names = getAccountListItemTexts(renderer);
+    expect(names[0]).toContain('sooner.json');
+    expect(names[1]).toContain('later.json');
+    expect(names[2]).toContain('unknown.json');
+  });
+
   it('renders xAI monthly billing and pay-as-you-go fallback on account cards', async () => {
     mocks.files = [
       {

--- a/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
+++ b/apps/web/src/features/accounts/model/accountDetailViewModel.test.ts
@@ -69,6 +69,7 @@ const makeRow = (overrides: AccountRowOverrides = {}): AccountRow => {
     inspection: null,
     raw,
     ...rowOverrides,
+    subscriptionUntilMs: rowOverrides.subscriptionUntilMs ?? null,
   };
 };
 

--- a/apps/web/src/features/accounts/model/accountHealthEvidence.test.ts
+++ b/apps/web/src/features/accounts/model/accountHealthEvidence.test.ts
@@ -66,6 +66,7 @@ const makeRow = (overrides: Partial<AccountRow> = {}): AccountRow => {
     inspection: null,
     raw,
     ...overrides,
+    subscriptionUntilMs: overrides.subscriptionUntilMs ?? null,
   };
 };
 

--- a/apps/web/src/features/accounts/model/accountListPresentation.test.ts
+++ b/apps/web/src/features/accounts/model/accountListPresentation.test.ts
@@ -57,6 +57,7 @@ const makeRow = (overrides: AccountRowOverrides = {}): AccountRow => {
     inspection: null,
     raw,
     ...rowOverrides,
+    subscriptionUntilMs: rowOverrides.subscriptionUntilMs ?? null,
   };
 };
 

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -2785,6 +2785,52 @@ describe('accountRows', () => {
     ).toEqual(['later.json', 'sooner.json', 'free.json', 'unknown.json']);
   });
 
+  it('sorts expired paid Codex remaining time by timestamp, with unknown last', () => {
+    const now = 1_800_000_000_000;
+    const expiredUntilMs = now - 2 * 86_400_000;
+    const activeUntilMs = now + 5 * 86_400_000;
+    const rows = buildAccountRows(
+      [
+        { name: 'unknown.json', type: 'codex', planType: 'plus' },
+        { name: 'active.json', type: 'codex', planType: 'plus' },
+        { name: 'expired.json', type: 'codex', planType: 'plus' },
+      ],
+      {
+        ...emptyStores(),
+        codexQuota: {
+          'expired.json': {
+            status: 'success',
+            windows: [],
+            planType: 'plus',
+            subscriptionActiveUntil: expiredUntilMs,
+          },
+          'active.json': {
+            status: 'success',
+            windows: [],
+            planType: 'plus',
+            subscriptionActiveUntil: activeUntilMs,
+          },
+          'unknown.json': {
+            status: 'success',
+            windows: [],
+            planType: 'plus',
+          },
+        },
+      }
+    );
+    const byName = Object.fromEntries(rows.map((row) => [row.fileName, row]));
+
+    expect(byName['expired.json']?.subscriptionUntilMs).toBe(expiredUntilMs);
+    expect(byName['active.json']?.subscriptionUntilMs).toBe(activeUntilMs);
+    expect(byName['unknown.json']?.subscriptionUntilMs).toBeNull();
+    expect(
+      sortAccountRows(rows, { key: 'remaining', direction: 'asc' }).map((row) => row.fileName)
+    ).toEqual(['expired.json', 'active.json', 'unknown.json']);
+    expect(
+      sortAccountRows(rows, { key: 'remaining', direction: 'desc' }).map((row) => row.fileName)
+    ).toEqual(['active.json', 'expired.json', 'unknown.json']);
+  });
+
   it('sorts the name column by account label instead of credential file name', () => {
     const rows = buildAccountRows(
       [

--- a/apps/web/src/features/accounts/model/accountRows.test.ts
+++ b/apps/web/src/features/accounts/model/accountRows.test.ts
@@ -2737,6 +2737,54 @@ describe('accountRows', () => {
     ).toEqual(['low.json', 'high.json', 'middle.json']);
   });
 
+  it('sorts paid Codex rows by subscription remaining time', () => {
+    const now = 1_800_000_000_000;
+    const rows = buildAccountRows(
+      [
+        { name: 'later.json', type: 'codex', planType: 'plus' },
+        { name: 'sooner.json', type: 'codex', planType: 'plus' },
+        { name: 'unknown.json', type: 'codex', planType: 'plus' },
+        { name: 'free.json', type: 'codex', planType: 'free' },
+      ],
+      {
+        ...emptyStores(),
+        codexQuota: {
+          'later.json': {
+            status: 'success',
+            windows: [],
+            planType: 'plus',
+            subscriptionActiveUntil: now + 20 * 86_400_000,
+          },
+          'sooner.json': {
+            status: 'success',
+            windows: [],
+            planType: 'plus',
+            subscriptionActiveUntil: now + 3 * 86_400_000,
+          },
+          'free.json': {
+            status: 'success',
+            windows: [],
+            planType: 'free',
+            subscriptionActiveUntil: now + 1 * 86_400_000,
+          },
+        },
+      }
+    );
+
+    expect(sortAccountRows(rows).map((row) => row.fileName)).toEqual([
+      'free.json',
+      'later.json',
+      'sooner.json',
+      'unknown.json',
+    ]);
+    expect(
+      sortAccountRows(rows, { key: 'remaining', direction: 'asc' }).map((row) => row.fileName)
+    ).toEqual(['sooner.json', 'later.json', 'free.json', 'unknown.json']);
+    expect(
+      sortAccountRows(rows, { key: 'remaining', direction: 'desc' }).map((row) => row.fileName)
+    ).toEqual(['later.json', 'sooner.json', 'free.json', 'unknown.json']);
+  });
+
   it('sorts the name column by account label instead of credential file name', () => {
     const rows = buildAccountRows(
       [

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -194,7 +194,7 @@ export interface AccountRow {
   priority: number | null;
   createdAtMs: number | null;
   updatedAtMs: number | null;
-  subscriptionUntilMs?: number | null;
+  subscriptionUntilMs: number | null;
   authenticationAtMs: number;
   rawCredentialStatusSuperseded: boolean;
   quota: AccountQuotaSummary;
@@ -1054,11 +1054,7 @@ const compareAccountRowsBySort = (left: AccountRow, right: AccountRow, sort: Acc
     return compareNullableNumbers(left.createdAtMs, right.createdAtMs, sort.direction);
   }
   if (sort.key === 'remaining') {
-    return compareNullableNumbers(
-      left.subscriptionUntilMs ?? null,
-      right.subscriptionUntilMs ?? null,
-      sort.direction
-    );
+    return compareNullableNumbers(left.subscriptionUntilMs, right.subscriptionUntilMs, sort.direction);
   }
   if (sort.key === 'reset') {
     return compareQuotaResets(left.quota, right.quota, sort.direction);

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -56,6 +56,7 @@ import {
   getPlanPresentation,
   resolveAuthFilePlanType,
 } from '@/utils/plans';
+import { buildAccountSubscriptionPresentation } from './accountSubscriptionPresentation';
 
 export {
   compareQuotaResetLabels,
@@ -193,6 +194,7 @@ export interface AccountRow {
   priority: number | null;
   createdAtMs: number | null;
   updatedAtMs: number | null;
+  subscriptionUntilMs?: number | null;
   authenticationAtMs: number;
   rawCredentialStatusSuperseded: boolean;
   quota: AccountQuotaSummary;
@@ -494,14 +496,23 @@ export const buildAccountRows = (
         updatedAtMs !== null &&
         authenticationAtMs >= updatedAtMs);
     const quota = resolveAccountQuota(effectiveFile, stores, overrides);
+    const planType = quota.planType ?? readPlanType(file);
+    const subscriptionUntilMs = buildAccountSubscriptionPresentation({
+      row: {
+        provider,
+        planType,
+        raw: file,
+      },
+      codexQuota,
+    }).subscriptionUntilMs;
     return {
       key: file.name,
       selectionKey,
       fileName: file.name,
       accountLabel: resolveAccountLabel(file),
       provider,
-      planType: quota.planType ?? readPlanType(file),
-      canonicalPlanType: getCanonicalPlanType(provider, quota.planType ?? readPlanType(file)),
+      planType,
+      canonicalPlanType: getCanonicalPlanType(provider, planType),
       disabled: effectiveFile.disabled === true,
       runtimeOnly:
         file.runtimeOnly === true || file.runtimeOnly === 'true' || file.runtime_only === true,
@@ -512,6 +523,7 @@ export const buildAccountRows = (
       priority: readNumber(file.priority),
       createdAtMs: readAuthFileCreatedAtMs(file),
       updatedAtMs,
+      subscriptionUntilMs,
       authenticationAtMs,
       rawCredentialStatusSuperseded,
       quota,
@@ -1040,6 +1052,13 @@ const compareAccountRowsBySort = (left: AccountRow, right: AccountRow, sort: Acc
   }
   if (sort.key === 'created') {
     return compareNullableNumbers(left.createdAtMs, right.createdAtMs, sort.direction);
+  }
+  if (sort.key === 'remaining') {
+    return compareNullableNumbers(
+      left.subscriptionUntilMs ?? null,
+      right.subscriptionUntilMs ?? null,
+      sort.direction
+    );
   }
   if (sort.key === 'reset') {
     return compareQuotaResets(left.quota, right.quota, sort.direction);

--- a/apps/web/src/features/accounts/model/accountRows.ts
+++ b/apps/web/src/features/accounts/model/accountRows.ts
@@ -103,6 +103,7 @@ export type AccountRowSortKey =
   | 'plan'
   | 'note'
   | 'reset'
+  | 'remaining'
   | 'priority'
   | 'recent'
   | 'quota'

--- a/apps/web/src/features/accounts/model/accountSubscriptionPresentation.ts
+++ b/apps/web/src/features/accounts/model/accountSubscriptionPresentation.ts
@@ -39,7 +39,7 @@ const asRecord = (value: unknown): Record<string, unknown> | null =>
     : null;
 
 export const resolveCodexSubscriptionUntilMs = (
-  row: AccountRow,
+  row: Pick<AccountRow, 'provider' | 'raw'>,
   codexQuota?: CodexQuotaState | null
 ): {
   liveSubscriptionUntilMs: number | null;
@@ -82,7 +82,7 @@ export const resolveCodexSubscriptionUntilMs = (
 };
 
 export const buildAccountSubscriptionPresentation = (input: {
-  row: AccountRow;
+  row: Pick<AccountRow, 'provider' | 'planType' | 'raw'>;
   codexQuota?: CodexQuotaState | null;
   t?: TFunction;
   nowMs?: number;

--- a/apps/web/src/features/accounts/model/accountsPagePresentation.ts
+++ b/apps/web/src/features/accounts/model/accountsPagePresentation.ts
@@ -27,7 +27,7 @@ export type AccountsView = 'accounts' | 'health' | 'oauth';
 export type DetailTab = 'overview' | 'quota' | 'config' | 'models' | 'diagnostics';
 export type SortableAccountColumn = Extract<
   AccountRowSortKey,
-  'name' | 'plan' | 'note' | 'reset' | 'priority' | 'recent' | 'quota' | 'created'
+  'name' | 'plan' | 'note' | 'reset' | 'remaining' | 'priority' | 'recent' | 'quota' | 'created'
 >;
 export type AccountSortFieldValue = 'default' | SortableAccountColumn;
 type AntigravityQuotaMatrixWindowKind = Extract<AccountQuotaWindowKind, 'five_hour' | 'weekly'>;
@@ -66,6 +66,7 @@ export const ACCOUNT_SORT_DEFAULT_DIRECTIONS: Record<
   plan: 'asc',
   note: 'asc',
   reset: 'asc',
+  remaining: 'asc',
   priority: 'desc',
   recent: 'desc',
   quota: 'desc',
@@ -84,6 +85,7 @@ export const ACCOUNT_SORT_FIELD_OPTIONS: Array<{
   DEFAULT_ACCOUNT_SORT_FIELD_OPTION,
   { value: 'name', labelKey: 'accounts.sort_name' },
   { value: 'plan', labelKey: 'accounts.col_plan' },
+  { value: 'remaining', labelKey: 'accounts.sort_remaining' },
   { value: 'note', labelKey: 'auth_files.note_label' },
   { value: 'reset', labelKey: 'accounts.col_reset' },
   { value: 'quota', labelKey: 'accounts.col_quota' },

--- a/apps/web/src/features/accounts/model/accountsWorkspaceUiState.ts
+++ b/apps/web/src/features/accounts/model/accountsWorkspaceUiState.ts
@@ -30,6 +30,7 @@ const SORT_KEYS = new Set([
   'plan',
   'note',
   'reset',
+  'remaining',
   'priority',
   'recent',
   'quota',

--- a/apps/web/src/features/accounts/model/accountsWorkspaceUrlState.test.ts
+++ b/apps/web/src/features/accounts/model/accountsWorkspaceUrlState.test.ts
@@ -137,6 +137,27 @@ describe('accountsWorkspaceUrlState', () => {
     expect(state.accountSort).toEqual({ key: 'name', direction: 'desc' });
   });
 
+  it('round-trips remaining-time sort from the accounts URL', () => {
+    const search = writeAccountsWorkspaceUrlSearch(
+      '',
+      {
+        ...DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE,
+        view: 'accounts',
+        healthMode: 'local',
+        account: null,
+        detailTab: 'overview',
+        editor: null,
+        editorProvider: '',
+        accountSort: { key: 'remaining', direction: 'asc' },
+      },
+      DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE
+    );
+    const state = readAccountsWorkspaceUrlState(search, DEFAULT_ACCOUNTS_WORKSPACE_UI_STATE);
+
+    expect(search).toBe('?sort=remaining&direction=asc');
+    expect(state.accountSort).toEqual({ key: 'remaining', direction: 'asc' });
+  });
+
   it('round-trips precise Codex status filters', () => {
     const search = writeAccountsWorkspaceUrlSearch(
       '',

--- a/apps/web/src/features/accounts/model/accountsWorkspaceUrlState.ts
+++ b/apps/web/src/features/accounts/model/accountsWorkspaceUrlState.ts
@@ -40,6 +40,7 @@ const SORT_KEY_SET: ReadonlySet<AccountsWorkspaceUiState['accountSort']['key']> 
   'plan',
   'note',
   'reset',
+  'remaining',
   'priority',
   'recent',
   'quota',

--- a/apps/web/src/features/accounts/model/quotaRecommendations.test.ts
+++ b/apps/web/src/features/accounts/model/quotaRecommendations.test.ts
@@ -55,6 +55,7 @@ const makeRow = (overrides: AccountRowOverrides = {}): AccountRow => {
     inspection: null,
     raw,
     ...rowOverrides,
+    subscriptionUntilMs: rowOverrides.subscriptionUntilMs ?? null,
   };
 };
 

--- a/apps/web/src/features/demo/demoInspect.test.ts
+++ b/apps/web/src/features/demo/demoInspect.test.ts
@@ -5,7 +5,7 @@ import {
   getDemoAccountWindowUsage,
   resetDemoEvidenceEpoch,
 } from './demoFixtures';
-import { buildAccountRows } from '@/features/accounts/model/accountRows';
+import { buildAccountRows, sortAccountRows } from '@/features/accounts/model/accountRows';
 import {
   buildAccountQuotaDisplayWindows,
   type BuildAccountQuotaDisplayWindowsOptions,
@@ -51,6 +51,28 @@ describe('Demo accounts quota & usage presentation regression', () => {
     expect(plusSub.isPaidCodex).toBe(true);
     expect(plusSub.effectivePlanType).toBe('plus');
     expect(plusSub.remainingDays).toBeGreaterThan(0);
+  });
+
+  it('sorts demo Codex accounts by paid subscription remaining time', () => {
+    const authFiles = getDemoAuthFiles().files;
+    const quotaState = getDemoQuotaStoreState();
+    const rows = buildAccountRows(authFiles, quotaState).filter((row) => row.provider === 'codex');
+    const sorted = sortAccountRows(rows, { key: 'remaining', direction: 'asc' });
+    const known = sorted.filter((row) => typeof row.subscriptionUntilMs === 'number');
+    const unknown = sorted.filter((row) => typeof row.subscriptionUntilMs !== 'number');
+
+    expect(known.length).toBeGreaterThan(1);
+    for (let index = 1; index < known.length; index += 1) {
+      expect(known[index].subscriptionUntilMs ?? 0).toBeGreaterThanOrEqual(
+        known[index - 1].subscriptionUntilMs ?? 0
+      );
+    }
+    expect(unknown.every((row) => sorted.indexOf(row) > sorted.indexOf(known[known.length - 1]))).toBe(
+      true
+    );
+    expect(sortAccountRows(rows).map((row) => row.fileName)).not.toEqual(
+      sorted.map((row) => row.fileName)
+    );
   });
 
   it('selects valid quota list windows and produces reliable actual usage and forecasts', () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -910,6 +910,7 @@
     "sort_descending": "Sort descending",
     "sort_default": "Default",
     "sort_name": "Credential name",
+    "sort_remaining": "Plan remaining",
     "sort_reset_asc": "Earliest reset",
     "sort_reset_desc": "Latest reset",
     "sort_priority_desc": "Use first",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -914,6 +914,7 @@
     "sort_descending": "Сортировать по убыванию",
     "sort_default": "По умолчанию",
     "sort_name": "Имя учетных данных",
+    "sort_remaining": "Остаток тарифа",
     "sort_reset_asc": "Сброс раньше",
     "sort_reset_desc": "Сброс позже",
     "sort_priority_desc": "Использовать раньше",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -908,6 +908,7 @@
     "sort_descending": "降序排序",
     "sort_default": "默认排序",
     "sort_name": "凭证名称",
+    "sort_remaining": "套餐剩余时间",
     "sort_reset_asc": "恢复时间最早",
     "sort_reset_desc": "恢复时间最晚",
     "sort_priority_desc": "优先使用靠前",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -908,6 +908,7 @@
     "sort_descending": "降序排序",
     "sort_default": "預設排序",
     "sort_name": "憑證名稱",
+    "sort_remaining": "方案剩餘時間",
     "sort_reset_asc": "恢復時間最早",
     "sort_reset_desc": "恢復時間最晚",
     "sort_priority_desc": "優先使用靠前",


### PR DESCRIPTION
## Summary

Codex accounts list shows paid plan remaining days but never sorts by them. `sort=default` is risk then filename. This PR adds `sort=remaining` and orders rows by the same `subscriptionUntilMs` the list already uses for remaining-day display.

> Community and maintenance PRs must target `dev`. Repository automation
> retargets other pull requests to `dev`; this can change the diff and make
> existing review comments outdated. `main` accepts only a promotion PR whose
> source is this repository's `dev` branch.

## Scope

- [x] Frontend panel
- [ ] Manager Server
- [x] CPA panel mode
- [x] Full Docker mode
- [ ] Native packages / release
- [ ] Docs / Wiki
- [ ] CI / build / tooling

## Changes

- `buildAccountRows` stores `subscriptionUntilMs` from `buildAccountSubscriptionPresentation`.
- `sortAccountRows` honors `sort=remaining` with unknown or free plans last.
- The accounts sort dropdown exposes that key. Default sort is unchanged.

## User Impact

On the accounts page, choose **Plan remaining** / **套餐剩余时间**. Ascending puts the soonest paid Codex expiry first. Existing `sort=default` bookmarks keep prior behavior.

## Compatibility / Runtime Notes

- CPA panel mode: frontend-only sort. No API change.
- Manager Server mode: frontend-only sort. No API change.
- Full Docker / native packages: same after panel rebuild / image update.

## Data / Security Notes

N/A. Sort uses existing local quota and token subscription fields.

## Risk / Rollback

Risk level: Low

Rollback notes: revert the commits. Other sort keys are unchanged.

## Verification

- [x] Type check
- [x] Lint
- [x] Tests
- [x] Build
- [x] Manual UI check
- [ ] Docs/link check
- [ ] Not applicable, docs-only

Commands / evidence:

```text
# failing before the fix
npm --workspace apps/web run test -- src/features/accounts/model/accountRows.test.ts -t "sorts paid Codex rows by subscription remaining time"
AssertionError: expected [ 'free.json', 'later.json', 'sooner.json', 'unknown.json' ]
to equal [ 'sooner.json', 'later.json', 'free.json', 'unknown.json' ]

# passing after the fix
npm run type-check
npm --workspace apps/web run test -- src/features/accounts/model/accountRows.test.ts src/features/accounts/model/accountSubscriptionPresentation.test.ts src/features/accounts/model/accountsWorkspaceUrlState.test.ts src/features/accounts/AccountsPage.test.tsx src/features/demo/demoInspect.test.ts -t "remaining|sorts paid Codex|sorts the name|sorts rows by priority|sorts account cards|sorts Codex account|sorts demo Codex"
# 15 passed

npm run build

# demo fixture remaining order (asc)
codex-pro-20x-01.json 2 days
codex-email-user.json 5 days
codex-fallback-02.json 12 days
codex-team-01.json 23 days

# demo UI: default paid remaining days 2, 12, 5, 23
# after Plan remaining (sort=remaining&direction=asc): 2, 5, 12, 23
```

## Screenshots / Recordings

Default sort does not order remaining days. After choosing Plan remaining, paid rows are soonest-expiry first. Screenshots from local verification of the same change are attached on the fork working PR: https://github.com/HuiCheng/CPA-Manager-Plus/pull/3

## Docs

- [ ] README / README_CN updated for user-visible capabilities
- [ ] Matching docs manual and navigation updated
- [ ] Demo fixtures, screenshots, and deep links reviewed
- [ ] Release notes needed
- [x] Not needed — explanation included below

Docs decision: existing sort control with one new dropdown label. No setup or API docs.

## Related

Fork working PR: https://github.com/HuiCheng/CPA-Manager-Plus/pull/3